### PR TITLE
fix(config): correct error handling for envConfig

### DIFF
--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"errors"
+	"github.com/shini4i/argo-watcher/internal/helpers"
 	"strconv"
 
 	envConfig "github.com/kelseyhightower/envconfig"
-	"github.com/shini4i/argo-watcher/internal/helpers"
 )
 
 type ServerConfig struct {
@@ -35,13 +35,21 @@ type ServerConfig struct {
 // Otherwise, it returns the parsed server configuration and any error encountered during the parsing process.
 func NewServerConfig() (*ServerConfig, error) {
 	// parse config
-	var config ServerConfig
-	err := envConfig.Process("", &config)
+	var (
+		err    error
+		config ServerConfig
+	)
+
+	if err := envConfig.Process("", &config); err != nil {
+		panic(err)
+	}
+
 	// custom checks
 	allowedTypes := []string{"postgres", "in-memory"}
 	if config.StateType == "" || !helpers.Contains(allowedTypes, config.StateType) {
 		return nil, errors.New("variable STATE_TYPE must be one of [\"postgres\", \"in-memory\"]")
 	}
+
 	// return config
 	return &config, err
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,7 +63,7 @@ cd cmd/argo-watcher
 # install dependencies
 go mod tidy
 # start argo-watcher
-ARGO_URL=http://localhost:8081 STATE_TYPE=in-memory go run .
+ARGO_URL=http://localhost:8081 STATE_TYPE=in-memory go run . -server
 ```
 
 ### Running the unit tests


### PR DESCRIPTION
Fix for cases when `envConfig.Process` returns an error. Now we are printing the correct error.