### PR TITLE
chore: bump keycloak-js to 26.0.5

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
         "axios": "^1.7.4",
         "date-fns": "^3.6.0",
         "http-proxy-middleware": "^2.0.7",
-        "keycloak-js": "^24.0.4",
+        "keycloak-js": "^26.0.5",
         "prettier": "^3.2.5",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -12617,11 +12617,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
-      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12799,23 +12794,11 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/keycloak-js": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-24.0.4.tgz",
-      "integrity": "sha512-eLjG7CzGGgAXh78M76QUJy1R8+QDQvIJXJf6T3bq9VJZ6RXBGZXMsXvII66b83ueYDFa1gi2JojmA31Z23HO0g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "js-sha256": "^0.11.0",
-        "jwt-decode": "^4.0.0"
-      }
+      "version": "26.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.5.tgz",
+      "integrity": "sha512-3biQ5e+yX8EkU3+2ZO+YbWl0emooXt1wyKgZdGCFW8gT0oKeQh/AK6R9a53ACWBzDVoTBI+0GbXP2jF1sFMznw==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "axios": "^1.7.4",
     "date-fns": "^3.6.0",
     "http-proxy-middleware": "^2.0.7",
-    "keycloak-js": "^24.0.4",
+    "keycloak-js": "^26.0.5",
     "prettier": "^3.2.5",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
fixes constant token refresh on recent keycloak version