### PR TITLE
ci(release): migrate goreleaser docker to dockers_v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,14 @@ jobs:
       - name: Set up QEMU # required for multi architecture build - https://goreleaser.com/cookbooks/multi-platform-docker-images/?h=multi#other-things-to-pay-attention-to
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
+      - name: Set up Docker Buildx # dockers_v2 pushes a multi-arch manifest, which needs the docker-container driver (the default docker driver can't)
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          # Matches the setup-go `cache: false` policy below: this release
+          # publishes signed artifacts, so don't restore the buildx binary from
+          # a cache a PR run could have poisoned.
+          cache-binary: false
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,93 +32,65 @@ builds:
       - amd64
       - arm64
 
-dockers:
+# dockers_v2 builds a multi-arch manifest per image in a single `docker buildx
+# build --push`, and attaches an SBOM to each. OCI metadata is set via
+# `annotations` (not `--label`) so it lands on the manifest index that GHCR
+# reads for multi-arch images.
+dockers_v2:
   # Server image
-  - image_templates:
-      - 'ghcr.io/shini4i/argo-watcher:{{ .Tag }}-amd64'
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=argo-watcher"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile.server
-    extra_files:
-      - web/dist
-      - db
+  - id: argo-watcher
     ids:
       - argo-watcher
-
-  - image_templates:
-      - 'ghcr.io/shini4i/argo-watcher:{{ .Tag }}-arm64'
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=argo-watcher"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: arm64
     dockerfile: Dockerfile.server
+    images:
+      - 'ghcr.io/shini4i/argo-watcher'
+    tags:
+      - '{{ .Tag }}'
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - web/dist
-      - db
-    ids:
-      - argo-watcher
+      - db/migrations
+    flags:
+      - "--pull"
+    # Attach an SBOM to the image. This is the dockers_v2 default, set
+    # explicitly since dockers_v2 is still experimental and defaults may shift.
+    sbom: "true"
+    annotations:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: argo-watcher
+      org.opencontainers.image.description: "A feedback loop for your GitOps workflow, bridging CI pipelines and Argo CD."
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.licenses: MIT
 
   # Client image
-  - image_templates:
-      - 'ghcr.io/shini4i/argo-watcher-client:{{ .Tag }}-amd64'
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=argo-watcher-client"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile.client
+  - id: client
     ids:
       - client
-
-  - image_templates:
-      - 'ghcr.io/shini4i/argo-watcher-client:{{ .Tag }}-arm64'
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=argo-watcher-client"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: arm64
     dockerfile: Dockerfile.client
-    ids:
-      - client
-
-docker_manifests:
-  - name_template: 'ghcr.io/shini4i/argo-watcher:{{ .Tag }}'
-    image_templates:
-      - 'ghcr.io/shini4i/argo-watcher:{{ .Tag }}-amd64'
-      - 'ghcr.io/shini4i/argo-watcher:{{ .Tag }}-arm64'
-
-  - name_template: 'ghcr.io/shini4i/argo-watcher-client:{{ .Tag }}'
-    image_templates:
-      - 'ghcr.io/shini4i/argo-watcher-client:{{ .Tag }}-amd64'
-      - 'ghcr.io/shini4i/argo-watcher-client:{{ .Tag }}-arm64'
+    images:
+      - 'ghcr.io/shini4i/argo-watcher-client'
+    tags:
+      - '{{ .Tag }}'
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    flags:
+      - "--pull"
+    # Attach an SBOM to the image. This is the dockers_v2 default, set
+    # explicitly since dockers_v2 is still experimental and defaults may shift.
+    sbom: "true"
+    annotations:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: argo-watcher-client
+      org.opencontainers.image.description: "CLI client for Argo Watcher, used from CI pipelines to track Argo CD rollouts."
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.licenses: MIT
 
 archives:
   - formats: ['tar.gz']
@@ -141,7 +113,9 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    artifacts: manifests
+    # Empty string selects the images built by dockers_v2 (which publishes a
+    # multi-arch manifest per image, not separate `manifests` artifacts).
+    artifacts: ""
     args:
       - "sign"
       - "${artifact}@${digest}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,7 +64,7 @@ dockers_v2:
       org.opencontainers.image.revision: "{{.FullCommit}}"
       org.opencontainers.image.version: "{{.Version}}"
       org.opencontainers.image.source: "{{.GitURL}}"
-      org.opencontainers.image.licenses: MIT
+      org.opencontainers.image.licenses: Apache-2.0
 
   # Client image
   - id: client
@@ -90,7 +90,7 @@ dockers_v2:
       org.opencontainers.image.revision: "{{.FullCommit}}"
       org.opencontainers.image.version: "{{.Version}}"
       org.opencontainers.image.source: "{{.GitURL}}"
-      org.opencontainers.image.licenses: MIT
+      org.opencontainers.image.licenses: Apache-2.0
 
 archives:
   - formats: ['tar.gz']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ends. Previously only manual lock/unlock pushed live updates, so a UI opened
   before a scheduled window started never showed the lockdown banner without a
   page refresh; connected clients are now notified within about a minute (#302).
+- Release images now publish a single multi-arch manifest tag
+  (`ghcr.io/shini4i/argo-watcher:<tag>` and the `-client` image) instead of
+  separate per-architecture `-amd64`/`-arm64` tags; pull the plain tag going
+  forward. Each published image now also ships an attached SBOM.
 
 ### Fixed
 

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,6 +1,10 @@
 FROM alpine:3.24
 
-COPY client /client
+# TARGETPLATFORM is set by buildx; goreleaser dockers_v2 lays binaries out per
+# platform (e.g. linux/amd64/client) in the build context.
+ARG TARGETPLATFORM
+
+COPY $TARGETPLATFORM/client /client
 
 RUN addgroup -S argo-watcher && adduser -S argo-watcher -G argo-watcher
 USER argo-watcher

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,11 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /app
 
-COPY --chown=nonroot:nonroot argo-watcher /usr/local/bin/argo-watcher
+# TARGETPLATFORM is set by buildx; goreleaser dockers_v2 lays binaries out per
+# platform (e.g. linux/amd64/argo-watcher) in the build context.
+ARG TARGETPLATFORM
+
+COPY --chown=nonroot:nonroot $TARGETPLATFORM/argo-watcher /usr/local/bin/argo-watcher
 COPY --chown=nonroot:nonroot web/dist ./static
 COPY --chown=nonroot:nonroot db ./db
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           mockgen
           go-swag
           toxiproxy
+          goreleaser
         ];
 
         preCommitTools = with pkgs; [


### PR DESCRIPTION
### **User description**
Replace the legacy dockers + docker_manifests config with two dockers_v2 blocks, each building a multi-arch manifest in a single buildx pass. Add OCI image.source and image.description annotations, attach a per-image SBOM, and narrow the server build context to db/migrations.

Update both Dockerfiles to copy binaries from the per-platform context path ($TARGETPLATFORM/<binary>), add setup-buildx-action with its binary cache disabled to match the release job's no-cache posture, and add goreleaser to the dev flake.

Release images now publish only the multi-arch manifest tag; the per-arch -amd64/-arm64 tags are no longer pushed.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Migrate goreleaser Docker configuration to `dockers_v2` for multi-arch manifests
  - Replace per-architecture tags with single multi-arch manifest tags
  - Attach SBOMs and add OCI annotations (source, description, etc.)

- Update release workflow to include Docker Buildx with binary cache disabled

- Adapt Dockerfiles to copy binaries from `$TARGETPLATFORM` context path

- Add `goreleaser` to dev flake and document changes in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release workflow adds Docker Buildx"] --> B["dockers_v2 config"]
  B --> C["Multi-arch images with SBOM & annotations"]
  B --> D["Dockerfiles copy via $TARGETPLATFORM"]
  C --> E["Single manifest tags published"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flake.nix</strong><dd><code>Add goreleaser to dev flake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flake.nix

- Added `goreleaser` to the Go development tools list.


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yaml</strong><dd><code>Add Docker Buildx to release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yaml

<ul><li>Added <code>setup-buildx-action</code> step with <code>cache-binary: false</code> to support <br>multi-arch manifest builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.goreleaser.yaml</strong><dd><code>Migrate to dockers_v2 with multi-arch, SBOMs, and OCI annotations</code></dd></summary>
<hr>

.goreleaser.yaml

<ul><li>Replaced legacy <code>dockers</code> and <code>docker_manifests</code> with two <code>dockers_v2</code> <br>blocks.<br> <li> Configured multi-arch builds (linux/amd64, linux/arm64) with single <br>image tags.<br> <li> Added OCI annotations (<code>image.source</code>, <code>image.description</code>, etc.) and SBOM <br>attachment.<br> <li> Restricted server build context to <code>db/migrations</code> instead of full <code>db</code>.<br> <li> Updated <code>docker_signs</code> to sign images from <code>dockers_v2</code> artifacts by using <br>empty string.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826">+51/-77</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.client</strong><dd><code>Adapt Dockerfile.client for platform-aware copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.client

<ul><li>Introduced <code>ARG TARGETPLATFORM</code> and updated <code>COPY</code> to use <br><code>$TARGETPLATFORM/client</code> for platform-specific binary placement.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-9107db9b8b4401fa570c838483ad08cbf6d1271bcb9d46d5a447751ab1e32aad">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.server</strong><dd><code>Adapt Dockerfile.server for platform-aware copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.server

<ul><li>Introduced <code>ARG TARGETPLATFORM</code> and updated <code>COPY</code> commands to use <br><code>$TARGETPLATFORM/argo-watcher</code> for platform-specific binary placement.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-bdfb8b5c7b1ac62ecd6d5857c4f634d1b5c716ca76774f306c341f17ae7644e6">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for new image tagging and SBOM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry describing the switch to multi-arch manifest tags and <br>per-image SBOM.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/457/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

