### PR TITLE
fix(web): process Keycloak login callback before SPA router redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a Keycloak redirect loop that appeared *after* a successful login, where
+  the browser bounced between the app and the Keycloak login page without ever
+  settling. The login callback is now processed during app startup, before the
+  router runs its initial redirect, so the authorization code is no longer
+  discarded. Keycloak-less deployments are unaffected and continue to render
+  immediately.
+
 ## [0.10.6] - 2026-06-30
 
 ### Added

--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,7 @@ React 18, React-admin 5, Material UI 5, Emotion, TypeScript, ESLint, and Vitest/
 
 | Path | Purpose |
 | ---- | ------- |
-| `src/main.tsx` | React entry point that wires React Router, shared providers, and the `App` component. |
+| `src/main.tsx` | React entry point that runs `bootstrapAuth()` to consume any Keycloak login callback before mounting, then wires React Router, shared providers, and the `App` component. |
 | `src/App.tsx` | Placeholder React-admin shell; extend this file with `<Admin>` resources as migration phases land. |
 | `src/auth/` | Authentication helpers. `authProvider.ts` talks to Keycloak + `/api/v1/config`, and `tokenStore.ts` persists bearer tokens. |
 | `src/data/` | HTTP layer and React-admin `dataProvider` implementation that targets `/api/v1/tasks` and related endpoints. |
@@ -79,7 +79,7 @@ Keycloak settings (URL, realm, client_id, privileged groups, token intervals) co
 
 - **HTTP client (`src/data/httpClient.ts`)** – wraps `fetch`, injects `Authorization`/`Keycloak-Authorization` headers from `tokenStore`, normalises errors into `HttpError`, and provides helpers such as `buildQueryString`.
 - **React-admin `dataProvider` (`src/data/dataProvider.ts`)** – currently implements the `tasks` resource (list/detail/create) and infers pagination totals when the backend omits them. Extend this file when exposing additional Argo watcher endpoints.
-- **Auth provider (`src/auth/authProvider.ts`)** – lazy-loads `/api/v1/config`, boots Keycloak when enabled using a top-level `login-required` redirect, periodically refreshes tokens, and exposes permissions (groups/privileged groups) to React-admin.
+- **Auth provider (`src/auth/authProvider.ts`)** – fetches `/api/v1/config` and, when Keycloak is enabled, initializes keycloak-js eagerly via `bootstrapAuth()` (called from `main.tsx` before React mounts) so the login callback (`#code=…` fragment) is consumed before the router's index redirect can strip it. `checkAuth`/`getPermissions` reuse the already-initialized instance; init runs exactly once. It uses a top-level `login-required` redirect, periodically refreshes tokens, and exposes permissions (groups/privileged groups) to React-admin. When Keycloak is disabled, `bootstrapAuth()` is a no-op and the app renders immediately.
 - **Keycloak toggle hook (`src/shared/hooks/useKeycloakEnabled.ts`)** – tiny helper for gating UI affordances when running without identity.
 - **Deploy lock service (`src/features/deployLock/deployLockService.ts`)** – shares lock state through REST endpoints plus the `/ws` channel. Automatic retries and subscriber management keep the UI in sync even if the socket drops.
 - **Global providers (`src/shared/providers/AppProviders.tsx`)** – wraps the app with the theme mode, timezone, and deploy-lock providers, plus a global banner that reflects lock status.
@@ -113,7 +113,7 @@ Keycloak settings (URL, realm, client_id, privileged groups, token intervals) co
 ## Troubleshooting
 
 - **Dev server cannot reach the API**: ensure `VITE_API_PROXY_TARGET` matches your backend host or export `VITE_API_BASE_URL` so the SPA calls the right origin.  
-- **Endless Keycloak redirects**: verify the backend Keycloak config lists the current app origin (including any base path) as a valid redirect URI for the client. The login flow uses a top-level redirect (`onLoad: 'login-required'`), so the redirect URI must be allow-listed there.  
+- **Endless Keycloak redirects**: verify the backend Keycloak config lists the current app origin (including any base path) as a valid redirect URI for the client. The login flow uses a top-level redirect (`onLoad: 'login-required'`), so the redirect URI must be allow-listed there. If the redirect URIs are correct and the loop only appears *after* a successful login, the callback fragment (`#code=…`) was stripped before keycloak-js could read it — this is why `bootstrapAuth()` must be awaited in `main.tsx` before React mounts; do not move Keycloak init back into the React tree.  
 - **WebSocket errors**: set `VITE_WS_BASE_URL` when proxying through TLS terminators that do not support upgrade requests, or confirm `/ws` is exposed by the Go server.  
 - **Timezones look wrong**: toggle the timezone via the user menu (wired to `TimezoneProvider`). The selection lives under `argo-watcher:timezone`.
 

--- a/web/src/auth/authProvider.test.ts
+++ b/web/src/auth/authProvider.test.ts
@@ -512,4 +512,107 @@ describe('authProvider', () => {
     expect(keycloakMock.login).not.toHaveBeenCalled();
     expect(getAccessToken()).toBeNull();
   });
+
+  describe('bootstrapAuth', () => {
+    it('is a no-op when Keycloak is disabled (preserves keycloak-less mode)', async () => {
+      mockConfig({ keycloak: { enabled: false } });
+      const module = await import('./authProvider');
+
+      // keycloak-less deployments must render immediately: no init, no redirect.
+      await expect(module.bootstrapAuth()).resolves.toBeUndefined();
+      expect(keycloakMock.init).not.toHaveBeenCalled();
+      expect(keycloakMock.login).not.toHaveBeenCalled();
+    });
+
+    it('authenticates eagerly so checkAuth reuses the session without re-initializing', async () => {
+      mockConfig({
+        keycloak: {
+          enabled: true,
+          url: 'https://keycloak.example.com',
+          realm: 'demo',
+          client_id: 'argo',
+          privileged_groups: ['admins'],
+        },
+      });
+      keycloakMock.init.mockResolvedValue(true);
+      const module = await import('./authProvider');
+
+      // Eager init consumes the login callback before the router strips the URL
+      // fragment, persisting the token without ever bouncing to the login page.
+      await module.bootstrapAuth();
+      expect(keycloakMock.init).toHaveBeenCalledTimes(1);
+      expect(getAccessToken()).toBe('token');
+      expect(keycloakMock.login).not.toHaveBeenCalled();
+
+      // checkAuth now finds the persisted token and takes the cached-session path,
+      // so it never re-enters init. (The init-once guard for the unauthenticated
+      // path — where no token is set — is covered by the failed-bootstrap test below.)
+      await expect(module.authProvider.checkAuth({})).resolves.toBeUndefined();
+      expect(keycloakMock.init).toHaveBeenCalledTimes(1);
+    });
+
+    it('redirects to the Keycloak login page when the bootstrap finds no session', async () => {
+      mockConfig({
+        keycloak: {
+          enabled: true,
+          url: 'https://keycloak.example.com',
+          realm: 'demo',
+          client_id: 'argo',
+          privileged_groups: [],
+        },
+      });
+      keycloakMock.init.mockResolvedValueOnce(false);
+      const module = await import('./authProvider');
+
+      await expect(module.bootstrapAuth()).resolves.toBeUndefined();
+      expect(keycloakMock.login).toHaveBeenCalledWith(
+        expect.objectContaining({
+          redirectUri: `${ensureBrowserWindow().location.origin}/`,
+        }),
+      );
+    });
+
+    it('recovers via login on checkAuth after a failed bootstrap, without re-initializing', async () => {
+      mockConfig({
+        keycloak: {
+          enabled: true,
+          url: 'https://keycloak.example.com',
+          realm: 'demo',
+          client_id: 'argo',
+          privileged_groups: [],
+        },
+      });
+      keycloakMock.init.mockRejectedValueOnce(new Error('bootstrap init failure'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const module = await import('./authProvider');
+
+      // Bootstrap swallows the init error so rendering is never blocked.
+      await expect(module.bootstrapAuth()).resolves.toBeUndefined();
+      expect(keycloakMock.init).toHaveBeenCalledTimes(1);
+
+      // The cached rejection means checkAuth must NOT call init again (keycloak-js
+      // forbids a second init on one instance); it falls through to a login redirect.
+      // login() fires twice in total — once from the failed bootstrap, once from
+      // checkAuth — but both merely (re)issue the top-level redirect, never logout.
+      await expect(module.authProvider.checkAuth({})).resolves.toBeUndefined();
+      expect(keycloakMock.init).toHaveBeenCalledTimes(1);
+      expect(keycloakMock.login).toHaveBeenCalledTimes(2);
+      expect(keycloakMock.logout).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('resolves (never throws) when the config endpoint is unreachable, so render still runs', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network offline'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const module = await import('./authProvider');
+
+      // A down backend must not block the SPA from mounting.
+      await expect(module.bootstrapAuth()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Eager authentication bootstrap failed'),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -24,6 +24,7 @@ interface Permissions {
 let serverConfigPromise: Promise<ServerConfig> | null = null;
 let serverConfig: ServerConfig | null = null;
 let keycloakInstance: KeycloakInstance | null = null;
+let initPromise: Promise<boolean> | null = null;
 let refreshInterval: number | null = null;
 let cachedUserGroups: string[] | null = null;
 let userGroupsLoadedFromProfile = false;
@@ -248,6 +249,19 @@ const runKeycloakInit = async (keycloak: KeycloakInstance, options: KeycloakInit
 };
 
 /**
+ * Runs keycloak.init exactly once for the singleton instance and caches the result.
+ *
+ * keycloak-js forbids calling init() twice on one instance, and only the first
+ * init consumes the login callback (`#state=...&code=...`). The eager bootstrap
+ * and the later checkAuth/getPermissions paths both funnel through here, so the
+ * callback is processed once and the instance is never re-initialized.
+ */
+const ensureInitialized = (keycloak: KeycloakInstance): Promise<boolean> => {
+  initPromise ??= runKeycloakInit(keycloak, buildInitOptions());
+  return initPromise;
+};
+
+/**
  * Central authentication path used by the authProvider to ensure the user session is valid.
  *
  * When no local token exists, this initializes Keycloak with `login-required`,
@@ -278,7 +292,7 @@ const authenticate = async () => {
 
   let authenticated = false;
   try {
-    authenticated = await runKeycloakInit(keycloak, buildInitOptions());
+    authenticated = await ensureInitialized(keycloak);
   } catch (error) {
     console.warn('[auth] Keycloak initialization failed; redirecting to the login page.', error);
     clearAccessToken();
@@ -314,6 +328,30 @@ const resolvePermissions = (): Permissions => {
   const privilegedGroups = config?.privileged_groups ?? [];
   const groups = cachedUserGroups ?? keycloakInstance?.tokenParsed?.groups ?? [];
   return { groups, privilegedGroups };
+};
+
+/**
+ * Eagerly initializes authentication before the React tree is mounted.
+ *
+ * keycloak-js parses the login callback (the `#state=...&code=...` fragment) the
+ * first time init() runs. The SPA router performs its default index redirect
+ * (`/` -> `/tasks`) the moment it mounts, which strips that fragment. Running
+ * init lazily inside checkAuth therefore raced the router and lost the code,
+ * leaving Keycloak to redirect to login again -> an endless login loop.
+ * Initializing here, before render, consumes the callback while the fragment is
+ * still present.
+ *
+ * Keycloak is OPTIONAL: when SSO is disabled server-side, authenticate() returns
+ * without initializing Keycloak or redirecting, so keycloak-less deployments
+ * render exactly as before with no added delay. Bootstrap failures are swallowed
+ * so rendering is never blocked; checkAuth re-runs the same path on mount.
+ */
+export const bootstrapAuth = async (): Promise<void> => {
+  try {
+    await authenticate();
+  } catch (error) {
+    console.warn('[auth] Eager authentication bootstrap failed; deferring to checkAuth.', error);
+  }
 };
 
 /**
@@ -405,6 +443,7 @@ export const __testing = {
     serverConfig = null;
     clearRefreshInterval();
     keycloakInstance = null;
+    initPromise = null;
     clearAccessToken();
     clearUserGroupsCache();
   },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
+import { bootstrapAuth } from './auth/authProvider';
 import { AppProviders } from './shared/providers/AppProviders';
 
 const rootElement = document.getElementById('root');
@@ -10,12 +11,25 @@ if (!rootElement) {
   throw new Error('Root element was not found. Ensure index.html contains a div with id="root".');
 }
 
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <AppProviders>
-        <App />
-      </AppProviders>
-    </BrowserRouter>
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(rootElement);
+
+/** Mounts the React application into the page root. */
+const renderApp = () => {
+  root.render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <AppProviders>
+          <App />
+        </AppProviders>
+      </BrowserRouter>
+    </React.StrictMode>,
+  );
+};
+
+// Process any Keycloak login callback BEFORE mounting React. keycloak-js can only
+// read the `#code=...` fragment on its first init(), and the router's index
+// redirect strips that fragment as soon as the tree mounts — so initializing
+// first is what prevents the post-login redirect loop. When Keycloak is disabled
+// the bootstrap resolves immediately, so keycloak-less deployments render with no
+// added delay. `finally` guarantees the app still renders if the bootstrap throws.
+bootstrapAuth().finally(renderApp);


### PR DESCRIPTION
keycloak-js only reads the login callback (the #code= URL fragment) on its first init(). Init ran lazily inside checkAuth, after awaiting the /api/v1/config fetch; during that await the router's index redirect (/ -> /tasks) stripped the fragment, so the authorization code was never exchanged and Keycloak redirected to login again -- an endless post-login loop.

Initialize Keycloak eagerly via a new bootstrapAuth() awaited in main.tsx before React mounts, so the callback is consumed while the fragment is still present. An ensureInitialized() guard caches the init promise so init runs exactly once (keycloak-js forbids a second init on one instance). Keycloak stays optional: when SSO is disabled, bootstrapAuth() calls neither init() nor login() and the app renders immediately.