### PR TITLE
feat(frontend): add task details page

### DIFF
--- a/cmd/argo-watcher/main.go
+++ b/cmd/argo-watcher/main.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,10 +14,6 @@ import (
 	"github.com/romana/rlog"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
-	"net/http"
-	"os"
-	"strconv"
-	"time"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/docs"
 	h "github.com/shini4i/argo-watcher/internal/helpers"
@@ -152,6 +153,12 @@ func getTaskStatus(c *gin.Context) {
 	} else {
 		c.JSON(http.StatusOK, m.TaskStatus{
 			Id:           task.Id,
+			Created: 	  task.Created,
+			Updated:      task.Updated,
+			App:          task.App,
+			Author:       task.Author,
+			Project:      task.Project,
+			Images:       task.Images,
 			Status:       task.Status,
 			StatusReason: task.StatusReason,
 		})

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -38,6 +38,12 @@ type HealthStatus struct {
 
 type TaskStatus struct {
 	Id           string `json:"id,omitempty"`
+	Created      float64 `json:"created,omitempty"`
+	Updated      float64 `json:"updated,omitempty"`
+	App          string  `json:"app" binding:"required" example:"argo-watcher"`
+	Author       string  `json:"author" binding:"required" example:"John Doe"`
+	Project      string  `json:"project" binding:"required" example:"Demo"`
+	Images       []Image `json:"images" binding:"required"`
 	Status       string `json:"status"`
 	StatusReason string `json:"status_reason"`
 	Error        string `json:"error,omitempty"`

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -6,11 +6,16 @@ import Layout from './Layout';
 import Page404 from './Page404';
 import { createTheme, ThemeProvider } from '@mui/material';
 import { ErrorProvider } from './ErrorContext';
+import TaskView from './Components/TaskView';
 
 const theme = createTheme({
   palette: {
     primary: {
       main: '#2E3B55',
+    },
+    neutral: {
+      main: 'gray',
+      light: '#F8F8F8',
     },
   },
 });
@@ -24,6 +29,7 @@ function App() {
             <Route path="/" element={<Layout />}>
               <Route index element={<RecentTasks />} />
               <Route path="/history" element={<HistoryTasks />} />
+              <Route path="/task/:id" element={<TaskView />} />
             </Route>
             <Route path="*" element={<Page404 />} />
           </Routes>

--- a/web/src/Components/TaskView.js
+++ b/web/src/Components/TaskView.js
@@ -1,0 +1,129 @@
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchTask } from '../Services/Data';
+import { useErrorContext } from '../ErrorContext';
+import { Grid, Chip } from '@mui/material';
+import {
+  chipColorByStatus,
+  formatDateTime,
+  ProjectDisplay,
+  StatusReasonDisplay,
+} from './TasksTable';
+export default function TaskView() {
+  const { id } = useParams();
+  const [task, setTask] = useState(null);
+  const { setError, setSuccess } = useErrorContext();
+
+  useEffect(() => {
+    fetchTask(id)
+      .then(item => {
+        setSuccess('fetchTask', 'Fetched tas successfully');
+        setTask(item);
+      })
+      .catch(error => {
+        setError('fetchTasks', error.message);
+      });
+  }, [id]);
+
+  return (
+    <Container maxWidth="lg">
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        alignItems="center"
+        sx={{ mb: 2 }}
+      >
+        <Typography
+          variant="h4"
+          gutterBottom
+          component="div"
+          sx={{ flexGrow: 1, display: 'flex', gap: '10px' }}
+        >
+          <Box>Task details</Box>
+          <Box sx={{ fontSize: '10px' }}>UTC</Box>
+        </Typography>
+      </Stack>
+      {!task && <Typography>Loading...</Typography>}
+      {task && (
+        <Grid container spacing={3}>
+          <Grid item xs={3}>
+            <Typography>Id</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2" sx={{ color: 'neutral.main' }}>
+              {task.id}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Created</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">
+              <span>{formatDateTime(task.created)}</span>
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Updated</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">
+              <span>{formatDateTime(task.updated)}</span>
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Application</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">{task.app}</Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Author</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">{task.author}</Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Project</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">
+              <ProjectDisplay project={task.project}></ProjectDisplay>
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Images</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">
+              {task.images.map((item, index) => {
+                return (
+                  <div key={index}>
+                    {item.image}:{item.tag}
+                  </div>
+                );
+              })}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Status</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Chip label={task.status} color={chipColorByStatus(task.status)} />
+          </Grid>
+          <Grid item xs={3}>
+            <Typography>Status details</Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="body2">
+              <StatusReasonDisplay reason={task.status_reason} />
+            </Typography>
+          </Grid>
+        </Grid>
+      )}
+    </Container>
+  );
+}

--- a/web/src/Components/TaskView.js
+++ b/web/src/Components/TaskView.js
@@ -71,7 +71,7 @@ export default function TaskView() {
           </Grid>
           <Grid item xs={9}>
             <Typography variant="body2">
-              <span>{formatDateTime(task.updated)}</span>
+              <span>{task.updated ? formatDateTime(task.updated) : '---'}</span>
             </Typography>
           </Grid>
           <Grid item xs={3}>
@@ -90,23 +90,21 @@ export default function TaskView() {
             <Typography>Project</Typography>
           </Grid>
           <Grid item xs={9}>
-            <Typography variant="body2">
-              <ProjectDisplay project={task.project}></ProjectDisplay>
-            </Typography>
+            <ProjectDisplay project={task.project}></ProjectDisplay>
           </Grid>
           <Grid item xs={3}>
             <Typography>Images</Typography>
           </Grid>
           <Grid item xs={9}>
-            <Typography variant="body2">
-              {task.images.map((item, index) => {
-                return (
-                  <div key={index}>
+            {task.images.map((item, index) => {
+              return (
+                <div key={index}>
+                  <Typography variant="body2">
                     {item.image}:{item.tag}
-                  </div>
-                );
-              })}
-            </Typography>
+                  </Typography>
+                </div>
+              );
+            })}
           </Grid>
           <Grid item xs={3}>
             <Typography>Status</Typography>
@@ -118,9 +116,7 @@ export default function TaskView() {
             <Typography>Status details</Typography>
           </Grid>
           <Grid item xs={9}>
-            <Typography variant="body2">
-              <StatusReasonDisplay reason={task.status_reason} />
-            </Typography>
+            <StatusReasonDisplay reason={task.status_reason} />
           </Grid>
         </Grid>
       )}

--- a/web/src/Components/TasksTable.js
+++ b/web/src/Components/TasksTable.js
@@ -15,15 +15,28 @@ import { fetchTasks } from '../Services/Data';
 import Box from '@mui/material/Box';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { Chip, Divider, Popover } from '@mui/material';
-import Link from '@mui/material/Link';
+import { Chip, Divider, Link, Popover } from '@mui/material';
 import { addMinutes, format } from 'date-fns';
 import Pagination from '@mui/material/Pagination';
-import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
+import { Link as ReactLink } from 'react-router-dom';
+import LaunchIcon from '@mui/icons-material/Launch';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
-const chipColorByStatus = status => {
+export function ProjectDisplay({ project }) {
+  console.log(project);
+  if (project.indexOf('http') === 0) {
+    return (
+      <Link href={project}>
+        {project.replace(/^http(s)?:\/\//, '').replace(/\/+$/, '')}
+      </Link>
+    );
+  }
+  return <Typography variant={'body2'}>{project}</Typography>;
+}
+
+export const chipColorByStatus = status => {
   if (status === 'in progress') {
     return 'primary';
   }
@@ -36,6 +49,22 @@ const chipColorByStatus = status => {
   return undefined;
 };
 
+export function StatusReasonDisplay({ reason }) {
+  return (
+    <Typography
+      sx={{
+        p: 2,
+        width: '100%',
+        overflow: 'auto',
+        backgroundColor: 'neutral.light',
+      }}
+      component={'pre'}
+    >
+      {reason}
+    </Typography>
+  );
+}
+
 const taskDuration = (created, updated) => {
   if (!updated) {
     updated = Math.round(Date.now() / 1000);
@@ -44,7 +73,7 @@ const taskDuration = (created, updated) => {
   return relativeHumanDuration(seconds);
 };
 
-const formatDateTime = timestamp => {
+export const formatDateTime = timestamp => {
   let dateTime = new Date(timestamp * 1000);
   return format(
     addMinutes(dateTime, dateTime.getTimezoneOffset()),
@@ -188,19 +217,25 @@ function TasksTable({
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        sx={{ minWidth: '300px', maxWidth: '500px' }}
+        PaperProps={{
+          elevation: 1,
+          square: true,
+        }}
+        sx={{ minWidth: '300px', maxWidth: '50%' }}
       >
-        <Typography
-          sx={{ p: 2, width: '100%', overflow: 'auto' }}
-          component={'pre'}
-        >
-          {statusReason}
-        </Typography>
+        <StatusReasonDisplay reason={statusReason} />
       </Popover>
       <TableContainer>
-        <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <Table sx={{ minWidth: 650 }}>
           <TableHead>
             <TableRow>
+              <TableCellSorted
+                sortField={sortField}
+                setSortField={setSortField}
+                field={'id'}
+              >
+                Id
+              </TableCellSorted>
               <TableCellSorted
                 sortField={sortField}
                 setSortField={setSortField}
@@ -258,17 +293,27 @@ function TasksTable({
                 key={task.id}
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
+                <TableCell>
+                  <Typography
+                    to={`/task/${task.id}`}
+                    sx={{
+                      textDecoration: 'none',
+                      color: 'neutral.main',
+                      '&:hover': {
+                        textDecoration: 'underline',
+                      },
+                      display: 'flex',
+                    }}
+                    component={ReactLink}
+                    variant={'body2'}
+                  >
+                    <span>{task.id.substring(0, 8)}</span>
+                    <LaunchIcon fontSize="small" sx={{ marginLeft: '5px' }} />
+                  </Typography>
+                </TableCell>
                 <TableCell>{task.app}</TableCell>
                 <TableCell>
-                  {task.project.indexOf('http') === 0 ? (
-                    <Link href={task.project}>
-                      {task.project
-                        .replace(/^http(s)?:\/\//, '')
-                        .replace(/\/+$/, '')}
-                    </Link>
-                  ) : (
-                    task.project
-                  )}
+                  <ProjectDisplay project={task.project} />
                 </TableCell>
                 <TableCell>{task.author}</TableCell>
                 <TableCell>
@@ -279,9 +324,10 @@ function TasksTable({
                   {task?.status_reason && (
                     <IconButton
                       size={'small'}
+                      sx={{ marginLeft: '5px' }}
                       onClick={e => handleClick(e, task.status_reason)}
                     >
-                      <InfoIcon fontSize={'small'} />
+                      <HelpOutlineIcon fontSize={'small'} />
                     </IconButton>
                   )}
                 </TableCell>
@@ -313,7 +359,7 @@ function TasksTable({
             {tasks.length === 0 && (
               <TableRow>
                 <TableCell colSpan={100} sx={{ textAlign: 'center' }}>
-                  No tasks were found within provided timeframe
+                  No tasks were found within provided time frame
                 </TableCell>
               </TableRow>
             )}

--- a/web/src/Services/Data.js
+++ b/web/src/Services/Data.js
@@ -36,6 +36,22 @@ export function fetchApplications() {
   });
 }
 
+export function fetchTask(id) {
+  return fetch(`/api/v1/tasks/${id}`)
+    .then(res => {
+      if (res.status !== 200) {
+        throw new Error(res.statusText);
+      }
+      return res.json();
+    })
+    .then(res => {
+      if (res?.error) {
+        throw new Error(res.error);
+      }
+      return res;
+    });
+}
+
 export function fetchVersion() {
   return fetch(`/api/v1/version`).then(res => {
     if (res.status !== 200) {


### PR DESCRIPTION
1. Created "Task details" page that can show all task info + have a unique link for the task
2. Improved task status details are shown in tables (not much improvement, but still)

The reasoning behind the changes is to make it easier to find task errors and get information on them

![image](https://user-images.githubusercontent.com/5130614/214438793-9f460496-150b-40b5-84f5-cd8769dc8d12.png)
![image](https://user-images.githubusercontent.com/5130614/214438824-e9fd8d57-15e9-45d5-9f55-b715b8c1ff59.png)
