### PR TITLE
refactor(notifications): Make WebhookService testable and robust

### DIFF
--- a/cmd/argo-watcher/argocd/argo_status_updater.go
+++ b/cmd/argo-watcher/argocd/argo_status_updater.go
@@ -323,7 +323,7 @@ func determineFailureStatus(task models.Task, err error) string {
 
 // sendWebhookEvent sends a notification about deployment status if webhooks are enabled
 func sendWebhookEvent(task models.Task, webhookService *notifications.WebhookService) {
-	if webhookService.Enabled {
+	if webhookService != nil && webhookService.Enabled {
 		if err := webhookService.SendWebhook(task); err != nil {
 			log.Error().Str("id", task.Id).Msgf("Failed to send webhook. Error: %s", err.Error())
 		}

--- a/cmd/argo-watcher/argocd/argo_status_updater_test.go
+++ b/cmd/argo-watcher/argocd/argo_status_updater_test.go
@@ -37,7 +37,8 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		// argo updater
 		updater := &ArgoStatusUpdater{}
-		updater.Init(*argo, 1, 0*time.Second, "test-registry", false, mockWebhookConfig)
+		err := updater.Init(*argo, 1, 0*time.Second, "test-registry", false, mockWebhookConfig)
+		assert.NoError(t, err)
 
 		// prepare test data
 		task := models.Task{

--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -25,6 +25,7 @@ type DatabaseConfig struct {
 type WebhookConfig struct {
 	Enabled              bool   `env:"WEBHOOK_ENABLED" envDefault:"false" json:"enabled"`
 	Url                  string `env:"WEBHOOK_URL" json:"url,omitempty"`
+	ContentType          string `env:"WEBHOOK_CONTENT_TYPE" envDefault:"application/json" json:"content_type,omitempty"`
 	Format               string `env:"WEBHOOK_FORMAT" json:"format,omitempty"`
 	AuthorizationHeader  string `env:"WEBHOOK_AUTHORIZATION_HEADER_NAME" envDefault:"Authorization" json:"authorization_header,omitempty"`
 	Token                string `env:"WEBHOOK_AUTHORIZATION_HEADER_VALUE" envDefault:"" json:"-"`

--- a/cmd/argo-watcher/notifications/webhook.go
+++ b/cmd/argo-watcher/notifications/webhook.go
@@ -2,70 +2,111 @@ package notifications
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"text/template"
-
-	"github.com/shini4i/argo-watcher/internal/helpers"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
+	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
+const (
+	maxErrorBodySize = 2 * 1024 // 2 KB
+)
+
+// HTTPClient defines the interface for a client that can perform HTTP requests.
+// This allows for mocking in unit tests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// WebhookService holds the configuration and a pre-compiled template for sending webhooks.
 type WebhookService struct {
-	Enabled bool
-	config  *config.WebhookConfig
-	client  *http.Client
+	Enabled              bool
+	url                  string
+	token                string
+	authorizationHeader  string
+	contentType          string
+	allowedResponseCodes []int
+	client               HTTPClient
+	template             *template.Template
 }
 
-func NewWebhookService(webhookConfig *config.WebhookConfig) *WebhookService {
-	return &WebhookService{
-		Enabled: webhookConfig.Enabled,
-		config:  webhookConfig,
-		client:  &http.Client{},
+// NewWebhookService creates and initializes the service.
+// It requires an HTTPClient, making the service testable.
+func NewWebhookService(cfg *config.WebhookConfig, client HTTPClient) (*WebhookService, error) {
+	if client == nil {
+		return nil, errors.New("HTTPClient cannot be nil")
 	}
-}
 
-func (service *WebhookService) SendWebhook(task models.Task) error {
-	tmpl, err := template.New("webhook").Parse(service.config.Format)
+	tmpl, err := template.New("webhook").Parse(cfg.Format)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to parse webhook template: %w", err)
 	}
+
+	return &WebhookService{
+		Enabled:              cfg.Enabled,
+		url:                  cfg.Url,
+		token:                cfg.Token,
+		authorizationHeader:  cfg.AuthorizationHeader,
+		contentType:          cfg.ContentType,
+		allowedResponseCodes: cfg.AllowedResponseCodes,
+		client:               client,
+		template:             tmpl,
+	}, nil
+}
+
+// SendWebhook sends a notification for a given task.
+func (s *WebhookService) SendWebhook(task models.Task) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	var payload bytes.Buffer
-	if err := tmpl.Execute(&payload, task); err != nil {
-		return err
+	if err := s.template.Execute(&payload, &task); err != nil {
+		return fmt.Errorf("failed to execute webhook template: %w", err)
 	}
 
 	log.Debug().Str("id", task.Id).Msgf("Sending webhook payload: %s", payload.String())
 
-	req, err := http.NewRequest("POST", service.config.Url, &payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", s.url, &payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create webhook request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	if service.config.Token != "" {
-		req.Header.Set(service.config.AuthorizationHeader, service.config.Token)
+	req.Header.Set("Content-Type", s.contentType)
+	if s.token != "" {
+		req.Header.Set(s.authorizationHeader, s.token)
 	}
 
-	resp, err := service.client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to send webhook: %w", err)
 	}
-
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to close response body")
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warn().Err(err).Str("id", task.Id).Msg("Failed to close response body")
 		}
-	}(resp.Body)
+	}()
 
-	if !helpers.Contains(service.config.AllowedResponseCodes, resp.StatusCode) {
-		return fmt.Errorf("received non-OK status code: %v", resp.StatusCode)
+	if !helpers.Contains(s.allowedResponseCodes, resp.StatusCode) {
+		lr := io.LimitReader(resp.Body, maxErrorBodySize)
+		body, readErr := io.ReadAll(lr)
+		if readErr != nil {
+			return fmt.Errorf("received non-allowed status code %d, and failed to read response body: %w", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("received non-allowed status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	_, err = io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		log.Warn().Err(err).Str("id", task.Id).Msg("Failed to discard response body on success")
 	}
 
 	return nil

--- a/cmd/argo-watcher/notifications/webhook.go
+++ b/cmd/argo-watcher/notifications/webhook.go
@@ -69,7 +69,7 @@ func (s *WebhookService) SendWebhook(task models.Task) error {
 	defer cancel()
 
 	var payload bytes.Buffer
-	if err := s.template.Execute(&payload, &task); err != nil {
+	if err := s.template.Execute(&payload, task); err != nil {
 		return fmt.Errorf("failed to execute webhook template: %w", err)
 	}
 

--- a/cmd/argo-watcher/server/server.go
+++ b/cmd/argo-watcher/server/server.go
@@ -58,13 +58,16 @@ func RunServer() {
 
 	// initialize argo updater
 	updater := &argocd.ArgoStatusUpdater{}
-	updater.Init(*argo,
+	err = updater.Init(*argo,
 		serverConfig.GetRetryAttempts(),
 		argocd.ArgoSyncRetryDelay,
 		serverConfig.RegistryProxyUrl,
 		serverConfig.AcceptSuspendedApp,
 		&serverConfig.Webhook,
 	)
+	if err != nil {
+		log.Fatal().Msgf("Couldn't initialize the Argo updater. Got the following error: %s", err)
+	}
 
 	// create environment
 	env, err := NewEnv(serverConfig, argo, metrics, updater)


### PR DESCRIPTION
The previous implementation of `WebhookService` had critical design flaws that made it difficult to test and maintain.

The primary issues were:
- **Tight Coupling:** The service directly instantiated a concrete `*http.Client`, making it impossible to unit test the `SendWebhook` logic without making live, external HTTP calls.
- **Brittle Configuration:** The `Content-Type` header was hardcoded to `application/json`, while the payload was generated from a configurable template. This created a high risk of mismatch if the template format were ever changed, leading to difficult-to-diagnose bugs.

This commit refactors the service to address these issues by applying dependency injection and making the configuration more explicit.

Changes:
- An `HTTPClient` interface is introduced to abstract the `http.Client`.
- `NewWebhookService` now accepts the `HTTPClient` as a dependency, allowing mock clients to be injected during unit tests.
- The webhook `Content-Type` is now a configurable field in `WebhookConfig`, removing the hardcoded value and making the configuration self-contained.
- The service now copies required values from the config struct on initialization rather than holding a pointer to it, slightly reducing coupling.