### PR TITLE
[WIP] Queue implementation

### DIFF
--- a/cmd/argo-watcher/argocd/argo_status_updater.go
+++ b/cmd/argo-watcher/argocd/argo_status_updater.go
@@ -68,6 +68,14 @@ func (updater *ArgoStatusUpdater) collectInitialAppStatus(task *models.Task) err
 }
 
 func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
+	// set tasks status into progress
+	errStatusChange := updater.argo.State.SetTaskStatus(task.Id, models.StatusInProgressMessage, "")
+	if errStatusChange != nil {
+		// deployment failed
+		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, errStatusChange)
+		return
+	}
+
 	// wait for application to get into deployed status or timeout
 	application, err := updater.waitForApplicationDeployment(task)
 

--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -27,6 +27,13 @@ type DatabaseConfig struct {
 	Password string `env:"DB_PASSWORD" json:"-"`
 }
 
+type RabbitMqConfig struct {
+	Host     string `env:"RBQ_HOST" json:"rbq_host,omitempty"`
+	Port     int    `env:"RBQ_PORT" json:"rbq_port,omitempty"`
+	User     string `env:"RBQ_USER" json:"rbq_user,omitempty"`
+	Password string `env:"RBQ_PASSWORD" json:"-"`
+}
+
 type ServerConfig struct {
 	ArgoUrl                  url.URL           `env:"ARGO_URL,required" json:"argo_cd_url"`
 	ArgoUrlAlias             string            `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App URL. Can be omitted if ArgoUrl is reachable from outside.
@@ -48,6 +55,7 @@ type ServerConfig struct {
 	Keycloak                 KeycloakConfig    `json:"keycloak,omitempty"`
 	ScheduledLockdownEnabled bool              `env:"SCHEDULED_LOCKDOWN_ENABLED" envDefault:"false" json:"scheduled_lockdown_enabled"`
 	LockdownSchedule         LockdownSchedules `env:"LOCKDOWN_SCHEDULE" json:"-"`
+	RabbitMq                 RabbitMqConfig    `json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables using the envconfig package.

--- a/cmd/argo-watcher/queue/queue_manager.go
+++ b/cmd/argo-watcher/queue/queue_manager.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE = 2
+	MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE = 10
 )
 
 type QueueManager struct {

--- a/cmd/argo-watcher/queue/queue_manager.go
+++ b/cmd/argo-watcher/queue/queue_manager.go
@@ -1,0 +1,130 @@
+package queue
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/argocd"
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+const (
+	QUEUE_TYPE_IN_MEMORY = iota
+	QUEUE_TYPE_RABBIT_MQ // TODO: implement Rabbit MQ polling
+)
+
+const (
+	MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE = 2
+)
+
+type QueueManager struct {
+	// public fields
+	Updater   *argocd.ArgoStatusUpdater
+	QueueType int
+	// common private fields
+	inflightMutex   sync.Mutex
+	inflightCounter int
+	// In-Memory private fields
+	tickerDone chan bool
+	queueMutex sync.Mutex
+	queueSlice []models.Task
+
+	// Rabbit MQ private fields
+	// ...
+}
+
+// Connect establishes a connection to the QueueManager
+func (queueManager *QueueManager) Connect(serverConfig *config.ServerConfig) error {
+	queueManager.QueueType = QUEUE_TYPE_IN_MEMORY
+	if serverConfig.RabbitMq.Host != "" {
+		queueManager.QueueType = QUEUE_TYPE_RABBIT_MQ
+	}
+
+	queueManager.inflightMutex = sync.Mutex{}
+	queueManager.inflightCounter = 0
+
+	if queueManager.QueueType == QUEUE_TYPE_IN_MEMORY {
+		queueManager.queueMutex = sync.Mutex{}
+	}
+
+	// println("Queue type: " + strconv.Itoa(queueManager.QueueType))
+	// println(serverConfig.RabbitMq.Host)
+	// println(serverConfig.RabbitMq.Port)
+	// println(serverConfig.RabbitMq.User)
+	// println(serverConfig.RabbitMq.Password)
+	return nil
+}
+
+func (queueManager *QueueManager) GetInflightCount() int {
+	queueManager.inflightMutex.Lock()
+	defer queueManager.inflightMutex.Unlock()
+	return queueManager.inflightCounter
+}
+
+func (queueManager *QueueManager) InflightCountIncrease() {
+	queueManager.inflightMutex.Lock()
+	defer queueManager.inflightMutex.Unlock()
+	queueManager.inflightCounter++
+}
+
+func (queueManager *QueueManager) InflightCountDecrease() {
+	queueManager.inflightMutex.Lock()
+	defer queueManager.inflightMutex.Unlock()
+	queueManager.inflightCounter--
+}
+
+func (queueManager *QueueManager) QueueTask(task models.Task) {
+	queueManager.queueMutex.Lock()
+	defer queueManager.queueMutex.Unlock()
+	queueManager.queueSlice = append(queueManager.queueSlice, task)
+}
+
+func (queueManager *QueueManager) PollTask() (task *models.Task, exists bool) {
+	queueManager.queueMutex.Lock()
+	defer queueManager.queueMutex.Unlock()
+	if len(queueManager.queueSlice) == 0 {
+		return nil, false
+	}
+	task = &queueManager.queueSlice[0]
+	queueManager.queueSlice = queueManager.queueSlice[1:]
+	return task, true
+}
+
+func (queueManager *QueueManager) StartListen() {
+	queueManager.tickerDone = make(chan bool)
+	ticker := time.NewTicker(1 * time.Second)
+
+	go func() {
+		for {
+			select {
+			case <-queueManager.tickerDone:
+				return
+			case <-ticker.C:
+				for {
+					// if 10 tasks already waiting for deployment - don't read any more tasks for now
+					if queueManager.GetInflightCount() >= MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE {
+						break
+					}
+					// read task for the queue
+					task, exists := queueManager.PollTask()
+					if !exists {
+						break
+					}
+					// increase count of running rollout routines
+					queueManager.InflightCountIncrease()
+					// create a go routine for the rollout
+					go func() {
+						queueManager.Updater.WaitForRollout(*task)
+						// decrease inflight count when done
+						queueManager.InflightCountDecrease()
+					}()
+				}
+			}
+		}
+	}()
+}
+
+func (queueManager *QueueManager) StopListen() {
+	queueManager.tickerDone <- true
+}

--- a/cmd/argo-watcher/queue/queue_manager.go
+++ b/cmd/argo-watcher/queue/queue_manager.go
@@ -1,12 +1,18 @@
 package queue
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/argocd"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
+
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 const (
@@ -16,6 +22,8 @@ const (
 
 const (
 	MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE = 10
+	QUEUE_NAME                              = "ArgoWatcherTaskQueue"
+	QUEUE_CONSUMER                          = "ArgoWatcherConsumer"
 )
 
 type QueueManager struct {
@@ -31,7 +39,10 @@ type QueueManager struct {
 	queueSlice []models.Task
 
 	// Rabbit MQ private fields
-	// ...
+	ampqConnection   *amqp.Connection
+	ampqWriteChannel *amqp.Channel
+	ampqReadChannel  *amqp.Channel
+	ampqReadMessages <-chan amqp.Delivery
 }
 
 // Connect establishes a connection to the QueueManager
@@ -45,53 +56,144 @@ func (queueManager *QueueManager) Connect(serverConfig *config.ServerConfig) err
 	queueManager.inflightCounter = 0
 
 	if queueManager.QueueType == QUEUE_TYPE_IN_MEMORY {
+		log.Info().Msg("Initializing in-memory queue")
 		queueManager.queueMutex = sync.Mutex{}
 	}
 
-	// println("Queue type: " + strconv.Itoa(queueManager.QueueType))
-	// println(serverConfig.RabbitMq.Host)
-	// println(serverConfig.RabbitMq.Port)
-	// println(serverConfig.RabbitMq.User)
-	// println(serverConfig.RabbitMq.Password)
+	if queueManager.QueueType == QUEUE_TYPE_RABBIT_MQ {
+		log.Info().Msg("Initializing RabbitMQ queue")
+
+		// TODO: figure out how to handle connection breaks / reconnect - https://github.com/isayme/go-amqp-reconnect/blob/master/rabbitmq/rabbitmq.go
+		var err error
+		queueManager.ampqConnection, err = amqp.Dial(
+			fmt.Sprintf("amqp://%s:%s@%s:%d/",
+				serverConfig.RabbitMq.User,
+				serverConfig.RabbitMq.Password,
+				serverConfig.RabbitMq.Host,
+				serverConfig.RabbitMq.Port,
+			))
+		if err != nil {
+			return err
+		}
+
+		queueManager.ampqWriteChannel, err = queueManager.ampqConnection.Channel()
+		if err != nil {
+			return err
+		}
+
+		_, err = queueManager.ampqWriteChannel.QueueDeclare(
+			QUEUE_NAME, // name
+			false,      // durable
+			false,      // delete when unused
+			false,      // exclusive
+			false,      // no-wait
+			nil,        // arguments
+		)
+		if err != nil {
+			return err
+		}
+
+		queueManager.ampqReadChannel, err = queueManager.ampqConnection.Channel()
+		if err != nil {
+			return err
+		}
+
+		queueManager.ampqReadMessages, err = queueManager.ampqReadChannel.Consume(
+			QUEUE_NAME,     // queue
+			QUEUE_CONSUMER, // consumer
+			true,           // auto-ack - this removes the message from the queue as soon as we read it
+			false,          // exclusive
+			false,          // no-local
+			false,          // no-wait
+			nil,            // args
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (queueManager *QueueManager) GetInflightCount() int {
-	queueManager.inflightMutex.Lock()
 	defer queueManager.inflightMutex.Unlock()
+	queueManager.inflightMutex.Lock()
 	return queueManager.inflightCounter
 }
 
 func (queueManager *QueueManager) InflightCountIncrease() {
-	queueManager.inflightMutex.Lock()
 	defer queueManager.inflightMutex.Unlock()
+	queueManager.inflightMutex.Lock()
 	queueManager.inflightCounter++
 }
 
 func (queueManager *QueueManager) InflightCountDecrease() {
-	queueManager.inflightMutex.Lock()
 	defer queueManager.inflightMutex.Unlock()
+	queueManager.inflightMutex.Lock()
 	queueManager.inflightCounter--
 }
 
-func (queueManager *QueueManager) QueueTask(task models.Task) {
-	queueManager.queueMutex.Lock()
-	defer queueManager.queueMutex.Unlock()
-	queueManager.queueSlice = append(queueManager.queueSlice, task)
+func (queueManager *QueueManager) QueueTask(task models.Task) error {
+	if queueManager.QueueType == QUEUE_TYPE_IN_MEMORY {
+		defer queueManager.queueMutex.Unlock()
+		queueManager.queueMutex.Lock()
+		queueManager.queueSlice = append(queueManager.queueSlice, task)
+	}
+	if queueManager.QueueType == QUEUE_TYPE_RABBIT_MQ {
+		// create context for publishing messages
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		encodedTask, err := json.Marshal(task)
+		if err != nil {
+			return err
+		}
+
+		err = queueManager.ampqWriteChannel.PublishWithContext(ctx,
+			"",         // exchange
+			QUEUE_NAME, // routing key
+			false,      // mandatory
+			false,      // immediate
+			amqp.Publishing{
+				ContentType: "text/plain",
+				Body:        encodedTask,
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (queueManager *QueueManager) PollTask() (task *models.Task, exists bool) {
-	queueManager.queueMutex.Lock()
-	defer queueManager.queueMutex.Unlock()
-	if len(queueManager.queueSlice) == 0 {
-		return nil, false
+	if queueManager.QueueType == QUEUE_TYPE_IN_MEMORY {
+		defer queueManager.queueMutex.Unlock()
+		queueManager.queueMutex.Lock()
+		if len(queueManager.queueSlice) == 0 {
+			return nil, false
+		}
+		task = &queueManager.queueSlice[0]
+		queueManager.queueSlice = queueManager.queueSlice[1:]
+		return task, true
 	}
-	task = &queueManager.queueSlice[0]
-	queueManager.queueSlice = queueManager.queueSlice[1:]
-	return task, true
+
+	if queueManager.QueueType == QUEUE_TYPE_RABBIT_MQ {
+		taskJson := <-queueManager.ampqReadMessages
+		var task models.Task
+		err := json.Unmarshal(taskJson.Body, &task)
+		if err != nil {
+			log.Error().Msgf("Error reading task from RabbitMQ. Unable to marshal JSON due to %s", err)
+			return nil, false
+		}
+		return &task, true
+	}
+
+	return nil, false
 }
 
-func (queueManager *QueueManager) StartListen() {
+func (queueManager *QueueManager) StartListen() error {
 	queueManager.tickerDone = make(chan bool)
 	ticker := time.NewTicker(1 * time.Second)
 
@@ -115,16 +217,27 @@ func (queueManager *QueueManager) StartListen() {
 					queueManager.InflightCountIncrease()
 					// create a go routine for the rollout
 					go func() {
-						queueManager.Updater.WaitForRollout(*task)
 						// decrease inflight count when done
-						queueManager.InflightCountDecrease()
+						defer queueManager.InflightCountDecrease()
+						// rollout the task
+						queueManager.Updater.WaitForRollout(*task)
 					}()
 				}
 			}
 		}
 	}()
+
+	return nil
 }
 
 func (queueManager *QueueManager) StopListen() {
+	// stop the ticket
 	queueManager.tickerDone <- true
+
+	// disconnect from RabbitMQ
+	if queueManager.QueueType == QUEUE_TYPE_RABBIT_MQ {
+		queueManager.ampqConnection.Close()
+		queueManager.ampqWriteChannel.Close()
+		queueManager.ampqReadChannel.Close()
+	}
 }

--- a/cmd/argo-watcher/server/router.go
+++ b/cmd/argo-watcher/server/router.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/auth"
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/queue"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/argocd"
 
@@ -45,8 +46,8 @@ type Env struct {
 	config *config.ServerConfig
 	// argo argo
 	argo *argocd.Argo
-	// argo updater
-	updater *argocd.ArgoStatusUpdater
+	// argo argo
+	queueManager *queue.QueueManager
 	// metrics
 	metrics *prometheus.Metrics
 	// auth service
@@ -154,7 +155,6 @@ func (env *Env) addTask(c *gin.Context) {
 	// not an optimal solution, but for PoC it's fine
 	// need to find a better way to pass the token later
 	deployToken := c.GetHeader("ARGO_WATCHER_DEPLOY_TOKEN")
-
 	keycloakToken := c.GetHeader("Authorization")
 
 	// need to rewrite this block
@@ -193,8 +193,8 @@ func (env *Env) addTask(c *gin.Context) {
 		return
 	}
 
-	// start rollout monitor
-	go env.updater.WaitForRollout(*newTask)
+	// queue rollout monitor
+	env.queueManager.QueueTask(*newTask)
 
 	// return information about created task
 	c.JSON(http.StatusAccepted, models.TaskStatus{

--- a/cmd/argo-watcher/server/router.go
+++ b/cmd/argo-watcher/server/router.go
@@ -194,7 +194,15 @@ func (env *Env) addTask(c *gin.Context) {
 	}
 
 	// queue rollout monitor
-	env.queueManager.QueueTask(*newTask)
+	err = env.queueManager.QueueTask(*newTask)
+	if err != nil {
+		log.Error().Msgf("Couldn't process new task. Got the following error: %s", err)
+		c.JSON(http.StatusInternalServerError, models.TaskStatus{
+			Status: "queue failure",
+			Error:  err.Error(),
+		})
+		return
+	}
 
 	// return information about created task
 	c.JSON(http.StatusAccepted, models.TaskStatus{

--- a/cmd/argo-watcher/server/server.go
+++ b/cmd/argo-watcher/server/server.go
@@ -79,9 +79,16 @@ func RunServer() {
 
 	// initialize queue manager
 	queueManager := &queue.QueueManager{Updater: updater}
-	queueManager.Connect(serverConfig)
+	err = queueManager.Connect(serverConfig)
+	if err != nil {
+		log.Fatal().Msgf("Couldn't start a queue manager. Got the following error: %s", err)
+	}
+
 	// TODO: process any tasks that are in status "Queued" but aren't in the queue, e.g. before we start listening
-	queueManager.StartListen()
+	err = queueManager.StartListen()
+	if err != nil {
+		log.Fatal().Msgf("Couldn't start a listening to task queue. Got the following error: %s", err)
+	}
 
 	// create environment
 	env := &Env{config: serverConfig, argo: argo, metrics: metrics, queueManager: queueManager}

--- a/cmd/argo-watcher/state/in_memory_state.go
+++ b/cmd/argo-watcher/state/in_memory_state.go
@@ -33,7 +33,7 @@ func (state *InMemoryState) Add(task models.Task) (*models.Task, error) {
 	task.Id = uuid.New().String()
 	task.Created = float64(time.Now().Unix())
 	task.Updated = float64(time.Now().Unix())
-	task.Status = models.StatusInProgressMessage
+	task.Status = models.StatusQueued
 	state.tasks = append(state.tasks, task)
 	return &task, nil
 }

--- a/cmd/argo-watcher/state/postgres_state.go
+++ b/cmd/argo-watcher/state/postgres_state.go
@@ -41,7 +41,7 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 func (state *PostgresState) Add(task models.Task) (*models.Task, error) {
 	ormTask := state_models.TaskModel{
 		Images:          datatypes.NewJSONSlice(task.Images),
-		Status:          models.StatusInProgressMessage,
+		Status:          models.StatusQueued,
 		ApplicationName: sql.NullString{String: task.App, Valid: true},
 		Author:          sql.NullString{String: task.Author, Valid: true},
 		Project:         sql.NullString{String: task.Project, Valid: true},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   postgres:
     image: postgres:15.3
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: watcher
       POSTGRES_DB: watcher
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U watcher" ]
+      test: ["CMD-SHELL", "pg_isready -U watcher"]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -16,6 +16,13 @@ services:
       - ./db/data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+  rabbitmq:
+    image: rabbitmq:3.13.0
+    environment:
+      RABBITMQ_DEFAULT_USER: watcher
+      RABBITMQ_DEFAULT_PASS: watcher
+    ports:
+      - "5672:5672"
   migrations:
     image: migrate/migrate:v4.17.0
     command: -path=/migrations/ -database postgres://watcher:watcher@postgres:5432/watcher?sslmode=disable up

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,8 @@
 ---
 hide:
-- navigation
+  - navigation
 ---
+
 # Development
 
 ## Prerequisites
@@ -81,10 +82,16 @@ Start database
 docker compose up postgres
 ```
 
+Install migrations tool
+
+```shell
+go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+```
+
 Run migrations
 
 ```shell
-migrate -path file://db/migrations -database "postgresql://watcher:watcher@localhost:5432/watcher?sslmode=disable" up
+migrate -path ./db/migrations -database "postgresql://watcher:watcher@localhost:5432/watcher?sslmode=disable" up
 ```
 
 Start server

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	github.com/rabbitmq/amqp091-go v1.9.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
+github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc3Aoo=
+github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
@@ -242,6 +244,7 @@ github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZ
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
 go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=

--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -2,6 +2,7 @@ package models
 
 const (
 	StatusAppNotFoundMessage       = "app not found"
+	StatusQueued                   = "queued"
 	StatusInProgressMessage        = "in progress"
 	StatusFailedMessage            = "failed"
 	StatusAborted                  = "aborted"


### PR DESCRIPTION
Implementing queue manager to add tasks to queue (via AddTask API call) and process them from queue in background.

Right now, the changes are very rough and are more of a tempalte / thoughts than actual implementation. But this is what an in-memory queue would look like in the code.

The idea for in-memory queue is to have a variable with tasks to process, protected by mutex. We add the tasks to the queue when we call AddTask API method. The queue is polled in the background every second. Once we identify a new task in the queue, we start processing the task in a go-routine. 

We allow for `MAX_CONCURRENT_DEPLOYMENTS_PER_INSTANCE` background go-routines to run in parallel. Any tasks that are added into the queue will have to wait until one of the go-routines finishes execution. Note: in the future we can move that to a configurable field.

Next steps:
1. Add Rabbit MQ connector, to write and read tasks from the Rabbit MQ queues
2. Add unit tests and / or integration tests to the code
