### PR TITLE
feat(web): add support for historical tasks export

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       postgres:
         condition: service_healthy
   backend:
-    image: golang:1.23-alpine3.20
+    image: golang:1.24-alpine3.20
     volumes:
       - .:/app
     working_dir: /app
@@ -58,7 +58,7 @@ services:
     ports:
       - "3000:3000"
   mock:
-    image: golang:1.23-alpine3.20
+    image: golang:1.24-alpine3.20
     volumes:
       - .:/app
     working_dir: /app

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "date-fns": "^3.6.0",
         "http-proxy-middleware": "^2.0.7",
         "keycloak-js": "^26.0.5",
+        "papaparse": "^5.5.2",
         "prettier": "^3.2.5",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -13672,6 +13673,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA==",
+      "license": "MIT"
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,7 +29,8 @@
         "react-router-dom": "^6.23.1",
         "react-scripts": "^5.0.1",
         "socket.io-client": "^4.8.0",
-        "web-vitals": "^3.5.2"
+        "web-vitals": "^3.5.2",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -5257,6 +5258,15 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -6237,6 +6247,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6451,6 +6474,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -6672,6 +6704,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-jest": {
@@ -9049,6 +9093,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -17630,6 +17683,18 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -19471,6 +19536,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -19842,6 +19925,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "date-fns": "^3.6.0",
     "http-proxy-middleware": "^2.0.7",
     "keycloak-js": "^26.0.5",
+    "papaparse": "^5.5.2",
     "prettier": "^3.2.5",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,8 @@
     "react-router-dom": "^6.23.1",
     "react-scripts": "^5.0.1",
     "socket.io-client": "^4.8.0",
-    "web-vitals": "^3.5.2"
+    "web-vitals": "^3.5.2",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -1,185 +1,248 @@
-import React, { forwardRef, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, {forwardRef, useEffect, useState} from 'react';
+import {useSearchParams} from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import Modal from '@mui/material/Modal';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-import { endOfDay, startOfDay } from 'date-fns';
+import {endOfDay, startOfDay} from 'date-fns';
+import * as XLSX from 'xlsx';
 
 import ApplicationsFilter from './ApplicationsFilter';
-import TasksTable, { useTasks } from './TasksTable';
-import { useErrorContext } from '../ErrorContext';
+import TasksTable, {useTasks} from './TasksTable';
+import {useErrorContext} from '../ErrorContext';
 
-interface DateRangePickerCustomInputProps {
-  value: string;
-  onClick: () => void;
-}
+const modalStyle = {
+    position: 'absolute' as 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 300,
+    bgcolor: 'background.paper',
+    boxShadow: 24,
+    p: 4,
+    borderRadius: 2,
+};
 
-const DateRangePickerCustomInput = forwardRef<HTMLInputElement, DateRangePickerCustomInputProps>(
-  ({ value, onClick }, ref) => (
-    <TextField
-      size="small"
-      sx={{ minWidth: '220px' }}
-      onClick={onClick}
-      ref={ref}
-      value={value}
-      label="Date range"
-      InputProps={{ readOnly: true }}
-    />
-  )
-);
+const HistoryTasks: React.FC = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const {setError, setSuccess} = useErrorContext();
+    const {tasks, sortField, setSortField, appNames, refreshTasksInRange, clearTasks} =
+        useTasks({setError, setSuccess});
+    const [currentApplication, setCurrentApplication] = useState<string | null>(
+        searchParams.get('app')
+    );
+    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([
+        searchParams.get('start') ? new Date(Number(searchParams.get('start')) * 1000) : startOfDay(new Date()),
+        searchParams.get('end') ? new Date(Number(searchParams.get('end')) * 1000) : startOfDay(new Date()),
+    ]);
+    const [startDate, endDate] = dateRange;
+    const [currentPage, setCurrentPage] = useState<number>(
+        searchParams.get('page') ? Number(searchParams.get('page')) : 1
+    );
+    const [isExportModalOpen, setExportModalOpen] = useState(false);
 
-DateRangePickerCustomInput.displayName = 'DateRangePickerCustomInput';
+    const updateSearchParameters = (start: Date, end: Date, application: string | null, page: number) => {
+        const params: Record<string, any> = {
+            start: Math.floor(start.getTime() / 1000),
+            end: Math.floor(end.getTime() / 1000),
+        };
 
-interface HistoryTasksProps {}
+        if (application) {
+            params.app = application;
+        }
 
-const HistoryTasks: React.FC<HistoryTasksProps> = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { setError, setSuccess } = useErrorContext();
-  const { tasks, sortField, setSortField, appNames, refreshTasksInRange, clearTasks } =
-    useTasks({ setError, setSuccess });
-  const [currentApplication, setCurrentApplication] = useState<string | null>(
-    searchParams.get('app')
-  );
-  const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([
-    searchParams.get('start') ? new Date(Number(searchParams.get('start')) * 1000) : startOfDay(new Date()),
-    searchParams.get('end') ? new Date(Number(searchParams.get('end')) * 1000) : startOfDay(new Date()),
-  ]);
-  const [startDate, endDate] = dateRange;
-  const [currentPage, setCurrentPage] = useState<number>(
-    searchParams.get('page') ? Number(searchParams.get('page')) : 1
-  );
+        if (page !== 1) {
+            params.page = page;
+        }
 
-  const updateSearchParameters = (start: Date, end: Date, application: string | null, page: number) => {
-    const params: Record<string, any> = {
-      start: Math.floor(start.getTime() / 1000),
-      end: Math.floor(end.getTime() / 1000),
+        setSearchParams(params);
     };
 
-    if (application) {
-      params.app = application;
-    }
-
-    if (page !== 1) {
-      params.page = page;
-    }
-
-    setSearchParams(params);
-  };
-
-  const refreshWithFilters = (start: Date | null, end: Date | null, application: string | null, page: number) => {
-    if (start && end) {
-      refreshTasksInRange(
-        Math.floor(startOfDay(start).getTime() / 1000),
-        Math.floor(endOfDay(end).getTime() / 1000),
-        application
-      );
-      updateSearchParameters(start, end, application, page);
-    } else {
-      clearTasks();
-    }
-  };
-
-  useEffect(() => {
-    refreshWithFilters(startDate!, endDate!, currentApplication, currentPage);
-  }, [startDate, endDate, currentApplication, currentPage]);
-
-  return (
-    <Container maxWidth="xl">
-      <Stack
-        direction={{ xs: 'column', md: 'row' }}
-        spacing={2}
-        alignItems="center"
-        sx={{ mb: 2 }}
-      >
-        <Typography
-          variant="h5"
-          gutterBottom
-          component="div"
-          sx={{
-            flexGrow: 1,
-            display: 'flex',
-            gap: '10px',
-            m: 0,
-            alignItems: 'center',
-          }}
-        >
-          <Box>History tasks</Box>
-          <Box sx={{ fontSize: '10px' }}>UTC</Box>
-        </Typography>
-        <Stack direction="row" spacing={2}>
-          <Box>
-            <ApplicationsFilter
-              value={currentApplication}
-              onChange={value => {
-                setCurrentApplication(value);
-                setCurrentPage(1);
-                refreshWithFilters(startDate!, endDate!, value, 1);
-              }}
-              appNames={appNames}
-            />
-          </Box>
-          <Box>
-            <DatePicker
-              selectsRange
-              startDate={startDate}
-              endDate={endDate}
-              onChange={(update: [Date | null, Date | null]) => {
-                setDateRange(update);
-                setCurrentPage(1);
-                refreshWithFilters(update[0], update[1], currentApplication, 1);
-              }}
-              maxDate={new Date()}
-              isClearable={false}
-              customInput={
-                <DateRangePickerCustomInput
-                  value={`${startDate ? startDate.toLocaleDateString() : ''} - ${endDate ? endDate.toLocaleDateString() : ''}`}
-                  onClick={() => {}}
-                />
-              }
-              required
-            />
-          </Box>
-          <Box>
-            <IconButton
-              edge="start"
-              color="primary"
-              title="Reload table"
-              onClick={() => {
-                setCurrentPage(1);
-                refreshWithFilters(startDate!, endDate!, currentApplication, 1);
-              }}
-            >
-              <RefreshIcon />
-            </IconButton>
-          </Box>
-        </Stack>
-      </Stack>
-      <Box sx={{ boxShadow: 2, borderRadius: 2, p: 2 }}>
-        <TasksTable
-          tasks={tasks}
-          sortField={sortField}
-          setSortField={setSortField}
-          relativeDate={false}
-          page={currentPage}
-          onPageChange={page => {
-            setCurrentPage(page);
-            updateSearchParameters(
-              startDate!,
-              endDate!,
-              currentApplication,
-              page
+    const refreshWithFilters = (start: Date | null, end: Date | null, application: string | null, page: number) => {
+        if (start && end) {
+            refreshTasksInRange(
+                Math.floor(startOfDay(start).getTime() / 1000),
+                Math.floor(endOfDay(end).getTime() / 1000),
+                application
             );
-          }}
-        />
-      </Box>
-    </Container>
-  );
+            updateSearchParameters(start, end, application, page);
+        } else {
+            clearTasks();
+        }
+    };
+
+    const exportData = (type: 'json' | 'csv' | 'xlsx') => {
+        if (!tasks || tasks.length === 0) {
+            setError('No data available for export.');
+            return;
+        }
+
+        const filename = `tasks_export_${Date.now()}.${type}`;
+        if (type === 'json') {
+            const blob = new Blob([JSON.stringify(tasks, null, 2)], {type: 'application/json'});
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = filename;
+            link.click();
+        } else if (type === 'csv') {
+            const csvContent = [
+                Object.keys(tasks[0]).join(','), // Header row
+                ...tasks.map(task => Object.values(task).join(',')), // Data rows
+            ].join('\n');
+            const blob = new Blob([csvContent], {type: 'text/csv'});
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = filename;
+            link.click();
+        } else if (type === 'xlsx') {
+            const worksheet = XLSX.utils.json_to_sheet(tasks);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'Tasks');
+            XLSX.writeFile(workbook, filename);
+        }
+
+        setExportModalOpen(false);
+        setSuccess('Data exported successfully.');
+    };
+
+    useEffect(() => {
+        refreshWithFilters(startDate!, endDate!, currentApplication, currentPage);
+    }, [startDate, endDate, currentApplication, currentPage]);
+
+    return (
+        <Container maxWidth="xl">
+            <Stack
+                direction={{xs: 'column', md: 'row'}}
+                spacing={2}
+                alignItems="center"
+                sx={{mb: 2}}
+            >
+                <Typography
+                    variant="h5"
+                    gutterBottom
+                    component="div"
+                    sx={{
+                        flexGrow: 1,
+                        display: 'flex',
+                        gap: '10px',
+                        m: 0,
+                        alignItems: 'center',
+                    }}
+                >
+                    <Box>History tasks</Box>
+                    <Box sx={{fontSize: '10px'}}>UTC</Box>
+                </Typography>
+                <Stack direction="row" spacing={2}>
+                    <Box>
+                        <ApplicationsFilter
+                            value={currentApplication}
+                            onChange={value => {
+                                setCurrentApplication(value);
+                                setCurrentPage(1);
+                                refreshWithFilters(startDate!, endDate!, value, 1);
+                            }}
+                            appNames={appNames}
+                        />
+                    </Box>
+                    <Box>
+                        <DatePicker
+                            selectsRange
+                            startDate={startDate}
+                            endDate={endDate}
+                            onChange={(update: [Date | null, Date | null]) => {
+                                setDateRange(update);
+                                setCurrentPage(1);
+                                refreshWithFilters(update[0], update[1], currentApplication, 1);
+                            }}
+                            maxDate={new Date()}
+                            isClearable={false}
+                            customInput={
+                                <TextField
+                                    size="small"
+                                    sx={{minWidth: '220px'}}
+                                    value={`${startDate ? startDate.toLocaleDateString() : ''} - ${endDate ? endDate.toLocaleDateString() : ''}`}
+                                    label="Date range"
+                                    InputProps={{readOnly: true}}
+                                />
+                            }
+                            required
+                        />
+                    </Box>
+                    <Box>
+                        <IconButton
+                            edge="start"
+                            color="primary"
+                            title="Reload table"
+                            onClick={() => {
+                                setCurrentPage(1);
+                                refreshWithFilters(startDate!, endDate!, currentApplication, 1);
+                            }}
+                        >
+                            <RefreshIcon/>
+                        </IconButton>
+                    </Box>
+                    <Box>
+                        <Button
+                            variant="contained"
+                            startIcon={<FileDownloadIcon/>}
+                            onClick={() => setExportModalOpen(true)}
+                        >
+                            Export
+                        </Button>
+                    </Box>
+                </Stack>
+            </Stack>
+            <Box sx={{boxShadow: 2, borderRadius: 2, p: 2}}>
+                <TasksTable
+                    tasks={tasks}
+                    sortField={sortField}
+                    setSortField={setSortField}
+                    relativeDate={false}
+                    page={currentPage}
+                    onPageChange={page => {
+                        setCurrentPage(page);
+                        updateSearchParameters(
+                            startDate!,
+                            endDate!,
+                            currentApplication,
+                            page
+                        );
+                    }}
+                />
+            </Box>
+            <Modal
+                open={isExportModalOpen}
+                onClose={() => setExportModalOpen(false)}
+                aria-labelledby="export-modal-title"
+                aria-describedby="export-modal-description"
+            >
+                <Box sx={modalStyle}>
+                    <Typography id="export-modal-title" variant="h6" component="h2">
+                        Select Export Type
+                    </Typography>
+                    <Stack direction="row" spacing={2} sx={{mt: 2}}>
+                        <Button variant="contained" onClick={() => exportData('json')}>
+                            JSON
+                        </Button>
+                        <Button variant="contained" onClick={() => exportData('csv')}>
+                            CSV
+                        </Button>
+                        <Button variant="contained" onClick={() => exportData('xlsx')}>
+                            Excel
+                        </Button>
+                    </Stack>
+                </Box>
+            </Modal>
+        </Container>
+    );
 };
 
 export default HistoryTasks;

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -257,13 +257,13 @@ const HistoryTasks: React.FC = () => {
                     </Typography>
                     <Stack direction="row" spacing={2} sx={{ justifyContent: 'center', mb: 2 }}>
                         <Button variant="contained" onClick={() => exportData('json')}>
-                            JSON
+                            .JSON
                         </Button>
                         <Button variant="contained" onClick={() => exportData('csv')}>
-                            CSV
+                            .CSV
                         </Button>
                         <Button variant="contained" onClick={() => exportData('xlsx')}>
-                            Excel
+                            .XLSX
                         </Button>
                     </Stack>
                     <FormGroup sx={{ alignItems: 'center' }}>

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -92,7 +92,7 @@ const HistoryTasks: React.FC = () => {
 
         let exportTasks = tasks;
         if (anonymize) {
-            exportTasks = tasks.map(({ author, ...rest }) => rest);
+            exportTasks = tasks.map(({ author, status_reason, ...rest }) => rest);
         }
 
         const filename = `tasks_export_${Date.now()}.${type}`;
@@ -258,7 +258,7 @@ const HistoryTasks: React.FC = () => {
                         </Button>
                     </Stack>
                     <FormGroup sx={{ alignItems: 'center' }}>
-                        <Tooltip title="Remove author from exported data">
+                        <Tooltip title="Remove author, and status_reason from exported data">
                             <FormControlLabel
                                 control={
                                     <Checkbox

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -224,11 +224,11 @@ const HistoryTasks: React.FC = () => {
                 aria-labelledby="export-modal-title"
                 aria-describedby="export-modal-description"
             >
-                <Box sx={modalStyle}>
+                <Box sx={{ ...modalStyle, textAlign: 'center' }}>
                     <Typography id="export-modal-title" variant="h6" component="h2">
                         Select Export Type
                     </Typography>
-                    <Stack direction="row" spacing={2} sx={{mt: 2}}>
+                    <Stack direction="row" spacing={2} sx={{ mt: 2, justifyContent: 'center' }}>
                         <Button variant="contained" onClick={() => exportData('json')}>
                             JSON
                         </Button>

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
@@ -14,6 +14,8 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import FormGroup from '@mui/material/FormGroup';
+import Tooltip from '@mui/material/Tooltip';
 import { endOfDay, startOfDay } from 'date-fns';
 import * as XLSX from 'xlsx';
 
@@ -241,20 +243,10 @@ const HistoryTasks: React.FC = () => {
                         whiteSpace: 'nowrap',
                     }}
                 >
-                    <Typography id="export-modal-title" variant="h6" component="h2">
+                    <Typography id="export-modal-title" variant="h6" component="h2" sx={{ mb: 2 }}>
                         Select Export Type
                     </Typography>
-                    <FormControlLabel
-                        control={
-                            <Checkbox
-                                checked={anonymize}
-                                onChange={(e) => setAnonymize(e.target.checked)}
-                            />
-                        }
-                        label="Anonymize (remove author)"
-                        sx={{ mt: 2 }}
-                    />
-                    <Stack direction="row" spacing={2} sx={{ mt: 2, justifyContent: 'center' }}>
+                    <Stack direction="row" spacing={2} sx={{ justifyContent: 'center', mb: 2 }}>
                         <Button variant="contained" onClick={() => exportData('json')}>
                             JSON
                         </Button>
@@ -265,6 +257,19 @@ const HistoryTasks: React.FC = () => {
                             Excel
                         </Button>
                     </Stack>
+                    <FormGroup sx={{ alignItems: 'center' }}>
+                        <Tooltip title="Remove author from exported data">
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={anonymize}
+                                        onChange={(e) => setAnonymize(e.target.checked)}
+                                    />
+                                }
+                                label="Anonymize"
+                            />
+                        </Tooltip>
+                    </FormGroup>
                 </Box>
             </Modal>
         </Container>

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -25,7 +25,7 @@ import TasksTable, { useTasks } from './TasksTable';
 import { useErrorContext } from '../ErrorContext';
 
 const modalStyle = {
-    position: 'absolute' as 'absolute',
+    position: 'absolute',
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -87,7 +87,7 @@ const HistoryTasks: React.FC = () => {
 
     const exportData = (type: 'json' | 'csv' | 'xlsx') => {
         if (!tasks || tasks.length === 0) {
-            setError('No data available for export.');
+            setError('export_error', 'No tasks available for export.');
             return;
         }
 

--- a/web/src/Components/HistoryTasks.tsx
+++ b/web/src/Components/HistoryTasks.tsx
@@ -101,6 +101,8 @@ const HistoryTasks: React.FC = () => {
         if (type !== 'json') {
             exportTasks = exportTasks.map((task) => ({
                 ...task,
+                created: new Date(task.created * 1000).toLocaleString('en-GB', { hour12: false }),
+                updated: task.updated ? new Date(task.updated * 1000).toLocaleString('en-GB', { hour12: false }) : null,
                 images: task.images.map((img) => `${img.image}:${img.tag}`).join(', '),
                 ...(anonymize ? {} : { status_reason: task.status_reason?.replace(/\n/g, '\\n') }),
             }));


### PR DESCRIPTION
This PR adds support for exporting historical tasks to JSON, CSV, or XLSX formats, with anonymization support.

<img width="1434" alt="Screenshot 2025-05-05 at 13 31 38" src="https://github.com/user-attachments/assets/fb91aaf6-9444-49a3-ab48-f9b260b5cc42" />
