### PR TITLE
feat(updater): allow extra push-race markers via EXTRA_PUSH_RACE_MARKERS

### DIFF
--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -70,3 +70,4 @@ These variables are required when using the built-in GitOps updater. See the [Gi
 | `SSH_COMMIT_MAIL`     | Git commit author email                                 | `argo-watcher@example.com` | No          |
 | `COMMIT_MESSAGE_FORMAT` | Go template string for commit messages                |         | No          |
 | `GIT_TIMEOUT`         | Total wall-clock budget per task for the git update flow (clone + commit + push + race recovery). Accepts a Go duration string (e.g. `30s`, `5m`). Must be greater than zero. | `3m` | No |
+| `EXTRA_PUSH_RACE_MARKERS` | Comma-separated substrings appended to the built-in push-race detection list. Use to handle a newly-observed server wording without a binary rebuild — for example, `EXTRA_PUSH_RACE_MARKERS="change conflicts,server panic"`. Matched case-insensitively. Additive only; built-in markers cannot be disabled. |         | No          |

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -70,4 +70,4 @@ These variables are required when using the built-in GitOps updater. See the [Gi
 | `SSH_COMMIT_MAIL`     | Git commit author email                                 | `argo-watcher@example.com` | No          |
 | `COMMIT_MESSAGE_FORMAT` | Go template string for commit messages                |         | No          |
 | `GIT_TIMEOUT`         | Total wall-clock budget per task for the git update flow (clone + commit + push + race recovery). Accepts a Go duration string (e.g. `30s`, `5m`). Must be greater than zero. | `3m` | No |
-| `EXTRA_PUSH_RACE_MARKERS` | Comma-separated substrings appended to the built-in push-race detection list. Use to handle a newly-observed server wording without a binary rebuild — for example, `EXTRA_PUSH_RACE_MARKERS="change conflicts,server panic"`. Matched case-insensitively. Additive only; built-in markers cannot be disabled. |         | No          |
+| `EXTRA_PUSH_RACE_MARKERS` | Comma-separated substrings appended to the built-in push-race detection list. Matched case-insensitively. Additive only — built-in markers cannot be disabled. Example: `"change conflicts,server panic"`. |         | No          |

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -290,7 +290,7 @@ func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo, gi
 	}
 
 	if err := repo.UpdateApp(ctx, app.Metadata.Name, releaseOverrides, task); err != nil {
-		if updater.IsPushRaceError(err, repo.ExtraPushRaceMarkers()) {
+		if repo.IsPushRaceError(err) {
 			// Recovery Path: another writer pushed between our fetch and push.
 			// Calling Clone() re-runs fetch + hard reset to the new remote tip,
 			// which intentionally discards the local in-progress commit — the

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -290,7 +290,7 @@ func (app *Application) UpdateGitImageTag(task *Task, gitopsRepo *GitopsRepo, gi
 	}
 
 	if err := repo.UpdateApp(ctx, app.Metadata.Name, releaseOverrides, task); err != nil {
-		if updater.IsPushRaceError(err) {
+		if updater.IsPushRaceError(err, repo.ExtraPushRaceMarkers()) {
 			// Recovery Path: another writer pushed between our fetch and push.
 			// Calling Clone() re-runs fetch + hard reset to the new remote tip,
 			// which intentionally discards the local in-progress commit — the

--- a/pkg/updater/config.go
+++ b/pkg/updater/config.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	envConfig "github.com/caarlos0/env/v11"
@@ -20,7 +21,13 @@ type GitConfig struct {
 	// wall-clock budget, not a per-operation timeout — this guarantees one task
 	// cannot hold the per-repo lock for longer than this duration, so the
 	// deployment queue cannot be wedged by a slow or hung remote.
-	GitTimeout          time.Duration `env:"GIT_TIMEOUT" envDefault:"3m"`
+	GitTimeout time.Duration `env:"GIT_TIMEOUT" envDefault:"3m"`
+	// ExtraPushRaceMarkers are operator-supplied substrings appended to the
+	// built-in pushRaceMarkers list. Comma-separated in the env var; trimmed
+	// and lowercased at parse time so IsPushRaceError's case-insensitive
+	// substring match works without per-call normalization. Additive only —
+	// the built-in list cannot be replaced or disabled from configuration.
+	ExtraPushRaceMarkers []string `env:"EXTRA_PUSH_RACE_MARKERS" envSeparator:","`
 }
 
 func NewGitConfig() (*GitConfig, error) {
@@ -31,5 +38,22 @@ func NewGitConfig() (*GitConfig, error) {
 	if config.GitTimeout <= 0 {
 		return nil, fmt.Errorf("GIT_TIMEOUT must be > 0, got %s", config.GitTimeout)
 	}
+	config.ExtraPushRaceMarkers = normalizeMarkers(config.ExtraPushRaceMarkers)
 	return &config, nil
+}
+
+// normalizeMarkers lowercases, trims, and drops empty entries from the input.
+// IsPushRaceError lowercases the error message but not the markers, so the
+// markers must be lowercased at load time. Empty entries (e.g. from a trailing
+// comma) would match every error, so they are filtered out.
+func normalizeMarkers(in []string) []string {
+	out := in[:0]
+	for _, m := range in {
+		m = strings.ToLower(strings.TrimSpace(m))
+		if m == "" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }

--- a/pkg/updater/config.go
+++ b/pkg/updater/config.go
@@ -47,7 +47,7 @@ func NewGitConfig() (*GitConfig, error) {
 // markers must be lowercased at load time. Empty entries (e.g. from a trailing
 // comma) would match every error, so they are filtered out.
 func normalizeMarkers(in []string) []string {
-	out := in[:0]
+	out := make([]string, 0, len(in))
 	for _, m := range in {
 		m = strings.ToLower(strings.TrimSpace(m))
 		if m == "" {

--- a/pkg/updater/config_test.go
+++ b/pkg/updater/config_test.go
@@ -98,4 +98,35 @@ func TestNewGitConfig(t *testing.T) {
 		assert.Nil(t, config)
 		assert.Contains(t, err.Error(), "GIT_TIMEOUT")
 	})
+
+	t.Run("ExtraPushRaceMarkers - unset defaults to empty", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/test/key")
+
+		config, err := NewGitConfig()
+
+		require.NoError(t, err)
+		assert.Empty(t, config.ExtraPushRaceMarkers)
+	})
+
+	t.Run("ExtraPushRaceMarkers - normalized (lowercase, trimmed, empties dropped)", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/test/key")
+		// Mixed casing, leading/trailing whitespace, and a trailing comma that
+		// produces an empty entry — all must be normalized away.
+		t.Setenv("EXTRA_PUSH_RACE_MARKERS", "Foo,  BAR  ,,baz")
+
+		config, err := NewGitConfig()
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz"}, config.ExtraPushRaceMarkers)
+	})
+
+	t.Run("ExtraPushRaceMarkers - single value", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/test/key")
+		t.Setenv("EXTRA_PUSH_RACE_MARKERS", "change conflicts")
+
+		config, err := NewGitConfig()
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"change conflicts"}, config.ExtraPushRaceMarkers)
+	})
 }

--- a/pkg/updater/config_test.go
+++ b/pkg/updater/config_test.go
@@ -129,4 +129,16 @@ func TestNewGitConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"change conflicts"}, config.ExtraPushRaceMarkers)
 	})
+
+	t.Run("ExtraPushRaceMarkers - empty value yields empty slice", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/test/key")
+		// EXTRA_PUSH_RACE_MARKERS explicitly set to empty: caarlos0/env may
+		// produce a single empty entry, which normalizeMarkers must drop.
+		t.Setenv("EXTRA_PUSH_RACE_MARKERS", "")
+
+		config, err := NewGitConfig()
+
+		require.NoError(t, err)
+		assert.Empty(t, config.ExtraPushRaceMarkers)
+	})
 }

--- a/pkg/updater/errors.go
+++ b/pkg/updater/errors.go
@@ -37,8 +37,9 @@ var pushRaceMarkers = []string{
 // the safe recovery is to refresh the cache via fetch + reset (Clone on an
 // existing cache), re-apply the change on top of the new tip, and retry the push.
 //
-// This checks only the built-in marker list. To also consult operator-supplied
-// extras from EXTRA_PUSH_RACE_MARKERS, call (*GitRepo).IsPushRaceError instead.
+// This checks only the built-in marker list. If you have a *GitRepo, call
+// repo.IsPushRaceError instead to also include any EXTRA_PUSH_RACE_MARKERS
+// configured at startup.
 func IsPushRaceError(err error) bool {
 	return matchPushRaceMarkers(err, nil)
 }

--- a/pkg/updater/errors.go
+++ b/pkg/updater/errors.go
@@ -37,12 +37,16 @@ var pushRaceMarkers = []string{
 // the safe recovery is to refresh the cache via fetch + reset (Clone on an
 // existing cache), re-apply the change on top of the new tip, and retry the push.
 //
-// extra is an optional list of additional lowercased substrings supplied by
-// operators (via EXTRA_PUSH_RACE_MARKERS) to handle new server wordings without
-// rebuilding the binary. Extras extend the built-in list — they cannot replace
-// or disable it. Callers are expected to lowercase and trim entries before
-// passing them in (see NewGitConfig).
-func IsPushRaceError(err error, extra []string) bool {
+// This checks only the built-in marker list. To also consult operator-supplied
+// extras from EXTRA_PUSH_RACE_MARKERS, call (*GitRepo).IsPushRaceError instead.
+func IsPushRaceError(err error) bool {
+	return matchPushRaceMarkers(err, nil)
+}
+
+// matchPushRaceMarkers returns true when err's message contains any built-in
+// marker or any entry in extra. Callers must pass extras already lowercased
+// (see normalizeMarkers); the message is lowercased here.
+func matchPushRaceMarkers(err error, extra []string) bool {
 	if err == nil {
 		return false
 	}

--- a/pkg/updater/errors.go
+++ b/pkg/updater/errors.go
@@ -36,12 +36,26 @@ var pushRaceMarkers = []string{
 // because the target ref advanced between our fetch and our push. When true,
 // the safe recovery is to refresh the cache via fetch + reset (Clone on an
 // existing cache), re-apply the change on top of the new tip, and retry the push.
-func IsPushRaceError(err error) bool {
+//
+// extra is an optional list of additional lowercased substrings supplied by
+// operators (via EXTRA_PUSH_RACE_MARKERS) to handle new server wordings without
+// rebuilding the binary. Extras extend the built-in list — they cannot replace
+// or disable it. Callers are expected to lowercase and trim entries before
+// passing them in (see NewGitConfig).
+func IsPushRaceError(err error, extra []string) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
 	for _, marker := range pushRaceMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	for _, marker := range extra {
+		if marker == "" {
+			continue
+		}
 		if strings.Contains(msg, marker) {
 			return true
 		}

--- a/pkg/updater/errors_test.go
+++ b/pkg/updater/errors_test.go
@@ -11,52 +11,61 @@ import (
 
 func TestIsPushRaceError(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		want bool
+		name  string
+		err   error
+		extra []string
+		want  bool
 	}{
 		// Negative cases
-		{"nil", nil, false},
-		{"unrelated error", errors.New("connection refused"), false},
-		{"empty message", errors.New(""), false},
+		{"nil", nil, nil, false},
+		{"unrelated error", errors.New("connection refused"), nil, false},
+		{"empty message", errors.New(""), nil, false},
 		// Ensure we don't false-positive on prose that incidentally contains
 		// a marker word in a non-race context.
-		{"false positive guard - fetch first in prose", errors.New("could not fetch first reference from remote"), false},
+		{"false positive guard - fetch first in prose", errors.New("could not fetch first reference from remote"), nil, false},
 
 		// go-git's own wording when the remote rejects a non-FF push.
-		{"go-git non-fast-forward", errors.New("non-fast-forward update: refs/heads/main"), true},
+		{"go-git non-fast-forward", errors.New("non-fast-forward update: refs/heads/main"), nil, true},
 
 		// Verbatim string captured from argo-watcher's failure UI in the user's
 		// GitLab-backed prod (pre-recovery-fix). Pin it so a future cleanup that
 		// narrows pushRaceMarkers fails loudly.
-		{"gitlab prod-observed (verbatim)", errors.New("command error on refs/heads/master: incorrect old value provided"), true},
+		{"gitlab prod-observed (verbatim)", errors.New("command error on refs/heads/master: incorrect old value provided"), nil, true},
 
 		// Common receive-pack wordings from GitHub / GitLab / vanilla git.
-		{"stale info", errors.New("failed to push some refs: ! [rejected] main -> main (stale info)"), true},
-		{"fetch first - rejection line", errors.New("! [rejected] main -> main (fetch first)"), true},
+		{"stale info", errors.New("failed to push some refs: ! [rejected] main -> main (stale info)"), nil, true},
+		{"fetch first - rejection line", errors.New("! [rejected] main -> main (fetch first)"), nil, true},
 
 		// git receive-pack concurrent ref-lock collision.
-		{"cannot lock ref", errors.New("remote: error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456"), true},
+		{"cannot lock ref", errors.New("remote: error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456"), nil, true},
 
 		// Gitea wording for a non-fast-forward push, captured from the integration
 		// test suite running against gitea/gitea:1.22 under concurrent writers.
-		{"gitea failed to update ref", errors.New("command error on refs/heads/master: failed to update ref"), true},
+		{"gitea failed to update ref", errors.New("command error on refs/heads/master: failed to update ref"), nil, true},
 
 		// Capitalised variants (some transports uppercase the first word).
-		{"capitalised stale info", errors.New("Stale info: refs/heads/main"), true},
-		{"capitalised fetch first - rejection line", errors.New("! [rejected] main -> main (Fetch first)"), true},
+		{"capitalised stale info", errors.New("Stale info: refs/heads/main"), nil, true},
+		{"capitalised fetch first - rejection line", errors.New("! [rejected] main -> main (Fetch first)"), nil, true},
 
 		// Wrapped errors must still be detected.
-		{"wrapped non-fast-forward", fmt.Errorf("push failed: %w", errors.New("non-fast-forward update")), true},
-		{"wrapped incorrect old value", fmt.Errorf("push failed: %w", errors.New("incorrect old value provided")), true},
+		{"wrapped non-fast-forward", fmt.Errorf("push failed: %w", errors.New("non-fast-forward update")), nil, true},
+		{"wrapped incorrect old value", fmt.Errorf("push failed: %w", errors.New("incorrect old value provided")), nil, true},
 
 		// errors.Join concatenates messages with newlines; marker must still be found.
-		{"joined errors", errors.Join(errors.New("unrelated"), errors.New("non-fast-forward update")), true},
+		{"joined errors", errors.Join(errors.New("unrelated"), errors.New("non-fast-forward update")), nil, true},
+
+		// Operator-supplied extra markers (e.g. a new server wording observed in prod):
+		// they extend the built-in list without replacing it.
+		{"extra marker matches", errors.New("gerrit: change conflicts with master"), []string{"change conflicts"}, true},
+		{"extra is additive — built-ins still match", errors.New("non-fast-forward update"), []string{"some unrelated marker"}, true},
+		{"empty extras behave like nil", errors.New("non-fast-forward update"), []string{}, true},
+		{"no match across built-ins or extras", errors.New("connection refused"), []string{"server panic"}, false},
+		{"extras are case-insensitive (caller normalizes)", errors.New("SERVER PANIC: refusing push"), []string{"server panic"}, true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, IsPushRaceError(tc.err))
+			assert.Equal(t, tc.want, IsPushRaceError(tc.err, tc.extra))
 		})
 	}
 }

--- a/pkg/updater/errors_test.go
+++ b/pkg/updater/errors_test.go
@@ -11,61 +11,77 @@ import (
 
 func TestIsPushRaceError(t *testing.T) {
 	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Negative cases
+		{"nil", nil, false},
+		{"unrelated error", errors.New("connection refused"), false},
+		{"empty message", errors.New(""), false},
+		// Ensure we don't false-positive on prose that incidentally contains
+		// a marker word in a non-race context.
+		{"false positive guard - fetch first in prose", errors.New("could not fetch first reference from remote"), false},
+
+		// go-git's own wording when the remote rejects a non-FF push.
+		{"go-git non-fast-forward", errors.New("non-fast-forward update: refs/heads/main"), true},
+
+		// Verbatim string captured from argo-watcher's failure UI in the user's
+		// GitLab-backed prod (pre-recovery-fix). Pin it so a future cleanup that
+		// narrows pushRaceMarkers fails loudly.
+		{"gitlab prod-observed (verbatim)", errors.New("command error on refs/heads/master: incorrect old value provided"), true},
+
+		// Common receive-pack wordings from GitHub / GitLab / vanilla git.
+		{"stale info", errors.New("failed to push some refs: ! [rejected] main -> main (stale info)"), true},
+		{"fetch first - rejection line", errors.New("! [rejected] main -> main (fetch first)"), true},
+
+		// git receive-pack concurrent ref-lock collision.
+		{"cannot lock ref", errors.New("remote: error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456"), true},
+
+		// Gitea wording for a non-fast-forward push, captured from the integration
+		// test suite running against gitea/gitea:1.22 under concurrent writers.
+		{"gitea failed to update ref", errors.New("command error on refs/heads/master: failed to update ref"), true},
+
+		// Capitalised variants (some transports uppercase the first word).
+		{"capitalised stale info", errors.New("Stale info: refs/heads/main"), true},
+		{"capitalised fetch first - rejection line", errors.New("! [rejected] main -> main (Fetch first)"), true},
+
+		// Wrapped errors must still be detected.
+		{"wrapped non-fast-forward", fmt.Errorf("push failed: %w", errors.New("non-fast-forward update")), true},
+		{"wrapped incorrect old value", fmt.Errorf("push failed: %w", errors.New("incorrect old value provided")), true},
+
+		// errors.Join concatenates messages with newlines; marker must still be found.
+		{"joined errors", errors.Join(errors.New("unrelated"), errors.New("non-fast-forward update")), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsPushRaceError(tc.err))
+		})
+	}
+}
+
+// TestMatchPushRaceMarkers_Extras covers the operator-supplied marker path used
+// by (*GitRepo).IsPushRaceError. The built-in cases are already covered above
+// (matchPushRaceMarkers with nil extras is the IsPushRaceError code path).
+func TestMatchPushRaceMarkers_Extras(t *testing.T) {
+	tests := []struct {
 		name  string
 		err   error
 		extra []string
 		want  bool
 	}{
-		// Negative cases
-		{"nil", nil, nil, false},
-		{"unrelated error", errors.New("connection refused"), nil, false},
-		{"empty message", errors.New(""), nil, false},
-		// Ensure we don't false-positive on prose that incidentally contains
-		// a marker word in a non-race context.
-		{"false positive guard - fetch first in prose", errors.New("could not fetch first reference from remote"), nil, false},
-
-		// go-git's own wording when the remote rejects a non-FF push.
-		{"go-git non-fast-forward", errors.New("non-fast-forward update: refs/heads/main"), nil, true},
-
-		// Verbatim string captured from argo-watcher's failure UI in the user's
-		// GitLab-backed prod (pre-recovery-fix). Pin it so a future cleanup that
-		// narrows pushRaceMarkers fails loudly.
-		{"gitlab prod-observed (verbatim)", errors.New("command error on refs/heads/master: incorrect old value provided"), nil, true},
-
-		// Common receive-pack wordings from GitHub / GitLab / vanilla git.
-		{"stale info", errors.New("failed to push some refs: ! [rejected] main -> main (stale info)"), nil, true},
-		{"fetch first - rejection line", errors.New("! [rejected] main -> main (fetch first)"), nil, true},
-
-		// git receive-pack concurrent ref-lock collision.
-		{"cannot lock ref", errors.New("remote: error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456"), nil, true},
-
-		// Gitea wording for a non-fast-forward push, captured from the integration
-		// test suite running against gitea/gitea:1.22 under concurrent writers.
-		{"gitea failed to update ref", errors.New("command error on refs/heads/master: failed to update ref"), nil, true},
-
-		// Capitalised variants (some transports uppercase the first word).
-		{"capitalised stale info", errors.New("Stale info: refs/heads/main"), nil, true},
-		{"capitalised fetch first - rejection line", errors.New("! [rejected] main -> main (Fetch first)"), nil, true},
-
-		// Wrapped errors must still be detected.
-		{"wrapped non-fast-forward", fmt.Errorf("push failed: %w", errors.New("non-fast-forward update")), nil, true},
-		{"wrapped incorrect old value", fmt.Errorf("push failed: %w", errors.New("incorrect old value provided")), nil, true},
-
-		// errors.Join concatenates messages with newlines; marker must still be found.
-		{"joined errors", errors.Join(errors.New("unrelated"), errors.New("non-fast-forward update")), nil, true},
-
-		// Operator-supplied extra markers (e.g. a new server wording observed in prod):
-		// they extend the built-in list without replacing it.
 		{"extra marker matches", errors.New("gerrit: change conflicts with master"), []string{"change conflicts"}, true},
 		{"extra is additive — built-ins still match", errors.New("non-fast-forward update"), []string{"some unrelated marker"}, true},
 		{"empty extras behave like nil", errors.New("non-fast-forward update"), []string{}, true},
 		{"no match across built-ins or extras", errors.New("connection refused"), []string{"server panic"}, false},
 		{"extras are case-insensitive (caller normalizes)", errors.New("SERVER PANIC: refusing push"), []string{"server panic"}, true},
+		{"empty entries in extras are ignored", errors.New("connection refused"), []string{"", ""}, false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, IsPushRaceError(tc.err, tc.extra))
+			assert.Equal(t, tc.want, matchPushRaceMarkers(tc.err, tc.extra))
 		})
 	}
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -363,10 +363,11 @@ func (repo *GitRepo) GitTimeout() time.Duration {
 	return repo.gitConfig.GitTimeout
 }
 
-// ExtraPushRaceMarkers returns the operator-supplied additional push-race
-// markers (already normalized to lowercase). Callers pass these into
-// IsPushRaceError so a newly-observed server wording can be handled via
-// EXTRA_PUSH_RACE_MARKERS without a binary rebuild.
-func (repo *GitRepo) ExtraPushRaceMarkers() []string {
-	return repo.gitConfig.ExtraPushRaceMarkers
+// IsPushRaceError reports whether err is a push-race error, consulting both
+// the built-in marker list and any operator-supplied extras from
+// EXTRA_PUSH_RACE_MARKERS. Use this on a constructed GitRepo so newly-observed
+// server wordings can be handled by config change instead of a binary rebuild.
+// The free-function updater.IsPushRaceError checks only the built-in list.
+func (repo *GitRepo) IsPushRaceError(err error) bool {
+	return matchPushRaceMarkers(err, repo.gitConfig.ExtraPushRaceMarkers)
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -362,3 +362,11 @@ func NewGitRepo(repoURL, branchName, path, fileName, repoCachePath string, gitHa
 func (repo *GitRepo) GitTimeout() time.Duration {
 	return repo.gitConfig.GitTimeout
 }
+
+// ExtraPushRaceMarkers returns the operator-supplied additional push-race
+// markers (already normalized to lowercase). Callers pass these into
+// IsPushRaceError so a newly-observed server wording can be handled via
+// EXTRA_PUSH_RACE_MARKERS without a binary rebuild.
+func (repo *GitRepo) ExtraPushRaceMarkers() []string {
+	return repo.gitConfig.ExtraPushRaceMarkers
+}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -284,7 +284,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 		err := repo.UpdateApp(ctx, "my-app", newParams, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "budget exhausted before push")
-		assert.False(t, IsPushRaceError(err), "budget-exhausted error must not be misclassified as a push race")
+		assert.False(t, IsPushRaceError(err, nil), "budget-exhausted error must not be misclassified as a push race")
 	})
 
 	t.Run("Failure - Push Fails due to Non-Fast-Forward", func(t *testing.T) {
@@ -324,7 +324,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 
 		err = repo.UpdateApp(context.Background(), "my-app", newParams, nil)
 		assert.Error(t, err)
-		assert.True(t, IsPushRaceError(err), "expected a push race error, got: %v", err)
+		assert.True(t, IsPushRaceError(err, nil), "expected a push race error, got: %v", err)
 	})
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -55,6 +55,29 @@ func TestGitTimeoutAccessor(t *testing.T) {
 	assert.Equal(t, 42*time.Second, repo.GitTimeout())
 }
 
+func TestGitRepoIsPushRaceError(t *testing.T) {
+	t.Run("built-in marker matches without extras configured", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/dev/null")
+		repo, err := NewGitRepo("u", "b", "p", "f", t.TempDir(), &GitClient{})
+		require.NoError(t, err)
+
+		assert.True(t, repo.IsPushRaceError(errors.New("non-fast-forward update")))
+		assert.False(t, repo.IsPushRaceError(errors.New("connection refused")))
+	})
+
+	t.Run("operator-supplied extra marker is honored", func(t *testing.T) {
+		t.Setenv("SSH_KEY_PATH", "/dev/null")
+		t.Setenv("EXTRA_PUSH_RACE_MARKERS", "change conflicts")
+		repo, err := NewGitRepo("u", "b", "p", "f", t.TempDir(), &GitClient{})
+		require.NoError(t, err)
+
+		// New wording the built-in list doesn't know about — only matches via the extra.
+		assert.True(t, repo.IsPushRaceError(errors.New("gerrit: change conflicts with master")))
+		// Built-ins still work alongside the extra.
+		assert.True(t, repo.IsPushRaceError(errors.New("non-fast-forward update")))
+	})
+}
+
 func TestGetRepoCachePath(t *testing.T) {
 	repo := newTestRepo(t, nil)
 	path1 := repo.getRepoCachePath()
@@ -284,7 +307,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 		err := repo.UpdateApp(ctx, "my-app", newParams, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "budget exhausted before push")
-		assert.False(t, IsPushRaceError(err, nil), "budget-exhausted error must not be misclassified as a push race")
+		assert.False(t, IsPushRaceError(err), "budget-exhausted error must not be misclassified as a push race")
 	})
 
 	t.Run("Failure - Push Fails due to Non-Fast-Forward", func(t *testing.T) {
@@ -324,7 +347,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 
 		err = repo.UpdateApp(context.Background(), "my-app", newParams, nil)
 		assert.Error(t, err)
-		assert.True(t, IsPushRaceError(err, nil), "expected a push race error, got: %v", err)
+		assert.True(t, IsPushRaceError(err), "expected a push race error, got: %v", err)
 	})
 }
 


### PR DESCRIPTION
  ## Summary

  Adds an `EXTRA_PUSH_RACE_MARKERS` env var that lets operators append additional substrings to the built-in push-race detection list. When a new Git server wording surfaces in production, it can be handled via `helm upgrade` + pod restart instead of cutting a new argo-watcher
  release.

  - Comma-separated input, normalized at load (lowercased, trimmed, empty entries dropped).
  - **Additive only** — built-in markers cannot be replaced or disabled from configuration.
  - Matched case-insensitively against the error message, same contract as the built-in list.

  ## Motivation

  The push-race detector relies on substring matching against opaque receive-pack error strings (`non-fast-forward`, `incorrect old value`, `failed to update ref`, etc.). Each new wording observed in prod has so far required a code change + release. For an event that happens
  infrequently but blocks deploys when it does, that release cadence is painful. This change moves the marker list onto the same `helm upgrade` path as every other operator knob, while keeping the tested baseline immutable.

  ## Design notes

  - The exported `updater.IsPushRaceError(err) bool` signature is **unchanged** (backward-compatible — checks built-ins only).
  - The extras-aware path is a new method `(*GitRepo).IsPushRaceError(err)` that reads `gitConfig.ExtraPushRaceMarkers`. The recovery call site in `internal/models/argo.go` uses this method directly, so there's no awkward accessor plumbing config back into a free function.
  - Both code paths share a private `matchPushRaceMarkers(err, extra)` helper.

  ## Usage

  ```yaml
  # values.yaml (chart follow-up PR exposes this)
  env:
    - name: EXTRA_PUSH_RACE_MARKERS
      value: "change conflicts,server panic"
