### PR TITLE
chore: client adjustments

### DIFF
--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -14,26 +14,28 @@ const (
 )
 
 type ServerConfig struct {
-	ArgoUrl          url.URL `env:"ARGO_URL,required" json:"argo_cd_url"`
-	ArgoToken        string  `env:"ARGO_TOKEN,required" json:"-"`
-	ArgoApiTimeout   int64   `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	ArgoTimeout      int     `env:"ARGO_TIMEOUT" envDefault:"0" json:"argo_timeout"`
-	ArgoRefreshApp   bool    `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
-	RegistryProxyUrl string  `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
-	StateType        string  `env:"STATE_TYPE,required" json:"state_type"`
-	StaticFilePath   string  `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
-	SkipTlsVerify    bool    `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
-	LogLevel         string  `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
-	LogFormat        string  `env:"LOG_FORMAT" envDefault:"json" json:"-"`
-	Host             string  `env:"HOST" envDefault:"0.0.0.0" json:"-"`
-	Port             string  `env:"PORT" envDefault:"8080" json:"-"`
-	DbHost           string  `env:"DB_HOST" json:"db_host,omitempty"`
-	DbPort           string  `env:"DB_PORT" json:"db_port,omitempty"`
-	DbName           string  `env:"DB_NAME" json:"db_name,omitempty"`
-	DbUser           string  `env:"DB_USER" json:"db_user,omitempty"`
-	DbPassword       string  `env:"DB_PASSWORD" json:"-"`
-	DbMigrationsPath string  `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations" json:"-"` // deprecated
-	DeployToken      string  `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
+	ArgoUrl url.URL `env:"ARGO_URL,required" json:"argo_cd_url"`
+	// ArgoUrlAlias is used to replace the ArgoUrl in the UI. This is useful when the ArgoUrl is an internal URL
+	ArgoUrlAlias     string `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"`
+	ArgoToken        string `env:"ARGO_TOKEN,required" json:"-"`
+	ArgoApiTimeout   int64  `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
+	ArgoTimeout      int    `env:"ARGO_TIMEOUT" envDefault:"0" json:"argo_timeout"`
+	ArgoRefreshApp   bool   `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
+	RegistryProxyUrl string `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
+	StateType        string `env:"STATE_TYPE,required" json:"state_type"`
+	StaticFilePath   string `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
+	SkipTlsVerify    bool   `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
+	LogLevel         string `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
+	LogFormat        string `env:"LOG_FORMAT" envDefault:"json" json:"-"`
+	Host             string `env:"HOST" envDefault:"0.0.0.0" json:"-"`
+	Port             string `env:"PORT" envDefault:"8080" json:"-"`
+	DbHost           string `env:"DB_HOST" json:"db_host,omitempty"`
+	DbPort           string `env:"DB_PORT" json:"db_port,omitempty"`
+	DbName           string `env:"DB_NAME" json:"db_name,omitempty"`
+	DbUser           string `env:"DB_USER" json:"db_user,omitempty"`
+	DbPassword       string `env:"DB_PASSWORD" json:"-"`
+	DbMigrationsPath string `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations" json:"-"` // deprecated
+	DeployToken      string `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables using the envconfig package.

--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -14,26 +14,26 @@ const (
 )
 
 type ServerConfig struct {
-	ArgoUrl          url.URL `env:"ARGO_URL,required"`
-	ArgoToken        string  `env:"ARGO_TOKEN,required"`
-	ArgoApiTimeout   int64   `env:"ARGO_API_TIMEOUT" envDefault:"60"`
-	ArgoTimeout      int     `env:"ARGO_TIMEOUT" envDefault:"0"`
-	ArgoRefreshApp   bool    `env:"ARGO_REFRESH_APP" envDefault:"true"`
-	RegistryProxyUrl string  `env:"DOCKER_IMAGES_PROXY"`
-	StateType        string  `env:"STATE_TYPE,required"`
-	StaticFilePath   string  `env:"STATIC_FILES_PATH" envDefault:"static"`
-	SkipTlsVerify    bool    `env:"SKIP_TLS_VERIFY" envDefault:"false"`
-	LogLevel         string  `env:"LOG_LEVEL" envDefault:"info"`
-	LogFormat        string  `env:"LOG_FORMAT" envDefault:"json"`
-	Host             string  `env:"HOST" envDefault:"0.0.0.0"`
-	Port             string  `env:"PORT" envDefault:"8080"`
-	DbHost           string  `env:"DB_HOST" envDefault:"localhost"`
-	DbPort           string  `env:"DB_PORT" envDefault:"5432"`
-	DbName           string  `env:"DB_NAME"`
-	DbUser           string  `env:"DB_USER"`
-	DbPassword       string  `env:"DB_PASSWORD"`
-	DbMigrationsPath string  `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations"` // deprecated
-	DeployToken      string  `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
+	ArgoUrl          url.URL `env:"ARGO_URL,required" json:"argo_cd_url"`
+	ArgoToken        string  `env:"ARGO_TOKEN,required" json:"-"`
+	ArgoApiTimeout   int64   `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
+	ArgoTimeout      int     `env:"ARGO_TIMEOUT" envDefault:"0" json:"argo_timeout"`
+	ArgoRefreshApp   bool    `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
+	RegistryProxyUrl string  `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
+	StateType        string  `env:"STATE_TYPE,required" json:"state_type"`
+	StaticFilePath   string  `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
+	SkipTlsVerify    bool    `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
+	LogLevel         string  `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
+	LogFormat        string  `env:"LOG_FORMAT" envDefault:"json" json:"-"`
+	Host             string  `env:"HOST" envDefault:"0.0.0.0" json:"-"`
+	Port             string  `env:"PORT" envDefault:"8080" json:"-"`
+	DbHost           string  `env:"DB_HOST" json:"db_host,omitempty"`
+	DbPort           string  `env:"DB_PORT" json:"db_port,omitempty"`
+	DbName           string  `env:"DB_NAME" json:"db_name,omitempty"`
+	DbUser           string  `env:"DB_USER" json:"db_user,omitempty"`
+	DbPassword       string  `env:"DB_PASSWORD" json:"-"`
+	DbMigrationsPath string  `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations" json:"-"` // deprecated
+	DeployToken      string  `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables using the envconfig package.

--- a/cmd/argo-watcher/config/config_test.go
+++ b/cmd/argo-watcher/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -49,4 +50,25 @@ func TestServerConfig_GetRetryAttempts(t *testing.T) {
 
 	// Assert that the retryAttempts value matches the expected result
 	assert.Equal(t, uint(5), retryAttempts)
+}
+
+func TestServerConfig_JSONExcludesSensitiveFields(t *testing.T) {
+	// Create a ServerConfig instance with some dummy data
+	config := &ServerConfig{
+		ArgoToken:   "secret-token",
+		DbPassword:  "db-password",
+		DeployToken: "deploy-token",
+	}
+
+	// Marshal the ServerConfig instance to JSON
+	jsonBytes, err := json.Marshal(config)
+	assert.NoError(t, err)
+
+	// Convert the JSON bytes to a string
+	jsonString := string(jsonBytes)
+
+	// Check that the sensitive fields are not present in the JSON string
+	assert.NotContains(t, jsonString, "secret-token")
+	assert.NotContains(t, jsonString, "db-password")
+	assert.NotContains(t, jsonString, "deploy-token")
 }

--- a/cmd/argo-watcher/router.go
+++ b/cmd/argo-watcher/router.go
@@ -238,7 +238,7 @@ func (env *Env) healthz(c *gin.Context) {
 // @Description Get the configuration of the server (excluding sensitive data)
 // @Tags backend
 // @Produce json
-// @Success 200 {object} config
+// @Success 200 {object} config.ServerConfig
 // @Router /api/v1/config [get].
 func (env *Env) getConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, env.config)

--- a/cmd/argo-watcher/router.go
+++ b/cmd/argo-watcher/router.go
@@ -58,6 +58,7 @@ func (env *Env) CreateRouter() *gin.Engine {
 		v1.GET("/tasks/:id", env.getTaskStatus)
 		v1.GET("/apps", env.getApps)
 		v1.GET("/version", env.getVersion)
+		v1.GET("/config", env.getConfig)
 	}
 
 	return router
@@ -230,4 +231,15 @@ func (env *Env) healthz(c *gin.Context) {
 		})
 	}
 
+}
+
+// getConfig godoc
+// @Summary Get the configuration of the server (excluding sensitive data)
+// @Description Get the configuration of the server (excluding sensitive data)
+// @Tags backend
+// @Produce json
+// @Success 200 {object} config
+// @Router /api/v1/config [get].
+func (env *Env) getConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, env.config)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -178,12 +178,12 @@ func (watcher *Watcher) waitForDeployment(id, appName string) error {
 	}
 }
 
-func getImagesList() []models.Image {
+func getImagesList(list []string, tag string) []models.Image {
 	var images []models.Image
-	for _, image := range clientConfig.Images {
+	for _, image := range list {
 		images = append(images, models.Image{
 			Image: image,
-			Tag:   clientConfig.Tag,
+			Tag:   tag,
 		})
 	}
 	return images
@@ -197,7 +197,7 @@ func Run() {
 		os.Exit(1)
 	}
 
-	images := getImagesList()
+	images := getImagesList(clientConfig.Images, clientConfig.Tag)
 
 	watcher := NewWatcher(
 		strings.TrimSuffix(clientConfig.Url, "/"),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"bytes"
-	"context"
+
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,40 +37,6 @@ func NewWatcher(baseUrl string, debugMode bool, timeout time.Duration) *Watcher 
 		debugMode: debugMode,
 		timeout:   timeout,
 	}
-}
-
-func (watcher *Watcher) doRequest(method, url string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), watcher.timeout)
-	defer cancel()
-
-	req = req.WithContext(ctx)
-
-	return watcher.client.Do(req)
-}
-
-func (watcher *Watcher) getJSON(url string, v interface{}) error {
-	resp, err := watcher.doRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			panic(err)
-		}
-	}(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
-	}
-
-	return json.NewDecoder(resp.Body).Decode(v)
 }
 
 func (watcher *Watcher) addTask(task models.Task, token string) (string, error) {
@@ -175,53 +141,6 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 			return nil
 		}
 	}
-}
-
-func getImagesList(list []string, tag string) []models.Image {
-	var images []models.Image
-	for _, image := range list {
-		images = append(images, models.Image{
-			Image: image,
-			Tag:   tag,
-		})
-	}
-	return images
-}
-
-func createTask(config *ClientConfig) models.Task {
-	images := getImagesList(config.Images, config.Tag)
-	return models.Task{
-		App:     config.App,
-		Author:  config.Author,
-		Project: config.Project,
-		Images:  images,
-	}
-}
-
-func printClientConfiguration(watcher *Watcher, task models.Task) {
-	fmt.Printf("Got the following configuration:\n"+
-		"ARGO_WATCHER_URL: %s\n"+
-		"ARGO_APP: %s\n"+
-		"COMMIT_AUTHOR: %s\n"+
-		"PROJECT_NAME: %s\n"+
-		"IMAGE_TAG: %s\n"+
-		"IMAGES: %s\n\n",
-		watcher.baseUrl, task.App, task.Author, task.Project, clientConfig.Tag, task.Images)
-	if clientConfig.Token == "" {
-		fmt.Println("ARGO_WATCHER_DEPLOY_TOKEN is not set, git commit will not be performed.")
-	}
-}
-
-func generateAppUrl(watcher *Watcher, task models.Task) string {
-	cfg, err := watcher.getWatcherConfig()
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	if cfg.ArgoUrlAlias != "" {
-		return fmt.Sprintf("%s/applications/%s", cfg.ArgoUrlAlias, task.App)
-	}
-	return fmt.Sprintf("%s://%s/applications/%s", cfg.ArgoUrl.Scheme, cfg.ArgoUrl.Host, task.App)
 }
 
 func Run() {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -232,8 +232,7 @@ func Run() {
 
 	id, err := watcher.addTask(task, deployToken)
 	if err != nil {
-		log.Printf("Couldn't add task. Got the following error: %s", err)
-		os.Exit(1)
+		log.Fatalf("Couldn't add task. Got the following error: %s", err)
 	}
 
 	// Giving Argo-Watcher some time to process the task
@@ -242,8 +241,7 @@ func Run() {
 	if err := watcher.waitForDeployment(id, task.App, clientConfig.Tag); err != nil {
 		cfg, err := watcher.getWatcherConfig()
 		if err != nil {
-			log.Println(err)
-			os.Exit(1)
+			log.Fatalln(err)
 		}
 
 		var appUrl string
@@ -254,8 +252,6 @@ func Run() {
 			appUrl = fmt.Sprintf("%s://%s/applications/%s", cfg.ArgoUrl.Scheme, cfg.ArgoUrl.Host, task.App)
 		}
 
-		log.Println(err)
-		log.Printf("To get more information about the problem, please check ArgoCD UI: %s\n", appUrl)
-		os.Exit(1)
+		log.Fatalf("To get more information about the problem, please check ArgoCD UI: %s\n", appUrl)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -154,7 +154,7 @@ func (watcher *Watcher) getWatcherConfig() (*config.ServerConfig, error) {
 	return &serverConfig, nil
 }
 
-func (watcher *Watcher) waitForDeployment(id, appName string) error {
+func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 	for {
 		taskInfo, err := watcher.getTaskStatus(id)
 		if err != nil {
@@ -172,7 +172,7 @@ func (watcher *Watcher) waitForDeployment(id, appName string) error {
 		case models.StatusArgoCDUnavailableMessage:
 			return fmt.Errorf("ArgoCD is unavailable. Please investigate.\n%s", taskInfo.StatusReason)
 		case models.StatusDeployedMessage:
-			log.Printf("The deployment of %s version is done.\n", clientConfig.Tag)
+			log.Print("The deployment version is done.", version)
 			return nil
 		}
 	}
@@ -239,7 +239,7 @@ func Run() {
 	// Giving Argo-Watcher some time to process the task
 	time.Sleep(5 * time.Second)
 
-	if err := watcher.waitForDeployment(id, task.App); err != nil {
+	if err := watcher.waitForDeployment(id, task.App, clientConfig.Tag); err != nil {
 		cfg, err := watcher.getWatcherConfig()
 		if err != nil {
 			log.Println(err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -85,7 +86,7 @@ func init() {
 	mux.HandleFunc("/api/v1/tasks", addTaskHandler)
 	mux.HandleFunc("/api/v1/tasks/", getTaskStatusHandler)
 	server = httptest.NewServer(mux)
-	client = &Watcher{baseUrl: server.URL, client: server.Client()}
+	client = &Watcher{baseUrl: server.URL, client: server.Client(), timeout: 30 * time.Second}
 }
 
 func TestAddTask(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -276,6 +276,11 @@ func TestWaitForDeployment(t *testing.T) {
 		expectedError string
 	}{
 		{
+			name:          "Successful deployment",
+			taskId:        taskId,
+			expectedError: "",
+		},
+		{
 			name:          "Failed deployment",
 			taskId:        failedTaskId,
 			expectedError: "The deployment has failed, please check logs.",
@@ -295,9 +300,13 @@ func TestWaitForDeployment(t *testing.T) {
 	// Run test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := client.waitForDeployment(tc.taskId, "test")
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tc.expectedError)
+			err := client.waitForDeployment(tc.taskId, "test", testVersion)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			}
 		})
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -129,23 +129,19 @@ func TestGetTaskStatus(t *testing.T) {
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
 }
 
-//func TestGetImagesList(t *testing.T) {
-//	tag = testVersion
-//
-//	expectedList := []models.Image{
-//		{
-//			Image: "example/app",
-//			Tag:   testVersion,
-//		},
-//		{
-//			Image: "example/web",
-//			Tag:   testVersion,
-//		},
-//	}
-//
-//	t.Setenv("IMAGES", "example/app,example/web")
-//
-//	images := getImagesList()
-//
-//	assert.Equal(t, expectedList, images)
-//}
+func TestGetImagesList(t *testing.T) {
+	expectedList := []models.Image{
+		{
+			Image: "example/app",
+			Tag:   testVersion,
+		},
+		{
+			Image: "example/web",
+			Tag:   testVersion,
+		},
+	}
+
+	images := getImagesList([]string{"example/app", "example/web"}, testVersion)
+
+	assert.Equal(t, expectedList, images)
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -129,23 +129,23 @@ func TestGetTaskStatus(t *testing.T) {
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
 }
 
-func TestGetImagesList(t *testing.T) {
-	tag = testVersion
-
-	expectedList := []models.Image{
-		{
-			Image: "example/app",
-			Tag:   testVersion,
-		},
-		{
-			Image: "example/web",
-			Tag:   testVersion,
-		},
-	}
-
-	t.Setenv("IMAGES", "example/app,example/web")
-
-	images := getImagesList()
-
-	assert.Equal(t, expectedList, images)
-}
+//func TestGetImagesList(t *testing.T) {
+//	tag = testVersion
+//
+//	expectedList := []models.Image{
+//		{
+//			Image: "example/app",
+//			Tag:   testVersion,
+//		},
+//		{
+//			Image: "example/web",
+//			Tag:   testVersion,
+//		},
+//	}
+//
+//	t.Setenv("IMAGES", "example/app,example/web")
+//
+//	images := getImagesList()
+//
+//	assert.Equal(t, expectedList, images)
+//}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,14 +1,11 @@
 package client
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -131,69 +128,6 @@ func TestNewWatcher(t *testing.T) {
 	assert.NotNil(t, watcher.client)
 }
 
-func TestDoRequest(t *testing.T) {
-	// Add a new handler to the existing server for testing doRequest
-	mux.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
-		// Test request parameters
-		assert.Equal(t, req.URL.String(), "/test")
-		// Send response to be tested
-		if _, err := rw.Write([]byte(`OK`)); err != nil {
-			t.Error(err)
-		}
-	})
-
-	// Call doRequest method
-	resp, err := client.doRequest(http.MethodGet, server.URL+"/test", nil)
-
-	// Assert there was no error
-	assert.NoError(t, err)
-
-	// Assert the response was as expected
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	// Read the response body
-	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
-
-	err = resp.Body.Close()
-	assert.NoError(t, err)
-
-	// Assert the response body was as expected
-	assert.Equal(t, "OK", string(body))
-}
-
-func TestGetJSON(t *testing.T) {
-	// Create a test server
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Test request parameters
-		assert.Equal(t, req.URL.String(), "/test")
-		// Send response to be tested
-		if _, err := rw.Write([]byte(`{"message": "OK"}`)); err != nil {
-			t.Error(err)
-		}
-	}))
-	// Close the server when test finishes
-	defer server.Close()
-
-	// Create a new Watcher instance
-	watcher := NewWatcher(server.URL, false, 30*time.Second)
-
-	// Define a struct to hold the response
-	type response struct {
-		Message string `json:"message"`
-	}
-	var resp response
-
-	// Call getJSON method
-	err := watcher.getJSON(server.URL+"/test", &resp)
-
-	// Assert there was no error
-	assert.NoError(t, err)
-
-	// Assert the response was as expected
-	assert.Equal(t, "OK", resp.Message)
-}
-
 func TestAddTask(t *testing.T) {
 	expected := models.TaskStatus{
 		Status: models.StatusAccepted,
@@ -233,23 +167,6 @@ func TestGetTaskStatus(t *testing.T) {
 	task, err = client.getTaskStatus(failedTaskId)
 	assert.NoError(t, err)
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
-}
-
-func TestGetImagesList(t *testing.T) {
-	expectedList := []models.Image{
-		{
-			Image: "example/app",
-			Tag:   testVersion,
-		},
-		{
-			Image: "example/web",
-			Tag:   testVersion,
-		},
-	}
-
-	images := getImagesList([]string{"example/app", "example/web"}, testVersion)
-
-	assert.Equal(t, expectedList, images)
 }
 
 func TestGetWatcherConfig(t *testing.T) {
@@ -337,158 +254,4 @@ func TestWaitForDeployment(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCreateTask(t *testing.T) {
-	config := &ClientConfig{
-		App:     "test-app",
-		Author:  "test-author",
-		Project: "test-project",
-		Images:  []string{"image1", "image2"},
-		Tag:     "test-tag",
-	}
-
-	expectedTask := models.Task{
-		App:     "test-app",
-		Author:  "test-author",
-		Project: "test-project",
-		Images: []models.Image{
-			{
-				Image: "image1",
-				Tag:   "test-tag",
-			},
-			{
-				Image: "image2",
-				Tag:   "test-tag",
-			},
-		},
-	}
-
-	task := createTask(config)
-
-	assert.Equal(t, expectedTask, task)
-}
-
-func TestPrintClientConfiguration(t *testing.T) {
-	// Initialize clientConfig
-	clientConfig = &ClientConfig{
-		Url:     "http://localhost:8080",
-		Images:  []string{"image1", "image2"},
-		Tag:     "test-tag",
-		App:     "test-app",
-		Author:  "test-author",
-		Project: "test-project",
-		Token:   "",
-		Timeout: 30 * time.Second,
-		Debug:   true,
-	}
-
-	// Create a Watcher and Task for testing
-	watcher := NewWatcher("http://localhost:8080", true, 30*time.Second)
-	task := models.Task{
-		App:     "test-app",
-		Author:  "test-author",
-		Project: "test-project",
-		Images: []models.Image{
-			{
-				Image: "image1",
-				Tag:   "test-tag",
-			},
-			{
-				Image: "image2",
-				Tag:   "test-tag",
-			},
-		},
-	}
-
-	// Expected output
-	expectedOutput := "Got the following configuration:\n" +
-		"ARGO_WATCHER_URL: http://localhost:8080\n" +
-		"ARGO_APP: test-app\n" +
-		"COMMIT_AUTHOR: test-author\n" +
-		"PROJECT_NAME: test-project\n" +
-		"IMAGE_TAG: test-tag\n" +
-		"IMAGES: [{image1 test-tag} {image2 test-tag}]\n\n" +
-		"ARGO_WATCHER_DEPLOY_TOKEN is not set, git commit will not be performed.\n"
-
-	// Redirect standard output to a buffer
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	// Call the function
-	printClientConfiguration(watcher, task)
-
-	// Restore standard output
-	err := w.Close()
-	assert.NoError(t, err)
-
-	os.Stdout = oldStdout
-
-	// Read the buffer
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
-	// Compare the buffer's content with the expected output
-	assert.Equal(t, expectedOutput, buf.String())
-}
-
-func TestGenerateAppUrl(t *testing.T) {
-	// Create a test server
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Test request parameters
-		assert.Equal(t, req.URL.String(), "/api/v1/config")
-
-		// Create the response data
-		configResponse := struct {
-			ArgoCDURL      url.URL `json:"argo_cd_url"`
-			ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
-		}{
-			ArgoCDURL:      url.URL{Scheme: "http", Host: "localhost:8080"},
-			ArgoCDURLAlias: "https://argo-cd.example.com",
-		}
-
-		// Marshal the response data to JSON
-		jsonData, err := json.Marshal(configResponse)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		// Write the JSON data to the response writer
-		if _, err := rw.Write(jsonData); err != nil {
-			t.Error(err)
-		}
-	}))
-	// Close the server when test finishes
-	defer server.Close()
-
-	// Create a new Watcher instance
-	watcher := NewWatcher(server.URL, false, 30*time.Second)
-
-	// Create a Task for testing
-	task := models.Task{
-		App:     "test-app",
-		Author:  "test-author",
-		Project: "test-project",
-		Images: []models.Image{
-			{
-				Image: "image1",
-				Tag:   "test-tag",
-			},
-			{
-				Image: "image2",
-				Tag:   "test-tag",
-			},
-		},
-	}
-
-	// Call the function
-	appUrl := generateAppUrl(watcher, task)
-
-	// Expected output
-	expectedOutput := "https://argo-cd.example.com/applications/test-app"
-
-	// Compare the function's output with the expected output
-	assert.Equal(t, expectedOutput, appUrl)
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type ClientConfig struct {
-	Url     string        `env:"ARGO_WATCHER_URL"`
-	Images  []string      `env:"IMAGES"`
-	Tag     string        `env:"IMAGE_TAG"`
-	App     string        `env:"ARGO_APP"`
-	Author  string        `env:"COMMIT_AUTHOR"`
+	Url     string        `env:"ARGO_WATCHER_URL,required"`
+	Images  []string      `env:"IMAGES,required"`
+	Tag     string        `env:"IMAGE_TAG,required"`
+	App     string        `env:"ARGO_APP,required"`
+	Author  string        `env:"COMMIT_AUTHOR,required"`
 	Project string        `env:"PROJECT_NAME"`
 	Token   string        `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
 	Timeout time.Duration `env:"TIMEOUT" envDefault:"60s"`

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"time"
+
+	envConfig "github.com/caarlos0/env/v9"
+)
+
+type ClientConfig struct {
+	Url     string        `env:"ARGO_WATCHER_URL"`
+	Images  []string      `env:"IMAGES"`
+	Tag     string        `env:"IMAGE_TAG"`
+	App     string        `env:"ARGO_APP"`
+	Author  string        `env:"COMMIT_AUTHOR"`
+	Project string        `env:"PROJECT_NAME"`
+	Token   string        `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
+	Timeout time.Duration `env:"TIMEOUT" envDefault:"60s"`
+	Debug   bool          `env:"DEBUG"`
+}
+
+func NewClientConfig() (*ClientConfig, error) {
+	var config ClientConfig
+
+	if err := envConfig.Parse(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientConfig(t *testing.T) {
+	t.Setenv("ARGO_WATCHER_URL", "http://localhost:8080")
+	t.Setenv("IMAGES", "image1,image2")
+	t.Setenv("IMAGE_TAG", "v1.0.0")
+	t.Setenv("ARGO_APP", "test-app")
+	t.Setenv("COMMIT_AUTHOR", "John Doe")
+	t.Setenv("PROJECT_NAME", "test-project")
+	t.Setenv("ARGO_WATCHER_DEPLOY_TOKEN", "test-token")
+	t.Setenv("TIMEOUT", "60s")
+	t.Setenv("DEBUG", "true")
+
+	// Call the function
+	config, err := NewClientConfig()
+
+	// Assert there was no error
+	assert.NoError(t, err)
+
+	// Assert the config was correctly populated
+	assert.Equal(t, "http://localhost:8080", config.Url)
+	assert.Equal(t, []string{"image1", "image2"}, config.Images)
+	assert.Equal(t, "v1.0.0", config.Tag)
+	assert.Equal(t, "test-app", config.App)
+	assert.Equal(t, "John Doe", config.Author)
+	assert.Equal(t, "test-project", config.Project)
+	assert.Equal(t, "test-token", config.Token)
+	assert.Equal(t, 60*time.Second, config.Timeout)
+	assert.Equal(t, true, config.Debug)
+}

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -18,20 +18,36 @@ func TestNewClientConfig(t *testing.T) {
 	t.Setenv("TIMEOUT", "60s")
 	t.Setenv("DEBUG", "true")
 
-	// Call the function
-	config, err := NewClientConfig()
+	t.Run("Successfully generated", func(t *testing.T) {
+		// Call the function
+		config, err := NewClientConfig()
 
-	// Assert there was no error
-	assert.NoError(t, err)
+		// Assert there was no error
+		assert.NoError(t, err)
 
-	// Assert the config was correctly populated
-	assert.Equal(t, "http://localhost:8080", config.Url)
-	assert.Equal(t, []string{"image1", "image2"}, config.Images)
-	assert.Equal(t, "v1.0.0", config.Tag)
-	assert.Equal(t, "test-app", config.App)
-	assert.Equal(t, "John Doe", config.Author)
-	assert.Equal(t, "test-project", config.Project)
-	assert.Equal(t, "test-token", config.Token)
-	assert.Equal(t, 60*time.Second, config.Timeout)
-	assert.Equal(t, true, config.Debug)
+		// Assert the config was correctly populated
+		assert.Equal(t, "http://localhost:8080", config.Url)
+		assert.Equal(t, []string{"image1", "image2"}, config.Images)
+		assert.Equal(t, "v1.0.0", config.Tag)
+		assert.Equal(t, "test-app", config.App)
+		assert.Equal(t, "John Doe", config.Author)
+		assert.Equal(t, "test-project", config.Project)
+		assert.Equal(t, "test-token", config.Token)
+		assert.Equal(t, 60*time.Second, config.Timeout)
+		assert.Equal(t, true, config.Debug)
+	})
+
+	t.Run("Failed to generate", func(t *testing.T) {
+		// Set an invalid value for TIMEOUT
+		t.Setenv("TIMEOUT", "invalid")
+
+		// Call the function
+		_, err := NewClientConfig()
+
+		// Assert that an error was returned
+		assert.Error(t, err)
+
+		// Assert that the error is the expected one
+		assert.Equal(t, "env: parse error on field \"Timeout\" of type \"time.Duration\": unable to parse duration: time: invalid duration \"invalid\"", err.Error())
+	})
 }

--- a/pkg/client/utility.go
+++ b/pkg/client/utility.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+func (watcher *Watcher) doRequest(method, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), watcher.timeout)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	return watcher.client.Do(req)
+}
+
+func (watcher *Watcher) getJSON(url string, v interface{}) error {
+	resp, err := watcher.doRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+func getImagesList(list []string, tag string) []models.Image {
+	var images []models.Image
+	for _, image := range list {
+		images = append(images, models.Image{
+			Image: image,
+			Tag:   tag,
+		})
+	}
+	return images
+}
+
+func createTask(config *ClientConfig) models.Task {
+	images := getImagesList(config.Images, config.Tag)
+	return models.Task{
+		App:     config.App,
+		Author:  config.Author,
+		Project: config.Project,
+		Images:  images,
+	}
+}
+
+func printClientConfiguration(watcher *Watcher, task models.Task) {
+	fmt.Printf("Got the following configuration:\n"+
+		"ARGO_WATCHER_URL: %s\n"+
+		"ARGO_APP: %s\n"+
+		"COMMIT_AUTHOR: %s\n"+
+		"PROJECT_NAME: %s\n"+
+		"IMAGE_TAG: %s\n"+
+		"IMAGES: %s\n\n",
+		watcher.baseUrl, task.App, task.Author, task.Project, clientConfig.Tag, task.Images)
+	if clientConfig.Token == "" {
+		fmt.Println("ARGO_WATCHER_DEPLOY_TOKEN is not set, git commit will not be performed.")
+	}
+}
+
+func generateAppUrl(watcher *Watcher, task models.Task) string {
+	cfg, err := watcher.getWatcherConfig()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if cfg.ArgoUrlAlias != "" {
+		return fmt.Sprintf("%s/applications/%s", cfg.ArgoUrlAlias, task.App)
+	}
+	return fmt.Sprintf("%s://%s/applications/%s", cfg.ArgoUrl.Scheme, cfg.ArgoUrl.Host, task.App)
+}

--- a/pkg/client/utility_test.go
+++ b/pkg/client/utility_test.go
@@ -1,0 +1,250 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoRequest(t *testing.T) {
+	// Add a new handler to the existing server for testing doRequest
+	mux.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
+		// Test request parameters
+		assert.Equal(t, req.URL.String(), "/test")
+		// Send response to be tested
+		if _, err := rw.Write([]byte(`OK`)); err != nil {
+			t.Error(err)
+		}
+	})
+
+	// Call doRequest method
+	resp, err := client.doRequest(http.MethodGet, server.URL+"/test", nil)
+
+	// Assert there was no error
+	assert.NoError(t, err)
+
+	// Assert the response was as expected
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	err = resp.Body.Close()
+	assert.NoError(t, err)
+
+	// Assert the response body was as expected
+	assert.Equal(t, "OK", string(body))
+}
+
+func TestGetJSON(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Test request parameters
+		assert.Equal(t, req.URL.String(), "/test")
+		// Send response to be tested
+		if _, err := rw.Write([]byte(`{"message": "OK"}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	// Create a new Watcher instance
+	watcher := NewWatcher(server.URL, false, 30*time.Second)
+
+	// Define a struct to hold the response
+	type response struct {
+		Message string `json:"message"`
+	}
+	var resp response
+
+	// Call getJSON method
+	err := watcher.getJSON(server.URL+"/test", &resp)
+
+	// Assert there was no error
+	assert.NoError(t, err)
+
+	// Assert the response was as expected
+	assert.Equal(t, "OK", resp.Message)
+}
+
+func TestGetImagesList(t *testing.T) {
+	expectedList := []models.Image{
+		{
+			Image: "example/app",
+			Tag:   testVersion,
+		},
+		{
+			Image: "example/web",
+			Tag:   testVersion,
+		},
+	}
+
+	images := getImagesList([]string{"example/app", "example/web"}, testVersion)
+
+	assert.Equal(t, expectedList, images)
+}
+
+func TestCreateTask(t *testing.T) {
+	config := &ClientConfig{
+		App:     "test-app",
+		Author:  "test-author",
+		Project: "test-project",
+		Images:  []string{"image1", "image2"},
+		Tag:     "test-tag",
+	}
+
+	expectedTask := models.Task{
+		App:     "test-app",
+		Author:  "test-author",
+		Project: "test-project",
+		Images: []models.Image{
+			{
+				Image: "image1",
+				Tag:   "test-tag",
+			},
+			{
+				Image: "image2",
+				Tag:   "test-tag",
+			},
+		},
+	}
+
+	task := createTask(config)
+
+	assert.Equal(t, expectedTask, task)
+}
+
+func TestPrintClientConfiguration(t *testing.T) {
+	// Initialize clientConfig
+	clientConfig = &ClientConfig{
+		Url:     "http://localhost:8080",
+		Images:  []string{"image1", "image2"},
+		Tag:     "test-tag",
+		App:     "test-app",
+		Author:  "test-author",
+		Project: "test-project",
+		Token:   "",
+		Timeout: 30 * time.Second,
+		Debug:   true,
+	}
+
+	// Create a Watcher and Task for testing
+	watcher := NewWatcher("http://localhost:8080", true, 30*time.Second)
+	task := models.Task{
+		App:     "test-app",
+		Author:  "test-author",
+		Project: "test-project",
+		Images: []models.Image{
+			{
+				Image: "image1",
+				Tag:   "test-tag",
+			},
+			{
+				Image: "image2",
+				Tag:   "test-tag",
+			},
+		},
+	}
+
+	// Expected output
+	expectedOutput := "Got the following configuration:\n" +
+		"ARGO_WATCHER_URL: http://localhost:8080\n" +
+		"ARGO_APP: test-app\n" +
+		"COMMIT_AUTHOR: test-author\n" +
+		"PROJECT_NAME: test-project\n" +
+		"IMAGE_TAG: test-tag\n" +
+		"IMAGES: [{image1 test-tag} {image2 test-tag}]\n\n" +
+		"ARGO_WATCHER_DEPLOY_TOKEN is not set, git commit will not be performed.\n"
+
+	// Redirect standard output to a buffer
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Call the function
+	printClientConfiguration(watcher, task)
+
+	// Restore standard output
+	err := w.Close()
+	assert.NoError(t, err)
+
+	os.Stdout = oldStdout
+
+	// Read the buffer
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	// Compare the buffer's content with the expected output
+	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func TestGenerateAppUrl(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Test request parameters
+		assert.Equal(t, req.URL.String(), "/api/v1/config")
+
+		// Create the response data
+		configResponse := struct {
+			ArgoCDURL      url.URL `json:"argo_cd_url"`
+			ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
+		}{
+			ArgoCDURL:      url.URL{Scheme: "http", Host: "localhost:8080"},
+			ArgoCDURLAlias: "https://argo-cd.example.com",
+		}
+
+		// Marshal the response data to JSON
+		jsonData, err := json.Marshal(configResponse)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		// Write the JSON data to the response writer
+		if _, err := rw.Write(jsonData); err != nil {
+			t.Error(err)
+		}
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	// Create a new Watcher instance
+	watcher := NewWatcher(server.URL, false, 30*time.Second)
+
+	// Create a Task for testing
+	task := models.Task{
+		App:     "test-app",
+		Author:  "test-author",
+		Project: "test-project",
+		Images: []models.Image{
+			{
+				Image: "image1",
+				Tag:   "test-tag",
+			},
+			{
+				Image: "image2",
+				Tag:   "test-tag",
+			},
+		},
+	}
+
+	// Call the function
+	appUrl := generateAppUrl(watcher, task)
+
+	// Expected output
+	expectedOutput := "https://argo-cd.example.com/applications/test-app"
+
+	// Compare the function's output with the expected output
+	assert.Equal(t, expectedOutput, appUrl)
+}


### PR DESCRIPTION
This PR contains the following changes:
- The server now has a separate endpoint for returning it's configuration (excluding sensitive fields). It is needed for new client functionality (closes #216). In the future, for separate pages in UI.
- The server has a new variable `ARGO_URL_ALIAS` that will be used to generate Application URL in case of in-cluster ArgoCD endpoint.
- The client will now print out a link to the relevant Application to simplify deployment issues troubleshooting.
- The client configuration was migrated to the standard configuration approach in the project.
- Minor code cleanup.