### PR TITLE
fix(lockdown): release logic if start day == end day

### DIFF
--- a/cmd/argo-watcher/server/lockdown_test.go
+++ b/cmd/argo-watcher/server/lockdown_test.go
@@ -206,15 +206,15 @@ func TestTimeWithinSchedule(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name:      "lockdown ends next day, current time is after end time",
-			now:       time.Date(2024, 11, 25, 10, 6, 0, 0, time.UTC), // Mon 10:06
+			name:      "across two days lockdown, current time is in next day and after end time",
+			now:       time.Date(2024, 11, 25, 11, 0, 0, 0, time.UTC), // next day Mon 11:00
 			startDay:  time.Sunday,
 			endDay:    time.Monday,
 			startHour: 10,
 			startMin:  0,
-			endHour:   10,
-			endMin:    5,
-			expected:  false, // because 10:06 is after the end time on Monday
+			endHour:   10, // end time is earlier than current time in hours
+			endMin:    30,
+			expected:  false, // because 11:00 on Monday is after the end time on Monday
 		},
 	}
 	for _, tc := range tt {

--- a/cmd/argo-watcher/server/lockdown_test.go
+++ b/cmd/argo-watcher/server/lockdown_test.go
@@ -205,6 +205,17 @@ func TestTimeWithinSchedule(t *testing.T) {
 			endMin:    5,
 			expected:  false,
 		},
+		{
+			name:      "lockdown ends next day, current time is after end time",
+			now:       time.Date(2024, 11, 25, 10, 6, 0, 0, time.UTC), // Mon 10:06
+			startDay:  time.Sunday,
+			endDay:    time.Monday,
+			startHour: 10,
+			startMin:  0,
+			endHour:   10,
+			endMin:    5,
+			expected:  false, // because 10:06 is after the end time on Monday
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/argo-watcher/server/lockdown_test.go
+++ b/cmd/argo-watcher/server/lockdown_test.go
@@ -183,6 +183,17 @@ func TestTimeWithinSchedule(t *testing.T) {
 			endMin:    0,
 			expected:  false,
 		},
+		{
+			name:      "same day start and end, outside lockdown hours",
+			now:       time.Date(2024, 11, 24, 10, 6, 0, 0, time.UTC),
+			startDay:  time.Sunday,
+			endDay:    time.Sunday,
+			startHour: 10,
+			startMin:  0,
+			endHour:   10,
+			endMin:    5,
+			expected:  false,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/argo-watcher/server/lockdown_test.go
+++ b/cmd/argo-watcher/server/lockdown_test.go
@@ -184,6 +184,17 @@ func TestTimeWithinSchedule(t *testing.T) {
 			expected:  false,
 		},
 		{
+			name:      "same day start and end, before end time",
+			now:       time.Date(2024, 11, 24, 10, 4, 0, 0, time.UTC), // Sun 10:04
+			startDay:  time.Sunday,
+			endDay:    time.Sunday,
+			startHour: 10,
+			startMin:  0,
+			endHour:   10,
+			endMin:    5,
+			expected:  true,
+		},
+		{
 			name:      "same day start and end, outside lockdown hours",
 			now:       time.Date(2024, 11, 24, 10, 6, 0, 0, time.UTC),
 			startDay:  time.Sunday,


### PR DESCRIPTION
Currently, in scenarios like Sun 10:00 - Sun 10:30, the lockdown is not released on Sun at all. These changes fix it.