### PR TITLE
chore(git): Implement Robust Caching and Error Handling

### DIFF
--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -54,6 +54,7 @@ type ServerConfig struct {
 	LockdownSchedule   string         `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
 	Webhook            WebhookConfig  `json:"webhook,omitempty"`
 	DevEnvironment     bool           `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
+	RepoCachePath      string         `env:"REPO_CACHE_PATH" envDefault:"/dev/shm" json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables using the envconfig package.

--- a/cmd/argo-watcher/server/server.go
+++ b/cmd/argo-watcher/server/server.go
@@ -79,6 +79,7 @@ func RunServer() {
 		serverConfig.GetRetryAttempts(),
 		argocd.ArgoSyncRetryDelay,
 		serverConfig.RegistryProxyUrl,
+		serverConfig.RepoCachePath,
 		serverConfig.AcceptSuspendedApp,
 		&serverConfig.Webhook,
 		locker,

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -250,15 +250,9 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 	return &overrideFileContent, nil
 }
 
-func (app *Application) UpdateGitImageTag(task *Task) error {
-	gitopsRepo, err := NewGitopsRepo(app)
-	if err != nil {
-		return err
-	}
-
+func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo) error {
 	if gitopsRepo.Path == "" {
 		log.Warn().Str("id", task.Id).Msgf("No path found for app %s, unsupported Application configuration", app.Metadata.Name)
-		// technically, unsupported Application configuration is not an error (or is it?)
 		return nil
 	}
 
@@ -272,15 +266,27 @@ func (app *Application) UpdateGitImageTag(task *Task) error {
 		return nil
 	}
 
-	git := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, updater.GitClient{})
+	git := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, gitopsRepo.RepoCachePath, updater.GitClient{})
 
+	// Fast Path
 	if err := git.Clone(); err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to clone git repository %s", app.Spec.Source.RepoURL)
+		log.Error().Str("id", task.Id).Msgf("Failed to clone/fetch git repository %s: %s", gitopsRepo.RepoUrl, err)
 		return err
 	}
 
 	if err := git.UpdateApp(app.Metadata.Name, releaseOverrides, task); err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to update git repository %s", app.Spec.Source.RepoURL)
+		if strings.Contains(err.Error(), "non-fast-forward") {
+			// Recovery Path
+			log.Warn().Str("id", task.Id).Msg("Non-fast-forward update detected. Re-cloning repository and retrying.")
+
+			if err := git.NukeAndReclone(); err != nil {
+				return fmt.Errorf("failed to nuke and re-clone: %w", err)
+			}
+
+			// Re-apply changes and push again
+			return git.UpdateApp(app.Metadata.Name, releaseOverrides, task)
+		}
+		// Other unrecoverable error
 		return err
 	}
 

--- a/internal/models/gitops.go
+++ b/internal/models/gitops.go
@@ -7,14 +7,20 @@ import (
 )
 
 type GitopsRepo struct {
-	RepoUrl    string `validate:"required"`
-	BranchName string `validate:"required"`
-	Path       string `validate:"required"`
-	Filename   string
+	RepoUrl       string `validate:"required"`
+	BranchName    string `validate:"required"`
+	Path          string `validate:"required"`
+	Filename      string
+	RepoCachePath string
 }
 
-func NewGitopsRepo(app *Application) (GitopsRepo, error) {
-	return extractGitOverrides(app.Metadata.Annotations, app, app.Spec.Sources == nil)
+func NewGitopsRepo(app *Application, repoCachePath string) (GitopsRepo, error) {
+	gitopsRepo, err := extractGitOverrides(app.Metadata.Annotations, app, app.Spec.Sources == nil)
+	if err != nil {
+		return gitopsRepo, err
+	}
+	gitopsRepo.RepoCachePath = repoCachePath
+	return gitopsRepo, nil
 }
 
 func extractGitOverrides(annotations map[string]string, app *Application, isSourceNil bool) (GitopsRepo, error) {

--- a/pkg/updater/interfaces.go
+++ b/pkg/updater/interfaces.go
@@ -1,21 +1,19 @@
 package updater
 
 import (
-	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/go-git/go-git/v5/storage"
 )
 
 type GitHandler interface {
-	Clone(s storage.Storer, worktree billy.Filesystem, o *git.CloneOptions) (*git.Repository, error)
+	PlainClone(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error)
 	AddSSHKey(user, path, passphrase string) (*ssh.PublicKeys, error)
 }
 
 type GitClient struct{}
 
-func (GitClient) Clone(s storage.Storer, worktree billy.Filesystem, o *git.CloneOptions) (*git.Repository, error) {
-	return git.Clone(s, worktree, o)
+func (GitClient) PlainClone(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+	return git.PlainClone(path, isBare, o)
 }
 
 func (GitClient) AddSSHKey(user, path, passphrase string) (*ssh.PublicKeys, error) {


### PR DESCRIPTION
Improves git operations by introducing a persistent file-based cache and adding robust error handling to prevent race conditions and recover from common git failures.

### Why

The previous implementation of git operations had several critical issues:
- **No Caching**: It cloned the git repository from scratch for every single task, causing significant performance overhead and unnecessary network traffic.
- **Unsafe Locking**: The locking mechanism was based on the application name, not the repository URL. This created a severe race condition in monorepo setups where concurrent tasks for different apps would corrupt the same git checkout.
- **Fragile Error Handling**: It did not handle `non-fast-forward` push errors. If the remote branch was updated between our clone and push, the operation would fail permanently, requiring manual intervention.

### What

This PR addresses these issues by overhauling the git updater logic:

- **Persistent Caching**:
    - Implemented a file-based cache for git repositories. The cache directory is configurable via the `REPO_CACHE_PATH` environment variable.
    - The cache key is a hash of the **repository URL and the branch name**, ensuring that concurrent operations on different branches of the same repository are safely isolated in separate directories.
    - On a cache hit, the updater now performs a fast `git fetch` and `git reset --hard` instead of a full clone.
    - The initial clone is now a `--single-branch` clone, making it much faster and more efficient.

- **Repository-Based Locking**:
    - The distributed lock is now acquired using the repository URL and branch name as the key. This correctly serializes all operations on a specific branch, making the system safe for monorepos and high-concurrency environments.

- **Robust Error Handling**:
    - The system now correctly detects `non-fast-forward` push errors.
    - When this error occurs, it triggers a recovery routine: the local cache for that specific branch is deleted, the repository is re-cloned to get a fresh state, and the change is re-applied and pushed a second time. This automatically resolves conflicts caused by a stale local state.

- **Bug Fixes & Refactoring**:
    - Corrected several bugs that were discovered during implementation, including a nil pointer dereference from using the wrong `go-git` clone function and a faulty hashing implementation.
    - Refactored the call chain to pass the `GitopsRepo` object down, avoiding redundant object creation and cleaning up the code.

Closes #219