### PR TITLE
fix(updater): broaden push-race error detection

### DIFF
--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/pkg/updater"
 )
 
 const (
@@ -270,7 +271,7 @@ func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task model
 }
 
 func (gitUpdater *GitUpdater) updateGitRepo(app *models.Application, task *models.Task, gitopsRepo *models.GitopsRepo) error {
-	err := app.UpdateGitImageTag(task, gitopsRepo)
+	err := app.UpdateGitImageTag(task, gitopsRepo, updater.GitClient{})
 	if err != nil {
 		log.Error().Str("id", task.Id).Msgf("Failed to update git repo. Error: %s", err.Error())
 		return err

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -250,7 +250,9 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 	return &overrideFileContent, nil
 }
 
-func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo) error {
+// UpdateGitImageTag writes the new image tag for app into the GitOps repository.
+// gitHandler is injected to enable testing; production callers pass updater.GitClient{}.
+func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo, gitHandler updater.GitHandler) error {
 	if gitopsRepo.Path == "" {
 		log.Warn().Str("id", task.Id).Msgf("No path found for app %s, unsupported Application configuration", app.Metadata.Name)
 		return nil
@@ -266,7 +268,7 @@ func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo) er
 		return nil
 	}
 
-	git, err := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, gitopsRepo.RepoCachePath, updater.GitClient{})
+	git, err := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, gitopsRepo.RepoCachePath, gitHandler)
 	if err != nil {
 		log.Error().Str("id", task.Id).Msgf("Failed to create git repo instance for %s: %s", gitopsRepo.RepoUrl, err)
 		return err
@@ -279,16 +281,20 @@ func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo) er
 	}
 
 	if err := git.UpdateApp(app.Metadata.Name, releaseOverrides, task); err != nil {
-		if strings.Contains(err.Error(), "non-fast-forward") {
-			// Recovery Path
-			log.Warn().Str("id", task.Id).Msg("Non-fast-forward update detected. Re-cloning repository and retrying.")
+		if updater.IsPushRaceError(err) {
+			// Recovery Path: another writer pushed between our fetch and push.
+			// Single retry is intentional — a second race is rare enough that
+			// the next scheduled invocation will handle it.
+			log.Warn().Err(err).Str("id", task.Id).Msg("Push race detected. Re-cloning repository and retrying.")
 
 			if err := git.NukeAndReclone(); err != nil {
 				return fmt.Errorf("failed to nuke and re-clone: %w", err)
 			}
 
-			// Re-apply changes and push again
-			return git.UpdateApp(app.Metadata.Name, releaseOverrides, task)
+			if err := git.UpdateApp(app.Metadata.Name, releaseOverrides, task); err != nil {
+				return fmt.Errorf("push retry after race recovery failed: %w", err)
+			}
+			return nil
 		}
 		// Other unrecoverable error
 		return err

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -2,10 +2,14 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 
+	"github.com/shini4i/argo-watcher/pkg/updater"
+	updatrmock "github.com/shini4i/argo-watcher/pkg/updater/mock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestListSyncResultResources(t *testing.T) {
@@ -433,13 +437,36 @@ func TestIsFireAndForgetModeActive(t *testing.T) {
 	}
 }
 
+// newAppWithImages builds an Application with managed-image annotations for testing.
+func newAppWithImages(name string) *Application {
+	return &Application{
+		Metadata: ApplicationMetadata{
+			Name: name,
+			Annotations: map[string]string{
+				"argo-watcher/managed-images":     "app=myimage",
+				"argo-watcher/app.helm.image-tag": "image.tag",
+			},
+		},
+	}
+}
+
+// newImageTask builds a Task with a single image for testing.
+func newImageTask() *Task {
+	return &Task{
+		Id: "test-id",
+		Images: []Image{
+			{Image: "myimage", Tag: "v1.0.0"},
+		},
+	}
+}
+
 func TestUpdateGitImageTag(t *testing.T) {
 	t.Run("Returns nil when path is empty", func(t *testing.T) {
 		app := &Application{}
 		task := &Task{Id: "test-id"}
 		gitopsRepo := &GitopsRepo{Path: ""}
 
-		err := app.UpdateGitImageTag(task, gitopsRepo)
+		err := app.UpdateGitImageTag(task, gitopsRepo, nil)
 		assert.NoError(t, err)
 	})
 
@@ -453,43 +480,39 @@ func TestUpdateGitImageTag(t *testing.T) {
 		task := &Task{Id: "test-id"}
 		gitopsRepo := &GitopsRepo{Path: "/some/path"}
 
-		err := app.UpdateGitImageTag(task, gitopsRepo)
+		err := app.UpdateGitImageTag(task, gitopsRepo, nil)
 		assert.NoError(t, err)
 	})
 
-	t.Run("Returns error when NewGitRepo fails", func(t *testing.T) {
-		// Ensure SSH_KEY_PATH is not set so NewGitRepo fails
-		originalSSHKeyPath, wasSet := os.LookupEnv("SSH_KEY_PATH")
+	t.Run("Returns error when NewGitRepo fails (no SSH_KEY_PATH)", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "")
+		// caarlos0/env treats empty-string the same as unset for required fields.
 		os.Unsetenv("SSH_KEY_PATH")
-		defer func() {
-			if wasSet {
-				os.Setenv("SSH_KEY_PATH", originalSSHKeyPath)
-			}
-		}()
 
-		app := &Application{
-			Metadata: ApplicationMetadata{
-				Name: "test-app",
-				Annotations: map[string]string{
-					"argo-watcher/managed-images":         "app=myimage",
-					"argo-watcher/app.helm.image-tag":     "image.tag",
-				},
-			},
-		}
-		task := &Task{
-			Id: "test-id",
-			Images: []Image{
-				{Image: "myimage", Tag: "v1.0.0"},
-			},
-		}
-		gitopsRepo := &GitopsRepo{
-			RepoUrl:    "git@github.com:test/repo.git",
-			BranchName: "main",
-			Path:       "/some/path",
-		}
-
-		err := app.UpdateGitImageTag(task, gitopsRepo)
+		err := newAppWithImages("test-app").UpdateGitImageTag(
+			newImageTask(),
+			&GitopsRepo{RepoUrl: "git@github.com:test/repo.git", BranchName: "main", Path: "/some/path"},
+			updater.GitClient{},
+		)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load git config")
+	})
+
+	t.Run("Returns error when Clone fails", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/dev/null")
+
+		ctrl := gomock.NewController(t)
+		mockHandler := updatrmock.NewMockGitHandler(ctrl)
+		mockHandler.EXPECT().
+			AddSSHKey(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("SSH key load failed"))
+
+		err := newAppWithImages("test-app").UpdateGitImageTag(
+			newImageTask(),
+			&GitopsRepo{RepoUrl: "git@github.com:test/repo.git", BranchName: "main", Path: "/some/path", RepoCachePath: t.TempDir()},
+			mockHandler,
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "SSH key load failed")
 	})
 }

--- a/pkg/updater/errors.go
+++ b/pkg/updater/errors.go
@@ -1,0 +1,44 @@
+package updater
+
+import "strings"
+
+// pushRaceMarkers are lowercase substrings that different Git servers and
+// protocol layers use to report the same underlying condition: a push was
+// rejected because the expected old value of the target ref no longer matches
+// the remote tip (i.e., another writer advanced the branch between our fetch
+// and our push). Matching is done case-insensitively to guard against servers
+// that capitalise differently.
+//
+// NOTE: go-git's push path uses fmt.Errorf (not %w) for these messages, so
+// errors.Is against go-git sentinels does not work here — substring matching
+// is intentional.
+var pushRaceMarkers = []string{
+	// go-git, when talking to a go-git bare remote.
+	"non-fast-forward",
+	// Gitea / Forgejo receive-pack wording.
+	"incorrect old value",
+	// GitHub / GitLab / vanilla git receive-pack wordings.
+	// "(fetch first)" matches the rejection line "! [rejected] main -> main (fetch first)"
+	// and avoids false-positives on unrelated messages like "fetch first reference from remote".
+	"stale info",
+	"(fetch first)",
+	// git receive-pack when two concurrent pushes race on the ref lock file.
+	"cannot lock ref",
+}
+
+// IsPushRaceError reports whether err describes a push rejected by the remote
+// because the target ref advanced between our fetch and our push. When true,
+// the safe recovery is to discard the local cache, re-clone, re-apply the
+// change on top of the new tip, and retry the push.
+func IsPushRaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range pushRaceMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/updater/errors_test.go
+++ b/pkg/updater/errors_test.go
@@ -1,0 +1,67 @@
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPushRaceError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Negative cases
+		{"nil", nil, false},
+		{"unrelated error", errors.New("connection refused"), false},
+		{"empty message", errors.New(""), false},
+		// Ensure we don't false-positive on prose that incidentally contains
+		// a marker word in a non-race context.
+		{"false positive guard - fetch first in prose", errors.New("could not fetch first reference from remote"), false},
+
+		// go-git's own wording when the remote rejects a non-FF push.
+		{"go-git non-fast-forward", errors.New("non-fast-forward update: refs/heads/main"), true},
+
+		// Wording reported by Gitea / Forgejo server-side receive hooks.
+		{"gitea incorrect old value", errors.New("command error on refs/heads/master: incorrect old value provided"), true},
+
+		// Common receive-pack wordings from GitHub / GitLab / vanilla git.
+		{"stale info", errors.New("failed to push some refs: ! [rejected] main -> main (stale info)"), true},
+		{"fetch first - rejection line", errors.New("! [rejected] main -> main (fetch first)"), true},
+
+		// git receive-pack concurrent ref-lock collision.
+		{"cannot lock ref", errors.New("remote: error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456"), true},
+
+		// Capitalised variants (some transports uppercase the first word).
+		{"capitalised stale info", errors.New("Stale info: refs/heads/main"), true},
+		{"capitalised fetch first - rejection line", errors.New("! [rejected] main -> main (Fetch first)"), true},
+
+		// Wrapped errors must still be detected.
+		{"wrapped non-fast-forward", fmt.Errorf("push failed: %w", errors.New("non-fast-forward update")), true},
+		{"wrapped incorrect old value", fmt.Errorf("push failed: %w", errors.New("incorrect old value provided")), true},
+
+		// errors.Join concatenates messages with newlines; marker must still be found.
+		{"joined errors", errors.Join(errors.New("unrelated"), errors.New("non-fast-forward update")), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsPushRaceError(tc.err))
+		})
+	}
+}
+
+func TestPushRaceMarkersNotEmpty(t *testing.T) {
+	assert.NotEmpty(t, pushRaceMarkers, "pushRaceMarkers must not be empty or IsPushRaceError will never trigger")
+}
+
+func TestPushRaceMarkersAreLowercase(t *testing.T) {
+	for _, marker := range pushRaceMarkers {
+		assert.Equal(t, strings.ToLower(marker), marker,
+			"marker %q must be lowercase — IsPushRaceError lowercases the haystack, not the needles", marker)
+	}
+}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -299,7 +299,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 
 		err = repo.UpdateApp("my-app", newParams, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "non-fast-forward update")
+		assert.True(t, IsPushRaceError(err), "expected a push race error, got: %v", err)
 	})
 }
 


### PR DESCRIPTION
The recovery path in UpdateGitImageTag previously matched only the substring "non-fast-forward", which is go-git's own wording when pushing to a go-git bare remote. Real git servers (Gitea/Forgejo, GitHub, GitLab) produce different phrases for the same condition — e.g. "incorrect old value provided" or "stale info" — causing the NukeAndReclone retry to be silently bypassed and the error to surface as a hard failure.

Adds IsPushRaceError helper in pkg/updater that recognises all known variants via case-insensitive substring matching and replaces the single-string check at the call site.

Also injects GitHandler into UpdateGitImageTag to enable future unit testing of the recovery path, fixes env-var cleanup in the existing test, and improves the retry error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and recovery from concurrent Git push failures, including automatic retry logic to prevent sync failures during high-concurrency scenarios.

* **Tests**
  * Added comprehensive test coverage for push race condition handling and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shini4i/argo-watcher/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->