### PR TITLE
fix(argocd): enforce deployment timeout as a wall-clock deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Enforce the deployment timeout (`DEPLOYMENT_TIMEOUT` / per-task timeout) as a
+  real wall-clock deadline instead of a fixed number of status-check attempts.
+  When the Argo CD API responded slowly, a rollout could previously run well
+  past its configured timeout; the deadline now also cancels in-flight Argo CD
+  API calls, so a deployment can no longer overrun the configured duration
+  (#304).
 - Reject invalid or unauthorized tokens with `401 Unauthorized` and an
   actionable reason instead of `500 Internal Server Error`, and distinguish a
   missing token from an invalid one in the `401` response.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760524057,
-        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
         viteShim = pkgs.writeShellApplication {
           name = "vite";
-          runtimeInputs = [ pkgs.nodejs_20 ];
+          runtimeInputs = [ pkgs.nodejs_24 ];
           text = ''
             set -euo pipefail
             if [ -x "$PWD/node_modules/.bin/vite" ]; then
@@ -53,45 +53,18 @@
 
         frontendToolchain =
           (with pkgs; [
-            nodejs_20
+            nodejs_24
             pnpm
             corepack
           ]) ++ [ viteShim ];
 
-        # mkdocs-llmstxt and its dependency chain (mdformat-tables, mdformat)
-        # are not packaged for python311 in nixpkgs, so we build them from PyPI
-        # sdists to keep the dev shell's `mkdocs build`/`serve` in sync with
-        # docs/requirements.txt. mdformat is pinned to 0.7.22 — the same version
-        # pip resolves on Read the Docs, since mdformat-tables caps mdformat
-        # <0.8.0 (nixpkgs only ships mdformat 1.0.0, which is disabled on 3.11).
-        py = pkgs.python311Packages;
-
-        mdformat-0_7 = py.buildPythonPackage rec {
-          pname = "mdformat";
-          version = "0.7.22";
-          pyproject = true;
-          src = pkgs.fetchPypi {
-            inherit pname version;
-            hash = "sha256-7vhPqPIz0xYnNGg8KopiIiJ6IpuSBocuYTlljZmsseo=";
-          };
-          build-system = [ py.setuptools ];
-          dependencies = [ py.markdown-it-py ];
-          pythonImportsCheck = [ "mdformat" ];
-        };
-
-        mdformat-tables = py.buildPythonPackage rec {
-          pname = "mdformat-tables";
-          version = "1.0.0";
-          pyproject = true;
-          src = pkgs.fetchPypi {
-            pname = "mdformat_tables";
-            inherit version;
-            hash = "sha256-pX2xrBfEoSXaeU70VTmQS7ipWS6AVX1SXh8WnJbaosg=";
-          };
-          build-system = [ py.flit-core ];
-          dependencies = [ mdformat-0_7 py.wcwidth ];
-          pythonImportsCheck = [ "mdformat_tables" ];
-        };
+        # mkdocs-llmstxt is not packaged in nixpkgs, so we build it from its PyPI
+        # sdist to keep the dev shell's `mkdocs build`/`serve` in sync with
+        # docs/requirements.txt. Everything it needs — mkdocs, mdformat 1.0.0 and
+        # mdformat-gfm (the successor to the archived mdformat-tables) — now ships
+        # in nixpkgs for the default python3 interpreter, so no other custom sdist
+        # builds are required.
+        py = pkgs.python3Packages;
 
         mkdocs-llmstxt = py.buildPythonPackage rec {
           pname = "mkdocs-llmstxt";
@@ -107,13 +80,16 @@
             py.mkdocs
             py.beautifulsoup4
             py.markdownify
-            mdformat-0_7
-            mdformat-tables
+            py.mdformat
+            py.mdformat-gfm
           ];
+          # mdformat-gfm supersedes the archived mdformat-tables and already provides
+          # the "tables" extension mkdocs-llmstxt requests, so strip the stale pin.
+          pythonRemoveDeps = [ "mdformat-tables" ];
           pythonImportsCheck = [ "mkdocs_llmstxt" ];
         };
 
-        docsPython = pkgs.python311.withPackages (ps: (with ps; [
+        docsPython = pkgs.python3.withPackages (ps: (with ps; [
           mkdocs
           mkdocs-material
           mkdocs-material-extensions

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -20,7 +21,7 @@ import (
 type ArgoApiInterface interface {
 	Init(serverConfig *config.ServerConfig) error
 	GetUserInfo() (*models.Userinfo, error)
-	GetApplication(app string) (*models.Application, error)
+	GetApplication(ctx context.Context, app string) (*models.Application, error)
 }
 
 type ArgoApi struct {
@@ -87,12 +88,18 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 // bytes along with the HTTP status code. Only the HTTP round-trip is retried; request creation
 // and body reading errors are not retried. HTTP error responses (4xx, 5xx) are valid API
 // responses and are returned as-is without retry.
-func (api *ArgoApi) doGet(reqURL string) ([]byte, int, error) {
+//
+// The supplied context bounds both the in-flight HTTP round-trip and the retry/backoff loop:
+// once it is cancelled or its deadline is exceeded, any pending request is aborted and no
+// further attempts are made, so a slow ArgoCD cannot stretch a single call past the caller's
+// deadline.
+func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, error) {
 	req, err := api.requestFn("GET", reqURL, nil)
 	if err != nil {
 		return nil, 0, err
 	}
 
+	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "application/json")
 
 	// Safe to reuse across retries: GET request has no body that would be consumed.
@@ -103,6 +110,7 @@ func (api *ArgoApi) doGet(reqURL string) ([]byte, int, error) {
 			resp, doErr = api.client.Do(req)
 			return doErr
 		},
+		retry.Context(ctx),
 		retry.Attempts(api.maxRetries),
 		retry.Delay(time.Second),
 		retry.MaxDelay(30*time.Second),
@@ -155,7 +163,7 @@ func parseArgoErrorResponse(body []byte) error {
 func (api *ArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	apiUrl := fmt.Sprintf("%s/api/v1/session/userinfo", api.baseUrl.String())
 
-	body, statusCode, err := api.doGet(apiUrl)
+	body, statusCode, err := api.doGet(context.Background(), apiUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -172,14 +180,16 @@ func (api *ArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	return &userInfo, nil
 }
 
-func (api *ArgoApi) GetApplication(app string) (*models.Application, error) {
+// GetApplication fetches the named ArgoCD application. The context bounds the request and its
+// retry loop so a caller polling under a deadline is never blocked past that deadline.
+func (api *ArgoApi) GetApplication(ctx context.Context, app string) (*models.Application, error) {
 	apiUrl := fmt.Sprintf("%s/api/v1/applications/%s", api.baseUrl.String(), url.PathEscape(app))
 
 	if api.refreshApp {
 		apiUrl += "?refresh=normal"
 	}
 
-	body, statusCode, err := api.doGet(apiUrl)
+	body, statusCode, err := api.doGet(ctx, apiUrl)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to execute request")
 		return nil, err

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -355,7 +356,7 @@ func TestArgoApiGetApplicationSuccess(t *testing.T) {
 	api.baseUrl = *parsedURL
 	api.client = server.Client()
 	api.maxRetries = 1
-	result, err := api.GetApplication("demo")
+	result, err := api.GetApplication(context.Background(), "demo")
 	require.NoError(t, err)
 	assert.Equal(t, app.Status.Health.Status, result.Status.Health.Status)
 	assert.Equal(t, app.Status.Sync.Status, result.Status.Sync.Status)
@@ -392,7 +393,7 @@ func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {
 			api.baseUrl = *parsedURL
 			api.client = server.Client()
 			api.maxRetries = 1
-			_, err = api.GetApplication(tc.appName)
+			_, err = api.GetApplication(context.Background(), tc.appName)
 			assert.NoError(t, err)
 		})
 	}
@@ -416,7 +417,7 @@ func TestArgoApiGetApplicationAddsRefreshQuery(t *testing.T) {
 	api.client = server.Client()
 	api.maxRetries = 1
 	api.refreshApp = true
-	_, err = api.GetApplication("demo")
+	_, err = api.GetApplication(context.Background(), "demo")
 	assert.NoError(t, err)
 }
 
@@ -611,7 +612,7 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(t, tc.api)
 			}
-			app, err := tc.api.GetApplication("demo")
+			app, err := tc.api.GetApplication(context.Background(), "demo")
 			if tc.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, app)
@@ -652,7 +653,7 @@ func TestArgoApiDoGetRetriesOnTransientError(t *testing.T) {
 		}),
 	}
 
-	body, statusCode, err := api.doGet("https://example.com/api/v1/session/userinfo")
+	body, statusCode, err := api.doGet(context.Background(), "https://example.com/api/v1/session/userinfo")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.JSONEq(t, string(successBody), string(body))
@@ -677,7 +678,7 @@ func TestArgoApiDoGetExhaustsRetries(t *testing.T) {
 		}),
 	}
 
-	body, statusCode, err := api.doGet("https://example.com/api/v1/session/userinfo")
+	body, statusCode, err := api.doGet(context.Background(), "https://example.com/api/v1/session/userinfo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "persistent timeout")
 	assert.Nil(t, body)
@@ -708,11 +709,73 @@ func TestArgoApiDoGetNoRetryOnSuccess(t *testing.T) {
 		}),
 	}
 
-	body, statusCode, err := api.doGet("https://example.com/api/v1/test")
+	body, statusCode, err := api.doGet(context.Background(), "https://example.com/api/v1/test")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, successBody, body)
 	assert.Equal(t, int32(1), callCount.Load())
+}
+
+// TestArgoApiDoGetHonorsContextCancellation verifies that a cancelled context stops the retry
+// loop after the in-flight attempt instead of exhausting maxRetries with backoff. This is what
+// lets the rollout deadline bound each individual API call (issue #304).
+func TestArgoApiDoGetHonorsContextCancellation(t *testing.T) {
+	var callCount atomic.Int32
+
+	baseURL, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	api := NewArgoApi()
+	api.baseUrl = *baseURL
+	api.maxRetries = 5
+	api.client = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			callCount.Add(1)
+			// Simulate the caller's deadline firing while the request is in flight.
+			cancel()
+			return nil, errors.New("transient")
+		}),
+	}
+
+	start := time.Now()
+	_, _, err = api.doGet(ctx, "https://example.com/api/v1/test")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), callCount.Load(), "cancellation must stop retries after the in-flight attempt")
+	assert.Less(t, elapsed, time.Second, "must not wait out the retry backoff after cancellation")
+}
+
+// TestArgoApiDoGetNoRequestWhenContextAlreadyDone verifies that a context already past its deadline
+// before the first attempt short-circuits doGet with no HTTP round-trip. This is the state a nearly
+// expired rollout deadline produces on its final poll.
+func TestArgoApiDoGetNoRequestWhenContextAlreadyDone(t *testing.T) {
+	var callCount atomic.Int32
+
+	baseURL, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done before doGet runs
+
+	api := NewArgoApi()
+	api.baseUrl = *baseURL
+	api.maxRetries = 5
+	api.client = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			callCount.Add(1)
+			return &http.Response{StatusCode: http.StatusOK, Body: &stubBody{data: []byte(`{}`)}, Header: make(http.Header)}, nil
+		}),
+	}
+
+	_, _, err = api.doGet(ctx, "https://example.com/api/v1/test")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(0), callCount.Load(), "an already-cancelled context must skip the HTTP round-trip entirely")
 }
 
 // TestArgoApiDoGetNoRetryOnNon2xx verifies that HTTP error responses (4xx/5xx)
@@ -739,7 +802,7 @@ func TestArgoApiDoGetNoRetryOnNon2xx(t *testing.T) {
 		}),
 	}
 
-	body, statusCode, err := api.doGet("https://example.com/api/v1/test")
+	body, statusCode, err := api.doGet(context.Background(), "https://example.com/api/v1/test")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, statusCode)
 	assert.Equal(t, errorBody, body)

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -68,9 +69,10 @@ func (monitor *DeploymentMonitor) EndTracking() {
 	monitor.argo.metrics.RemoveInProgressTask()
 }
 
-// FetchApplication retrieves the ArgoCD application by name.
-func (monitor *DeploymentMonitor) FetchApplication(appName string) (*models.Application, error) {
-	return monitor.argo.api.GetApplication(appName)
+// FetchApplication retrieves the ArgoCD application by name. The context bounds the underlying
+// API call so callers polling under a deadline are not blocked past it.
+func (monitor *DeploymentMonitor) FetchApplication(ctx context.Context, appName string) (*models.Application, error) {
+	return monitor.argo.api.GetApplication(ctx, appName)
 }
 
 // StoreInitialAppStatus caches the initial rollout status for comparison during monitoring.
@@ -92,35 +94,67 @@ func (monitor *DeploymentMonitor) StoreInitialAppStatus(task *models.Task, appli
 }
 
 // WaitRollout polls the application status until it reaches a final state or times out.
+//
+// The timeout is enforced as a wall-clock deadline, not merely as a fixed number of poll
+// attempts: a context deadline bounds the whole loop (and, through FetchApplication, each
+// individual API call). This prevents the deployment from running far past its configured
+// timeout when ArgoCD responds slowly — the failure mode reported in issue #304.
 func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Application, error) {
+	// application holds the most recent successfully-fetched state. It is deliberately assigned only
+	// inside the success branch so that a fetch aborted by the deadline (which returns a nil application)
+	// cannot clobber the last-known-good status we want to report on timeout.
 	var application *models.Application
-	var err error
 
-	retryOptions := monitor.configureRetryOptions(task)
-	log.Debug().Str("id", task.Id).Msg("Waiting for rollout")
+	retryOptions, deadline := monitor.configureRetryOptions(task)
 
-	err = retry.Do(func() error {
-		application, err = monitor.FetchApplication(task.App)
-		if err != nil {
-			return handleApplicationFetchError(task, err)
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+	retryOptions = append(retryOptions, retry.Context(ctx))
+
+	log.Debug().Str("id", task.Id).Dur("deadline", deadline).Msg("Waiting for rollout")
+
+	err := retry.Do(func() error {
+		app, fetchErr := monitor.FetchApplication(ctx, task.App)
+		if fetchErr != nil {
+			return handleApplicationFetchError(task, fetchErr)
 		}
+		application = app
 
 		// Early return for fire and forget mode
-		if application.IsFireAndForgetModeActive() {
+		if app.IsFireAndForgetModeActive() {
 			log.Debug().Str("id", task.Id).Msg("Fire and forget mode is active, skipping checks...")
 			return nil
 		}
 
-		return checkRolloutStatus(task, application, monitor.registryProxyUrl, monitor.acceptSuspended)
+		return checkRolloutStatus(task, app, monitor.registryProxyUrl, monitor.acceptSuspended)
 	}, retryOptions...)
 
-	// Once the retry budget is exhausted while still polling, surface the last-fetched application instead of the
-	// internal sentinel so the caller can report the real rollout status (e.g. "not synced", "not healthy") to the user.
-	if errors.Is(err, errForceRetry) && application != nil {
+	// Once the retry budget or the wall-clock deadline is exhausted while still polling, surface the
+	// last successfully-fetched application instead of the internal sentinel or the context error, so
+	// the caller can report the real rollout status (e.g. "not synced", "not healthy") to the user.
+	// If no fetch ever succeeded (application is nil), the error is returned so the caller can classify
+	// the underlying failure (e.g. connection refused -> aborted).
+	if application != nil && (errors.Is(err, errForceRetry) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
 		err = nil
 	}
 
 	return application, err
+}
+
+// mulDurationSaturating returns count*unit, clamped to math.MaxInt64 to avoid the uint->int64
+// overflow that a very large (client-supplied) attempt count could otherwise wrap into a negative
+// duration. A non-positive unit or zero count yields 0.
+func mulDurationSaturating(count uint, unit time.Duration) time.Duration {
+	if unit <= 0 || count == 0 {
+		return 0
+	}
+	// unit > 0 is guaranteed above, so the quotient is a non-negative int64 that fits in uint64.
+	maxCount := uint64(math.MaxInt64 / int64(unit)) // #nosec G115 -- non-negative quotient
+	if uint64(count) > maxCount {
+		return time.Duration(math.MaxInt64)
+	}
+	// The guard above proves count fits in a positive int64, so this conversion cannot overflow.
+	return time.Duration(count) * unit // #nosec G115 -- count bounded by check above
 }
 
 // ceilDivDuration returns the ceiling of d/unit as an int64, with a minimum of 1.
@@ -150,7 +184,12 @@ func safeIntToUint(v int64) uint {
 }
 
 // configureRetryOptions derives retry attempts by preferring per-task overrides, then monitor defaults, and finally a legacy retry window aligned with the current retry delay.
-func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) []retry.Option {
+//
+// Alongside the retry options it returns the wall-clock deadline for the whole polling loop,
+// computed as attempts*delay. The attempt count still caps the number of polls, while the
+// deadline caps the elapsed time so that slow API responses cannot stretch the loop past the
+// intended timeout (see WaitRollout).
+func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]retry.Option, time.Duration) {
 	retryOptions := append([]retry.Option{}, monitor.retryOptions...)
 
 	delay := monitor.retryDelay
@@ -171,7 +210,7 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) []retr
 
 	if task.Timeout <= 0 {
 		log.Debug().Str("id", task.Id).Msgf("Task timeout is non-positive, defaulting to %d attempts", defaultAttempts)
-		return append(retryOptions, retry.Attempts(defaultAttempts))
+		return append(retryOptions, retry.Attempts(defaultAttempts)), mulDurationSaturating(defaultAttempts, delay)
 	}
 
 	attempts := safeIntToUint(int64(task.Timeout)/delaySeconds + 1)
@@ -184,7 +223,7 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) []retr
 		attempts,
 	)
 
-	return append(retryOptions, retry.Attempts(attempts))
+	return append(retryOptions, retry.Attempts(attempts)), mulDurationSaturating(attempts, delay)
 }
 
 // ProcessDeploymentResult determines if the deployment was successful and updates the appropriate status and metrics.
@@ -360,8 +399,9 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 // waitForApplicationDeployment coordinates the deployment monitoring process
 // It checks initial status, updates the git repo if needed, and waits for rollout
 func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, error) {
-	// Fetch initial app state
-	app, err := updater.monitor.FetchApplication(task.App)
+	// Fetch initial app state. This single call happens before the timed polling loop, so it is
+	// bounded only by the HTTP client's per-request timeout rather than the rollout deadline.
+	app, err := updater.monitor.FetchApplication(context.Background(), task.App)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -1,8 +1,10 @@
 package argocd
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"testing"
@@ -121,7 +123,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -172,8 +174,8 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		healthyApp.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
-		apiMock.EXPECT().GetApplication(task.App).Return(&healthyApp, nil).Times(1)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -216,7 +218,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -261,7 +263,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -296,7 +298,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -326,7 +328,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -356,7 +358,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(nil, fmt.Errorf("unexpected failure"))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf("unexpected failure"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -397,7 +399,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Summary.Images = []string{"test-image:v0.0.1"}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -447,7 +449,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.OperationState.Message = "Not working test app"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -495,7 +497,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "NotHealthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -784,13 +786,13 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 	task := models.Task{App: "demo", Validated: true}
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
-		api.EXPECT().GetApplication(task.App).Return(nil, errors.New("network")).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, errors.New("network")).Times(1)
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
-		api.EXPECT().GetApplication(task.App).Return(nil, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, nil).Times(1)
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
@@ -799,7 +801,7 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
 		app.Spec.Source.RepoURL = ""
-		api.EXPECT().GetApplication(task.App).Return(app, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(app, nil).Times(1)
 
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
@@ -823,7 +825,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 	t.Run("handlesFireAndForget", func(t *testing.T) {
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{"argo-watcher/fire-and-forget": "true"}
-		api.EXPECT().GetApplication(task.App).Return(app, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(app, nil).Times(1)
 
 		received, err := monitor.WaitRollout(task)
 		require.NoError(t, err)
@@ -832,12 +834,120 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 
 	t.Run("wrapsApplicationFetchErrors", func(t *testing.T) {
 		errNotFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
-		api.EXPECT().GetApplication(task.App).Return(nil, errNotFound).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, errNotFound).Times(1)
 
 		_, err := monitor.WaitRollout(task)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), errNotFound.Error())
 	})
+}
+
+// TestDeploymentMonitorWaitRolloutRespectsDeadline verifies that WaitRollout stops at its
+// wall-clock deadline instead of exhausting the full attempt budget when the ArgoCD API
+// responds slowly. This is the regression guard for issue #304: with the attempt budget alone,
+// slow polls would let a rollout run far past its configured timeout.
+func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := mock.NewMockArgoApiInterface(ctrl)
+	monitor := NewDeploymentMonitor(
+		Argo{api: api},
+		"",
+		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+
+	// Timeout 20 with a ~1s-rounded step yields 21 attempts and a 21ms deadline. Each poll sleeps
+	// far longer than the deadline, so the loop must abort after the first poll, not after 21.
+	task := models.Task{Id: "test-id", App: "demo", Timeout: 20}
+
+	// A perpetually non-final application keeps checkRolloutStatus returning the force-retry sentinel.
+	app := &models.Application{}
+	app.Status.Sync.Status = "OutOfSync"
+	app.Status.Health.Status = "Progressing"
+
+	api.EXPECT().GetApplication(gomock.Any(), task.App).DoAndReturn(
+		func(_ context.Context, _ string) (*models.Application, error) {
+			time.Sleep(40 * time.Millisecond)
+			return app, nil
+		}).MinTimes(1).MaxTimes(3)
+
+	start := time.Now()
+	received, err := monitor.WaitRollout(task)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "deadline expiry while polling must be swallowed so the caller reports the real status")
+	assert.Equal(t, app, received)
+	assert.Less(t, elapsed, 300*time.Millisecond, "loop must honor the wall-clock deadline, not run all 21 attempts")
+}
+
+// TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline verifies that when the deadline
+// fires while a poll is in flight (the realistic slow-ArgoCD case for issue #304), WaitRollout still
+// returns the last successfully-fetched application — so ProcessDeploymentResult reports the real
+// rollout status rather than a raw "context deadline exceeded" error.
+func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := mock.NewMockArgoApiInterface(ctrl)
+	monitor := NewDeploymentMonitor(
+		Argo{api: api},
+		"",
+		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	task := models.Task{Id: "test-id", App: "demo", Timeout: 1}
+
+	goodApp := &models.Application{}
+	goodApp.Status.Sync.Status = "OutOfSync"
+	goodApp.Status.Health.Status = "Progressing"
+
+	firstDone := false
+	api.EXPECT().GetApplication(gomock.Any(), task.App).DoAndReturn(
+		func(ctx context.Context, _ string) (*models.Application, error) {
+			if !firstDone {
+				firstDone = true
+				return goodApp, nil
+			}
+			// Subsequent poll is still in flight when the deadline fires: it is cancelled and
+			// returns a nil application, exactly as the real HTTP layer would.
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).MinTimes(2).MaxTimes(3)
+
+	received, err := monitor.WaitRollout(task)
+	require.NoError(t, err)
+	assert.Equal(t, goodApp, received, "should report the last successfully-fetched application, not nil")
+}
+
+// TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds verifies that when ArgoCD is
+// unreachable for the entire window, WaitRollout surfaces the underlying fetch error (not a swallowed
+// nil) so the caller can classify it — e.g. "connect: connection refused" -> aborted.
+func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := mock.NewMockArgoApiInterface(ctrl)
+	monitor := NewDeploymentMonitor(
+		Argo{api: api},
+		"",
+		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	task := models.Task{Id: "test-id", App: "demo", Timeout: 1}
+
+	api.EXPECT().GetApplication(gomock.Any(), task.App).
+		Return(nil, errors.New(argoUnavailableErrorMessage)).MinTimes(1)
+
+	received, err := monitor.WaitRollout(task)
+	require.Error(t, err)
+	assert.Nil(t, received)
+	assert.Contains(t, err.Error(), argoUnavailableErrorMessage,
+		"the underlying cause must survive so determineFailureStatus can classify it")
 }
 
 func TestHandleApplicationFetchError(t *testing.T) {
@@ -1034,6 +1144,30 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 	})
 }
 
+func TestMulDurationSaturating(t *testing.T) {
+	testCases := []struct {
+		name     string
+		count    uint
+		unit     time.Duration
+		expected time.Duration
+	}{
+		{name: "normal", count: 3, unit: 15 * time.Second, expected: 45 * time.Second},
+		{name: "zeroCount", count: 0, unit: time.Second, expected: 0},
+		{name: "zeroUnit", count: 5, unit: 0, expected: 0},
+		{name: "negativeUnit", count: 5, unit: -time.Second, expected: 0},
+		{name: "overflowClampsToMaxInt64", count: math.MaxUint32, unit: time.Hour, expected: time.Duration(math.MaxInt64)},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := mulDurationSaturating(tc.count, tc.unit)
+			assert.Equal(t, tc.expected, got)
+			assert.GreaterOrEqual(t, got, time.Duration(0), "deadline must never be negative")
+		})
+	}
+}
+
 func TestCeilDivDuration(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -1214,9 +1348,17 @@ func TestDeploymentMonitor_configureRetryOptions(t *testing.T) {
 				false,
 				tc.retryDelay,
 			)
-			options := monitor.configureRetryOptions(models.Task{Id: "test-id", Timeout: tc.timeout})
+			options, deadline := monitor.configureRetryOptions(models.Task{Id: "test-id", Timeout: tc.timeout})
 			attempts := countAttempts(options)
 			assert.Equal(t, tc.expectedAttempts, attempts)
+
+			// The deadline must match attempts*delay so the wall-clock cap and the attempt cap
+			// describe the same budget (delay falls back to ArgoSyncRetryDelay when non-positive).
+			delay := tc.retryDelay
+			if delay <= 0 {
+				delay = ArgoSyncRetryDelay
+			}
+			assert.Equal(t, time.Duration(tc.expectedAttempts)*delay, deadline)
 		})
 	}
 
@@ -1233,8 +1375,9 @@ func TestDeploymentMonitor_configureRetryOptions(t *testing.T) {
 		)
 		monitor.defaultAttempts = 5
 
-		options := monitor.configureRetryOptions(models.Task{Id: "test-id", Timeout: 0})
+		options, deadline := monitor.configureRetryOptions(models.Task{Id: "test-id", Timeout: 0})
 		attempts := countAttempts(options)
 		assert.Equal(t, 5, attempts, "Should use the configured defaultAttempts when timeout is zero")
+		assert.Equal(t, 5*ArgoSyncRetryDelay, deadline, "Default-attempts deadline should be attempts*delay")
 	})
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -38,7 +38,7 @@ func (m *mockArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	return &models.Userinfo{LoggedIn: true, Username: "test"}, nil
 }
 
-func (m *mockArgoApi) GetApplication(_ string) (*models.Application, error) {
+func (m *mockArgoApi) GetApplication(_ context.Context, _ string) (*models.Application, error) {
 	return &models.Application{}, nil
 }
 


### PR DESCRIPTION
  ## Summary

  Fixes #304. The rollout timeout was enforced only as a fixed number of
  status-check attempts (`timeout/delay + 1`). When the Argo CD API responded
  slowly, each poll took longer than the assumed step, so the actual duration
  drifted well past the configured `DEPLOYMENT_TIMEOUT` / per-task timeout —
  deployments were reported as failed 40–60 minutes into a 30-minute budget.
  
  ## Changes
  
  - Bound the poll loop in `WaitRollout` with `context.WithTimeout` and
    `retry.Context`, using a deadline derived from the attempt budget
    (`attempts × delay`). The attempt count still caps the number of polls;
    the deadline caps elapsed time.
  - Thread the context through `GetApplication` into `doGet` and add
    `retry.Context` to the HTTP retry loop, so a slow in-flight Argo CD call is
    cancelled at the deadline instead of stretching the loop.
  - Swallow context cancellation like the existing force-retry sentinel, so the
    real rollout status (e.g. "not synced", "not healthy") is still reported on
    timeout rather than a raw "context deadline exceeded".
  - Assign the last successfully-fetched application only on success, so a
    deadline-aborted poll (which returns nil) cannot clobber the status reported
    on timeout.
  - Clamp the `attempts × delay` deadline computation to avoid a `uint → int64`
    overflow wrapping a large client-supplied timeout into a negative (instantly
    expired) deadline.

  ## Compatibility
  
  No new configuration and no API changes. `DEPLOYMENT_TIMEOUT` now behaves as
  the hard upper bound its documentation already describes.