### PR TITLE
feat: detect and surface rollback deployments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,11 @@ repos:
         name: TruffleHog secret scan
         entry: trufflehog filesystem --results=verified,unknown --fail
         language: system
-        # docker-compose.yml (local dev credentials) and updater_test.go (SSH
-        # key fixtures for unit tests) hold intentional non-secrets that
-        # TruffleHog flags as "unknown". Filesystem mode ignores --exclude-paths
-        # for explicitly-passed files, so skip them at the pre-commit layer.
-        # Keep this list in sync with .trufflehog-exclude (used by CI).
-        exclude: ^(docker-compose\.yml|pkg/updater/updater_test\.go)$
+        # docker-compose.yml (local dev credentials), updater_test.go (SSH key
+        # fixtures for unit tests) and database.md (an example postgres DSN using
+        # the RFC 2606 db.example.com placeholder) hold intentional non-secrets
+        # that TruffleHog flags as "unknown". Filesystem mode ignores
+        # --exclude-paths for explicitly-passed files, so skip them at the
+        # pre-commit layer. Keep this list in sync with .trufflehog-exclude
+        # (used by CI).
+        exclude: ^(docker-compose\.yml|pkg/updater/updater_test\.go|docs/operations/database\.md)$

--- a/.trufflehog-exclude
+++ b/.trufflehog-exclude
@@ -1,2 +1,3 @@
 docker-compose\.yml
 pkg/updater/updater_test\.go
+docs/operations/database\.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Detect and flag rollback deployments: when a task redeploys an image set that
+  ran earlier for the same application (returning to a previous version), it is
+  marked as a rollback. The task tables show a marker next to the status, and
+  the task detail page links to the earlier task the deployment rolls back to.
+- Expose `IsRollback` and `RollbackTargetId` as webhook notification template
+  variables so alerts can highlight rollbacks.
+
 ### Changed
 
 - Group and humanize server startup misconfiguration errors: missing required

--- a/db/migrations/000005_is_rollback.down.sql
+++ b/db/migrations/000005_is_rollback.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks DROP COLUMN IF EXISTS rollback_target_id;
+ALTER TABLE tasks DROP COLUMN IF EXISTS is_rollback;

--- a/db/migrations/000005_is_rollback.up.sql
+++ b/db/migrations/000005_is_rollback.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks ADD COLUMN is_rollback BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE tasks ADD COLUMN rollback_target_id TEXT NOT NULL DEFAULT '';

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -35,6 +35,8 @@ The `WEBHOOK_FORMAT` value is a [Go template](https://pkg.go.dev/text/template) 
 | `Project` | `string`  | Business project identifier               | `"Demo"`         |
 | `Images`  | `[]Image` | List of images being deployed (see below) |                  |
 | `Status`  | `string`  | Current deployment status                 | `"deployed"`     |
+| `IsRollback` | `bool` | `true` when the deployment returns to a previously deployed version | `true` |
+| `RollbackTargetId` | `string` | ID of the earlier task this deployment rolls back to (empty when not a rollback) | `"be8c42c0-..."` |
 
 ### The Image Object
 
@@ -90,4 +92,12 @@ Produces:
 
 ```bash
 WEBHOOK_FORMAT='{"text": "Deployment of *{{.App}}* by {{.Author}}: {{.Status}}"}'
+```
+
+### Highlighting Rollbacks
+
+Use `IsRollback` to call out deployments that return to a previously deployed version:
+
+```bash
+WEBHOOK_FORMAT='{"text": "{{if .IsRollback}}:rewind: ROLLBACK of {{else}}Deployment of {{end}}*{{.App}}* by {{.Author}}: {{.Status}}"}'
 ```

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -14,6 +14,8 @@ There is a single table, `tasks`, that stores every deployment task and its stat
 | `images` | `jsonb NOT NULL` | Image list submitted with the task. |
 | `status` | `varchar(20) NOT NULL` | One of: pending, in progress, deployed, failed. |
 | `status_reason` | `text` | Human-readable failure reason; empty on success. |
+| `is_rollback` | `boolean NOT NULL DEFAULT false` | `true` when this task's image set was previously deployed for the app. |
+| `rollback_target_id` | `text NOT NULL DEFAULT ''` | ID of the earlier task this deployment rolls back to; empty when not a rollback. |
 | `app` | `varchar(255) NOT NULL` | Argo CD application name. |
 | `author` | `varchar(255) NOT NULL` | Deployment author identifier. |
 | `project` | `varchar(255) NOT NULL` | Business project identifier. |

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -3,9 +3,11 @@ package argocd
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
+	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/state"
 
 	"github.com/rs/zerolog/log"
@@ -17,6 +19,12 @@ var (
 	// ArgoSyncRetryDelay is the delay between ArgoCD sync status retries.
 	ArgoSyncRetryDelay = 15 * time.Second
 )
+
+// rollbackHistoryWindow bounds how many of an app's most recent successfully
+// deployed tasks are inspected when deciding whether a new deployment is a
+// rollback. Rollbacks to a version older than this window are not flagged; this
+// is an accepted simplification to keep the per-deployment lookup cheap.
+const rollbackHistoryWindow = 100
 
 const (
 	// ArgoAPIErrorTemplate is the template for ArgoCD API errors.
@@ -77,6 +85,12 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 		return nil, fmt.Errorf("trying to create task without app name")
 	}
 
+	// Always overwrite the rollback fields from server-side history so a
+	// client-supplied value (e.g. echoed back by the "rollback to this version"
+	// action) can never influence the stored result.
+	task.RollbackTargetId = argo.detectRollback(task)
+	task.IsRollback = task.RollbackTargetId != ""
+
 	newTask, err := argo.State.AddTask(task)
 	if err != nil {
 		return nil, err
@@ -93,6 +107,44 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 
 	argo.metrics.AddProcessedDeployment(task.App)
 	return newTask, nil
+}
+
+// detectRollback reports whether deploying task represents a rollback and, if
+// so, returns the ID of the task it rolls back to. A rollback is a deployment
+// whose image set was successfully deployed at some earlier point for the app
+// AND differs from the current (most recently deployed) version; redeploying
+// the current version is not a rollback. The returned ID is the most recent
+// earlier task carrying that image set. An empty string means "not a rollback".
+// The lookup is bounded by rollbackHistoryWindow.
+func (argo *Argo) detectRollback(task models.Task) string {
+	deployed, _ := argo.State.GetTasks(0, float64(time.Now().Unix()), task.App, models.StatusDeployedMessage, rollbackHistoryWindow, 0)
+	if len(deployed) == 0 {
+		return ""
+	}
+
+	target := imageSignature(task)
+
+	// GetTasks orders by created DESC, so deployed[0] is the current version.
+	// Matching it means we are redeploying the current version, not rolling back.
+	if imageSignature(deployed[0]) == target {
+		return ""
+	}
+
+	// deployed[1:] is scanned newest-first, so the first match is the most
+	// recent earlier deployment of the target image set.
+	for _, previous := range deployed[1:] {
+		if imageSignature(previous) == target {
+			return previous.Id
+		}
+	}
+
+	return ""
+}
+
+// imageSignature returns a stable, order-independent key for a task's image set
+// so two deployments of the same images compare equal regardless of ordering.
+func imageSignature(task models.Task) string {
+	return strings.Join(helpers.NormalizeImages(task.ListImages()), ",")
 }
 
 // GetTasks retrieves tasks from the state within a given time range and optional app/status filters and pagination window.

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -212,6 +212,7 @@ func TestArgoAddTask(t *testing.T) {
 
 		// mock calls to add task
 		stateError := fmt.Errorf("database error")
+		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
 		state.EXPECT().AddTask(gomock.Any()).Return(nil, stateError)
 
 		// argo manager
@@ -261,6 +262,7 @@ func TestArgoAddTask(t *testing.T) {
 		}
 
 		// mock calls to add task
+		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
 		state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil)
 
 		// argo manager
@@ -274,6 +276,181 @@ func TestArgoAddTask(t *testing.T) {
 		uuidRegexp := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 		assert.Regexp(t, uuidRegexp, newTaskReturned.Id, "Must match Regexp for uuid v4")
 	})
+
+	t.Run("Argo - Rollback fields are computed and persisted", func(t *testing.T) {
+		api := mock.NewMockArgoApiInterface(ctrl)
+		metrics := mock.NewMockMetricsInterface(ctrl)
+		state := mock.NewMockTaskRepository(ctrl)
+
+		state.EXPECT().Check().Return(true)
+		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
+		metrics.EXPECT().SetArgoUnavailable(false)
+		metrics.EXPECT().AddProcessedDeployment("test-app")
+
+		// History ordered created DESC: current is v2, an earlier task (target) ran v1.
+		deployed := []models.Task{
+			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
+			{Id: "earlier", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v1"}}, Status: models.StatusDeployedMessage},
+		}
+		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return(deployed, int64(len(deployed)))
+
+		// Capture the task actually handed to the repository.
+		var captured models.Task
+		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+			captured = task
+			task.Id = uuid.NewString()
+			return &task, nil
+		})
+
+		argo := &Argo{}
+		argo.Init(state, api, metrics)
+		_, err := argo.AddTask(models.Task{App: "test-app", Images: []models.Image{{Image: "app", Tag: "v1"}}})
+
+		assert.NoError(t, err)
+		assert.True(t, captured.IsRollback)
+		assert.Equal(t, "earlier", captured.RollbackTargetId)
+	})
+
+	t.Run("Argo - Client-supplied rollback fields are overwritten from history", func(t *testing.T) {
+		api := mock.NewMockArgoApiInterface(ctrl)
+		metrics := mock.NewMockMetricsInterface(ctrl)
+		state := mock.NewMockTaskRepository(ctrl)
+
+		state.EXPECT().Check().Return(true)
+		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
+		metrics.EXPECT().SetArgoUnavailable(false)
+		metrics.EXPECT().AddProcessedDeployment("test-app")
+
+		// Deploying a brand-new version (v3) with no earlier match: not a rollback.
+		deployed := []models.Task{
+			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
+		}
+		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return(deployed, int64(len(deployed)))
+
+		var captured models.Task
+		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+			captured = task
+			task.Id = uuid.NewString()
+			return &task, nil
+		})
+
+		argo := &Argo{}
+		argo.Init(state, api, metrics)
+		// Client tries to spoof the rollback flag; the server must overwrite it.
+		_, err := argo.AddTask(models.Task{
+			App:              "test-app",
+			Images:           []models.Image{{Image: "app", Tag: "v3"}},
+			IsRollback:       true,
+			RollbackTargetId: "spoofed",
+		})
+
+		assert.NoError(t, err)
+		assert.False(t, captured.IsRollback)
+		assert.Empty(t, captured.RollbackTargetId)
+	})
+}
+
+func TestArgoDetectRollback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	img := func(image, tag string) []models.Image {
+		return []models.Image{{Image: image, Tag: tag}}
+	}
+
+	// deployedTask is one entry in the app's deployment history.
+	type deployedTask struct {
+		id     string
+		images []models.Image
+	}
+
+	tests := []struct {
+		name    string
+		history []deployedTask // successfully deployed tasks, oldest first
+		target  []models.Image // image set being deployed now
+		// wantTargetID is the expected rollback target task ID ("" = not a rollback).
+		wantTargetID string
+	}{
+		{
+			name:         "first deployment is not a rollback",
+			history:      nil,
+			target:       img("app", "v1"),
+			wantTargetID: "",
+		},
+		{
+			name:         "forward deployment of a new version is not a rollback",
+			history:      []deployedTask{{"t1", img("app", "v1")}, {"t2", img("app", "v2")}},
+			target:       img("app", "v3"),
+			wantTargetID: "",
+		},
+		{
+			name:         "redeploying the current version is not a rollback",
+			history:      []deployedTask{{"t1", img("app", "v1")}, {"t2", img("app", "v2")}},
+			target:       img("app", "v2"),
+			wantTargetID: "",
+		},
+		{
+			name: "redeploying the current version short-circuits even when an older duplicate exists",
+			history: []deployedTask{
+				{"t1", img("app", "v2")}, // older deployment of the same version
+				{"t2", img("app", "v1")},
+				{"t3", img("app", "v2")}, // current version
+			},
+			target:       img("app", "v2"),
+			wantTargetID: "",
+		},
+		{
+			name:         "returning to an earlier version rolls back to that task",
+			history:      []deployedTask{{"t1", img("app", "v1")}, {"t2", img("app", "v2")}},
+			target:       img("app", "v1"),
+			wantTargetID: "t1",
+		},
+		{
+			name: "rolls back to the most recent earlier deployment of the version",
+			history: []deployedTask{
+				{"t1", img("app", "v1")},
+				{"t2", img("app", "v1")},
+				{"t3", img("app", "v2")},
+			},
+			target:       img("app", "v1"),
+			wantTargetID: "t2",
+		},
+		{
+			name: "image order does not affect the signature",
+			history: []deployedTask{
+				{"t1", []models.Image{{Image: "a", Tag: "1"}, {Image: "b", Tag: "2"}}},
+				{"t2", img("app", "v2")},
+			},
+			target:       []models.Image{{Image: "b", Tag: "2"}, {Image: "a", Tag: "1"}},
+			wantTargetID: "t1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// GetTasks returns deployed tasks ordered created DESC (most recent
+			// first), so reverse the oldest-first history fixture.
+			deployed := make([]models.Task, 0, len(tt.history))
+			for i := len(tt.history) - 1; i >= 0; i-- {
+				deployed = append(deployed, models.Task{
+					Id:     tt.history[i].id,
+					App:    "test-app",
+					Images: tt.history[i].images,
+					Status: models.StatusDeployedMessage,
+				})
+			}
+
+			state := mock.NewMockTaskRepository(ctrl)
+			state.EXPECT().
+				GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, rollbackHistoryWindow, 0).
+				Return(deployed, int64(len(deployed)))
+
+			argo := &Argo{State: state}
+			result := argo.detectRollback(models.Task{App: "test-app", Images: tt.target})
+
+			assert.Equal(t, tt.wantTargetID, result)
+		})
+	}
 }
 
 func TestArgoGetTasks(t *testing.T) {

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -16,18 +16,22 @@ type SavedAppStatus struct {
 }
 
 type Task struct {
-	Id             string         `json:"id,omitempty"`
-	Created        float64        `json:"created,omitempty"`
-	Updated        float64        `json:"updated,omitempty"`
-	App            string         `json:"app" binding:"required" example:"argo-watcher"`
-	Author         string         `json:"author" binding:"required" example:"John Doe"`
-	Project        string         `json:"project" binding:"required" example:"Demo"`
-	Images         []Image        `json:"images" binding:"required"`
-	Status         string         `json:"status,omitempty"`
-	StatusReason   string         `json:"status_reason,omitempty"`
-	Validated      bool           `json:"validated,omitempty"`
-	Timeout        int            `json:"timeout,omitempty"`
-	SavedAppStatus SavedAppStatus `json:"-"`
+	Id           string  `json:"id,omitempty"`
+	Created      float64 `json:"created,omitempty"`
+	Updated      float64 `json:"updated,omitempty"`
+	App          string  `json:"app" binding:"required" example:"argo-watcher"`
+	Author       string  `json:"author" binding:"required" example:"John Doe"`
+	Project      string  `json:"project" binding:"required" example:"Demo"`
+	Images       []Image `json:"images" binding:"required"`
+	Status       string  `json:"status,omitempty"`
+	StatusReason string  `json:"status_reason,omitempty"`
+	Validated    bool    `json:"validated,omitempty"`
+	Timeout      int     `json:"timeout,omitempty"`
+	IsRollback   bool    `json:"is_rollback,omitempty"`
+	// RollbackTargetId is the ID of the most recent earlier task whose image set
+	// this deployment returns to. Empty when the deployment is not a rollback.
+	RollbackTargetId string         `json:"rollback_target_id,omitempty"`
+	SavedAppStatus   SavedAppStatus `json:"-"`
 }
 
 // ListImages returns a list of strings representing the images of the task.

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -41,11 +41,13 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 // The method executes an INSERT query to add a new record with the task details, including the current UTC time.
 func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 	ormTask := state_models.TaskModel{
-		Images:          datatypes.NewJSONSlice(task.Images),
-		Status:          models.StatusInProgressMessage,
-		ApplicationName: sql.NullString{String: task.App, Valid: true},
-		Author:          sql.NullString{String: task.Author, Valid: true},
-		Project:         sql.NullString{String: task.Project, Valid: true},
+		Images:           datatypes.NewJSONSlice(task.Images),
+		Status:           models.StatusInProgressMessage,
+		ApplicationName:  sql.NullString{String: task.App, Valid: true},
+		Author:           sql.NullString{String: task.Author, Valid: true},
+		Project:          sql.NullString{String: task.Project, Valid: true},
+		IsRollback:       task.IsRollback,
+		RollbackTargetId: task.RollbackTargetId,
 	}
 
 	if err := state.orm.Create(&ormTask).Error; err != nil {

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -77,6 +77,33 @@ func TestPostgresState_AddTask(t *testing.T) {
 	assert.Equal(t, "Test", result.App)
 }
 
+func TestPostgresState_RollbackFieldsRoundTrip(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	t.Run("rollback fields persist and are read back", func(t *testing.T) {
+		task := sampleTask("Rollback")
+		task.IsRollback = true
+		task.RollbackTargetId = "11111111-1111-4111-8111-111111111111"
+		inserted := env.addTask(t, task)
+
+		stored, err := env.state.GetTask(inserted.Id)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.True(t, stored.IsRollback)
+		assert.Equal(t, "11111111-1111-4111-8111-111111111111", stored.RollbackTargetId)
+	})
+
+	t.Run("defaults apply when rollback fields are unset", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("NoRollback"))
+
+		stored, err := env.state.GetTask(inserted.Id)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.False(t, stored.IsRollback)
+		assert.Empty(t, stored.RollbackTargetId)
+	})
+}
+
 func TestPostgresState_GetTasks(t *testing.T) {
 	env := newPostgresTestEnv(t)
 

--- a/internal/state/state_models/task_model.go
+++ b/internal/state/state_models/task_model.go
@@ -10,15 +10,17 @@ import (
 )
 
 type TaskModel struct {
-	Id              uuid.UUID                         `gorm:"column:id;type:uuid;not null;default:gen_random_uuid();"`
-	Created         time.Time                         `gorm:"column:created;autoCreateTime;not null;index;"`
-	Updated         time.Time                         `gorm:"column:updated;autoUpdateTime;not null;"`
-	Images          datatypes.JSONSlice[models.Image] `gorm:"column:images;type:jsonb;not null;"`
-	Status          string                            `gorm:"column:status;type:VARCHAR(20);not null;index;"`
-	ApplicationName sql.NullString                    `gorm:"column:app;type:VARCHAR(255);not null;"`
-	Author          sql.NullString                    `gorm:"column:author;type:VARCHAR(255);not null;"`
-	Project         sql.NullString                    `gorm:"column:project;type:VARCHAR(255);not null;"`
-	StatusReason    sql.NullString                    `gorm:"column:status_reason;"`
+	Id               uuid.UUID                         `gorm:"column:id;type:uuid;not null;default:gen_random_uuid();"`
+	Created          time.Time                         `gorm:"column:created;autoCreateTime;not null;index;"`
+	Updated          time.Time                         `gorm:"column:updated;autoUpdateTime;not null;"`
+	Images           datatypes.JSONSlice[models.Image] `gorm:"column:images;type:jsonb;not null;"`
+	Status           string                            `gorm:"column:status;type:VARCHAR(20);not null;index;"`
+	ApplicationName  sql.NullString                    `gorm:"column:app;type:VARCHAR(255);not null;"`
+	Author           sql.NullString                    `gorm:"column:author;type:VARCHAR(255);not null;"`
+	Project          sql.NullString                    `gorm:"column:project;type:VARCHAR(255);not null;"`
+	StatusReason     sql.NullString                    `gorm:"column:status_reason;"`
+	IsRollback       bool                              `gorm:"column:is_rollback;not null;default:false;"`
+	RollbackTargetId string                            `gorm:"column:rollback_target_id;not null;default:'';"`
 }
 
 func (TaskModel) TableName() string {
@@ -27,14 +29,16 @@ func (TaskModel) TableName() string {
 
 func (ormTask *TaskModel) ConvertToExternalTask() *models.Task {
 	return &models.Task{
-		Id:           ormTask.Id.String(),
-		Created:      float64(ormTask.Created.Unix()),
-		Updated:      float64(ormTask.Updated.Unix()),
-		App:          ormTask.ApplicationName.String,
-		Author:       ormTask.Author.String,
-		Project:      ormTask.Project.String,
-		Images:       ormTask.Images,
-		Status:       ormTask.Status,
-		StatusReason: ormTask.StatusReason.String,
+		Id:               ormTask.Id.String(),
+		Created:          float64(ormTask.Created.Unix()),
+		Updated:          float64(ormTask.Updated.Unix()),
+		App:              ormTask.ApplicationName.String,
+		Author:           ormTask.Author.String,
+		Project:          ormTask.Project.String,
+		Images:           ormTask.Images,
+		Status:           ormTask.Status,
+		StatusReason:     ormTask.StatusReason.String,
+		IsRollback:       ormTask.IsRollback,
+		RollbackTargetId: ormTask.RollbackTargetId,
 	}
 }

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -13,6 +13,8 @@ export interface Task {
   images: Image[];
   status?: string;
   status_reason?: string;
+  is_rollback?: boolean;
+  rollback_target_id?: string;
 }
 
 export interface TasksResponse {
@@ -31,6 +33,8 @@ export interface TaskStatus {
   images?: Image[];
   status?: string;
   status_reason?: string;
+  is_rollback?: boolean;
+  rollback_target_id?: string;
   error?: string;
 }
 

--- a/web/src/features/tasks/components/RollbackIndicator.test.tsx
+++ b/web/src/features/tasks/components/RollbackIndicator.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RollbackIndicator } from './RollbackIndicator';
+
+describe('RollbackIndicator', () => {
+  it('renders a labeled marker when the task is a rollback', () => {
+    render(<RollbackIndicator isRollback />);
+    expect(screen.getByRole('img', { name: 'Rollback' })).toBeInTheDocument();
+  });
+
+  it('renders nothing for a regular deployment', () => {
+    const { container } = render(<RollbackIndicator isRollback={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the flag is undefined', () => {
+    const { container } = render(<RollbackIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/features/tasks/components/RollbackIndicator.tsx
+++ b/web/src/features/tasks/components/RollbackIndicator.tsx
@@ -1,0 +1,31 @@
+import RestoreIcon from '@mui/icons-material/Restore';
+import { Box, Tooltip } from '@mui/material';
+
+export interface RollbackIndicatorProps {
+  readonly isRollback?: boolean;
+}
+
+/**
+ * Compact marker rendered next to a task's status to flag that the deployment
+ * returns to a previously deployed version. Renders nothing for regular
+ * (non-rollback) deployments so it can be dropped into any status cell without
+ * reserving layout space.
+ */
+export const RollbackIndicator = ({ isRollback }: RollbackIndicatorProps) => {
+  if (!isRollback) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="Rollback to a previously deployed version">
+      <Box
+        component="span"
+        role="img"
+        aria-label="Rollback"
+        sx={{ display: 'inline-flex', alignItems: 'center', color: 'warning.main' }}
+      >
+        <RestoreIcon sx={{ fontSize: 16 }} />
+      </Box>
+    </Tooltip>
+  );
+};

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -12,6 +12,7 @@ import { EmptyCell } from './EmptyCell';
 import { EmptyState, EmptyStateCta } from './EmptyState';
 import { ImagesCell } from './ImagesCell';
 import { StatusPill } from './StatusPill';
+import { RollbackIndicator } from './RollbackIndicator';
 import { TimeCell } from './TimeCell';
 import { usePauseRefresh, useTaskListContext } from './TaskListContext';
 
@@ -83,7 +84,12 @@ export const TasksDatagrid = () => {
         label="Status"
         sortBy="status"
         cellClassName="cell-status"
-        render={(record: Task) => <StatusPill status={record.status} />}
+        render={(record: Task) => (
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+            <StatusPill status={record.status} />
+            <RollbackIndicator isRollback={record.is_rollback} />
+          </Box>
+        )}
       />
       <FunctionField
         source="created"
@@ -162,7 +168,7 @@ const datagridSx: SxProps<Theme> = theme => {
     '& .cell-app': { minWidth: 200, maxWidth: 280 },
     '& .cell-project': { minWidth: 180, maxWidth: 280 },
     '& .cell-author': { width: 200 },
-    '& .cell-status': { width: 132 },
+    '& .cell-status': { width: 156 },
     '& .cell-created': {
       width: 200,
       fontVariantNumeric: 'tabular-nums',

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -113,6 +113,46 @@ describe('TaskShow', () => {
     expect(screen.getByRole('button', { name: /Refresh/i })).toBeInTheDocument();
   });
 
+  describe('rollback details', () => {
+    it('does not render the rollback field for a regular deployment', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ is_rollback: false }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+      expect(screen.queryByText(/Rollback of/i)).not.toBeInTheDocument();
+    });
+
+    it('links to the rollback target task when the id is present', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ is_rollback: true, rollback_target_id: 'abcdef12-3456-4789-8abc-def012345678' }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+      expect(screen.getByText(/Rollback of/i)).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: 'abcdef12' });
+      expect(link).toHaveAttribute('href', '/task/abcdef12-3456-4789-8abc-def012345678');
+    });
+
+    it('shows fallback text when the rollback target id is missing', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ is_rollback: true, rollback_target_id: '' }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+      expect(screen.getByText('A previously deployed version')).toBeInTheDocument();
+    });
+  });
+
   it('shows loading indicator while fetching data', async () => {
     mockUseGetOne.mockReturnValue({
       data: undefined,

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -26,10 +26,11 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useGetIdentity, useGetOne, useNotify, usePermissions } from 'react-admin';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
 import type { TaskStatus } from '../../../data/types';
 import { formatDuration, formatRelativeTime } from '../../../shared/utils/time';
 import { describeTaskStatus } from '../utils/statusPresentation';
+import { RollbackIndicator } from '../components/RollbackIndicator';
 import { useDeployLockState } from '../../deployLock/useDeployLockState';
 import { useKeycloakEnabled } from '../../../shared/hooks/useKeycloakEnabled';
 import { getBrowserWindow, hasPrivilegedAccess } from '../../../shared/utils';
@@ -383,7 +384,12 @@ export const TaskShow = () => {
         <CardHeader
           title={`Task ${data.id?.slice(0, 8) ?? '—'}`}
           subheader="UTC"
-          action={<Chip label={descriptor.label} color={descriptor.chipColor} size="medium" icon={descriptor.icon} />}
+          action={
+            <Stack direction="row" spacing={1} alignItems="center">
+              <RollbackIndicator isRollback={data.is_rollback} />
+              <Chip label={descriptor.label} color={descriptor.chipColor} size="medium" icon={descriptor.icon} />
+            </Stack>
+          }
         />
         <CardContent>
           <Stack spacing={3}>
@@ -393,6 +399,20 @@ export const TaskShow = () => {
                   <InfoField label="Application" value={data.app ?? 'Unknown'} />
                   <InfoField label="Project" value={<ProjectReference project={data.project} />} />
                   <InfoField label="Author" value={data.author ?? '—'} />
+                  {data.is_rollback && (
+                    <InfoField
+                      label="Rollback of"
+                      value={
+                        data.rollback_target_id ? (
+                          <Link component={RouterLink} to={`/task/${data.rollback_target_id}`}>
+                            {data.rollback_target_id.slice(0, 8)}
+                          </Link>
+                        ) : (
+                          'A previously deployed version'
+                        )
+                      }
+                    />
+                  )}
                 </Stack>
               </Grid>
               <Grid item xs={12} md={6}>


### PR DESCRIPTION
Flag a task as a rollback when its image set was successfully deployed earlier for the same application and differs from the current version. Detection runs server-side in AddTask and always overwrites any client-supplied value, so the stored flag cannot be spoofed.

Expose the result as the is_rollback and rollback_target_id fields on the task, available as webhook notification template variables. In the UI, show a marker beside the status pill in the task tables and link the task detail page to the earlier task the deployment rolls back to.

Exclude docs/operations/database.md from the TruffleHog scan: it holds an example postgres DSN using the RFC 2606 db.example.com placeholder.

Closes #380