### PR TITLE
feat(lockdown): notify clients on scheduled lock transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update backend and frontend dependencies to their latest releases. The bundled
   web UI now runs on React 19 and Material UI 9, and building from source
   requires Go 1.26.
+- Notify the Web UI when a scheduled lockdown window automatically begins or
+  ends. Previously only manual lock/unlock pushed live updates, so a UI opened
+  before a scheduled window started never showed the lockdown banner without a
+  page refresh; connected clients are now notified within about a minute (#302).
 
 ### Fixed
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -209,6 +209,8 @@ scheduledLockdown:
 
 In this example, deployments are blocked between Wednesday 20:00 and Thursday 08:00, and between Friday 20:00 and Monday 08:00.
 
+The Web UI lockdown banner updates automatically (within about a minute) when a scheduled window begins or ends — no page refresh is needed.
+
 ### Manual Lockdown
 
 #### Via API

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -166,6 +166,38 @@ func (l *Lockdown) ReleaseLock() {
 	}
 }
 
+// WatchTransitions polls the lock state on the given interval and invokes notify
+// with "locked" or "unlocked" whenever the computed state changes. Scheduled
+// lockdowns are evaluated lazily by IsLocked, so this is the only mechanism that
+// informs clients when a schedule window automatically begins or ends. The
+// initial state is recorded without notifying, so only genuine transitions
+// produce a notification. It runs until stop is closed.
+func (l *Lockdown) WatchTransitions(stop <-chan struct{}, interval time.Duration, notify func(string)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	last := l.IsLocked()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			current := l.IsLocked()
+			if current == last {
+				continue
+			}
+			last = current
+
+			if current {
+				notify("locked")
+			} else {
+				notify("unlocked")
+			}
+		}
+	}
+}
+
 // NewLockdown initializes a new Lockdown structure and parses the lockdown schedules
 // if provided. If the schedule parsing is successful, it returns the new Lockdown.
 // Otherwise, it returns an error.

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -304,6 +304,111 @@ func TestLockdown_ConcurrentAccess(t *testing.T) {
 	assert.False(t, l.IsLocked())
 }
 
+// TestLockdown_WatchTransitions verifies that the watcher notifies clients only
+// when the computed lock state actually changes, and that it stops on request.
+func TestLockdown_WatchTransitions(t *testing.T) {
+	// recv waits for a single message or fails the test on timeout.
+	recv := func(t *testing.T, msgs <-chan string) string {
+		t.Helper()
+		select {
+		case m := <-msgs:
+			return m
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for notification")
+			return ""
+		}
+	}
+
+	t.Run("notifies on lock state transitions", func(t *testing.T) {
+		l := &Lockdown{}
+		stop := make(chan struct{})
+		defer close(stop)
+
+		// Establish a locked baseline, then let the watcher record it before
+		// mutating state, so the transitions below are detected deterministically.
+		l.SetLock()
+
+		msgs := make(chan string, 4)
+		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
+		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its baseline
+
+		l.ReleaseLock()
+		assert.Equal(t, "unlocked", recv(t, msgs))
+
+		l.SetLock()
+		assert.Equal(t, "locked", recv(t, msgs))
+	})
+
+	t.Run("notifies on a schedule-derived transition", func(t *testing.T) {
+		// Build a schedule window spanning four minutes around now so IsLocked
+		// is true via the schedule (not ManualLock) at baseline. The wide margin
+		// keeps the window covering "now" across hour/day/week boundaries.
+		now := time.Now()
+		start := now.Add(-2 * time.Minute)
+		end := now.Add(2 * time.Minute)
+		l := &Lockdown{Schedules: []LockdownSchedule{{
+			StartDay:  start.Weekday(),
+			StartHour: start.Hour(),
+			StartMin:  start.Minute(),
+			EndDay:    end.Weekday(),
+			EndHour:   end.Hour(),
+			EndMin:    end.Minute(),
+		}}}
+		assert.True(t, l.IsLocked(), "schedule should lock the system at baseline")
+
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 4)
+		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
+		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its locked baseline
+
+		// Enabling override mode makes isLockedInternal return false without
+		// touching ManualLock, simulating a scheduled window boundary.
+		l.mu.Lock()
+		l.OverrideMode = true
+		l.mu.Unlock()
+
+		assert.Equal(t, "unlocked", recv(t, msgs))
+	})
+
+	t.Run("does not notify without a transition", func(t *testing.T) {
+		l := &Lockdown{}
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 1)
+		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
+
+		select {
+		case m := <-msgs:
+			t.Fatalf("unexpected notification: %q", m)
+		case <-time.After(50 * time.Millisecond):
+			// no transition occurred, so no notification is expected
+		}
+	})
+
+	t.Run("stops when stop channel is closed", func(t *testing.T) {
+		l := &Lockdown{}
+		stop := make(chan struct{})
+		done := make(chan struct{})
+
+		go func() {
+			l.WatchTransitions(stop, 5*time.Millisecond, func(string) {})
+			close(done)
+		}()
+
+		close(stop)
+
+		select {
+		case <-done:
+			// returned as expected
+		case <-time.After(time.Second):
+			t.Fatal("WatchTransitions did not return after stop was closed")
+		}
+	})
+}
+
 // TestLockdown_IsLockedInternal tests the internal lock checking logic.
 func TestLockdown_IsLockedInternal(t *testing.T) {
 	t.Run("returns true when ManualLock is set", func(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -357,6 +357,28 @@ func (env *Env) StartRouter(router *gin.Engine) *http.Server {
 	}
 }
 
+// lockdownPollInterval is how often the scheduled-lockdown watcher re-evaluates
+// the lock state to detect schedule boundary transitions. Schedules have
+// minute granularity, so a one-minute tick bounds the notification lag.
+const lockdownPollInterval = time.Minute
+
+// StartLockdownWatcher launches a background goroutine that notifies WebSocket
+// clients when a scheduled lockdown window automatically begins or ends. It is a
+// no-op when no schedules are configured, since manual set/release already
+// notify clients directly. The goroutine is tracked by connWg and stops when the
+// shutdown channel is closed.
+func (env *Env) StartLockdownWatcher() {
+	if len(env.lockdown.Schedules) == 0 {
+		return
+	}
+
+	env.connWg.Add(1)
+	go func() {
+		defer env.connWg.Done()
+		env.lockdown.WatchTransitions(env.shutdownCh, lockdownPollInterval, notifyWebSocketClients)
+	}()
+}
+
 // Shutdown gracefully shuts down the server and all WebSocket connections.
 // This method is safe to call multiple times. It blocks until all WebSocket
 // goroutines have finished or the shutdown timeout is reached. If the timeout

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1248,6 +1248,51 @@ func TestEnvShutdown(t *testing.T) {
 	})
 }
 
+// TestStartLockdownWatcher verifies the watcher goroutine lifecycle: it is a
+// no-op without schedules, and when schedules exist it is tracked by connWg and
+// stops when the shutdown channel is closed.
+func TestStartLockdownWatcher(t *testing.T) {
+	// waitTracked reports whether connWg reaches zero within the timeout.
+	waitTracked := func(env *Env, timeout time.Duration) bool {
+		done := make(chan struct{})
+		go func() {
+			env.connWg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+			return true
+		case <-time.After(timeout):
+			return false
+		}
+	}
+
+	t.Run("no-op when no schedules are configured", func(t *testing.T) {
+		env := &Env{shutdownCh: make(chan struct{})}
+		env.lockdown = &Lockdown{}
+
+		env.StartLockdownWatcher()
+
+		// No goroutine should have been started, so connWg is already at zero.
+		assert.True(t, waitTracked(env, 100*time.Millisecond), "no watcher goroutine expected without schedules")
+	})
+
+	t.Run("tracks the watcher and stops on shutdown", func(t *testing.T) {
+		env := &Env{shutdownCh: make(chan struct{})}
+		env.lockdown = &Lockdown{Schedules: []LockdownSchedule{
+			{StartDay: time.Monday, StartHour: 0, StartMin: 0, EndDay: time.Monday, EndHour: 1, EndMin: 0},
+		}}
+
+		env.StartLockdownWatcher()
+
+		// The watcher is running; connWg must not drain until shutdown.
+		assert.False(t, waitTracked(env, 100*time.Millisecond), "watcher should keep connWg non-zero before shutdown")
+
+		close(env.shutdownCh)
+		assert.True(t, waitTracked(env, time.Second), "watcher should exit after shutdown channel is closed")
+	})
+}
+
 // TestStartRouter tests the StartRouter method.
 func TestStartRouter(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,6 +113,10 @@ func (s *Server) Run() {
 
 	srv := s.env.StartRouter(s.router)
 
+	// Notify clients about scheduled lockdown transitions they wouldn't
+	// otherwise learn about (scheduled state is evaluated lazily).
+	s.env.StartLockdownWatcher()
+
 	// Start server in goroutine
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
### **User description**
Scheduled lockdown state is evaluated lazily, so WebSocket clients were only notified about manual lock/unlock. A UI opened before a scheduled window began never showed the lockdown banner without a page refresh.

Add a background watcher that polls the lock state every minute and broadcasts "locked"/"unlocked" on transition, tracked by connWg and stopped via the shutdown channel. No-op when no schedules are configured.

Closes #302


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add a background watcher that polls the lockdown state every minute and notifies WebSocket clients on scheduled lockdown transitions

- Notifications are sent when a scheduled window automatically begins or ends, eliminating the need for a page refresh

- The watcher is a no-op when no schedules are configured and is tracked by `connWg` for graceful shutdown

- Updated documentation and changelog to describe the new live-update behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Server.Run()"] -- "starts (if schedules exist)" --> B["StartLockdownWatcher"]
    B --> C["goroutine: WatchTransitions"]
    C --> D{"Ticker every 1 min"}
    D --> E["IsLocked()"]
    E --> F{"State changed?"}
    F -->|Yes| G["notifyWebSocketClients(locked/unlocked)"]
    F -->|No| D
    G --> D
    D -- stop channel closed --> H["goroutine exits"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>lockdown.go</strong><dd><code>Add WatchTransitions method for scheduled lock notifications</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-13aa8da54e1b3578eb6b9f4d4372224c034489e909039fd15628f30792a38aa1">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.go</strong><dd><code>Add StartLockdownWatcher method and polling interval constant</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-9f58d31f48b31a1fa23cfee5460796fc34ce5461fb6277f40107bc0dff6b204c">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Launch lockdown watcher during server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>lockdown_test.go</strong><dd><code>Add tests for WatchTransitions covering transitions, idempotency, and </code><br><code>shutdown</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-3f7114773f90000e8f14d2cf88a2cb3d1f8ec79f79ec96c36486f923f37304d4">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>router_test.go</strong><dd><code>Test watcher goroutine lifecycle and no-op behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-0e7d3d9b9adc77e35d95609d14f1d1f255b669d8d89589080b2c6da28c6760c5">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document scheduled lockdown live notifications in changelog</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gitops-updater.md</strong><dd><code>Add note about auto‑updating lockdown banner in the Web UI</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/456/files#diff-e1e8d9dd9a673694905f05a76210f88733008a51bfa12c6a27f850110ec4fd17">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

