### PR TITLE
fix: in-memory ui glitch + version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/shini4i/argo-watcher/cmd/argo-watcher/server.version={{.Version}}
+      - -s -w -X github.com/shini4i/argo-watcher/internal/server.version={{.Version}}
     goos:
       - linux
     goarch:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
       CGO_ENABLED: 0
     cmds:
       - echo "===> Building the project"
-      - go build -ldflags="-s -w -X github.com/shini4i/argo-watcher/cmd/argo-watcher/server.version=local" -o argo-watcher ./cmd/argo-watcher
+      - go build -ldflags="-s -w -X github.com/shini4i/argo-watcher/internal/server.version=local" -o argo-watcher ./cmd/argo-watcher
       - echo "===> Done"
     sources:
       - cmd/argo-watcher/**/*.go

--- a/web/src/data/dataProvider.test.ts
+++ b/web/src/data/dataProvider.test.ts
@@ -154,7 +154,8 @@ describe('dataProvider', () => {
     expect(params.get('to_timestamp')).toBe(String(nowSeconds));
   });
 
-  it('throws HttpError when backend responds with error payload', async () => {
+  it('returns an empty list when backend reports a soft error alongside no tasks', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     mockFetch().mockResolvedValue(
       jsonResponse({
         tasks: [],
@@ -162,7 +163,35 @@ describe('dataProvider', () => {
       }),
     );
 
-    await expect(dataProvider.getList('tasks', createListParams())).rejects.toThrow(HttpError);
+    const result = await dataProvider.getList('tasks', createListParams());
+
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('argocd is unavailable'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('still returns tasks when backend reports a soft error alongside results', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockFetch().mockResolvedValue(
+      jsonResponse({
+        tasks: [
+          { id: '1', created: 1, updated: 1, app: 'demo', author: 'alice', project: 'proj', images: [] },
+          { id: '2', created: 2, updated: 2, app: 'demo', author: 'bob', project: 'proj', images: [] },
+        ],
+        total: 2,
+        error: 'argocd is unavailable',
+      }),
+    );
+
+    const result = await dataProvider.getList('tasks', createListParams());
+
+    expect(result.data).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('argocd is unavailable'));
+
+    warnSpy.mockRestore();
   });
 
   it('retrieves a single task status', async () => {

--- a/web/src/data/dataProvider.ts
+++ b/web/src/data/dataProvider.ts
@@ -105,6 +105,14 @@ const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
 
   const { data } = await httpClient<TasksResponse>(`/api/v1/${RESOURCE_TASKS}${query}`);
   const response = data ?? { tasks: [], total: 0 };
+
+  // Backend returns HTTP 200 with a non-empty `error` field when ArgoCD is unreachable.
+  // Treat it as an empty result rather than rejecting, so the empty-state placeholder
+  // can render instead of leaving the Datagrid in its loading skeleton forever.
+  if (response.error) {
+    console.warn(`Tasks endpoint reported a soft error: ${String(response.error).slice(0, 200)}`);
+  }
+
   return toRaListResult(response, params);
 };
 

--- a/web/src/data/httpClient.test.ts
+++ b/web/src/data/httpClient.test.ts
@@ -115,6 +115,19 @@ describe('httpClient', () => {
     await expect(httpClient('/status')).rejects.toThrow('Failed to parse server response');
   });
 
+  it('does not throw on 2xx responses that carry an error field', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ status: 'degraded', error: 'argocd is unavailable' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await httpClient<{ status: string; error: string }>('/status');
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ status: 'degraded', error: 'argocd is unavailable' });
+  });
+
   it('prefers descriptive fields when building HttpErrors', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ status: 'custom-status' }), {

--- a/web/src/data/httpClient.ts
+++ b/web/src/data/httpClient.ts
@@ -128,10 +128,6 @@ export const httpClient = async <T>(path: string, options: HttpClientOptions = {
     throw buildHttpError(response.status, data, response.statusText);
   }
 
-  if (data && typeof data === 'object' && 'error' in data && data.error) {
-    throw buildHttpError(response.status, data, response.statusText);
-  }
-
   return {
     data,
     status: response.status,


### PR DESCRIPTION
## Summary

Two independent bugs surfaced when running a fresh in-memory setup:

1. **Tasks table never finishes loading** — the React Admin Datagrid stays
   in its skeleton placeholder state indefinitely instead of rendering the
   "No recent tasks so far…" empty-state.
2. **Version chip in the top bar always shows `local`** — even on tagged
   release builds produced by goreleaser.

Both have been root-caused and fixed in two atomic commits.

## Bug #1 — Build: version stuck at `local`

### Root cause

The `version` package-level variable was relocated from
`cmd/argo-watcher/server` to `internal/server` in PR #418
("refactor: simplify Go backend", commit `28b3621`), but neither
`Taskfile.yml` nor `.goreleaser.yaml` were updated. The `-X` ldflag silently
no-ops when the target symbol does not exist, so every binary — including
goreleaser-produced releases — kept the literal default `"local"` baked in
at `internal/server/router.go:30`.

### Fix

Updated both build configs to point at the correct package path:

```diff
- -X github.com/shini4i/argo-watcher/cmd/argo-watcher/server.version=...
+ -X github.com/shini4i/argo-watcher/internal/server.version=...
```

Verified with a local build: the override string now appears in the binary
via `strings`.

## Bug #2 — Frontend: tasks table stuck in skeleton state

### Root cause

When ArgoCD is unreachable, `Argo.Check()`
(`internal/argocd/argo.go:43`) fails, and `GetTasks`
(`internal/argocd/argo.go:99-105`) returns HTTP `200 OK` with body:

```json
{ "tasks": [], "error": "<argo unreachable>", "total": 0 }
```

The frontend `httpClient` had a blanket guard that threw `HttpError` on
any 2xx response carrying a non-empty `error` field. Combined with the
30-second auto-refresh, this kept the React Admin Datagrid permanently
in its loading-skeleton state — the empty-state placeholder
(`NoTasksPlaceholder`) never got a chance to render.

### Fix

- **`web/src/data/httpClient.ts`** — removed the redundant 200-OK +
  `error`-field auto-throw. Callers that need application-level error
  handling (`getOne`, `createTask`) already do their own explicit checks.
- **`web/src/data/dataProvider.ts`** — `getList` now logs a `console.warn`
  when the backend returns a soft error, but still passes through the
  (typically empty) tasks/total payload so React Admin can render the
  empty-state placeholder. The error string is truncated to 200 chars
  before logging to avoid polluting devtools with untrusted backend output.
- **Regression tests** added in both `httpClient.test.ts` and
  `dataProvider.test.ts` covering: 2xx responses with `error` fields no
  longer throw; soft errors are logged regardless of whether tasks are
  returned alongside them.

## Changes

| File | Change |
|------|--------|
| `Taskfile.yml` | Corrected ldflag package path |
| `.goreleaser.yaml` | Corrected ldflag package path |
| `web/src/data/httpClient.ts` | Dropped 200-OK + error-field auto-throw |
| `web/src/data/dataProvider.ts` | Log + truncate soft errors, return empty list |
| `web/src/data/dataProvider.test.ts` | Updated/added soft-error tests |
| `web/src/data/httpClient.test.ts` | Added 2xx + error-field regression test |

```
 .goreleaser.yaml                  |  2 +-
 Taskfile.yml                      |  2 +-
 web/src/data/dataProvider.test.ts | 33 ++++++++++++++++++++++++++++++--
 web/src/data/dataProvider.ts      |  8 ++++++++
 web/src/data/httpClient.test.ts   | 13 +++++++++++++
 web/src/data/httpClient.ts        |  4 ----
 6 files changed, 54 insertions(+), 8 deletions(-)
```

## Validation

- All 156 frontend tests pass (`npx vitest run`).
- Code review: clean (no blockers, all four reviewer questions resolved).
- Security scan: one MEDIUM finding addressed (error-string truncation).
- Documentation: no updates required (no docs reference ldflag paths or
  the removed httpClient branch).
- Local build verified the new ldflag path actually overrides the
  `version` symbol.