### PR TITLE
feat(docs): generate llms.txt for AI agent navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Publish `llms.txt` and `llms-full.txt` on the documentation site, following
+  the [llmstxt.org](https://llmstxt.org/) standard, so AI agents can discover
+  and consume the docs.
+
 ## [0.10.5] - 2026-06-12
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # Argo Watcher
 
 !!! note "Documentation is a work in progress"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
 mkdocs-material[imaging]==9.7.6
 mkdocs-material-extensions==1.3.1
 mkdocs-git-committers-plugin-2==2.5.0
-mkdocs-git-revision-date-localized-plugin==1.5.1
+mkdocs-git-revision-date-localized-plugin==1.5.3
 mkdocs-glightbox==0.5.2
 mkdocs-redirects==1.2.3
-mkdocs-swagger-ui-tag==0.7.2
-pymdown-extensions==10.21.2
+mkdocs-swagger-ui-tag==0.8.0
+mkdocs-llmstxt==0.5.0
+pymdown-extensions==11.0

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,62 @@
             corepack
           ]) ++ [ viteShim ];
 
-        docsPython = pkgs.python311.withPackages (ps: with ps; [
+        # mkdocs-llmstxt and its dependency chain (mdformat-tables, mdformat)
+        # are not packaged for python311 in nixpkgs, so we build them from PyPI
+        # sdists to keep the dev shell's `mkdocs build`/`serve` in sync with
+        # docs/requirements.txt. mdformat is pinned to 0.7.22 — the same version
+        # pip resolves on Read the Docs, since mdformat-tables caps mdformat
+        # <0.8.0 (nixpkgs only ships mdformat 1.0.0, which is disabled on 3.11).
+        py = pkgs.python311Packages;
+
+        mdformat-0_7 = py.buildPythonPackage rec {
+          pname = "mdformat";
+          version = "0.7.22";
+          pyproject = true;
+          src = pkgs.fetchPypi {
+            inherit pname version;
+            hash = "sha256-7vhPqPIz0xYnNGg8KopiIiJ6IpuSBocuYTlljZmsseo=";
+          };
+          build-system = [ py.setuptools ];
+          dependencies = [ py.markdown-it-py ];
+          pythonImportsCheck = [ "mdformat" ];
+        };
+
+        mdformat-tables = py.buildPythonPackage rec {
+          pname = "mdformat-tables";
+          version = "1.0.0";
+          pyproject = true;
+          src = pkgs.fetchPypi {
+            pname = "mdformat_tables";
+            inherit version;
+            hash = "sha256-pX2xrBfEoSXaeU70VTmQS7ipWS6AVX1SXh8WnJbaosg=";
+          };
+          build-system = [ py.flit-core ];
+          dependencies = [ mdformat-0_7 py.wcwidth ];
+          pythonImportsCheck = [ "mdformat_tables" ];
+        };
+
+        mkdocs-llmstxt = py.buildPythonPackage rec {
+          pname = "mkdocs-llmstxt";
+          version = "0.5.0";
+          pyproject = true;
+          src = pkgs.fetchPypi {
+            pname = "mkdocs_llmstxt";
+            inherit version;
+            hash = "sha256-svqebWjfQddGfpSKR0VyW2yZQ0o2s2IEhX29e7Pf4EE=";
+          };
+          build-system = [ py.pdm-backend ];
+          dependencies = [
+            py.mkdocs
+            py.beautifulsoup4
+            py.markdownify
+            mdformat-0_7
+            mdformat-tables
+          ];
+          pythonImportsCheck = [ "mkdocs_llmstxt" ];
+        };
+
+        docsPython = pkgs.python311.withPackages (ps: (with ps; [
           mkdocs
           mkdocs-material
           mkdocs-material-extensions
@@ -70,7 +125,7 @@
           pymdown-extensions
           pillow
           cairosvg
-        ]);
+        ]) ++ [ mkdocs-llmstxt ]);
 
         docsToolchain = [ docsPython ] ++ (with pkgs; [
           cairo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,3 +120,43 @@ plugins:
         api.md: reference/api.md
         development.md: contributing/development.md
         concepts.md: getting-started/concepts.md
+  # Generates /llms.txt (an index for AI agents, per https://llmstxt.org/) and
+  # /llms-full.txt (the full docs as a single Markdown file). Must run last so
+  # it sees the fully rendered pages produced by the plugins above.
+  - llmstxt:
+      # On Read the Docs, links must point at the versioned path
+      # (e.g. /en/latest/). READTHEDOCS_CANONICAL_URL is injected by the RTD
+      # build; the fallback keeps local `mkdocs build` working.
+      base_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://argo-watcher.readthedocs.io/en/latest/']
+      full_output: llms-full.txt
+      markdown_description: >-
+        Argo Watcher is a feedback loop for your GitOps workflow. It bridges the
+        gap between your CI pipeline and Argo CD, reporting real-time deployment
+        status back to the pipeline and optionally updating image tags in your
+        GitOps repository.
+      sections:
+        Getting Started:
+          - getting-started/index.md: Starting point for new users, linking to Quick Start and Concepts.
+          - getting-started/quick-start.md: Run a local instance in five minutes with Docker Compose.
+          - getting-started/concepts.md: The problem Argo Watcher solves, its architecture, and key terms.
+        Guides:
+          - guides/index.md: Index of task-oriented guides.
+          - guides/install.md: Installing the server and client.
+          - guides/gitops-updater.md: Configuring the GitOps Updater to commit image tag changes.
+          - guides/notifications.md: Sending deployment notifications.
+          - guides/keycloak.md: Securing the Web UI with Keycloak/OIDC.
+        Reference:
+          - reference/index.md: Index of technical reference material.
+          - reference/api.md: REST API endpoints, authentication, and examples.
+          - reference/server-env.md: Server environment variables.
+          - reference/client-env.md: Client environment variables.
+          - reference/annotations.md: Argo CD application annotations recognised by Argo Watcher.
+        Operations:
+          - operations/index.md: Index of operational guides.
+          - operations/observability.md: Prometheus metrics, suggested alerts, and Grafana panel queries.
+          - operations/database.md: Database backends and configuration.
+          - operations/troubleshooting.md: Diagnosing common problems.
+        Contributing:
+          - contributing/index.md: How to contribute.
+          - contributing/development.md: Setting up a development environment.
+          - contributing/style.md: Documentation and code style guide.


### PR DESCRIPTION
Add the mkdocs-llmstxt plugin so the docs site publishes /llms.txt (an index per the llmstxt.org standard) and /llms-full.txt (the full docs as one Markdown file). Links use READTHEDOCS_CANONICAL_URL so they resolve to the correct versioned path, with a local-build fallback.

The plugin and its dependency chain (mdformat-tables, mdformat) are not in nixpkgs for python311, so build them from PyPI sdists in flake.nix to keep the dev shell's mkdocs in sync with docs/requirements.txt. mdformat is pinned to 0.7.22 to match what pip resolves on Read the Docs.

Also bump pymdown-extensions, mkdocs-swagger-ui-tag, and the git-revision plugin to latest, and hide the redundant single-item nav and ToC on the documentation home page.