### PR TITLE
feat(updater): add fire and forget mode

### DIFF
--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -78,6 +78,16 @@ sandbox/charts/demo/.argocd-source-demo.yaml
 
 > This is not an ideal solution, but so far it is the only way to reliably determine the correct override file to update.
 
+### Fire and forget mode
+
+In rare cases, we need to force update an application without waiting for image to be detected by ArgoCD as a running. For example for Applications with `CronJob` only.
+
+The following annotation will force argo-watcher to just update the image, and consider application `deployed`:
+
+```bash
+argo-watcher/fire-and-forget: "true"
+```
+
 ### Additional information
 
 - The `app` alias is intended to correspond with an alias specified in the `argo-watcher/ALIAS.helm.image-tag` annotation.

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -25,6 +25,7 @@ const (
 	managedGitBranch        = "argo-watcher/write-back-branch"
 	managedGitPath          = "argo-watcher/write-back-path"
 	managedGitFile          = "argo-watcher/write-back-filename"
+	fireAndForgetAnnotation = "argo-watcher/fire-and-forget"
 )
 
 type ApplicationOperationResource struct {
@@ -284,6 +285,14 @@ func (app *Application) UpdateGitImageTag(task *Task) error {
 	}
 
 	return nil
+}
+
+// IsFireAndForgetModeActive checks if 'fire-and-forget' mode is enabled in Application's annotations.
+func (app *Application) IsFireAndForgetModeActive() bool {
+	if app.Metadata.Annotations == nil {
+		return false
+	}
+	return app.Metadata.Annotations[fireAndForgetAnnotation] == "true"
 }
 
 // extractManagedImages extracts the managed images from the application's annotations.

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -386,3 +386,49 @@ func TestExtractManagedImages(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFireAndForgetModeActive(t *testing.T) {
+	tt := []struct {
+		name string
+		app  Application
+		want bool
+	}{
+		{
+			name: "FireAndForget mode active",
+			app: Application{
+				Metadata: ApplicationMetadata{
+					Annotations: map[string]string{
+						fireAndForgetAnnotation: "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "FireAndForget mode inactive",
+			app: Application{
+				Metadata: ApplicationMetadata{
+					Annotations: map[string]string{
+						fireAndForgetAnnotation: "false",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Annotations are nil",
+			app: Application{
+				Metadata: ApplicationMetadata{
+					Annotations: nil,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.app.IsFireAndForgetModeActive())
+		})
+	}
+}


### PR DESCRIPTION
Closes #308 by implementing `argo-watcher/fire-and-forget` annotation.