### PR TITLE
chore: rename ArgoTimeout to DeploymentTimeout

### DIFF
--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -19,7 +19,7 @@ type ServerConfig struct {
 	ArgoUrlAlias      string `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"`
 	ArgoToken         string `env:"ARGO_TOKEN,required" json:"-"`
 	ArgoApiTimeout    int64  `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	DeploymentTimeout int    `env:"DEPLOYMENT_TIMEOUT" envDefault:"300" json:"deployment_timeout"`
+	DeploymentTimeout uint   `env:"DEPLOYMENT_TIMEOUT" envDefault:"300" json:"deployment_timeout"`
 	ArgoRefreshApp    bool   `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
 	RegistryProxyUrl  string `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
 	StateType         string `env:"STATE_TYPE,required" json:"state_type"`
@@ -63,10 +63,10 @@ func NewServerConfig() (*ServerConfig, error) {
 	return &config, err
 }
 
-// GetRetryAttempts calculates the number of retry attempts based on the Argo timeout value in the server configuration.
-// It converts the Argo timeout to an integer value and divides it by 15 to determine the number of 15-second intervals.
+// GetRetryAttempts calculates the number of retry attempts based on the Deployment timeout value in the server configuration.
+// It divides it by 15 to determine the number of 15-second intervals.
 // The calculated value is incremented by 1 to account for the initial attempt.
 // It returns the number of retry attempts as an unsigned integer.
 func (config *ServerConfig) GetRetryAttempts() uint {
-	return uint((config.DeploymentTimeout / 15) + 1)
+	return (config.DeploymentTimeout / 15) + 1
 }

--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -16,26 +16,26 @@ const (
 type ServerConfig struct {
 	ArgoUrl url.URL `env:"ARGO_URL,required" json:"argo_cd_url"`
 	// ArgoUrlAlias is used to replace the ArgoUrl in the UI. This is useful when the ArgoUrl is an internal URL
-	ArgoUrlAlias     string `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"`
-	ArgoToken        string `env:"ARGO_TOKEN,required" json:"-"`
-	ArgoApiTimeout   int64  `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	ArgoTimeout      int    `env:"ARGO_TIMEOUT" envDefault:"0" json:"argo_timeout"`
-	ArgoRefreshApp   bool   `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
-	RegistryProxyUrl string `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
-	StateType        string `env:"STATE_TYPE,required" json:"state_type"`
-	StaticFilePath   string `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
-	SkipTlsVerify    bool   `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
-	LogLevel         string `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
-	LogFormat        string `env:"LOG_FORMAT" envDefault:"json" json:"-"`
-	Host             string `env:"HOST" envDefault:"0.0.0.0" json:"-"`
-	Port             string `env:"PORT" envDefault:"8080" json:"-"`
-	DbHost           string `env:"DB_HOST" json:"db_host,omitempty"`
-	DbPort           int    `env:"DB_PORT" json:"db_port,omitempty"`
-	DbName           string `env:"DB_NAME" json:"db_name,omitempty"`
-	DbUser           string `env:"DB_USER" json:"db_user,omitempty"`
-	DbPassword       string `env:"DB_PASSWORD" json:"-"`
-	DbMigrationsPath string `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations" json:"-"`
-	DeployToken      string `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
+	ArgoUrlAlias      string `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"`
+	ArgoToken         string `env:"ARGO_TOKEN,required" json:"-"`
+	ArgoApiTimeout    int64  `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
+	DeploymentTimeout int    `env:"DEPLOYMENT_TIMEOUT" envDefault:"300" json:"deployment_timeout"`
+	ArgoRefreshApp    bool   `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
+	RegistryProxyUrl  string `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
+	StateType         string `env:"STATE_TYPE,required" json:"state_type"`
+	StaticFilePath    string `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
+	SkipTlsVerify     bool   `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
+	LogLevel          string `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
+	LogFormat         string `env:"LOG_FORMAT" envDefault:"json" json:"-"`
+	Host              string `env:"HOST" envDefault:"0.0.0.0" json:"-"`
+	Port              string `env:"PORT" envDefault:"8080" json:"-"`
+	DbHost            string `env:"DB_HOST" json:"db_host,omitempty"`
+	DbPort            int    `env:"DB_PORT" json:"db_port,omitempty"`
+	DbName            string `env:"DB_NAME" json:"db_name,omitempty"`
+	DbUser            string `env:"DB_USER" json:"db_user,omitempty"`
+	DbPassword        string `env:"DB_PASSWORD" json:"-"`
+	DbMigrationsPath  string `env:"DB_MIGRATIONS_PATH" envDefault:"db/migrations" json:"-"`
+	DeployToken       string `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables using the envconfig package.
@@ -68,5 +68,5 @@ func NewServerConfig() (*ServerConfig, error) {
 // The calculated value is incremented by 1 to account for the initial attempt.
 // It returns the number of retry attempts as an unsigned integer.
 func (config *ServerConfig) GetRetryAttempts() uint {
-	return uint((config.ArgoTimeout / 15) + 1)
+	return uint((config.DeploymentTimeout / 15) + 1)
 }

--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -19,7 +19,7 @@ type ServerConfig struct {
 	ArgoUrlAlias      string `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"`
 	ArgoToken         string `env:"ARGO_TOKEN,required" json:"-"`
 	ArgoApiTimeout    int64  `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	DeploymentTimeout uint   `env:"DEPLOYMENT_TIMEOUT" envDefault:"300" json:"deployment_timeout"`
+	DeploymentTimeout uint   `env:"DEPLOYMENT_TIMEOUT" envDefault:"900" json:"deployment_timeout"`
 	ArgoRefreshApp    bool   `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
 	RegistryProxyUrl  string `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
 	StateType         string `env:"STATE_TYPE,required" json:"state_type"`

--- a/cmd/argo-watcher/config/config_test.go
+++ b/cmd/argo-watcher/config/config_test.go
@@ -51,9 +51,9 @@ func TestNewServerConfig_RequiredFieldsMissing(t *testing.T) {
 }
 
 func TestServerConfig_GetRetryAttempts(t *testing.T) {
-	// Create a ServerConfig instance with a specific ArgoTimeout value
+	// Create a ServerConfig instance with a specific DeploymentTimeout value
 	config := &ServerConfig{
-		ArgoTimeout: 60,
+		DeploymentTimeout: 60,
 	}
 
 	// Call the GetRetryAttempts function


### PR DESCRIPTION
Change `ArgoTimeout` (ARGO_TIMEOUT) to `DeploymentTimeout` (DEPLOYMENT_TIMEOUT) to avoid confusion in the variable purpose.