### PR TITLE
test(argocd): guard against crash when app disappears mid-rollout

### DIFF
--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -1070,6 +1070,59 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	updater.WaitForRollout(task)
 }
 
+// TestArgoStatusUpdaterAppDisappearsMidRollout is the regression guard for issue #387:
+// the application exists at the initial check, then disappears (is deleted from ArgoCD)
+// while the rollout is still being polled. The rollout must not crash the process — it
+// runs in a goroutine, so a panic here would take down the whole server — and must abort
+// the task with a terminal "app not found" status instead of retrying indefinitely.
+func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	metricsMock := mock.NewMockMetricsInterface(ctrl)
+	stateMock := mock.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+	stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+
+	task := models.Task{
+		Id:      "test-id",
+		App:     "test-app",
+		Timeout: 15,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
+	}
+
+	// Not-final app so the loop keeps polling past the initial check.
+	inProgress := models.Application{}
+	inProgress.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
+	inProgress.Status.Sync.Status = "Synced"
+	inProgress.Status.Health.Status = "Progressing"
+
+	notFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
+
+	gomock.InOrder(
+		// Initial check and first poll succeed: the app is present but still progressing.
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&inProgress, nil).Times(2),
+		// The app is then deleted mid-rollout; every subsequent fetch reports not found.
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, notFound).MinTimes(1),
+	)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().AddFailedDeployment(task.App)
+	stateMock.EXPECT().SetTaskStatus(
+		task.Id,
+		models.StatusAppNotFoundMessage,
+		fmt.Sprintf(ArgoAPIErrorTemplate, notFound.Error()),
+	)
+
+	updater.WaitForRollout(task)
+}
+
 // TestArgoStatusUpdaterProceedsWhenStatusReadFails verifies that a transient
 // failure to read the task status (the supersession check) does not abort an
 // otherwise healthy rollout: taskSuperseded returns false on a read error, so the


### PR DESCRIPTION
### **User description**
Add a regression test for issue #387: an ArgoCD application that exists at the initial check but is deleted while the rollout is still being polled must not panic the process (WaitForRollout runs in a goroutine) and must abort the task with a terminal "app not found" status.

The behavior is already handled by the retry/nil-safety refactoring; this test locks it in.


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Adds a regression test for issue #387: ArgoCD application disappears mid-rollout.

- Verifies the process does not panic and aborts the task with an "app not found" status.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ArgoCD app deleted during rollout"] --> B["WaitForRollout detects not found"]
  B --> C["Task aborted with app‑not‑found status (no panic)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argo_status_updater_test.go</strong><dd><code>Add regression test for app disappearing mid-rollout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/argocd/argo_status_updater_test.go

<ul><li>Introduces <code>TestArgoStatusUpdaterAppDisappearsMidRollout</code> function.<br> <li> Uses mocked API responses: first two calls return a progressing app, <br>subsequent calls return not found.<br> <li> Asserts that <code>WaitForRollout</code> does not crash, removes in‑progress task, <br>records a failed deployment metric, and sets the task status to <br>app‑not‑found with the appropriate error message.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/455/files#diff-09b297447b7e2fbfea57e00fa6d493a1ffd2757f47fcc08456ad96a8c8a1e5e3">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

