### PR TITLE
fix(argocd): report real rollout status on deployment timeout

### DIFF
--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -25,6 +25,10 @@ const (
 	legacyRetryIntervals = 15
 )
 
+// errForceRetry is an internal sentinel used to keep retry-go polling while the rollout has not reached a final state.
+// It must never reach the user-visible task status — WaitRollout swallows it so the caller can report the actual rollout state instead.
+var errForceRetry = errors.New("force retry")
+
 // DeploymentMonitor encapsulates the logic for tracking ArgoCD application rollouts.
 type DeploymentMonitor struct {
 	argo             Argo
@@ -107,6 +111,12 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 
 		return checkRolloutStatus(task, application, monitor.registryProxyUrl, monitor.acceptSuspended)
 	}, retryOptions...)
+
+	// Once the retry budget is exhausted while still polling, surface the last-fetched application instead of the
+	// internal sentinel so the caller can report the real rollout status (e.g. "not synced", "not healthy") to the user.
+	if errors.Is(err, errForceRetry) && application != nil {
+		err = nil
+	}
 
 	return application, err
 }
@@ -392,7 +402,7 @@ func checkRolloutStatus(task models.Task, application *models.Application, regis
 	default:
 		log.Debug().Str("id", task.Id).Msgf("Application status is not final. Status received \"%s\"", status)
 	}
-	return errors.New("force retry")
+	return errForceRetry
 }
 
 // determineFailureStatus converts API errors into appropriate status messages

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -265,7 +265,12 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: force retry")
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
+			"Application deployment failed. Rollout status is not available\n\n"+
+				"List of current images (last app check):\n"+
+				"\ttest-registry/ghcr.io/shini4i/argo-watcher:dev\n\n"+
+				"List of expected images:\n"+
+				"\tghcr.io/shini4i/argo-watcher:dev")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -396,7 +401,12 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: force retry")
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
+			"Application deployment failed. Rollout status is not available\n\n"+
+				"List of current images (last app check):\n"+
+				"\ttest-image:v0.0.1\n\n"+
+				"List of expected images:\n"+
+				"\tghcr.io/shini4i/argo-watcher:dev")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -441,7 +451,12 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: force retry")
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
+			"Application deployment failed. Rollout status is not synced\n\n"+
+				"App status \"NotWorking\"\n"+
+				"App message \"Not working test app\"\n"+
+				"Resources:\n"+
+				"\t")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -484,7 +499,12 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: force retry")
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
+			"Application deployment failed. Rollout status is not healthy\n\n"+
+				"App sync status \"Synced\"\n"+
+				"App health status \"NotHealthy\"\n"+
+				"Resources:\n"+
+				"\t")
 
 		// run the rollout
 		updater.WaitForRollout(task)


### PR DESCRIPTION
The internal "force retry" sentinel returned by checkRolloutStatus to keep retry-go polling was leaking into the user-visible task status as "ArgoCD API Error: force retry" once retries exhausted. Promote it to a typed errForceRetry sentinel and swallow it in WaitRollout when the last-fetched application is available, so the caller falls through to ProcessDeploymentResult and reports the actual rollout state via GetRolloutMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting during rollout status monitoring to display detailed information about rollout states, including current versus expected configurations, synchronization and health statuses, and resource details, rather than generic retry messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->