### PR TITLE
fix(client): retry transient network and 5xx errors while polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retry transient failures (network errors or `5xx` responses) up to 3 times
+  with a 2-second backoff while the CLI client polls the server for deployment
+  status, instead of aborting the pipeline on the first blip. Terminal failures
+  (`4xx`, invalid tokens, malformed responses) still fail fast, and task
+  submission is not retried (#217).
 - Enforce the deployment timeout (`DEPLOYMENT_TIMEOUT` / per-task timeout) as a
   real wall-clock deadline instead of a fixed number of status-check attempts.
   When the Argo CD API responded slowly, a rollout could previously run well

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -40,6 +40,8 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - Verify the app name: `argocd app get <ARGO_APP>`.
 - Check the image that was pushed to the registry.
 
+> **Note:** While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses) up to 3 times with a 2-second backoff, so a single blip is not fatal. A non-zero exit here means the failure persisted past those retries or was terminal (`4xx`, invalid token).
+
 **Fix:**
 1. Ensure `ARGO_WATCHER_URL` is accessible from the CI environment (check firewall rules and DNS).
 2. Verify the application name in `ARGO_APP` matches Argo CD exactly (case-sensitive).

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -24,3 +24,7 @@ The Argo Watcher client is a lightweight CLI tool distributed as a Docker image 
 | `RETRY_INTERVAL`            | Interval between status polling attempts (e.g. `15s`, `1m`)                                    |
 | `EXPECTED_DEPLOY_TIME`      | Expected deployment duration; affects polling behavior (e.g. `15m`, `30m`)                     |
 | `DEBUG`                     | Enable verbose debug output                                                                      |
+
+## Retry Behavior
+
+While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses from the server) up to 3 times with a fixed 2-second delay before giving up. This retry count and delay are not configurable. Terminal failures (`4xx` responses, invalid tokens, malformed responses) fail immediately, and task submission (the initial `POST`) is not retried.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,18 +23,29 @@ var (
 	clientConfig *Config
 )
 
+const (
+	// maxTransientRetries is how many times a GET request is retried after a
+	// transient failure (network error or 5xx) before giving up. Deployments
+	// can poll for many minutes, so a single blip must not abort the process.
+	maxTransientRetries = 3
+	// defaultRetryDelay is the fixed backoff between transient retries.
+	defaultRetryDelay = 2 * time.Second
+)
+
 type Watcher struct {
-	baseUrl   string
-	client    *http.Client
-	debugMode bool
+	baseUrl    string
+	client     *http.Client
+	debugMode  bool
+	retryDelay time.Duration
 }
 
 // NewWatcher creates a new Watcher instance with the given base URL, timeout, and debug mode.
 func NewWatcher(baseUrl string, debugMode bool, timeout time.Duration) *Watcher {
 	return &Watcher{
-		baseUrl:   baseUrl,
-		client:    &http.Client{Timeout: timeout},
-		debugMode: debugMode,
+		baseUrl:    baseUrl,
+		client:     &http.Client{Timeout: timeout},
+		debugMode:  debugMode,
+		retryDelay: defaultRetryDelay,
 	}
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -177,6 +177,9 @@ func TestNewWatcher(t *testing.T) {
 	assert.Equal(t, baseUrl, watcher.baseUrl)
 	assert.Equal(t, debugMode, watcher.debugMode)
 	assert.NotNil(t, watcher.client)
+	// The retry backoff must default to a non-zero value, otherwise a persistent
+	// outage would spin through all retries with no pause (see issue #217).
+	assert.Equal(t, defaultRetryDelay, watcher.retryDelay)
 }
 
 func TestAddTask(t *testing.T) {

--- a/pkg/client/utility.go
+++ b/pkg/client/utility.go
@@ -2,14 +2,27 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 )
+
+// transientError wraps a failure that is safe to retry: a network-level error
+// (connection refused/reset, DNS, timeout) or a 5xx response from argo-watcher.
+// Terminal failures (4xx, malformed 200 bodies) are returned unwrapped so the
+// retry loop stops immediately.
+type transientError struct {
+	err error
+}
+
+func (e transientError) Error() string { return e.err.Error() }
+func (e transientError) Unwrap() error { return e.err }
 
 // doRequest creates a new HTTP request and sends it using the watcher's client,
 // returning the response or an error.
@@ -21,12 +34,38 @@ func (watcher *Watcher) doRequest(method, url string, body io.Reader) (*http.Res
 	return watcher.client.Do(req)
 }
 
-// getJSON sends a GET request to a provided URL,
-// parses the JSON response and stores it in the value pointed by v.
+// getJSON sends a GET request to a provided URL, parses the JSON response and
+// stores it in the value pointed by v. Transient failures (network errors or
+// 5xx responses) are retried up to maxTransientRetries times with a fixed
+// backoff, so a temporary networking problem does not abort a long-running
+// deployment poll. Terminal failures (4xx, malformed responses) are returned
+// immediately — retrying them never succeeds.
 func (watcher *Watcher) getJSON(url string, v interface{}) error {
+	for attempt := 0; ; attempt++ {
+		err := watcher.getJSONOnce(url, v)
+		if err == nil {
+			return nil
+		}
+
+		var te transientError
+		if !errors.As(err, &te) || attempt >= maxTransientRetries {
+			return err
+		}
+
+		log.Printf("transient error talking to argo-watcher (attempt %d/%d): %v; retrying in %s",
+			attempt+1, maxTransientRetries, err, watcher.retryDelay)
+		time.Sleep(watcher.retryDelay)
+	}
+}
+
+// getJSONOnce performs a single GET request and decodes the JSON response into
+// v. It classifies failures as transient (retryable) or terminal by wrapping
+// the former in transientError.
+func (watcher *Watcher) getJSONOnce(url string, v interface{}) error {
 	resp, err := watcher.doRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return err
+		// Network-level failure: connection refused/reset, DNS, timeout.
+		return transientError{err}
 	}
 
 	defer func() {
@@ -37,7 +76,12 @@ func (watcher *Watcher) getJSON(url string, v interface{}) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return serverErrorFromResponse(resp.StatusCode, body)
+		serverErr := serverErrorFromResponse(resp.StatusCode, body)
+		if resp.StatusCode >= http.StatusInternalServerError {
+			// 5xx: the server is up but temporarily unavailable (e.g. restarting).
+			return transientError{serverErr}
+		}
+		return serverErr
 	}
 
 	return json.NewDecoder(resp.Body).Decode(v)

--- a/pkg/client/utility_test.go
+++ b/pkg/client/utility_test.go
@@ -3,17 +3,172 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/stretchr/testify/assert"
 )
+
+// newTestWatcher builds a Watcher pointing at the given URL with retries enabled
+// but a zero backoff, so retry-path tests run instantly.
+func newTestWatcher(url string) *Watcher {
+	watcher := NewWatcher(url, false, 30*time.Second)
+	watcher.retryDelay = 0
+	return watcher
+}
+
+// flakyTransport fails the first `failures` round-trips with a network error,
+// then delegates to fallback. It counts every attempt so tests can assert how
+// many requests actually left the client.
+type flakyTransport struct {
+	failures int32
+	calls    int32
+	fallback http.RoundTripper
+}
+
+func (f *flakyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := atomic.AddInt32(&f.calls, 1)
+	if n <= f.failures {
+		return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	}
+	return f.fallback.RoundTrip(req)
+}
+
+// TestGetJSON_RetriesOn5xxThenSucceeds verifies a transient 5xx is retried and
+// the eventual 200 is decoded, rather than aborting the whole process.
+func TestGetJSON_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if calls.Add(1) <= 2 {
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = rw.Write([]byte(`{"error":"temporarily unavailable"}`))
+			return
+		}
+		_, _ = rw.Write([]byte(`{"message":"OK"}`))
+	}))
+	defer server.Close()
+
+	watcher := newTestWatcher(server.URL)
+	var resp struct {
+		Message string `json:"message"`
+	}
+	err := watcher.getJSON(server.URL, &resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", resp.Message)
+	assert.Equal(t, int32(3), calls.Load(), "two 503s then a 200 should be three requests")
+}
+
+// TestGetJSON_RetriesNetworkErrorThenSucceeds verifies a transport-level failure
+// (connection refused/reset, DNS, timeout) is retried.
+func TestGetJSON_RetriesNetworkErrorThenSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte(`{"message":"OK"}`))
+	}))
+	defer server.Close()
+
+	transport := &flakyTransport{failures: 2, fallback: server.Client().Transport}
+	watcher := newTestWatcher(server.URL)
+	watcher.client.Transport = transport
+
+	var resp struct {
+		Message string `json:"message"`
+	}
+	err := watcher.getJSON(server.URL, &resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", resp.Message)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&transport.calls), "two dial failures then success should be three attempts")
+}
+
+// TestGetJSON_ExhaustsRetriesOnPersistent5xx verifies retries are bounded and
+// the final error surfaces the server status.
+func TestGetJSON_ExhaustsRetriesOnPersistent5xx(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		rw.WriteHeader(http.StatusBadGateway)
+		_, _ = rw.Write([]byte(`{"error":"bad gateway"}`))
+	}))
+	defer server.Close()
+
+	watcher := newTestWatcher(server.URL)
+	var dummy struct{}
+	err := watcher.getJSON(server.URL, &dummy)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+	assert.Equal(t, int32(maxTransientRetries+1), calls.Load(), "should try once then retry maxTransientRetries times")
+}
+
+// TestGetJSON_DoesNotRetryMalformedBody verifies a 200 response with an
+// unparseable body is terminal: retrying an unchanging bad payload never
+// succeeds, so it must fail on the first attempt.
+func TestGetJSON_DoesNotRetryMalformedBody(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		_, _ = rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	watcher := newTestWatcher(server.URL)
+	var dummy struct{}
+	err := watcher.getJSON(server.URL, &dummy)
+
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load(), "a malformed 200 body must not be retried")
+}
+
+// TestGetJSON_ExhaustsRetriesOnNetworkError verifies a persistent transport-level
+// failure is retried up to the bound and then surfaces the underlying error.
+func TestGetJSON_ExhaustsRetriesOnNetworkError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte(`{"message":"OK"}`))
+	}))
+	defer server.Close()
+
+	// Fail every attempt so the retry budget is exhausted.
+	transport := &flakyTransport{failures: maxTransientRetries + 1, fallback: server.Client().Transport}
+	watcher := newTestWatcher(server.URL)
+	watcher.client.Transport = transport
+
+	var dummy struct{}
+	err := watcher.getJSON(server.URL, &dummy)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.Equal(t, int32(maxTransientRetries+1), atomic.LoadInt32(&transport.calls), "should try once then retry maxTransientRetries times")
+}
+
+// TestGetJSON_DoesNotRetryTerminalError verifies a 4xx (auth failure) fails fast
+// without wasting retries — retrying a rejected token never succeeds.
+func TestGetJSON_DoesNotRetryTerminalError(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		rw.WriteHeader(http.StatusUnauthorized)
+		_, _ = rw.Write([]byte(`{"error":"deploy token is invalid"}`))
+	}))
+	defer server.Close()
+
+	watcher := newTestWatcher(server.URL)
+	var dummy struct{}
+	err := watcher.getJSON(server.URL, &dummy)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.Equal(t, int32(1), calls.Load(), "a terminal 4xx must not be retried")
+}
 
 func TestDoRequest(t *testing.T) {
 	// Test case 1: The server returns a 200 OK status code
@@ -375,9 +530,10 @@ func TestGenerateAppUrl(t *testing.T) {
 	})
 
 	t.Run("ErrorScenario", func(t *testing.T) {
-		// Create a new Watcher instance with an invalid URL
+		// Create a new Watcher instance with an invalid URL. A dial failure is
+		// transient, so use the zero-backoff test watcher to skip retry sleeps.
 		invalidURL := "http://invalid-url"
-		watcher := NewWatcher(invalidURL, false, 30*time.Second)
+		watcher := newTestWatcher(invalidURL)
 
 		// Create a Task for testing
 		task := models.Task{


### PR DESCRIPTION
The CLI client aborted the entire deployment on the first failed status poll, so a temporary networking blip failed the whole pipeline. getJSON now retries transient failures (network errors or 5xx) up to 3 times with a 2s backoff; terminal failures (4xx, auth, malformed responses) still fail fast. Task submission (POST) is intentionally not retried, as it is non-idempotent and a retried connection error could duplicate the task.

Closes #217