### PR TITLE
fix!: jwt validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ site/
 
 # sandbox directory for random stuff
 sandbox/
+
+# codebuddy
+.codebuddy

--- a/cmd/argo-watcher/auth/auth.go
+++ b/cmd/argo-watcher/auth/auth.go
@@ -32,6 +32,6 @@ func NewDeployTokenAuthService(token string) *DeployTokenAuthService {
 // It takes a secret key string and returns a pointer to a JWTAuthService.
 func NewJWTAuthService(secret string) *JWTAuthService {
 	return &JWTAuthService{
-		secretKey: secret,
+		secretKey: []byte(secret),
 	}
 }

--- a/cmd/argo-watcher/auth/auth_test.go
+++ b/cmd/argo-watcher/auth/auth_test.go
@@ -28,5 +28,5 @@ func TestNewKeycloakAuthService(t *testing.T) {
 func TestNewJWTAuthService(t *testing.T) {
 	secret := "testSecret"
 	jwtAuthService := NewJWTAuthService(secret)
-	assert.Equal(t, jwtAuthService.secretKey, secret)
+	assert.Equal(t, jwtAuthService.secretKey, []byte(secret))
 }

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -1,10 +1,7 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
-	"time"
-
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -30,23 +27,17 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 		return false, err
 	}
 
-	// Extract and validate claims
+	if !token.Valid {
+		return false, fmt.Errorf("invalid token")
+	}
+
 	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok || !token.Valid {
+	if !ok {
 		return false, fmt.Errorf("invalid token claims")
 	}
 
-	// Validate standard claims
-	if expVal, ok := claims["exp"]; ok {
-		if exp, valid := expVal.(float64); valid {
-			if time.Now().Unix() > int64(exp) {
-				return false, errors.New("token expired")
-			}
-		} else {
-			return false, errors.New("invalid exp claim type")
-		}
-	} else {
-		return false, errors.New("missing exp claim")
+	if _, exists := claims["exp"]; !exists {
+		return false, fmt.Errorf("missing exp claim")
 	}
 
 	return true, nil

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -1,39 +1,49 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// JWTAuthService is a struct that manages JWT authentication using a secret key.
+// JWTAuthService manages JWT authentication.
 type JWTAuthService struct {
-	// secretKey is the signing key for JWT.
-	secretKey string
+	secretKey []byte
 }
 
-// Init initializes the JWT authentication service with a provided secret key.
+// Init initializes the JWTAuthService with a provided secret key.
 func (j *JWTAuthService) Init(secretKey string) {
-	j.secretKey = secretKey
+	j.secretKey = []byte(secretKey) // Convert to byte slice for security
 }
 
-// Validate verifies the validity of a JWT token string.
-// It uses the stored secretKey for verification.
-// The function returns a boolean indicating the validity of the token, and any errors encountered during the process.
+// Validate verifies a JWT token, checking signature and claims.
 func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
-		return []byte(j.secretKey), nil
+		return j.secretKey, nil
 	})
 
 	if err != nil {
 		return false, err
 	}
 
-	if _, ok := token.Claims.(jwt.Claims); !ok && !token.Valid {
-		return false, fmt.Errorf("token is not valid")
+	// Extract and validate claims
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return false, errors.New("invalid token")
+	}
+
+	// Validate standard claims
+	if exp, ok := claims["exp"].(float64); ok {
+		if time.Now().Unix() > int64(exp) {
+			return false, errors.New("token expired")
+		}
+	} else {
+		return false, errors.New("missing exp claim")
 	}
 
 	return true, nil

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -30,11 +30,8 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 		return false, err
 	}
 
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return false, errors.New("invalid token claims")
-	}
-
+	// we are not checking validity of token error as it is already validated above
+	claims, _ := token.Claims.(jwt.MapClaims)
 	if _, exists := claims["exp"]; !exists {
 		return false, errors.New("missing exp claim")
 	}

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -13,11 +13,6 @@ type JWTAuthService struct {
 	secretKey []byte
 }
 
-// Init initializes the JWTAuthService with a provided secret key.
-func (j *JWTAuthService) Init(secretKey string) {
-	j.secretKey = []byte(secretKey) // Convert to byte slice for security
-}
-
 // Validate verifies a JWT token, checking signature and claims.
 func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -8,13 +8,17 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// JWTAuthService manages JWT authentication.
+// JWTAuthService manages JSON Web Token authentication.
 type JWTAuthService struct {
 	secretKey []byte
 }
 
-// Validate verifies a JWT token, checking signature and claims.
+// Validate verifies a JSON Web Token, checking signature and claims.
 func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
+	if tokenStr == "" {
+		return false, fmt.Errorf("empty token")
+	}
+
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -29,13 +33,17 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 	// Extract and validate claims
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
-		return false, errors.New("invalid token")
+		return false, fmt.Errorf("invalid token claims")
 	}
 
 	// Validate standard claims
-	if exp, ok := claims["exp"].(float64); ok {
-		if time.Now().Unix() > int64(exp) {
-			return false, errors.New("token expired")
+	if expVal, ok := claims["exp"]; ok {
+		if exp, valid := expVal.(float64); valid {
+			if time.Now().Unix() > int64(exp) {
+				return false, errors.New("token expired")
+			}
+		} else {
+			return false, errors.New("invalid exp claim type")
 		}
 	} else {
 		return false, errors.New("missing exp claim")

--- a/cmd/argo-watcher/auth/jwt.go
+++ b/cmd/argo-watcher/auth/jwt.go
@@ -27,15 +27,7 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 		return false, err
 	}
 
-	if !token.Valid {
-		return false, fmt.Errorf("invalid token")
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return false, fmt.Errorf("invalid token claims")
-	}
-
+	claims, _ := token.Claims.(jwt.MapClaims)
 	if _, exists := claims["exp"]; !exists {
 		return false, fmt.Errorf("missing exp claim")
 	}

--- a/cmd/argo-watcher/auth/jwt_test.go
+++ b/cmd/argo-watcher/auth/jwt_test.go
@@ -39,15 +39,10 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Invalid token claims
-	t.Run("invalid token claims", func(t *testing.T) {
-		claims := jwt.MapClaims{"exp": nil}
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-		tokenStr, _ := token.SignedString([]byte(secretKey))
-
-		isValid, err := service.Validate(tokenStr)
+	// Completely invalid token
+	t.Run("completely invalid token", func(t *testing.T) {
+		isValid, err := service.Validate("randomgarbage123")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token has invalid claims")
 		assert.False(t, isValid)
 	})
 
@@ -63,18 +58,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Invalid exp claim type
-	t.Run("invalid exp claim type", func(t *testing.T) {
-		claims := jwt.MapClaims{"exp": "invalid_type"}
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-		tokenStr, _ := token.SignedString([]byte(secretKey))
-
-		isValid, err := service.Validate(tokenStr)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token has invalid claims")
-		assert.False(t, isValid)
-	})
-
 	// Expired JWT
 	t.Run("expired JWT", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(-time.Hour).Unix())}
@@ -83,7 +66,7 @@ func TestJWTAuthService(t *testing.T) {
 
 		isValid, err := service.Validate(tokenStr)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token has invalid claims")
+		assert.Contains(t, err.Error(), "token has invalid claims: token is expired")
 		assert.False(t, isValid)
 	})
 

--- a/cmd/argo-watcher/auth/jwt_test.go
+++ b/cmd/argo-watcher/auth/jwt_test.go
@@ -10,8 +10,7 @@ import (
 
 func TestJWTAuthService(t *testing.T) {
 	secretKey := "test_secret_key"
-	service := &JWTAuthService{}
-	service.Init(secretKey)
+	service := &JWTAuthService{secretKey: []byte(secretKey)}
 
 	t.Run("valid JWT", func(t *testing.T) {
 		claims := &jwt.RegisteredClaims{

--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -36,24 +36,32 @@ argo:
 
 ### JWT Settings
 
-If you picked JWT approach, you can use [jwt-cli](https://github.com/mike-engel/jwt-cli), providing the secret from `JWT_SECRET`.
+If you chose the JWT approach, you can use [jwt-cli](https://github.com/mike-engel/jwt-cli) to generate tokens, using the secret stored in `JWT_SECRET`.
 
-```JSON
+#### Example JWT Payload
+```json
 {
-  "sub": "argo-watcher-client", # can be any value
-  "cluster": "prod", # can be any value
-  "allowed_projects": ["app1"], # can be replaced with "*" to allow deployment to any project
-  "iat": 1738692070, # To keep it simple, it should be the output of `date +%s`
-  "exp": 1770228106 # Set the reasonable expiration, the output of `date -v+1y +%s`
+  "sub": "argo-watcher-client",
+  "cluster": "prod",
+  "allowed_apps": ["app1"],
+  "iat": 1738692070,
+  "exp": 1770228106
 }
 ```
 
-```bash
-jwt encode --secret="PREVIOUSLY_GENERATED_SECRET" '{"sub":"argo-watcher-client","cluster":"prod","allowed_project":["app1"],"iat":1738692070,"exp":1770228106}'
-````
+- sub: `"argo-watcher-client"` → Can be **any value**.
+- cluster: `"prod"` → Can be **any value**.
+- allowed_apps: `["app1"]` → Replace with `"*"` to allow deployment to **any Application**.
+- iat: `date +%s` → Should be the **current Unix timestamp**.
+- exp: `date -v+1y +%s` → Set to a **reasonable expiration time** (e.g., **1 year**).
 
-> [!NOTE]
-> allowed_projects filtration is not implemented yet, but expected by version v1.0.0
+#### Generating JWT Token
+```bash
+jwt encode --secret="PREVIOUSLY_GENERATED_SECRET" '{"sub":"argo-watcher-client","cluster":"prod","allowed_apps":["app1"],"iat":1738692070,"exp":1770228106}'
+```
+
+!!! note
+    Application filtration is not implemented yet, but is expected in version **v1.0.0**.
 
 ## Application side configuration
 
@@ -96,7 +104,8 @@ Assuming that our application name is `Demo`, argo-watcher will create/update th
 sandbox/charts/demo/.argocd-source-demo.yaml
 ```
 
-> This is not an ideal solution, but so far it is the only way to reliably determine the correct override file to update.
+!!! note
+    This is not an ideal solution, but so far it is the only way to reliably determine the correct override file to update.
 
 ### Fire and forget mode
 
@@ -145,7 +154,8 @@ BEARER_TOKEN=Bearer previously_generated_jwt
 
 That's it! Starting from this point, Argo-Watcher will be able to commit changes to your GitOps repository.
 
-> Keep in mind, that `argo-watcher` will use the provided tag value as is, without any validation. So, it is up to user to make sure that the tag is valid and can be used for deployment.
+!!! note
+    Keep in mind, that `argo-watcher` will use the provided tag value as is, without any validation. So, it is up to user to make sure that the tag is valid and can be used for deployment.
 
 ## Lockdown mode
 
@@ -188,7 +198,8 @@ and to remove it make DELETE request:
 curl -X DELETE https://argo-watcher.example.com/api/v1/deploy-lock
 ```
 
-> Keep in mind that it will work only if keycloak integration is not enabled.
+!!! note
+    Keep in mind that it will work only if keycloak integration is not enabled.
 
 #### Frontend
 
@@ -196,4 +207,5 @@ You can set Lockdown mode manually via the frontend. To do so, click on `Argo-Wa
 
 ![Image title](https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher/deployment-lock.png)
 
-> If you have keycloak integration enabled, you need to be a member of one of pre-defined privileged groups to be able to set deployment lock.
+!!! note
+    If you have keycloak integration enabled, you need to be a member of one of pre-defined privileged groups to be able to set deployment lock.

--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -21,7 +21,6 @@ Before moving to the actual configuration, you need to:
 1. Generate secret that would be used to validate new tasks (pick one of the options below)
    1. Generate a token that would be used to validate requests from GitLab/Github. It can be any string. (it should be added to the secret used by argo-watcher under the `ARGO_WATCHER_DEPLOY_TOKEN` key)
    2. Generate a secret that will be used for generating and validating JWT tokens. (it should be added to the secret used by argo-watcher under the `JWT_SECRET` key) - the recommended approach
-   3. If you picked JWT approach, use https://jwt.io/ to generate a token using the secret from `JWT_SECRET`. (you can use any other approach for generating this token)
 2. Create a secret with ssh key that will be used by `argo-watcher` to make commits to the GitOps repository. (by default, we expect it to be available under the `sshPrivateKey`, but can be configured via helm chart values)
 3. Bump chart version to > `0.4.3` to support the necessary configuration
 
@@ -34,6 +33,24 @@ argo:
     commitAuthor: "Argo Watcher"
     commitEmail: "argo-watcher@example.com"
 ```
+
+### JWT Settings
+
+If you picked JWT approach, you can use [jwt-cli](https://github.com/mike-engel/jwt-cli), providing the secret from `JWT_SECRET`.
+
+```JSON
+{
+  "sub": "argo-watcher-client", # can be any value
+  "cluster": "prod", # can be any value
+  "allowed_project": ["app1"], # can be replaced with "*" to allow deployment to any project
+  "iat": 1738692070, # To keep it simple, it should be the output of `date +%s`
+  "exp": 1770228106 # Set the reasonable expiration, the output of `date -v+1y +%s`
+}
+```
+
+```bash
+jwt encode --secret="PREVIOUSLY_GENERATED_SECRET" '{"sub":"argo-watcher-client","cluster":"prod","allowed_project":["app1"],"iat":1738692070,"exp":1770228106}'
+````
 
 ## Application side configuration
 

--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -19,8 +19,8 @@ We assume you already have a working instance of Argo-Watcher and want to extend
 Before moving to the actual configuration, you need to:
 
 1. Generate secret that would be used to validate new tasks (pick one of the options below)
-   1. Generate a token that would be used to validate requests from GitLab/Github. It can be any string. (it should be added to the secret used by argo-watcher under the `ARGO_WATCHER_DEPLOY_TOKEN` key)
-   2. Generate a secret that will be used for generating and validating JWT tokens. (it should be added to the secret used by argo-watcher under the `JWT_SECRET` key) - the recommended approach
+      - Generate a token that would be used to validate requests from GitLab/Github. It can be any string. (it should be added to the secret used by argo-watcher under the `ARGO_WATCHER_DEPLOY_TOKEN` key)
+      - Generate a secret that will be used for generating and validating JWT tokens. (it should be added to the secret used by argo-watcher under the `JWT_SECRET` key) - the recommended approach
 2. Create a secret with ssh key that will be used by `argo-watcher` to make commits to the GitOps repository. (by default, we expect it to be available under the `sshPrivateKey`, but can be configured via helm chart values)
 3. Bump chart version to > `0.4.3` to support the necessary configuration
 
@@ -42,7 +42,7 @@ If you picked JWT approach, you can use [jwt-cli](https://github.com/mike-engel/
 {
   "sub": "argo-watcher-client", # can be any value
   "cluster": "prod", # can be any value
-  "allowed_project": ["app1"], # can be replaced with "*" to allow deployment to any project
+  "allowed_projects": ["app1"], # can be replaced with "*" to allow deployment to any project
   "iat": 1738692070, # To keep it simple, it should be the output of `date +%s`
   "exp": 1770228106 # Set the reasonable expiration, the output of `date -v+1y +%s`
 }
@@ -51,6 +51,9 @@ If you picked JWT approach, you can use [jwt-cli](https://github.com/mike-engel/
 ```bash
 jwt encode --secret="PREVIOUSLY_GENERATED_SECRET" '{"sub":"argo-watcher-client","cluster":"prod","allowed_project":["app1"],"iat":1738692070,"exp":1770228106}'
 ````
+
+> [!NOTE]
+> allowed_projects filtration is not implemented yet, but expected by version v1.0.0
 
 ## Application side configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
   - attr_list
   - md_in_html
+  - admonition
 
 plugins:
   - search


### PR DESCRIPTION
Now, we are validating whether the token has expired and enforcing expiration to be set. The documentation was also adjusted to simplify the bootstrap.

This `will` break backward compatibility with tokens accepted before if they miss mandatory fields.

Related to #288 