### PR TITLE
fix: Correct Postgres advisory lock implementation to prevent deadlocks

### DIFF
--- a/internal/lock/in_memory_test.go
+++ b/internal/lock/in_memory_test.go
@@ -8,117 +8,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewInMemoryLocker ensures that the constructor returns a valid, non-nil Locker.
-func TestNewInMemoryLocker(t *testing.T) {
-	locker := NewInMemoryLocker()
-	assert.NotNil(t, locker, "NewInMemoryLocker() should not return nil")
-}
-
-// TestLockUnlock ensures that a single goroutine can acquire and release a lock.
-func TestLockUnlock(t *testing.T) {
+func TestInMemoryLocker(t *testing.T) {
 	locker := NewInMemoryLocker()
 	key := "test-key"
-
-	err := locker.Lock(key)
-	assert.NoError(t, err, "Lock should not return an error")
-
-	err = locker.Unlock(key)
-	assert.NoError(t, err, "Unlock should not return an error")
-}
-
-// TestBlockingLock verifies that the Lock method is indeed blocking.
-func TestBlockingLock(t *testing.T) {
-	locker := NewInMemoryLocker()
-	key := "blocking-key"
 	var wg sync.WaitGroup
-	var secondLockAcquired bool
+	// The buffer must be large enough to hold all sent values before they are read.
+	executionOrder := make(chan int, 4)
 
-	// First goroutine acquires the lock
-	err := locker.Lock(key)
-	assert.NoError(t, err)
-
+	// Goroutine 1
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// This should block until the first lock is released.
-		err := locker.Lock(key)
-		assert.NoError(t, err)
-		secondLockAcquired = true
-		err = locker.Unlock(key)
+		err := locker.WithLock(key, func() error {
+			executionOrder <- 1
+			// Hold the lock for a moment to ensure the second goroutine has to wait.
+			time.Sleep(10 * time.Millisecond)
+			executionOrder <- 1
+			return nil
+		})
 		assert.NoError(t, err)
 	}()
 
-	// Give the second goroutine a moment to try and acquire the lock
-	time.Sleep(100 * time.Millisecond)
-	assert.False(t, secondLockAcquired, "Second goroutine should be blocked and not have acquired the lock yet")
+	// Give the first goroutine a moment to acquire the lock
+	time.Sleep(1 * time.Millisecond)
 
-	// Release the first lock
-	err = locker.Unlock(key)
-	assert.NoError(t, err)
+	// Goroutine 2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := locker.WithLock(key, func() error {
+			executionOrder <- 2
+			executionOrder <- 2
+			return nil
+		})
+		assert.NoError(t, err)
+	}()
 
-	// Wait for the second goroutine to finish
 	wg.Wait()
-	assert.True(t, secondLockAcquired, "Second goroutine should have acquired the lock after it was released")
-}
+	close(executionOrder)
 
-// TestConcurrentAccess tests that multiple goroutines trying to lock the same key
-// do so sequentially, not concurrently.
-func TestConcurrentAccess(t *testing.T) {
-	locker := NewInMemoryLocker()
-	key := "concurrent-key"
-	var counter int
-	var wg sync.WaitGroup
-	numRoutines := 5
-
-	wg.Add(numRoutines)
-	for i := 0; i < numRoutines; i++ {
-		go func() {
-			defer wg.Done()
-			err := locker.Lock(key)
-			assert.NoError(t, err)
-
-			// Simulate some work
-			current := counter
-			time.Sleep(10 * time.Millisecond)
-			counter = current + 1
-
-			err = locker.Unlock(key)
-			assert.NoError(t, err)
-		}()
+	// Verify execution order
+	// Expected: 1 (start), 1 (end), 2 (start), 2 (end)
+	var order []int
+	for i := range executionOrder {
+		order = append(order, i)
 	}
 
-	wg.Wait()
-
-	// If locking was sequential, the counter should be exactly the number of routines.
-	// If it was concurrent, we would have a race condition and the final value would be unpredictable.
-	assert.Equal(t, numRoutines, counter, "Counter should be incremented sequentially by each goroutine")
-}
-
-// TestMultipleKeys ensures that locks for different keys do not interfere with each other.
-func TestMultipleKeys(t *testing.T) {
-	locker := NewInMemoryLocker()
-	key1 := "key1"
-	key2 := "key2"
-	var wg sync.WaitGroup
-
-	// Lock the first key
-	err := locker.Lock(key1)
-	assert.NoError(t, err)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// This should not block, as it's a different key.
-		err := locker.Lock(key2)
-		assert.NoError(t, err)
-		err = locker.Unlock(key2)
-		assert.NoError(t, err)
-	}()
-
-	// Wait for the second goroutine, it should finish almost immediately
-	wg.Wait()
-
-	// Release the first lock
-	err = locker.Unlock(key1)
-	assert.NoError(t, err)
+	expectedOrder := []int{1, 1, 2, 2}
+	assert.Equal(t, expectedOrder, order, "The second goroutine should not start until the first one has finished")
 }

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -2,8 +2,7 @@ package lock
 
 // Locker defines the interface for a distributed, blocking locking mechanism.
 type Locker interface {
-	// Lock acquires a lock for the given key. It blocks until the lock is available.
-	Lock(key string) error
-	// Unlock releases the lock for the given key.
-	Unlock(key string) error
+	// WithLock acquires a lock for the given key, executes the provided function,
+	// and guarantees the lock is released afterward.
+	WithLock(key string, f func() error) error
 }


### PR DESCRIPTION
## Description

This pull request addresses a critical flaw in the PostgreSQL advisory lock implementation that leads to application hangs under concurrent load. The previous implementation used session-scoped locks (`pg_advisory_lock`) with the GORM connection pool, creating a race condition where locks could be acquired on one database connection and never released.

This change refactors the locking mechanism to be fundamentally safe and robust.

## Changes

-   **Refactored `Locker` Interface**: The `Locker` interface has been changed from a stateful `Lock`/`Unlock` pattern to a functional `WithLock(key string, f func() error) error` pattern. This guarantees that lock acquisition and release are always paired correctly.
-   **Corrected `PostgresLocker`**: The implementation now uses transaction-scoped locks (`pg_advisory_xact_lock`) within a `gorm.Transaction`. This ties the lock's lifecycle directly to the transaction, ensuring it is automatically released upon commit or rollback, thus preventing leaks.
-   **Updated Call Sites**: The `ArgoStatusUpdater` has been updated to use the new `WithLock` method, simplifying the code and making it safer.
-   **Updated Unit Tests**: The unit tests for both `InMemoryLocker` and `PostgresLocker` have been updated to reflect the new `WithLock` interface. A bug in the test setup that caused a deadlock has also been fixed.

## Impact

This resolves a latent but critical bug that could cause production instability. The application's git update functionality is now correctly serialized and safe for concurrent execution.
