### PR TITLE
feat(argocd): cancel superseded deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The CLI client now treats any unrecognized deployment status as terminal and
+  exits with an error instead of polling in a tight loop. **Upgrade CLI clients
+  to this version**: older clients do not understand the new `cancelled` status
+  and will busy-loop against the server if one of their deployments is superseded
+  (#353).
 - Group and humanize server startup misconfiguration errors: missing required
   and invalid environment variables are now reported together in a single
   message listing every offending variable, so you can fix them all in one pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the task detail page links to the earlier task the deployment rolls back to.
 - Expose `IsRollback` and `RollbackTargetId` as webhook notification template
   variables so alerts can highlight rollbacks.
+- Cancel superseded deployments: when a new deployment for an application is
+  triggered while a previous one is still in progress, the older deployment is
+  cancelled and marked with the new `cancelled` status instead of continuing to
+  poll Argo CD until it times out. The CLI client reports the cancellation and
+  the status is filterable in the Web UI (#353).
 
 ### Changed
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -26,6 +26,7 @@ A task in Argo Watcher moves through the following states:
 2. **In Progress** — Image detected in Argo CD, deployment is syncing or running.
 3. **Deployed** — Deployment succeeded; application is healthy and synced.
 4. **Failed** — Deployment failed due to health/sync issues or timeout.
+5. **Cancelled** — Superseded by a newer deployment for the same application before reaching a final state; polling stops. Unlike Failed, a cancelled task is not counted as a deployment failure.
 
 ## Deployment Locking
 

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -12,7 +12,7 @@ There is a single table, `tasks`, that stores every deployment task and its stat
 | `created` | `timestamptz NOT NULL` | Indexed via `idx_tasks_created_app` (descending, with `app`). |
 | `updated` | `timestamptz NOT NULL` | Last status transition. |
 | `images` | `jsonb NOT NULL` | Image list submitted with the task. |
-| `status` | `varchar(20) NOT NULL` | One of: pending, in progress, deployed, failed. |
+| `status` | `varchar(20) NOT NULL` | A task status value defined in `internal/models/constants.go` (e.g. in progress, deployed, failed, cancelled, aborted, app not found). |
 | `status_reason` | `text` | Human-readable failure reason; empty on success. |
 | `is_rollback` | `boolean NOT NULL DEFAULT false` | `true` when this task's image set was previously deployed for the app. |
 | `rollback_target_id` | `text NOT NULL DEFAULT ''` | ID of the earlier task this deployment rolls back to; empty when not a rollback. |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -33,6 +33,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - The `ARGO_APP` name does not match an application in Argo CD.
 - The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
 - The client timed out waiting for the deployment to complete.
+- A newer deployment for the same application was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
 
 **How to verify:**
 - Check the client logs in the CI output.

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -31,6 +31,9 @@ const (
 	ArgoAPIErrorTemplate = "ArgoCD API Error: %s"
 	// argoUnavailableErrorMessage is the specific error message for a refused connection.
 	argoUnavailableErrorMessage = "connect: connection refused"
+	// supersededTaskReason is the status reason stored on a deployment that was
+	// cancelled because a newer deployment for the same app superseded it.
+	supersededTaskReason = "superseded by a newer deployment for the same application"
 )
 
 // Argo is the primary controller for watcher operations.
@@ -90,6 +93,17 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// action) can never influence the stored result.
 	task.RollbackTargetId = argo.detectRollback(task)
 	task.IsRollback = task.RollbackTargetId != ""
+
+	// Supersede any in-flight deployment for this app before starting a new one, so
+	// the watcher stops polling ArgoCD for a rollout nobody is waiting on anymore
+	// (issue #353). This runs against the shared state, so in an HA setup it also
+	// cancels rollouts being watched by other replicas. Best-effort: a failure here
+	// must not block the new deployment.
+	if cancelled, err := argo.State.CancelInProgressTasks(task.App, supersededTaskReason); err != nil {
+		log.Warn().Str("app", task.App).Msgf("Failed to cancel in-progress deployments for the app: %s", err)
+	} else if cancelled > 0 {
+		log.Info().Str("app", task.App).Msgf("Cancelled %d in-progress deployment(s) superseded by the new task", cancelled)
+	}
 
 	newTask, err := argo.State.AddTask(task)
 	if err != nil {

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -127,6 +127,10 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 
 	err := retry.Do(func() error {
 		// Stop before hitting ArgoCD if a newer deployment superseded this task.
+		// The check is per-iteration: a cancellation that lands mid-iteration is
+		// caught on the next poll, and if this iteration reaches a final state
+		// first, its terminal status wins over "cancelled". That last-writer race
+		// is accepted (issue #353) to avoid a status-conditional write.
 		if monitor.taskSuperseded(task.Id) {
 			return retry.Unrecoverable(errTaskSuperseded)
 		}

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -32,6 +32,12 @@ const (
 // It must never reach the user-visible task status — WaitRollout swallows it so the caller can report the actual rollout state instead.
 var errForceRetry = errors.New("force retry")
 
+// errTaskSuperseded is an internal sentinel returned by the poll loop when the task
+// has been marked cancelled in the shared state by a newer deployment for the same
+// app. Unlike errForceRetry it is not swallowed: WaitForRollout uses it to stop
+// without overwriting the "cancelled" status the newer deployment already wrote.
+var errTaskSuperseded = errors.New("task superseded by a newer deployment")
+
 // DeploymentMonitor encapsulates the logic for tracking ArgoCD application rollouts.
 type DeploymentMonitor struct {
 	argo             Argo
@@ -99,6 +105,12 @@ func (monitor *DeploymentMonitor) StoreInitialAppStatus(task *models.Task, appli
 // attempts: a context deadline bounds the whole loop (and, through FetchApplication, each
 // individual API call). This prevents the deployment from running far past its configured
 // timeout when ArgoCD responds slowly — the failure mode reported in issue #304.
+//
+// Before each poll it re-reads the task status from the shared state: if a newer
+// deployment for the same app has marked this task "cancelled" (issue #353), it
+// stops immediately so no further ArgoCD API calls are made. Because the check
+// goes through the shared state, this works across replicas in an HA setup — the
+// cancelling deployment may be handled by a different replica than this poller.
 func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Application, error) {
 	// application holds the most recent successfully-fetched state. It is deliberately assigned only
 	// inside the success branch so that a fetch aborted by the deadline (which returns a nil application)
@@ -114,6 +126,11 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 	log.Debug().Str("id", task.Id).Dur("deadline", deadline).Msg("Waiting for rollout")
 
 	err := retry.Do(func() error {
+		// Stop before hitting ArgoCD if a newer deployment superseded this task.
+		if monitor.taskSuperseded(task.Id) {
+			return retry.Unrecoverable(errTaskSuperseded)
+		}
+
 		app, fetchErr := monitor.FetchApplication(ctx, task.App)
 		if fetchErr != nil {
 			return handleApplicationFetchError(task, fetchErr)
@@ -238,6 +255,19 @@ func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, app
 	} else {
 		monitor.handleDeploymentFailure(task, status, application)
 	}
+}
+
+// taskSuperseded reports whether the task has been marked cancelled in the shared
+// state, i.e. a newer deployment for the same app has superseded it. A read error
+// is treated as "not superseded" so a transient state hiccup does not abort an
+// otherwise healthy rollout; the check runs again on the next poll.
+func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
+	current, err := monitor.argo.State.GetTask(id)
+	if err != nil {
+		log.Warn().Str("id", id).Msgf("Could not read task status to check for supersession: %s", err)
+		return false
+	}
+	return current.Status == models.StatusCancelledMessage
 }
 
 // HandleArgoAPIFailure processes API errors and updates task status accordingly.
@@ -373,7 +403,8 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 }
 
 // WaitForRollout is the main entry point for tracking an application deployment
-// It monitors the application until it reaches a final state (deployed or failed)
+// It monitors the application until it reaches a final state (deployed or failed),
+// or stops early if a newer deployment for the same app supersedes it (issue #353).
 func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
@@ -384,10 +415,17 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	// wait for application to get into deployed status or timeout
 	application, err := updater.waitForApplicationDeployment(task)
 
-	if err != nil {
+	switch {
+	case errors.Is(err, errTaskSuperseded):
+		// A newer deployment for the same app already marked this task "cancelled"
+		// in the shared state (possibly on another replica). Stop without writing a
+		// status so we do not overwrite it; reflect it locally for the notification.
+		log.Info().Str("id", task.Id).Msg("Deployment superseded by a newer deployment for the same app; stopping.")
+		task.Status = models.StatusCancelledMessage
+	case err != nil:
 		// handle application failure
 		updater.monitor.HandleArgoAPIFailure(task, err)
-	} else {
+	default:
 		// process deployment result
 		updater.monitor.ProcessDeploymentResult(&task, application)
 	}
@@ -397,8 +435,14 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 }
 
 // waitForApplicationDeployment coordinates the deployment monitoring process
-// It checks initial status, updates the git repo if needed, and waits for rollout
+// It checks initial status, updates the git repo if needed, and waits for rollout.
 func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, error) {
+	// Bail out before any ArgoCD call or git update if the task was already
+	// superseded by a newer deployment for the same app.
+	if updater.monitor.taskSuperseded(task.Id) {
+		return nil, errTaskSuperseded
+	}
+
 	// Fetch initial app state. This single call happens before the timed polling loop, so it is
 	// bounded only by the HTTP client's per-request timeout rather than the rollout deadline.
 	app, err := updater.monitor.FetchApplication(context.Background(), task.App)

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -51,8 +51,28 @@ func (s failingStrategy) Send(models.Task) error {
 	return s.err
 }
 
+// capturingStrategy records every task passed to a notifier so tests can assert
+// on the status reported in the outgoing notification.
+type capturingStrategy struct {
+	sent []models.Task
+}
+
+func (s *capturingStrategy) Send(task models.Task) error {
+	s.sent = append(s.sent, task)
+	return nil
+}
+
 func zeroDelay(_ uint, _ error, _ *retry.Config) time.Duration {
 	return 0
+}
+
+// notSupersededState returns a TaskRepository mock whose GetTask always reports an
+// in-progress task, so the poll loop's supersession check never fires. Use it when
+// a test exercises rollout polling but is not about cancellation.
+func notSupersededState(ctrl *gomock.Controller) *mock.MockTaskRepository {
+	state := mock.NewMockTaskRepository(ctrl)
+	state.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+	return state
 }
 
 func newUpdaterTestConfig(locker lock.Locker) ArgoStatusUpdaterConfig {
@@ -97,6 +117,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
@@ -142,6 +163,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
@@ -194,6 +216,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -237,6 +260,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
@@ -287,6 +311,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -317,6 +342,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -347,6 +373,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -377,6 +404,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -423,6 +451,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -473,6 +502,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
+		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
@@ -776,6 +806,7 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 
 	argo := &Argo{}
 	argo.Init(state, api, metrics)
+	state.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 	cfg := newUpdaterTestConfig(locker)
 	cfg.RegistryProxyURL = ""
@@ -814,7 +845,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 
 	api := mock.NewMockArgoApiInterface(ctrl)
 	monitor := NewDeploymentMonitor(
-		Argo{api: api},
+		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
 		[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)},
 		false,
@@ -852,7 +883,7 @@ func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
 
 	api := mock.NewMockArgoApiInterface(ctrl)
 	monitor := NewDeploymentMonitor(
-		Argo{api: api},
+		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
 		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
 		false,
@@ -893,7 +924,7 @@ func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.
 
 	api := mock.NewMockArgoApiInterface(ctrl)
 	monitor := NewDeploymentMonitor(
-		Argo{api: api},
+		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
 		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
 		false,
@@ -932,7 +963,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 
 	api := mock.NewMockArgoApiInterface(ctrl)
 	monitor := NewDeploymentMonitor(
-		Argo{api: api},
+		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
 		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
 		false,
@@ -948,6 +979,136 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	assert.Nil(t, received)
 	assert.Contains(t, err.Error(), argoUnavailableErrorMessage,
 		"the underlying cause must survive so determineFailureStatus can classify it")
+}
+
+// TestArgoStatusUpdaterStopsWhenSuperseded verifies that once a newer deployment
+// has marked the task "cancelled" in the shared state, the poll loop stops before
+// making any ArgoCD call and does not overwrite the cancelled status. Because the
+// signal travels through the shared state, this is exactly how cross-replica
+// supersession works in an HA setup.
+func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	metricsMock := mock.NewMockMetricsInterface(ctrl)
+	stateMock := mock.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := models.Task{
+		Id:      "old-id",
+		App:     "test-app",
+		Timeout: 15,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
+	}
+
+	// The task is already cancelled in the shared state (a newer deployment, maybe
+	// on another replica, set it). The poller must observe this and stop.
+	stateMock.EXPECT().GetTask(task.Id).Return(&models.Task{Id: task.Id, Status: models.StatusCancelledMessage}, nil).AnyTimes()
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// No ArgoCD call and no status write: the poller bails immediately, leaving the
+	// "cancelled" status the newer deployment already wrote untouched. Any
+	// GetApplication or SetTaskStatus call would be unexpected and fail the test.
+
+	updater.WaitForRollout(task)
+
+	// The final outgoing notification must report the cancelled status.
+	require.NotEmpty(t, capture.sent)
+	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
+}
+
+// TestArgoStatusUpdaterStopsMidPollWhenSuperseded verifies that a task cancelled
+// while a rollout is already polling is detected on the next poll iteration: the
+// loop stops and the terminal status is not overwritten.
+func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	metricsMock := mock.NewMockMetricsInterface(ctrl)
+	stateMock := mock.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+
+	task := models.Task{
+		Id:      "old-id",
+		App:     "test-app",
+		Timeout: 15,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
+	}
+
+	// Not-final app so the loop would keep polling if not cancelled.
+	application := models.Application{}
+	application.Status.Summary.Images = []string{"test-registry/ghcr.io/shini4i/argo-watcher:dev"}
+	application.Status.Sync.Status = "OutOfSync"
+	application.Status.Health.Status = "Progressing"
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).AnyTimes()
+
+	// First status read (initial supersession check) reports in-progress; the next
+	// read — at the top of the first poll iteration — reports cancelled.
+	gomock.InOrder(
+		stateMock.EXPECT().GetTask(task.Id).Return(&models.Task{Id: task.Id, Status: models.StatusInProgressMessage}, nil),
+		stateMock.EXPECT().GetTask(task.Id).Return(&models.Task{Id: task.Id, Status: models.StatusCancelledMessage}, nil).AnyTimes(),
+	)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// No SetTaskStatus and no failed-deployment metric: a superseded rollout is not
+	// a failure and its status must not be overwritten.
+
+	updater.WaitForRollout(task)
+}
+
+// TestArgoStatusUpdaterProceedsWhenStatusReadFails verifies that a transient
+// failure to read the task status (the supersession check) does not abort an
+// otherwise healthy rollout: taskSuperseded returns false on a read error, so the
+// deployment proceeds to its normal terminal result.
+func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	metricsMock := mock.NewMockMetricsInterface(ctrl)
+	stateMock := mock.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+
+	task := models.Task{
+		Id:      "test-id",
+		App:     "test-app",
+		Timeout: 15,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
+	}
+
+	application := models.Application{}
+	application.Status.Summary.Images = []string{"test-registry/ghcr.io/shini4i/argo-watcher:dev"}
+	application.Status.Sync.Status = "Synced"
+	application.Status.Health.Status = "Healthy"
+
+	// Every supersession check fails to read the status; the rollout must carry on.
+	stateMock.EXPECT().GetTask(task.Id).Return(nil, errors.New("db unavailable")).AnyTimes()
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(1)
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().ResetFailedDeployment(task.App)
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// Proceeds to a normal deployed result rather than stopping as superseded.
+	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
+
+	updater.WaitForRollout(task)
 }
 
 func TestHandleApplicationFetchError(t *testing.T) {
@@ -1045,6 +1206,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
+	stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 	updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
@@ -1130,6 +1292,7 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
+	stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
 	updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -213,6 +213,7 @@ func TestArgoAddTask(t *testing.T) {
 		// mock calls to add task
 		stateError := fmt.Errorf("database error")
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).Return(nil, stateError)
 
 		// argo manager
@@ -261,9 +262,14 @@ func TestArgoAddTask(t *testing.T) {
 			},
 		}
 
-		// mock calls to add task
+		// mock calls to add task. In-progress deployments for the app MUST be
+		// cancelled before the new task is persisted; otherwise the new task would
+		// match the cancel filter and cancel itself. gomock.InOrder locks that.
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
-		state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil)
+		gomock.InOrder(
+			state.EXPECT().CancelInProgressTasks("test-app", supersededTaskReason).Return(int64(0), nil),
+			state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil),
+		)
 
 		// argo manager
 		argo := &Argo{}
@@ -275,6 +281,34 @@ func TestArgoAddTask(t *testing.T) {
 		assert.NotNil(t, newTaskReturned)
 		uuidRegexp := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 		assert.Regexp(t, uuidRegexp, newTaskReturned.Id, "Must match Regexp for uuid v4")
+	})
+
+	t.Run("Argo - Cancel failure does not block new deployment", func(t *testing.T) {
+		// mocks
+		api := mock.NewMockArgoApiInterface(ctrl)
+		metrics := mock.NewMockMetricsInterface(ctrl)
+		state := mock.NewMockTaskRepository(ctrl)
+
+		state.EXPECT().Check().Return(true)
+		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
+		metrics.EXPECT().SetArgoUnavailable(false)
+		metrics.EXPECT().AddProcessedDeployment("test-app")
+
+		task := models.Task{App: "test-app", Images: []models.Image{{Tag: taskImageTag}}}
+		newTask := models.Task{Id: uuid.NewString(), App: "test-app", Images: []models.Image{{Tag: taskImageTag}}}
+
+		// Cancelling prior in-progress tasks is best-effort: a failure here must not
+		// block the new deployment from being persisted.
+		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
+		state.EXPECT().CancelInProgressTasks("test-app", supersededTaskReason).Return(int64(0), fmt.Errorf("cancel failed"))
+		state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil)
+
+		argo := &Argo{}
+		argo.Init(state, api, metrics)
+		newTaskReturned, err := argo.AddTask(task)
+
+		assert.NoError(t, err, "a best-effort cancel failure must not fail the new deployment")
+		assert.NotNil(t, newTaskReturned)
 	})
 
 	t.Run("Argo - Rollback fields are computed and persisted", func(t *testing.T) {
@@ -296,6 +330,7 @@ func TestArgoAddTask(t *testing.T) {
 
 		// Capture the task actually handed to the repository.
 		var captured models.Task
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
 			captured = task
 			task.Id = uuid.NewString()
@@ -328,6 +363,7 @@ func TestArgoAddTask(t *testing.T) {
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return(deployed, int64(len(deployed)))
 
 		var captured models.Task
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
 			captured = task
 			task.Id = uuid.NewString()

--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -10,6 +10,11 @@ const (
 	StatusArgoCDFailedLogin        = "failed to login to argocd"
 	StatusDeployedMessage          = "deployed"
 	StatusAccepted                 = "accepted"
+	// StatusCancelledMessage marks a deployment that was superseded by a newer
+	// deployment for the same application before it reached a final state. The
+	// watcher stops polling ArgoCD for the superseded task to avoid wasting API
+	// calls on a rollout nobody is waiting for anymore.
+	StatusCancelledMessage = "cancelled"
 )
 
 // allowedTaskStatusFilters lists every status string the /api/v1/tasks
@@ -29,6 +34,7 @@ var allowedTaskStatusFilters = map[string]struct{}{
 	StatusArgoCDFailedLogin:        {},
 	StatusDeployedMessage:          {},
 	StatusAccepted:                 {},
+	StatusCancelledMessage:         {},
 }
 
 // IsAllowedTaskStatus reports whether the given status string is accepted

--- a/internal/models/constants_test.go
+++ b/internal/models/constants_test.go
@@ -1,0 +1,25 @@
+package models
+
+import "testing"
+
+func TestIsAllowedTaskStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{"cancelled is allowed", StatusCancelledMessage, true},
+		{"in progress is allowed", StatusInProgressMessage, true},
+		{"deployed is allowed", StatusDeployedMessage, true},
+		{"unknown is rejected", "totally-bogus", false},
+		{"empty is rejected", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAllowedTaskStatus(tc.status); got != tc.want {
+				t.Errorf("IsAllowedTaskStatus(%q) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -505,7 +505,7 @@ func (env *Env) addTask(c *gin.Context) {
 // @Description Get all tasks that match the provided parameters
 // @Tags backend, frontend
 // @Param app query string false "App name"
-// @Param status query string false "Task status (e.g. 'in progress', 'failed', 'deployed')"
+// @Param status query string false "Task status (e.g. 'in progress', 'failed', 'deployed', 'cancelled')"
 // @Param from_timestamp query int true "From timestamp" default(1648390029)
 // @Param to_timestamp query int false "To timestamp"
 // @Param limit query int false "Maximum number of tasks to return (1-1000, defaults to 1000)"

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -76,6 +76,10 @@ func (m *mockTaskRepository) SetTaskStatus(_, _, _ string) error {
 	return nil
 }
 
+func (m *mockTaskRepository) CancelInProgressTasks(_, _ string) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockTaskRepository) Check() bool {
 	return true
 }

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -153,6 +153,26 @@ func (state *InMemoryState) SetTaskStatus(id string, status string, reason strin
 	return errors.New("task not found")
 }
 
+// CancelInProgressTasks marks every in-progress task for the given app as
+// cancelled and returns how many were updated. It is used to supersede an older
+// deployment when a newer one for the same app is triggered.
+func (state *InMemoryState) CancelInProgressTasks(app string, reason string) (int64, error) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	var count int64
+	now := float64(time.Now().Unix())
+	for idx := range state.tasks {
+		if state.tasks[idx].App == app && state.tasks[idx].Status == models.StatusInProgressMessage {
+			state.tasks[idx].Status = models.StatusCancelledMessage
+			state.tasks[idx].StatusReason = reason
+			state.tasks[idx].Updated = now
+			count++
+		}
+	}
+	return count, nil
+}
+
 // Check is a placeholder method that implements the Check() bool interface.
 // It always returns true and does not perform any actual state checking.
 // This method exists to fulfill the TaskRepository interface requirement and has no functional value.

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -156,7 +156,7 @@ func (state *InMemoryState) SetTaskStatus(id string, status string, reason strin
 // CancelInProgressTasks marks every in-progress task for the given app as
 // cancelled and returns how many were updated. It is used to supersede an older
 // deployment when a newer one for the same app is triggered.
-func (state *InMemoryState) CancelInProgressTasks(app string, reason string) (int64, error) {
+func (state *InMemoryState) CancelInProgressTasks(app, reason string) (int64, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -207,6 +207,42 @@ func TestInMemoryState_SetTaskStatus_NotFound(t *testing.T) {
 	assert.Equal(t, "task not found", err.Error())
 }
 
+// TestInMemoryState_CancelInProgressTasks verifies that only the in-progress
+// tasks for the target app are switched to cancelled, and that already-finished
+// tasks and tasks for other apps are left untouched.
+func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
+	state := InMemoryState{}
+
+	inProgress, err := state.AddTask(createTestTask("app-a"))
+	require.NoError(t, err)
+
+	otherApp, err := state.AddTask(createTestTask("app-b"))
+	require.NoError(t, err)
+
+	finished, err := state.AddTask(createTestTask("app-a"))
+	require.NoError(t, err)
+	require.NoError(t, state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
+
+	count, err := state.CancelInProgressTasks("app-a", "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "only the in-progress app-a task should be cancelled")
+
+	got, err := state.GetTask(inProgress.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, got.Status)
+	assert.Equal(t, "superseded", got.StatusReason)
+
+	// A different app is untouched.
+	gotOther, err := state.GetTask(otherApp.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotOther.Status)
+
+	// An already-deployed task is untouched.
+	gotFinished, err := state.GetTask(finished.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusDeployedMessage, gotFinished.Status)
+}
+
 // TestInMemoryState_ProcessObsoleteTasks verifies that stale in-progress tasks
 // are marked as aborted after the threshold period.
 func TestInMemoryState_ProcessObsoleteTasks(t *testing.T) {

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -19,6 +19,9 @@ import (
 	"github.com/shini4i/argo-watcher/internal/state/state_models"
 )
 
+// whereStatusEquals is the GORM condition matching a task by its status column.
+const whereStatusEquals = "status = ?"
+
 type PostgresState struct {
 	orm *gorm.DB
 }
@@ -143,10 +146,10 @@ func (state *PostgresState) SetTaskStatus(id string, status string, reason strin
 // CancelInProgressTasks marks every in-progress task for the given app as
 // cancelled in a single atomic UPDATE and returns how many rows were affected.
 // It supersedes older deployments when a newer one for the same app arrives.
-func (state *PostgresState) CancelInProgressTasks(app string, reason string) (int64, error) {
+func (state *PostgresState) CancelInProgressTasks(app, reason string) (int64, error) {
 	result := state.orm.Model(&state_models.TaskModel{}).
 		Where(`"tasks"."app" = ?`, app).
-		Where("status = ?", models.StatusInProgressMessage).
+		Where(whereStatusEquals, models.StatusInProgressMessage).
 		Updates(state_models.TaskModel{
 			Status:       models.StatusCancelledMessage,
 			StatusReason: sql.NullString{String: reason, Valid: true},
@@ -207,12 +210,12 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 	log.Debug().Msg("Removing obsolete tasks...")
 
 	log.Debug().Msg("Removing app not found tasks older than 1 hour from the database...")
-	if err := state.orm.Where("status = ?", models.StatusAppNotFoundMessage).Where("created < now() - interval '1 hour'").Delete(&state_models.TaskModel{}).Error; err != nil {
+	if err := state.orm.Where(whereStatusEquals, models.StatusAppNotFoundMessage).Where("created < now() - interval '1 hour'").Delete(&state_models.TaskModel{}).Error; err != nil {
 		return err
 	}
 
 	log.Debug().Msg("Marking in progress tasks older than 1 hour as aborted...")
-	if err := state.orm.Where("status = ?", models.StatusInProgressMessage).Where("created < now() - interval '1 hour'").Updates(&state_models.TaskModel{Status: models.StatusAborted}).Error; err != nil {
+	if err := state.orm.Where(whereStatusEquals, models.StatusInProgressMessage).Where("created < now() - interval '1 hour'").Updates(&state_models.TaskModel{Status: models.StatusAborted}).Error; err != nil {
 		return err
 	}
 

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -140,6 +140,23 @@ func (state *PostgresState) SetTaskStatus(id string, status string, reason strin
 	return nil
 }
 
+// CancelInProgressTasks marks every in-progress task for the given app as
+// cancelled in a single atomic UPDATE and returns how many rows were affected.
+// It supersedes older deployments when a newer one for the same app arrives.
+func (state *PostgresState) CancelInProgressTasks(app string, reason string) (int64, error) {
+	result := state.orm.Model(&state_models.TaskModel{}).
+		Where(`"tasks"."app" = ?`, app).
+		Where("status = ?", models.StatusInProgressMessage).
+		Updates(state_models.TaskModel{
+			Status:       models.StatusCancelledMessage,
+			StatusReason: sql.NullString{String: reason, Valid: true},
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}
+
 // Check verifies the connection to the PostgreSQL database by executing a simple test query.
 // It returns true if the database connection is successful and the test query is executed without errors.
 // It returns false if there is an error in the database connection or the test query execution.

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -155,6 +155,32 @@ func TestPostgresState_SetTaskStatus(t *testing.T) {
 	assert.Equal(t, "finished", taskInfo.StatusReason)
 }
 
+func TestPostgresState_CancelInProgressTasks(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	inProgress := env.addTask(t, sampleTask("app-a"))
+	otherApp := env.addTask(t, sampleTask("app-b"))
+	finished := env.addTask(t, sampleTask("app-a"))
+	require.NoError(t, env.state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
+
+	count, err := env.state.CancelInProgressTasks("app-a", "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "only the in-progress app-a task should be cancelled")
+
+	got, err := env.state.GetTask(inProgress.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, got.Status)
+	assert.Equal(t, "superseded", got.StatusReason)
+
+	gotOther, err := env.state.GetTask(otherApp.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotOther.Status)
+
+	gotFinished, err := env.state.GetTask(finished.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusDeployedMessage, gotFinished.Status)
+}
+
 func TestPostgresState_ProcessObsoleteTasks(t *testing.T) {
 	env := newPostgresTestEnv(t)
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,7 +25,7 @@ type TaskRepository interface {
 	// older deployment when a newer one for the same app arrives (issue #353).
 	// Operating on the shared state makes the cancellation visible to every
 	// replica, not just the one handling the new deployment.
-	CancelInProgressTasks(app string, reason string) (int64, error)
+	CancelInProgressTasks(app, reason string) (int64, error)
 	Check() bool
 	ProcessObsoleteTasks(retryTimes uint)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,6 +20,12 @@ type TaskRepository interface {
 	GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) ([]models.Task, int64)
 	GetTask(id string) (*models.Task, error)
 	SetTaskStatus(id string, status string, reason string) error
+	// CancelInProgressTasks marks every in-progress task for the given app as
+	// cancelled and returns how many were affected. It is used to supersede an
+	// older deployment when a newer one for the same app arrives (issue #353).
+	// Operating on the shared state makes the cancellation visible to every
+	// replica, not just the one handling the new deployment.
+	CancelInProgressTasks(app string, reason string) (int64, error)
 	Check() bool
 	ProcessObsoleteTasks(retryTimes uint)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -170,10 +170,9 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 			log.Printf("The deployment of %s version is done.", version)
 			return nil
 		default:
-			// Any status we do not explicitly handle (a server newer than this
-			// client, or a terminal state like "aborted") is treated as terminal.
-			// Without this the loop would spin with no delay on an unknown status,
-			// hammering the server and never returning.
+			// Treat any status this client does not recognize (e.g. one added by a
+			// newer server) as terminal. Without this the loop would re-poll with no
+			// delay on an unknown status, hammering the server and never returning.
 			return fmt.Errorf("Received unexpected deployment status %q from the server; the client may be out of date.\n%s", taskInfo.Status, taskInfo.StatusReason)
 		}
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -169,6 +169,12 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 		case models.StatusDeployedMessage:
 			log.Printf("The deployment of %s version is done.", version)
 			return nil
+		default:
+			// Any status we do not explicitly handle (a server newer than this
+			// client, or a terminal state like "aborted") is treated as terminal.
+			// Without this the loop would spin with no delay on an unknown status,
+			// hammering the server and never returning.
+			return fmt.Errorf("Received unexpected deployment status %q from the server; the client may be out of date.\n%s", taskInfo.Status, taskInfo.StatusReason)
 		}
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -152,6 +152,8 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 		switch taskInfo.Status {
 		case models.StatusFailedMessage:
 			return fmt.Errorf("The deployment has failed, please check logs.\n%s", taskInfo.StatusReason)
+		case models.StatusCancelledMessage:
+			return fmt.Errorf("The deployment was cancelled because a newer deployment superseded it.\n%s", taskInfo.StatusReason)
 		case models.StatusInProgressMessage:
 			if !isDeploymentOverTime(retryCount, clientConfig.RetryInterval, clientConfig.ExpectedDeploymentTime) {
 				log.Println("Application deployment is in progress...")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -23,6 +23,7 @@ var (
 	failedTaskId        = "be8c42c0-a645-11ec-8ea5-f2c4bb72758b"
 	appNotFoundId       = "be8c42c0-a645-11ec-8ea5-f2c4bb72758c"
 	argocdUnavailableId = "be8c42c0-a645-11ec-8ea5-f2c4bb72758d"
+	cancelledTaskId     = "be8c42c0-a645-11ec-8ea5-f2c4bb72758e"
 )
 
 func addTaskHandler(w http.ResponseWriter, r *http.Request) {
@@ -72,6 +73,8 @@ func getTaskStatusHandler(w http.ResponseWriter, r *http.Request) {
 		status = models.StatusArgoCDUnavailableMessage
 	case failedTaskId:
 		status = models.StatusFailedMessage
+	case cancelledTaskId:
+		status = models.StatusCancelledMessage
 	}
 
 	if err := json.NewEncoder(w).Encode(models.TaskStatus{
@@ -319,6 +322,11 @@ func TestWaitForDeployment(t *testing.T) {
 			name:          "ArgoCD unavailable",
 			taskId:        argocdUnavailableId,
 			expectedError: "ArgoCD is unavailable. Please investigate.",
+		},
+		{
+			name:          "Cancelled deployment",
+			taskId:        cancelledTaskId,
+			expectedError: "The deployment was cancelled because a newer deployment superseded it.",
 		},
 	}
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -24,6 +24,7 @@ var (
 	appNotFoundId       = "be8c42c0-a645-11ec-8ea5-f2c4bb72758c"
 	argocdUnavailableId = "be8c42c0-a645-11ec-8ea5-f2c4bb72758d"
 	cancelledTaskId     = "be8c42c0-a645-11ec-8ea5-f2c4bb72758e"
+	unhandledStatusId   = "be8c42c0-a645-11ec-8ea5-f2c4bb72758f"
 )
 
 func addTaskHandler(w http.ResponseWriter, r *http.Request) {
@@ -75,6 +76,8 @@ func getTaskStatusHandler(w http.ResponseWriter, r *http.Request) {
 		status = models.StatusFailedMessage
 	case cancelledTaskId:
 		status = models.StatusCancelledMessage
+	case unhandledStatusId:
+		status = models.StatusAborted
 	}
 
 	if err := json.NewEncoder(w).Encode(models.TaskStatus{
@@ -327,6 +330,11 @@ func TestWaitForDeployment(t *testing.T) {
 			name:          "Cancelled deployment",
 			taskId:        cancelledTaskId,
 			expectedError: "The deployment was cancelled because a newer deployment superseded it.",
+		},
+		{
+			name:          "Unhandled status exits instead of busy-looping",
+			taskId:        unhandledStatusId,
+			expectedError: "Received unexpected deployment status",
 		},
 	}
 

--- a/web/src/data/dataProvider.test.ts
+++ b/web/src/data/dataProvider.test.ts
@@ -119,6 +119,16 @@ describe('dataProvider', () => {
     expect(params.get('status')).toBe('in progress');
   });
 
+  it('forwards the cancelled status filter to the backend query', async () => {
+    const fetch = mockFetch().mockResolvedValue(jsonResponse({ tasks: [], total: 0 }));
+    await dataProvider.getList('tasks', {
+      ...createListParams(),
+      filter: { status: 'cancelled' },
+    });
+    const params = getQueryParams(fetch.mock.calls[0][0] as string);
+    expect(params.get('status')).toBe('cancelled');
+  });
+
   it('omits the status param when no status filter is set', async () => {
     const fetch = mockFetch().mockResolvedValue(jsonResponse({ tasks: [], total: 0 }));
     await dataProvider.getList('tasks', createListParams());

--- a/web/src/data/dataProvider.ts
+++ b/web/src/data/dataProvider.ts
@@ -39,6 +39,7 @@ const ALLOWED_TASK_STATUSES: ReadonlySet<string> = new Set([
   'failed to login to argocd',
   'deployed',
   'accepted',
+  'cancelled',
 ]);
 
 /** Normalizes various date/timestamp inputs to seconds since epoch. */

--- a/web/src/features/tasks/utils/statusPresentation.test.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.test.tsx
@@ -63,6 +63,16 @@ const statusCases: StatusCase[] = [
     },
   },
   {
+    status: 'cancelled',
+    expected: {
+      label: 'Cancelled',
+      displayLabel: 'Cancelled',
+      chipColor: 'default',
+      timelineDotColor: 'default',
+      reasonSeverity: 'info',
+    },
+  },
+  {
     status: 'custom',
     expected: {
       label: 'custom',

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -80,6 +80,19 @@ export const describeTaskStatus = (status?: string | null): TaskStatusPresentati
         pillBgDark: tokens.statusRunningBgDark,
         pillFgDark: tokens.statusRunningFgDark,
       };
+    case 'cancelled':
+      return {
+        label: 'Cancelled',
+        displayLabel: 'Cancelled',
+        chipColor: 'default',
+        timelineDotColor: 'default',
+        reasonSeverity: 'info',
+        icon: <CancelOutlinedIcon fontSize="small" />,
+        pillBg: tokens.statusInfoBg,
+        pillFg: tokens.statusInfoFg,
+        pillBgDark: tokens.statusInfoBgDark,
+        pillFgDark: tokens.statusInfoFgDark,
+      };
     case 'app not found':
       return {
         label: 'App Not Found',


### PR DESCRIPTION
When a new deployment for an app is triggered while a previous one is still polling Argo CD, mark the older task "cancelled" and stop polling, instead of hammering the Argo CD API until the old rollout times out (#353).

Cancellation is coordinated through the shared state backend, so it works across replicas in an HA setup: AddTask cancels in-progress tasks for the app before persisting the new one, and each poll re-reads the task status and stops (without overwriting it) once superseded. The CLI client treats "cancelled" as terminal and the Web UI can filter by it.

Closes #353 