### PR TITLE
feat(keycloak): simplify redeploy logic

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
     main: ./cmd/argo-watcher
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X server/router.version={{.Version}}
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ test: mocks ## Run tests
 .PHONY: build
 build: docs ## Build the binaries
 	@echo "===> Building [$(CYAN)${VERSION}$(RESET)] version of [$(CYAN)argo-watcher$(RESET)] binary"
-	@CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o argo-watcher ./cmd/argo-watcher
+	@CGO_ENABLED=0 go build -ldflags="-s -w -X server/router.version=${VERSION}" -o argo-watcher ./cmd/argo-watcher
 	@echo "===> Done"
 
 .PHONY: kind-upload
 kind-upload:
 	@echo "===> Building [$(CYAN)dev$(RESET)] version of [$(CYAN)argo-watcher$(RESET)] binary"
-	@CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -ldflags="-s -w -X main.version=dev" -o argo-watcher ./cmd/argo-watcher
+	@CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -ldflags="-s -w -X server/router.version=dev" -o argo-watcher ./cmd/argo-watcher
 	@echo "===> Building web UI"
 	@cd web && npm run build
 	@echo "===> Building [$(CYAN)argo-watcher$(RESET)] docker image"

--- a/cmd/argo-watcher/auth/auth.go
+++ b/cmd/argo-watcher/auth/auth.go
@@ -1,0 +1,10 @@
+package auth
+
+type ExternalAuthService interface {
+	Init(url, realm, clientId string)
+	Validate(token string) (bool, error)
+}
+
+func NewExternalAuthService() ExternalAuthService {
+	return &KeycloakAuthService{}
+}

--- a/cmd/argo-watcher/auth/auth.go
+++ b/cmd/argo-watcher/auth/auth.go
@@ -1,8 +1,9 @@
 package auth
 
 type ExternalAuthService interface {
-	Init(url, realm, clientId string)
+	Init(url, realm, clientId string, privilegedGroups []string)
 	Validate(token string) (bool, error)
+	allowedToRollback(groups []string) bool
 }
 
 func NewExternalAuthService() ExternalAuthService {

--- a/cmd/argo-watcher/auth/auth_test.go
+++ b/cmd/argo-watcher/auth/auth_test.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A super simple test to check if NewExternalAuthService returns a KeycloakAuthService
+// We have it just not to lose test coverage percentage at the moment
+func TestNewExternalAuthService(t *testing.T) {
+	service := NewExternalAuthService()
+	assert.IsType(t, &KeycloakAuthService{}, service)
+}

--- a/cmd/argo-watcher/auth/keycloak.go
+++ b/cmd/argo-watcher/auth/keycloak.go
@@ -69,7 +69,7 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 
 	if resp.StatusCode == http.StatusOK && userPrivileged {
 		return true, nil
-	} else if !userPrivileged {
+	} else if resp.StatusCode == http.StatusOK && !userPrivileged {
 		return false, fmt.Errorf("user is not a member of any of the privileged groups")
 	}
 

--- a/cmd/argo-watcher/auth/keycloak.go
+++ b/cmd/argo-watcher/auth/keycloak.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+type KeycloakAuthService struct {
+	Url      string
+	Realm    string
+	ClientId string
+	client   *http.Client
+}
+
+// Init is used to initialize KeycloakAuthService with Keycloak URL, realm and client ID
+func (k *KeycloakAuthService) Init(url, realm, clientId string) {
+	k.Url = url
+	k.Realm = realm
+	k.ClientId = clientId
+	k.client = &http.Client{}
+}
+
+// Validate implements quite simple token validation approach
+// We just call Keycloak userinfo endpoint and check if it returns 200
+// effectively delegating token validation to Keycloak
+func (k *KeycloakAuthService) Validate(token string) (bool, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/realms/%s/protocol/openid-connect/userinfo", k.Url, k.Realm), nil)
+	if err != nil {
+		return false, fmt.Errorf("error creating request: %v", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+
+	resp, err := k.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error on response: %v", err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Error().Msgf("error closing response body: %v", err)
+		}
+	}(resp.Body)
+
+	log.Debug().Msgf("Token validation response: %v", resp.Status)
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("token validation failed with status: %v", resp.Status)
+}

--- a/cmd/argo-watcher/auth/keycloak_test.go
+++ b/cmd/argo-watcher/auth/keycloak_test.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeycloakAuthService_Init(t *testing.T) {
+	service := &KeycloakAuthService{}
+
+	url := "http://localhost:8080/auth"
+	realm := "test"
+	clientId := "test"
+
+	service.Init(url, realm, clientId)
+
+	assert.Equal(t, url, service.Url)
+	assert.Equal(t, realm, service.Realm)
+	assert.Equal(t, clientId, service.ClientId)
+	assert.IsType(t, &http.Client{}, service.client)
+}
+
+func TestKeycloakAuthService_Validate(t *testing.T) {
+	t.Run("should return 200 if token is valid", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, req.URL.String(), "/realms/test/protocol/openid-connect/userinfo")
+			// we don't care about the response body, just the status code
+			_, err := rw.Write([]byte(`OK`))
+			if err != nil {
+				t.Error(err)
+			}
+		}))
+		defer server.Close()
+
+		service := &KeycloakAuthService{
+			Url:      server.URL,
+			Realm:    "test",
+			ClientId: "test",
+			client:   server.Client(),
+		}
+
+		ok, err := service.Validate("test")
+
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("should return 401 if token is invalid", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, req.URL.String(), "/realms/test/protocol/openid-connect/userinfo")
+			rw.WriteHeader(http.StatusUnauthorized)
+			// we don't care about the response body, just the status code
+			_, err := rw.Write([]byte(`Unauthorized`))
+			if err != nil {
+				t.Error(err)
+			}
+		}))
+		defer server.Close()
+
+		service := &KeycloakAuthService{
+			Url:      server.URL,
+			Realm:    "test",
+			ClientId: "test",
+			client:   server.Client(),
+		}
+
+		ok, err := service.Validate("test")
+
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/cmd/argo-watcher/server/router.go
+++ b/cmd/argo-watcher/server/router.go
@@ -126,10 +126,14 @@ func (env *Env) addTask(c *gin.Context) {
 
 	keycloakToken := c.GetHeader("Authorization")
 
+	// need to rewrite this block
 	if keycloakToken != "" {
 		valid, err := env.auth.Validate(keycloakToken)
 		if err != nil {
-			log.Error().Msgf("Couldn't validate keycloak token. Got the following error: %s", err)
+			log.Error().Msgf("couldn't validate keycloak token, got the following error: %s", err)
+			c.JSON(http.StatusUnauthorized, models.TaskStatus{
+				Status: "You are not authorized to perform this action",
+			})
 			return
 		}
 		log.Debug().Msgf("keycloak token is validated for app %s", task.App)

--- a/cmd/argo-watcher/server/router.go
+++ b/cmd/argo-watcher/server/router.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/auth"
+
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/argocd"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
@@ -33,6 +35,8 @@ type Env struct {
 	updater *argocd.ArgoStatusUpdater
 	// metrics
 	metrics *prometheus.Metrics
+	// auth service
+	auth auth.ExternalAuthService
 }
 
 // CreateRouter initialize router.
@@ -120,7 +124,17 @@ func (env *Env) addTask(c *gin.Context) {
 	// need to find a better way to pass the token later
 	deployToken := c.GetHeader("ARGO_WATCHER_DEPLOY_TOKEN")
 
-	if deployToken != "" && deployToken == env.config.DeployToken {
+	keycloakToken := c.GetHeader("Authorization")
+
+	if keycloakToken != "" {
+		valid, err := env.auth.Validate(keycloakToken)
+		if err != nil {
+			log.Error().Msgf("Couldn't validate keycloak token. Got the following error: %s", err)
+			return
+		}
+		log.Debug().Msgf("keycloak token is validated for app %s", task.App)
+		task.Validated = valid
+	} else if deployToken != "" && deployToken == env.config.DeployToken {
 		log.Debug().Msgf("deploy token is validated for app %s", task.App)
 		task.Validated = true
 	} else if deployToken != "" && deployToken != env.config.DeployToken {

--- a/cmd/argo-watcher/server/server.go
+++ b/cmd/argo-watcher/server/server.go
@@ -77,7 +77,12 @@ func RunServer() {
 	// initialize auth service
 	if serverConfig.Keycloak.Url != "" {
 		env.auth = auth.NewExternalAuthService()
-		env.auth.Init(serverConfig.Keycloak.Url, serverConfig.Keycloak.Realm, serverConfig.Keycloak.ClientId)
+		env.auth.Init(
+			serverConfig.Keycloak.Url,
+			serverConfig.Keycloak.Realm,
+			serverConfig.Keycloak.ClientId,
+			serverConfig.Keycloak.PrivilegedGroups,
+		)
 	}
 
 	// start the server

--- a/cmd/argo-watcher/server/server.go
+++ b/cmd/argo-watcher/server/server.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/auth"
+
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/argocd"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
@@ -71,6 +73,12 @@ func RunServer() {
 
 	// create environment
 	env := &Env{config: serverConfig, argo: argo, metrics: metrics, updater: updater}
+
+	// initialize auth service
+	if serverConfig.Keycloak.Url != "" {
+		env.auth = auth.NewExternalAuthService()
+		env.auth.Init(serverConfig.Keycloak.Url, serverConfig.Keycloak.Realm, serverConfig.Keycloak.ClientId)
+	}
 
 	// start the server
 	log.Info().Msg("Starting web server")

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
+	github.com/swaggo/swag v1.16.2
 	go.uber.org/mock v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/datatypes v1.2.0
@@ -78,7 +79,6 @@ require (
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
-	github.com/swaggo/swag v1.16.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/web/src/Components/TaskView.js
+++ b/web/src/Components/TaskView.js
@@ -88,9 +88,9 @@ export default function TaskView() {
             });
 
             if (response.status === 401) { // HTTP 401 Unauthorized
-                throw new Error("Invalid deploy token!");
+                throw new Error("You are not authorized to perform this action!");
             } else if (response.status !== 202) { // HTTP 202 Accepted
-                throw new Error(`HTTP error! Status code: ${response.status}`);
+                throw new Error(`Received unexpected status code: ${response.status}`);
             }
 
             navigate('/');

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -34,10 +34,10 @@ export function useAuth() {
                                     .then(refreshed => {
                                         if (refreshed) {
                                             console.log('Token refreshed, valid for ' + Math.round(keycloak.tokenParsed.exp + keycloak.timeSkew - new Date().getTime() / 1000) + ' seconds');
+                                            // we need to set the token again here to handle cases
+                                            // when the UI was open for a long time
+                                            setKeycloakToken(keycloak.token);
                                         }
-                                        // we need to set the token again here to handle cases
-                                        // when the UI was open for a long time
-                                        setKeycloakToken(keycloak.token);
                                     }).catch(() => {
                                     console.error('Failed to refresh token');
                                 });

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -9,6 +9,7 @@ export function useAuth() {
     const [email, setEmail] = useState(null);
     const [groups, setGroups] = useState([]);
     const [privilegedGroups, setPrivilegedGroups] = useState([]);
+    const [keycloakToken, setKeycloakToken] = useState(null);
 
     useEffect(() => {
         fetchConfig().then(config => {
@@ -26,6 +27,7 @@ export function useAuth() {
                             setEmail(keycloak.tokenParsed.email);
                             setGroups(keycloak.tokenParsed.groups);
                             setPrivilegedGroups(config.keycloak.privileged_groups);
+                            setKeycloakToken(keycloak.token);
 
                             setInterval(() => {
                                 keycloak.updateToken(20)
@@ -50,5 +52,5 @@ export function useAuth() {
         });
     }, []);
 
-    return { authenticated, email, groups, privilegedGroups };
+    return { authenticated, email, groups, privilegedGroups, keycloakToken };
 }

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -35,6 +35,9 @@ export function useAuth() {
                                         if (refreshed) {
                                             console.log('Token refreshed, valid for ' + Math.round(keycloak.tokenParsed.exp + keycloak.timeSkew - new Date().getTime() / 1000) + ' seconds');
                                         }
+                                        // we need to set the token again here to handle cases
+                                        // when the UI was open for a long time
+                                        setKeycloakToken(keycloak.token);
                                     }).catch(() => {
                                     console.error('Failed to refresh token');
                                 });


### PR DESCRIPTION
This PR removes the necessity to provide deploy tokens in the front end.

Now, we only prompt the user for basic confirmation:
<img width="1187" alt="Screenshot 2024-01-19 at 13 57 47" src="https://github.com/shini4i/argo-watcher/assets/16435550/1b2df514-eaae-411d-952c-046cea51cf3b">

Additionally, the "ROLLBACK TO THIS VERSION" button is no longer active while the task status is "in progress":
<img width="1143" alt="Screenshot 2024-01-19 at 13 56 41" src="https://github.com/shini4i/argo-watcher/assets/16435550/ef92833c-983a-48ed-9cbd-9e339f5e81ae">
