### PR TITLE
feat(ui): items per page and minor improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,5 +65,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -18,6 +18,15 @@ const theme = createTheme({
       light: '#F8F8F8',
     },
   },
+  components: {
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          padding: '12px',
+        },
+      },
+    },
+  },
 });
 
 function App() {

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -4,7 +4,7 @@ import RecentTasks from './Components/RecentTasks';
 import HistoryTasks from './Components/HistoryTasks';
 import Layout from './Layout';
 import Page404 from './Page404';
-import { createTheme, ThemeProvider } from '@mui/material';
+import { createTheme, ThemeProvider, lighten } from '@mui/material';
 import { ErrorProvider } from './ErrorContext';
 import TaskView from './Components/TaskView';
 
@@ -15,7 +15,9 @@ const theme = createTheme({
     },
     neutral: {
       main: 'gray',
-      light: '#F8F8F8',
+    },
+    reason_color: {
+      main: lighten('#ff9800', 0.5),
     },
   },
   components: {

--- a/web/src/Components/HistoryTasks.js
+++ b/web/src/Components/HistoryTasks.js
@@ -85,10 +85,10 @@ function HistoryTasks() {
         sx={{ mb: 2 }}
       >
         <Typography
-          variant="h4"
+          variant="h5"
           gutterBottom
           component="div"
-          sx={{ flexGrow: 1, display: 'flex', gap: '10px' }}
+          sx={{ flexGrow: 1, display: 'flex', gap: '10px', m: 0 }}
         >
           <Box>History tasks</Box>
           <Box sx={{ fontSize: '10px' }}>UTC</Box>

--- a/web/src/Components/RecentTasks.js
+++ b/web/src/Components/RecentTasks.js
@@ -94,10 +94,10 @@ function RecentTasks() {
         sx={{ mb: 2 }}
       >
         <Typography
-          variant="h4"
+          variant="h5"
           gutterBottom
           component="div"
-          sx={{ flexGrow: 1, display: 'flex', gap: '10px' }}
+          sx={{ flexGrow: 1, display: 'flex', gap: '10px', m: 0 }}
         >
           <Box>Recent tasks</Box>
           <Box sx={{ fontSize: '10px' }}>UTC</Box>

--- a/web/src/Components/TaskView.js
+++ b/web/src/Components/TaskView.js
@@ -38,7 +38,7 @@ export default function TaskView() {
         sx={{ mb: 2 }}
       >
         <Typography
-          variant="h4"
+          variant="h5"
           gutterBottom
           component="div"
           sx={{ flexGrow: 1, display: 'flex', gap: '10px' }}
@@ -116,7 +116,7 @@ export default function TaskView() {
             <Typography>Status details</Typography>
           </Grid>
           <Grid item xs={9}>
-            <StatusReasonDisplay reason={task.status_reason} />
+            <StatusReasonDisplay reason={task.status_reason} sx={{ p: 0 }} />
           </Grid>
         </Grid>
       )}

--- a/web/src/Components/TaskView.js
+++ b/web/src/Components/TaskView.js
@@ -116,7 +116,7 @@ export default function TaskView() {
             <Typography>Status details</Typography>
           </Grid>
           <Grid item xs={9}>
-            <StatusReasonDisplay reason={task.status_reason} sx={{ p: 0 }} />
+            <StatusReasonDisplay reason={task.status_reason} />
           </Grid>
         </Grid>
       )}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,12 @@
 /** Global CSS goes here */
-/** .... */
-html, body, div#root {
-    min-height: 100%;
-    min-width: 640px;
+html,
+body,
+div#root {
+  min-height: 100%;
+  min-width: 640px;
+}
+
+/** Fix for date picker going under "items per page" select **/
+.react-datepicker-popper {
+  z-index: 1000 !important;
 }


### PR DESCRIPTION
Pull requests for #123 

* Created a dropdown for pagination, which is saved on refresh or event browser tab reopen (used local storage)
* Improved styling a bit, so that with default ten items per page the table fits the screen without scroll
* Reworked how item errors work. Instead of a popup they will appear in a separate row in the table now

![image](https://github.com/shini4i/argo-watcher/assets/5130614/37d5bf44-8b47-4486-97d4-4ebf2f45ba03)
