### PR TITLE
chore: argo status updater changes

### DIFF
--- a/cmd/argo-watcher/argo.go
+++ b/cmd/argo-watcher/argo.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	argoSyncRetryDelay    = 15 * time.Second
-	errorArgoPlannedRetry = fmt.Errorf("planned retry")
+	argoSyncRetryDelay = 15 * time.Second
 )
 
 const (

--- a/cmd/argo-watcher/argo_status_updater.go
+++ b/cmd/argo-watcher/argo_status_updater.go
@@ -78,7 +78,7 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 
 	// wait for application to get into deployed status or timeout
 	log.Debug().Str("id", task.Id).Msg("Waiting for rollout")
-	retry.Do(func() error {
+	_ = retry.Do(func() error {
 		application, err = updater.argo.api.GetApplication(task.App)
 		if err != nil {
 			// check if ArgoCD didn't have the app

--- a/cmd/argo-watcher/argo_status_updater.go
+++ b/cmd/argo-watcher/argo_status_updater.go
@@ -8,162 +8,95 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/rs/zerolog/log"
-	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-const defaultErrorMessage string = "could not retrieve details"
 const failedToUpdateTaskStatusTemplate string = "Failed to change task status: %s"
 
 type ArgoStatusUpdater struct {
 	argo             Argo
-	retryAttempts    uint
-	retryDelay       time.Duration
 	registryProxyUrl string
+	retryOptions     []retry.Option
 }
 
 func (updater *ArgoStatusUpdater) Init(argo Argo, retryAttempts uint, retryDelay time.Duration, registryProxyUrl string) {
 	updater.argo = argo
-	updater.retryAttempts = retryAttempts
-	updater.retryDelay = retryDelay
 	updater.registryProxyUrl = registryProxyUrl
+	updater.retryOptions = []retry.Option{
+		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(retryAttempts),
+		retry.Delay(retryDelay),
+		retry.LastErrorOnly(true),
+	}
 }
 
 func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
-	// continuously check for application status change
-	status, err := updater.checkWithRetry(task)
 
-	// application synced successfully
-	if status == ArgoAppSuccess {
-		updater.handleDeploymentSuccess(task)
-		return
-	}
+	// wait for application to get into deployed status or timeout
+	application, err := updater.waitForApplicationDeployment(task)
 
-	// we had some unexpected error with ArgoCD API
-	if status == ArgoAppFailed {
+	// handle application failure
+	if err != nil {
 		updater.handleArgoAPIFailure(task, err)
 		return
 	}
 
-	// fetch application details
-	app, err := updater.argo.api.GetApplication(task.App)
-
-	// handle application sync failure
-	switch status {
-	// not all images were deployed to the application
-	case ArgoAppNotAvailable:
-		// show list of missing images
-		var message string
-		// define details
-		if err != nil {
-			message = defaultErrorMessage
-		} else {
-			message = fmt.Sprintf(
-				"List of current images (last app check):\n"+
-					"\t%s\n\n"+
-					"List of expected images:\n"+
-					"\t%s",
-				strings.Join(app.Status.Summary.Images, "\n\t"),
-				strings.Join(task.ListImages(), "\n\t"),
-			)
+	// get application status
+	status := application.GetRolloutStatus(task.ListImages(), updater.registryProxyUrl)
+	if application.IsFinalRolloutStatus(status) {
+		log.Info().Str("id", task.Id).Msg("App is running on the excepted version.")
+		// deployment success
+		updater.argo.metrics.ResetFailedDeployment(task.App)
+		// update task status
+		errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
+		if errStatusChange != nil {
+			log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
 		}
-		// handle error
-		updater.handleAppNotAvailable(task, errors.New(message))
-	// application sync status wasn't valid
-	case ArgoAppNotSynced:
-		// display sync status and last sync message
-		var message string
-		// define details
-		if err != nil {
-			message = defaultErrorMessage
-		} else {
-			message = fmt.Sprintf(
-				"App status \"%s\"\n"+
-					"App message \"%s\"\n"+
-					"Resources:\n"+
-					"\t%s",
-				app.Status.OperationState.Phase,
-				app.Status.OperationState.Message,
-				strings.Join(app.ListSyncResultResources(), "\n\t"),
-			)
+	} else {
+		log.Info().Str("id", task.Id).Msg("App deployment failed.")
+		// deployment failed
+		updater.argo.metrics.AddFailedDeployment(task.App)
+		// generate failure reason
+		reason := fmt.Sprintf(
+			"Application deployment failed. Rollout status \"%s\"\n\n%s",
+			status,
+			application.GetRolloutMessage(status, task.ListImages()),
+		)
+		// update task status
+		errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
+		if errStatusChange != nil {
+			log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
 		}
-		// handle error
-		updater.handleAppOutOfSync(task, errors.New(message))
-	// application is not in a healthy status
-	case ArgoAppNotHealthy:
-		// display current health of pods
-		var message string
-		// define details
-		if err != nil {
-			message = defaultErrorMessage
-		} else {
-			message = fmt.Sprintf(
-				"App sync status \"%s\"\n"+
-					"App health status \"%s\"\n"+
-					"Resources:\n"+
-					"\t%s",
-				app.Status.Sync.Status,
-				app.Status.Health.Status,
-				strings.Join(app.ListUnhealthyResources(), "\n\t"),
-			)
-		}
-		// handle error
-		updater.handleAppNotHealthy(task, errors.New(message))
-	// handle unexpected status
-	default:
-		updater.handleDeploymentUnexpectedStatus(task, fmt.Errorf("received unexpected status \"%d\"", status))
 	}
 }
 
-func (updater *ArgoStatusUpdater) checkWithRetry(task models.Task) (int, error) {
-	var lastStatus int
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, error) {
+	var application *models.Application
+	var err error
 
-	err := retry.Do(
-		func() error {
-			app, err := updater.argo.api.GetApplication(task.App)
+	// wait for application to get into deployed status or timeout
+	log.Debug().Str("id", task.Id).Msg("Waiting for rollout")
+	retry.Do(func() error {
+		application, err = updater.argo.api.GetApplication(task.App)
+		if err != nil {
+			// print application api failure here
+			log.Debug().Str("id", task.Id).Msgf("Failed fetching application status. Error: %s", err.Error())
+			return err
+		}
+		// print application debug here
+		status := application.GetRolloutStatus(task.ListImages(), updater.registryProxyUrl)
+		if !application.IsFinalRolloutStatus(status) {
+			// print status debug here
+			log.Debug().Str("id", task.Id).Msgf("Application status is not final. Status received \"%s\"", status)
+			return errors.New("force retry")
+		}
+		// all good
+		log.Debug().Str("id", task.Id).Msgf("Application rollout finished")
+		return nil
+	}, updater.retryOptions...)
 
-			if err != nil {
-				log.Warn().Str("app", task.App).Msg(err.Error())
-				lastStatus = ArgoAppFailed
-				return err
-			}
-
-			for _, image := range task.Images {
-				expected := fmt.Sprintf("%s:%s", image.Image, image.Tag)
-				if !helpers.ImagesContains(app.Status.Summary.Images, expected, updater.registryProxyUrl) {
-					log.Debug().Str("app", task.App).Str("id", task.Id).Msgf("%s is not available yet", expected)
-					lastStatus = ArgoAppNotAvailable
-					return errorArgoPlannedRetry
-				} else {
-					log.Debug().Str("app", task.App).Str("id", task.Id).Msgf("Expected image is in the app summary")
-				}
-			}
-
-			if app.Status.Sync.Status != "Synced" {
-				log.Debug().Str("id", task.Id).Msgf("%s is not synced yet", task.App)
-				lastStatus = ArgoAppNotSynced
-				return errorArgoPlannedRetry
-			}
-
-			if app.Status.Health.Status != "Healthy" {
-				log.Debug().Str("id", task.Id).Msgf("%s is not healthy yet", task.App)
-				lastStatus = ArgoAppNotHealthy
-				return errorArgoPlannedRetry
-			}
-
-			lastStatus = ArgoAppSuccess
-			return nil
-		},
-		retry.DelayType(retry.FixedDelay),
-		retry.Delay(updater.retryDelay),
-		retry.Attempts(updater.retryAttempts),
-		retry.RetryIf(func(err error) bool {
-			return errors.Is(err, errorArgoPlannedRetry)
-		}),
-		retry.LastErrorOnly(true),
-	)
-
-	return lastStatus, err
+	// return application and latest error
+	return application, err
 }
 
 func (updater *ArgoStatusUpdater) handleArgoAPIFailure(task models.Task, err error) {
@@ -205,56 +138,6 @@ func (updater *ArgoStatusUpdater) handleDeploymentFailed(task models.Task, err e
 	log.Warn().Str("id", task.Id).Msgf("Deployment failed. Aborting with error: %s", err)
 	updater.argo.metrics.AddFailedDeployment(task.App)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
-	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
-	if errStatusChange != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
-	}
-}
-
-func (updater *ArgoStatusUpdater) handleDeploymentSuccess(task models.Task) {
-	log.Info().Str("id", task.Id).Msg("App is running on the excepted version.")
-	updater.argo.metrics.ResetFailedDeployment(task.App)
-	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
-	if errStatusChange != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
-	}
-}
-
-func (updater *ArgoStatusUpdater) handleAppNotAvailable(task models.Task, err error) {
-	log.Warn().Str("id", task.Id).Msgf("Deployment failed. Application not available\n%s", err.Error())
-	updater.argo.metrics.AddFailedDeployment(task.App)
-	reason := fmt.Sprintf("Application not available\n\n%s", err.Error())
-	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
-	if errStatusChange != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
-	}
-}
-
-func (updater *ArgoStatusUpdater) handleAppNotHealthy(task models.Task, err error) {
-	log.Warn().Str("id", task.Id).Msgf("Deployment failed. Application not healthy\n%s", err.Error())
-	updater.argo.metrics.AddFailedDeployment(task.App)
-	reason := fmt.Sprintf("Application not healthy\n\n%s", err.Error())
-	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
-	if errStatusChange != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
-	}
-}
-
-func (updater *ArgoStatusUpdater) handleAppOutOfSync(task models.Task, err error) {
-	log.Warn().Str("id", task.Id).Msgf("Deployment failed. Application out of sync\n%s", err.Error())
-	updater.argo.metrics.AddFailedDeployment(task.App)
-	reason := fmt.Sprintf("Application out of sync\n\n%s", err.Error())
-	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
-	if errStatusChange != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
-	}
-}
-
-func (updater *ArgoStatusUpdater) handleDeploymentUnexpectedStatus(task models.Task, err error) {
-	log.Error().Str("id", task.Id).Msg("Deployment timed out with unexpected status. Aborting.")
-	log.Error().Str("id", task.Id).Msgf("Deployment error\n%s", err.Error())
-	updater.argo.metrics.AddFailedDeployment(task.App)
-	reason := fmt.Sprintf("Deployment timeout\n\n%s", err.Error())
 	errStatusChange := updater.argo.state.SetTaskStatus(task.Id, models.StatusFailedMessage, reason)
 	if errStatusChange != nil {
 		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)

--- a/cmd/argo-watcher/argo_status_updater_test.go
+++ b/cmd/argo-watcher/argo_status_updater_test.go
@@ -208,6 +208,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		// mock calls
 		apiMock.EXPECT().GetApplication(task.App).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
+		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAppNotFoundMessage, "ArgoCD API Error: applications.argoproj.io \"test-app\" not found")
 
 		// run the rollout
@@ -236,6 +237,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		// mock calls
 		apiMock.EXPECT().GetApplication(task.App).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
+		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: connect: connection refused")
 
 		// run the rollout

--- a/cmd/argo-watcher/argo_status_updater_test.go
+++ b/cmd/argo-watcher/argo_status_updater_test.go
@@ -177,10 +177,10 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(2)
+		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
-			"Application not available\n\nList of current images (last app check):\n\ttest-registry/ghcr.io/shini4i/argo-watcher:dev\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:dev")
+			"Application deployment failed. Rollout status \"not available\"\n\nList of current images (last app check):\n\ttest-registry/ghcr.io/shini4i/argo-watcher:dev\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:dev")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -302,10 +302,10 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Summary.Images = []string{"test-image:v0.0.1"}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(2)
+		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
-			"Application not available\n\nList of current images (last app check):\n\ttest-image:v0.0.1\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:dev")
+			"Application deployment failed. Rollout status \"not available\"\n\nList of current images (last app check):\n\ttest-image:v0.0.1\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:dev")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -346,10 +346,10 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.OperationState.Message = "Not working test app"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(2)
+		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
-			"Application out of sync\n\nApp status \"NotWorking\"\nApp message \"Not working test app\"\nResources:\n\t")
+			"Application deployment failed. Rollout status \"not synced\"\n\nApp status \"NotWorking\"\nApp message \"Not working test app\"\nResources:\n\t")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -388,10 +388,10 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "NotHealthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(2)
+		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
-			"Application not healthy\n\nApp sync status \"Synced\"\nApp health status \"NotHealthy\"\nResources:\n\t")
+			"Application deployment failed. Rollout status \"not healthy\"\n\nApp sync status \"Synced\"\nApp health status \"NotHealthy\"\nResources:\n\t")
 
 		// run the rollout
 		updater.WaitForRollout(task)

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -14,6 +14,27 @@ const (
 	ArgoRolloutAppNotHealthy   = "not healthy"
 )
 
+type ApplicationOperationResource struct {
+	HookPhase string `json:"hookPhase"` // example: Failed
+	HookType  string `json:"hookType"`  // example: PreSync
+	Kind      string `json:"kind"`      // example: Pod | Job
+	Message   string `json:"message"`   // example: Job has reached the specified backoff limit
+	Status    string `json:"status"`    // example: Synced
+	SyncPhase string `json:"syncPhase"` // example: PreSync
+	Name      string `json:"name"`      // example: app-migrations
+	Namespace string `json:"namespace"` // example: app
+}
+
+type ApplicationResource struct {
+	Kind      string `json:"kind"`      // example: Pod | Job
+	Name      string `json:"name"`      // example: app-migrations
+	Namespace string `json:"namespace"` // example: app
+	Health    struct {
+		Message string `json:"message"` // example: Job has reached the specified backoff limit
+		Status  string `json:"status"`  // example: Synced
+	} `json:"health"`
+}
+
 type Application struct {
 	Status struct {
 		Health struct {
@@ -23,28 +44,11 @@ type Application struct {
 			Phase      string `json:"phase"`
 			Message    string `json:"message"`
 			SyncResult struct {
-				Resources []struct {
-					HookPhase string `json:"hookPhase"` // example: Failed
-					HookType  string `json:"hookType"`  // example: PreSync
-					Kind      string `json:"kind"`      // example: Pod | Job
-					Message   string `json:"message"`   // example: Job has reached the specified backoff limit
-					Status    string `json:"status"`    // example: Synced
-					SyncPhase string `json:"syncPhase"` // example: PreSync
-					Name      string `json:"name"`      // example: app-migrations
-					Namespace string `json:"namespace"` // example: app
-				} `json:"resources"`
+				Resources []ApplicationOperationResource `json:"resources"`
 			} `json:"syncResult"`
 		} `json:"operationState"`
-		Resources []struct {
-			Kind      string `json:"kind"`      // example: Pod | Job
-			Name      string `json:"name"`      // example: app-migrations
-			Namespace string `json:"namespace"` // example: app
-			Health    struct {
-				Message string `json:"message"` // example: Job has reached the specified backoff limit
-				Status  string `json:"status"`  // example: Synced
-			} `json:"health"`
-		} `json:"resources"`
-		Summary struct {
+		Resources []ApplicationResource `json:"resources"`
+		Summary   struct {
 			Images []string `json:"images"`
 		}
 		Sync struct {
@@ -53,7 +57,7 @@ type Application struct {
 	} `json:"status"`
 }
 
-// Calculates application rollout status depending on the expected images and proxy configuration
+// Calculates application rollout status depending on the expected images and proxy configuration.
 func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUrl string) string {
 	// check if all the images rolled out
 	for _, image := range rolloutImages {
@@ -76,7 +80,7 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 	return ArgoRolloutAppSuccess
 }
 
-// Generate rollout failure message
+// Generate rollout failure message.
 func (app *Application) GetRolloutMessage(status string, rolloutImages []string) string {
 	// handle application sync failure
 	switch status {
@@ -124,7 +128,7 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string)
 	)
 }
 
-// check if rollout status is final
+// Check if rollout status is final.
 func (app *Application) IsFinalRolloutStatus(status string) bool {
 	return status == ArgoRolloutAppSuccess
 }

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -1,6 +1,9 @@
 package models
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Image struct {
 	Image string `json:"image" example:"ghcr.io/shini4i/argo-watcher"`
@@ -28,6 +31,12 @@ func (task *Task) ListImages() []string {
 		list[index] = fmt.Sprintf("%s:%s", task.Images[index].Image, task.Images[index].Tag)
 	}
 	return list
+}
+
+// Check if app not found error
+func (task *Task) IsAppNotFoundError(err error) bool {
+	var appNotFoundError string = fmt.Sprintf("applications.argoproj.io \"%s\" not found", task.App)
+	return strings.Contains(err.Error(), appNotFoundError)
 }
 
 type TasksResponse struct {

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -33,7 +33,7 @@ func (task *Task) ListImages() []string {
 	return list
 }
 
-// Check if app not found error
+// Check if app not found error.
 func (task *Task) IsAppNotFoundError(err error) bool {
 	var appNotFoundError string = fmt.Sprintf("applications.argoproj.io \"%s\" not found", task.App)
 	return strings.Contains(err.Error(), appNotFoundError)

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,29 @@ func TestTask_ListImages(t *testing.T) {
 	result := task.ListImages()
 
 	assert.Equal(t, expected, result, "List of images does not match")
+}
+
+func TestTask_ListImages_Empty(t *testing.T) {
+	task := Task{
+		Images: []Image{},
+	}
+
+	expected := []string{}
+	result := task.ListImages()
+
+	assert.Equal(t, expected, result, "List of images does not match")
+}
+
+func TestTask_IsAppNotFoundError(t *testing.T) {
+	task := Task{
+		App: "test",
+	}
+	assert.Equal(t, true, task.IsAppNotFoundError(errors.New("applications.argoproj.io \"test\" not found")))
+}
+
+func TestTask_IsAppNotFoundError_Fail(t *testing.T) {
+	task := Task{
+		App: "test",
+	}
+	assert.Equal(t, false, task.IsAppNotFoundError(errors.New("random but very important error")))
 }


### PR DESCRIPTION
We talked about simplifying this class, since it's too bulky and non-trivial.

This PR is an attempt to make it more straight forward.

Notable changes:
1. Instead of fetching application extra time, we now re-use last application object we fetched
2. We don't do retries anymore in cases when application is not found
3. Error messages are standardized, with application deployment status in logs and reasons