### PR TITLE
feat(notifications): add Mattermost notification strategy

### DIFF
--- a/cmd/argo-watcher/config/config.go
+++ b/cmd/argo-watcher/config/config.go
@@ -42,30 +42,40 @@ type WebhookConfig struct {
 	AllowedResponseCodes []int  `env:"WEBHOOK_ALLOWED_RESPONSE_CODES" envDefault:"200" json:"allowed_response_codes,omitempty"`
 }
 
+type MattermostConfig struct {
+	Enabled       bool   `env:"MATTERMOST_ENABLED" envDefault:"false" json:"enabled"`
+	Url           string `env:"MATTERMOST_URL" json:"url,omitempty"` // base URL of the Mattermost instance, without /api/v4
+	Token         string `env:"MATTERMOST_TOKEN" json:"-"`           // bot access token
+	ChannelId     string `env:"MATTERMOST_CHANNEL_ID" json:"channel_id,omitempty"`
+	Format        string `env:"MATTERMOST_FORMAT" json:"format,omitempty"`                          // Go template rendering models.Task into the post markdown message
+	MentionAuthor bool   `env:"MATTERMOST_MENTION_AUTHOR" envDefault:"false" json:"mention_author"` // prepend @<Author> to every post
+}
+
 type ServerConfig struct {
-	ArgoUrl            url.URL        `env:"ARGO_URL,required" json:"argo_cd_url"`
-	ArgoUrlAlias       string         `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
-	ArgoToken          string         `env:"ARGO_TOKEN,required" json:"-"`
-	ArgoApiTimeout     int64          `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	AcceptSuspendedApp bool           `env:"ACCEPT_SUSPENDED_APP" envDefault:"false" json:"accept_suspended_app"` // If true, we will accept "Suspended" health status as valid
-	DeploymentTimeout  uint           `env:"DEPLOYMENT_TIMEOUT" envDefault:"900" json:"deployment_timeout"`
-	ArgoRefreshApp     bool           `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
-	RegistryProxyUrl   string         `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
-	StateType          string         `env:"STATE_TYPE,required" validate:"oneof=postgres in-memory" json:"state_type"`
-	StaticFilePath     string         `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
-	SkipTlsVerify      bool           `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
-	LogLevel           string         `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
-	Host               string         `env:"HOST" envDefault:"0.0.0.0" json:"-"`
-	Port               string         `env:"PORT" envDefault:"8080" json:"-"`
-	DeployToken        string         `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
-	JWTSecret          string         `env:"JWT_SECRET" json:"-"`
-	Db                 DatabaseConfig `json:"-"`
-	Keycloak           KeycloakConfig `json:"keycloak,omitempty"`
-	LockdownSchedule   string         `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
-	Webhook            WebhookConfig  `json:"webhook,omitempty"`
-	DevEnvironment     bool           `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
-	ArgoApiRetries     uint           `env:"ARGO_API_RETRIES" envDefault:"3" validate:"min=1,max=10" json:"argo_api_retries"` // Total attempts (including initial); passed to retry.Attempts()
-	RepoCachePath      string         `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`
+	ArgoUrl            url.URL          `env:"ARGO_URL,required" json:"argo_cd_url"`
+	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
+	ArgoToken          string           `env:"ARGO_TOKEN,required" json:"-"`
+	ArgoApiTimeout     int64            `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
+	AcceptSuspendedApp bool             `env:"ACCEPT_SUSPENDED_APP" envDefault:"false" json:"accept_suspended_app"` // If true, we will accept "Suspended" health status as valid
+	DeploymentTimeout  uint             `env:"DEPLOYMENT_TIMEOUT" envDefault:"900" json:"deployment_timeout"`
+	ArgoRefreshApp     bool             `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
+	RegistryProxyUrl   string           `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
+	StateType          string           `env:"STATE_TYPE,required" validate:"oneof=postgres in-memory" json:"state_type"`
+	StaticFilePath     string           `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
+	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
+	LogLevel           string           `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
+	Host               string           `env:"HOST" envDefault:"0.0.0.0" json:"-"`
+	Port               string           `env:"PORT" envDefault:"8080" json:"-"`
+	DeployToken        string           `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
+	JWTSecret          string           `env:"JWT_SECRET" json:"-"`
+	Db                 DatabaseConfig   `json:"-"`
+	Keycloak           KeycloakConfig   `json:"keycloak,omitempty"`
+	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
+	Webhook            WebhookConfig    `json:"webhook,omitempty"`
+	Mattermost         MattermostConfig `json:"mattermost,omitempty"`
+	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"`                        // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
+	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" validate:"min=1,max=10" json:"argo_api_retries"` // Total attempts (including initial); passed to retry.Attempts()
+	RepoCachePath      string           `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`
 }
 
 // NewServerConfig parses the server configuration from environment variables.
@@ -83,6 +93,7 @@ func NewServerConfig() (*ServerConfig, error) {
 	config.ArgoToken = strings.TrimSpace(config.ArgoToken)
 	config.DeployToken = strings.TrimSpace(config.DeployToken)
 	config.JWTSecret = strings.TrimSpace(config.JWTSecret)
+	config.Mattermost.Token = strings.TrimSpace(config.Mattermost.Token)
 
 	if err := validate.Struct(&config); err != nil {
 		return nil, prettifyValidatorError(err)

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -101,3 +101,30 @@ Use `IsRollback` to call out deployments that return to a previously deployed ve
 ```bash
 WEBHOOK_FORMAT='{"text": "{{if .IsRollback}}:rewind: ROLLBACK of {{else}}Deployment of {{end}}*{{.App}}* by {{.Author}}: {{.Status}}"}'
 ```
+
+## Mattermost
+
+The generic webhook sends an independent message per event, which gets noisy. The Mattermost strategy uses the Mattermost REST API instead: the deployment start creates a root channel post, and the deployment result is posted as a **thread reply** to it, mentioning the task author (`@<Author>`).
+
+It requires a [bot account](https://docs.mattermost.com/integrations/cloud-bot-accounts.html) with access to the target channel; incoming webhooks cannot reply in threads.
+
+### Configuration
+
+| Variable                | Description                                                     | Default | Example                        |
+|-------------------------|-----------------------------------------------------------------|---------|--------------------------------|
+| `MATTERMOST_ENABLED`    | Enable Mattermost notifications                                 | `false` |                                |
+| `MATTERMOST_URL`        | Base URL of the Mattermost instance (without `/api/v4`)         |         | `https://mattermost.example.com` |
+| `MATTERMOST_TOKEN`      | Bot account access token                                        |         |                                |
+| `MATTERMOST_CHANNEL_ID` | Target channel id (26-character id, not the channel name)       |         | `qz3c4kx8w3nqir6nqz3c4kx8w3`   |
+| `MATTERMOST_FORMAT`     | Go template rendering the post message (markdown)               |         | see below                      |
+| `MATTERMOST_MENTION_AUTHOR` | Prepend `@<Author>` to every post to notify the deploy author | `false` | `true`                       |
+
+`MATTERMOST_FORMAT` uses the same template variables as `WEBHOOK_FORMAT`. The rendered text becomes the post `message`; branch on `{{.Status}}` to distinguish the start and result posts. With `MATTERMOST_MENTION_AUTHOR=true` the author mention is prepended automatically to every post, so the template does not need `{{.Author}}`. The mention only notifies when `Author` matches a Mattermost username.
+
+```bash
+MATTERMOST_FORMAT='{{if eq .Status "in progress"}}:rocket: Deploying **{{.App}}** {{range $i, $img := .Images}}{{if $i}}, {{end}}`{{$img.Tag}}`{{end}}{{else if eq .Status "deployed"}}:white_check_mark: **{{.App}}** deployed{{else}}:x: **{{.App}}**: {{.Status}}{{end}}'
+```
+
+Both strategies can be enabled at the same time; each enabled strategy receives every event.
+
+> **Note:** the mapping between the start post and its thread is kept in memory. If argo-watcher restarts mid-deployment (or runs with multiple replicas), the result is posted as a regular channel message instead of a thread reply.

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -371,6 +371,7 @@ type ArgoStatusUpdaterConfig struct {
 	RepoCachePath    string
 	AcceptSuspended  bool
 	WebhookConfig    *config.WebhookConfig
+	MattermostConfig *config.MattermostConfig
 	Locker           lock.Locker
 }
 
@@ -389,20 +390,35 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 	updater.monitor.defaultAttempts = cfg.RetryAttempts
 	updater.gitUpdater = NewGitUpdater(cfg.Locker, cfg.RepoCachePath)
 
-	if cfg.WebhookConfig == nil || !cfg.WebhookConfig.Enabled {
-		return nil
-	}
+	var strategies []notifications.NotificationStrategy
 
 	httpClient := &http.Client{
 		Timeout: 15 * time.Second,
 	}
 
-	webhookStrategy, err := notifications.NewWebhookStrategy(cfg.WebhookConfig, httpClient)
-	if err != nil {
-		return err
+	if cfg.WebhookConfig != nil && cfg.WebhookConfig.Enabled {
+		webhookStrategy, err := notifications.NewWebhookStrategy(cfg.WebhookConfig, httpClient)
+		if err != nil {
+			return err
+		}
+
+		strategies = append(strategies, webhookStrategy)
 	}
 
-	updater.notifier = notifications.NewNotifier(webhookStrategy)
+	if cfg.MattermostConfig != nil && cfg.MattermostConfig.Enabled {
+		mattermostStrategy, err := notifications.NewMattermostStrategy(cfg.MattermostConfig, httpClient)
+		if err != nil {
+			return err
+		}
+
+		strategies = append(strategies, mattermostStrategy)
+	}
+
+	if len(strategies) == 0 {
+		return nil
+	}
+
+	updater.notifier = notifications.NewNotifier(strategies...)
 	return nil
 }
 

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -785,6 +785,42 @@ func TestArgoStatusUpdaterInitWebhook(t *testing.T) {
 		require.NotNil(t, updater.notifier)
 	})
 
+	t.Run("configuresNotifierWhenMattermostEnabled", func(t *testing.T) {
+		updater := &ArgoStatusUpdater{}
+		cfg := &config.MattermostConfig{
+			Enabled:   true,
+			Url:       "http://mattermost.example.com",
+			Token:     "token",
+			ChannelId: "channel123",
+			Format:    `{{.App}}: {{.Status}}`,
+		}
+
+		err := updater.Init(Argo{}, ArgoStatusUpdaterConfig{
+			RetryAttempts:    1,
+			RetryDelay:       time.Second,
+			MattermostConfig: cfg,
+			Locker:           locker,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updater.notifier)
+	})
+
+	t.Run("returnsErrorOnMattermostSetupFailure", func(t *testing.T) {
+		updater := &ArgoStatusUpdater{}
+		cfg := &config.MattermostConfig{
+			Enabled: true,
+			Url:     "http://mattermost.example.com",
+		}
+
+		err := updater.Init(Argo{}, ArgoStatusUpdaterConfig{
+			RetryAttempts:    1,
+			RetryDelay:       time.Second,
+			MattermostConfig: cfg,
+			Locker:           locker,
+		})
+		assert.Error(t, err)
+	})
+
 	t.Run("returnsErrorWhenLockerMissing", func(t *testing.T) {
 		updater := &ArgoStatusUpdater{}
 		err := updater.Init(Argo{}, ArgoStatusUpdaterConfig{

--- a/internal/notifications/mattermost.go
+++ b/internal/notifications/mattermost.go
@@ -1,0 +1,184 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// MattermostStrategy posts deployment notifications via the Mattermost REST API.
+// The deployment start produces a root channel post; the deployment result is
+// posted as a thread reply to it, mentioning the task author.
+type MattermostStrategy struct {
+	baseURL       string
+	token         string
+	channelID     string
+	mentionAuthor bool
+	client        HTTPClient
+	template      *template.Template
+
+	mu        sync.Mutex
+	rootPosts map[string]string // task.Id -> mattermost post id
+}
+
+type mattermostPostRequest struct {
+	ChannelId string `json:"channel_id"`
+	Message   string `json:"message"`
+	RootId    string `json:"root_id,omitempty"`
+}
+
+type mattermostPostResponse struct {
+	Id string `json:"id"`
+}
+
+// NewMattermostStrategy creates and initializes the Mattermost strategy.
+func NewMattermostStrategy(cfg *config.MattermostConfig, client HTTPClient) (*MattermostStrategy, error) {
+	if cfg == nil {
+		return nil, errors.New("mattermost configuration cannot be nil")
+	}
+	if !cfg.Enabled {
+		return nil, errors.New("mattermost strategy disabled")
+	}
+	if strings.TrimSpace(cfg.Url) == "" {
+		return nil, errors.New("mattermost url cannot be empty")
+	}
+	if strings.TrimSpace(cfg.Token) == "" {
+		return nil, errors.New("mattermost token cannot be empty")
+	}
+	if strings.TrimSpace(cfg.ChannelId) == "" {
+		return nil, errors.New("mattermost channel id cannot be empty")
+	}
+	if strings.TrimSpace(cfg.Format) == "" {
+		return nil, errors.New("mattermost format cannot be empty")
+	}
+	if client == nil {
+		return nil, errors.New("HTTPClient cannot be nil")
+	}
+
+	tmpl, err := template.New("mattermost").Parse(cfg.Format)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mattermost template: %w", err)
+	}
+
+	return &MattermostStrategy{
+		baseURL:       strings.TrimSuffix(cfg.Url, "/"),
+		token:         cfg.Token,
+		channelID:     cfg.ChannelId,
+		mentionAuthor: cfg.MentionAuthor,
+		client:        client,
+		template:      tmpl,
+		rootPosts:     make(map[string]string),
+	}, nil
+}
+
+// Send delivers the Mattermost notification for the provided task.
+// A task with the "in progress" status creates a root post whose id is
+// remembered; any other status replies in that post's thread and forgets it.
+func (s *MattermostStrategy) Send(task models.Task) error {
+	var message bytes.Buffer
+	if err := s.template.Execute(&message, task); err != nil {
+		return fmt.Errorf("failed to execute mattermost template: %w", err)
+	}
+
+	text := message.String()
+	if s.mentionAuthor && task.Author != "" {
+		// mention must live in the message field: mentions inside attachments do not notify
+		text = "@" + task.Author + " " + text
+	}
+
+	if task.Status == models.StatusInProgressMessage {
+		postId, err := s.createPost(mattermostPostRequest{
+			ChannelId: s.channelID,
+			Message:   text,
+		})
+		if err != nil {
+			return err
+		}
+
+		s.mu.Lock()
+		s.rootPosts[task.Id] = postId
+		s.mu.Unlock()
+
+		return nil
+	}
+
+	s.mu.Lock()
+	rootId := s.rootPosts[task.Id]
+	delete(s.rootPosts, task.Id)
+	s.mu.Unlock()
+
+	// empty rootId (e.g. watcher restarted mid-deployment) degrades to a regular channel post
+	_, err := s.createPost(mattermostPostRequest{
+		ChannelId: s.channelID,
+		Message:   text,
+		RootId:    rootId,
+	})
+	return err
+}
+
+// createPost sends POST /api/v4/posts and returns the created post id.
+func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	payload, err := json.Marshal(post)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal mattermost post: %w", err)
+	}
+
+	log.Debug().Msgf("Sending mattermost post: %s", string(payload))
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/api/v4/posts", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("failed to create mattermost request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send mattermost post: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warn().Err(err).Msg("Failed to close mattermost response body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		lr := io.LimitReader(resp.Body, maxErrorBodySize)
+		body, readErr := io.ReadAll(lr)
+		if readErr != nil {
+			return "", fmt.Errorf("mattermost returned status code %d, and failed to read response body: %w", resp.StatusCode, readErr)
+		}
+		return "", fmt.Errorf("mattermost returned status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	var created mattermostPostResponse
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return "", fmt.Errorf("failed to decode mattermost response: %w", err)
+	}
+	if created.Id == "" {
+		return "", errors.New("mattermost response is missing post id")
+	}
+
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		log.Warn().Err(err).Msg("Failed to discard mattermost response body")
+	}
+
+	return created.Id, nil
+}

--- a/internal/notifications/mattermost_test.go
+++ b/internal/notifications/mattermost_test.go
@@ -1,0 +1,342 @@
+package notifications
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+func validMattermostConfig() *config.MattermostConfig {
+	return &config.MattermostConfig{
+		Enabled:   true,
+		Url:       "http://mattermost.local",
+		Token:     "bot-token",
+		ChannelId: "channel123",
+		Format:    `{{.App}}: {{.Status}}`,
+
+		MentionAuthor: true,
+	}
+}
+
+// TestNewMattermostStrategy tests the constructor for MattermostStrategy.
+func TestNewMattermostStrategy(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		cfg := validMattermostConfig()
+		cfg.Url = "http://mattermost.local/"
+		client := &MockHTTPClient{}
+
+		service, err := NewMattermostStrategy(cfg, client)
+
+		require.NoError(t, err)
+		assert.NotNil(t, service)
+		assert.Equal(t, "http://mattermost.local", service.baseURL)
+		assert.Equal(t, cfg.Token, service.token)
+		assert.Equal(t, cfg.ChannelId, service.channelID)
+		assert.True(t, service.mentionAuthor)
+		assert.NotNil(t, service.template)
+		assert.NotNil(t, service.rootPosts)
+		assert.Same(t, client, service.client)
+	})
+
+	t.Run("Nil Config", func(t *testing.T) {
+		service, err := NewMattermostStrategy(nil, &MockHTTPClient{})
+
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Equal(t, "mattermost configuration cannot be nil", err.Error())
+	})
+
+	t.Run("Disabled Config", func(t *testing.T) {
+		cfg := validMattermostConfig()
+		cfg.Enabled = false
+
+		service, err := NewMattermostStrategy(cfg, &MockHTTPClient{})
+
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Equal(t, "mattermost strategy disabled", err.Error())
+	})
+
+	t.Run("Empty Fields", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			mutate   func(*config.MattermostConfig)
+			expected string
+		}{
+			{"Url", func(c *config.MattermostConfig) { c.Url = " " }, "mattermost url cannot be empty"},
+			{"Token", func(c *config.MattermostConfig) { c.Token = "" }, "mattermost token cannot be empty"},
+			{"ChannelId", func(c *config.MattermostConfig) { c.ChannelId = "" }, "mattermost channel id cannot be empty"},
+			{"Format", func(c *config.MattermostConfig) { c.Format = "  " }, "mattermost format cannot be empty"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := validMattermostConfig()
+				tc.mutate(cfg)
+
+				service, err := NewMattermostStrategy(cfg, &MockHTTPClient{})
+
+				require.Error(t, err)
+				assert.Nil(t, service)
+				assert.Equal(t, tc.expected, err.Error())
+			})
+		}
+	})
+
+	t.Run("Nil HTTPClient", func(t *testing.T) {
+		service, err := NewMattermostStrategy(validMattermostConfig(), nil)
+
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Equal(t, "HTTPClient cannot be nil", err.Error())
+	})
+
+	t.Run("Invalid Template", func(t *testing.T) {
+		cfg := validMattermostConfig()
+		cfg.Format = "{{.App"
+
+		service, err := NewMattermostStrategy(cfg, &MockHTTPClient{})
+
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Contains(t, err.Error(), "failed to parse mattermost template")
+	})
+}
+
+func newTestMattermostStrategy(t *testing.T, client HTTPClient) *MattermostStrategy {
+	t.Helper()
+
+	tmpl, err := template.New("mattermost").Parse(`{{.App}}: {{.Status}}`)
+	require.NoError(t, err)
+
+	return &MattermostStrategy{
+		baseURL:       "http://mattermost.local",
+		token:         "bot-token",
+		channelID:     "channel123",
+		mentionAuthor: true,
+		client:        client,
+		template:      tmpl,
+		rootPosts:     map[string]string{},
+	}
+}
+
+func decodePostBody(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	return decoded
+}
+
+// TestMattermostSend tests the Send method of the MattermostStrategy.
+func TestMattermostSend(t *testing.T) {
+	t.Run("Start Creates Root Post And Stores Post Id", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "http://mattermost.local/api/v4/posts", req.URL.String())
+				assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+				assert.Equal(t, "Bearer bot-token", req.Header.Get("Authorization"))
+
+				body := decodePostBody(t, req)
+				assert.Equal(t, "channel123", body["channel_id"])
+				assert.Equal(t, "@jdoe app1: in progress", body["message"])
+				assert.NotContains(t, body, "root_id")
+
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"post123"}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage, Author: "jdoe"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "post123", service.rootPosts["task-1"])
+	})
+
+	t.Run("Result Replies In Thread With Mention", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body := decodePostBody(t, req)
+				assert.Equal(t, "post123", body["root_id"])
+				assert.Equal(t, "@jdoe app1: deployed", body["message"])
+
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"post456"}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+		service.rootPosts["task-1"] = "post123"
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusDeployedMessage, Author: "jdoe"})
+
+		require.NoError(t, err)
+		assert.NotContains(t, service.rootPosts, "task-1")
+	})
+
+	t.Run("Mention Disabled Leaves Message As Is", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body := decodePostBody(t, req)
+				assert.Equal(t, "app1: deployed", body["message"])
+
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"post456"}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+		service.mentionAuthor = false
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusDeployedMessage, Author: "jdoe"})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Result Without Known Root Posts To Channel", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body := decodePostBody(t, req)
+				assert.NotContains(t, body, "root_id")
+				assert.Equal(t, "app1: failed", body["message"])
+
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"post456"}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusFailedMessage})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Root Entry Deleted Even If Result Post Fails", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+		service.rootPosts["task-1"] = "post123"
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusFailedMessage})
+
+		require.Error(t, err)
+		assert.NotContains(t, service.rootPosts, "task-1")
+	})
+
+	t.Run("Failed Start Does Not Store Post Id", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"message":"no access"}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mattermost returned status code 403")
+		assert.Contains(t, err.Error(), "no access")
+		assert.Empty(t, service.rootPosts)
+	})
+
+	t.Run("Missing Post Id In Response", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Equal(t, "mattermost response is missing post id", err.Error())
+	})
+
+	t.Run("Invalid Response Body", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`not-json`)),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode mattermost response")
+	})
+
+	t.Run("Failed Request Creation", func(t *testing.T) {
+		service := newTestMattermostStrategy(t, &MockHTTPClient{})
+		service.baseURL = ":invalid-url:"
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create mattermost request")
+	})
+
+	t.Run("Non-201 Status With Body Read Error", func(t *testing.T) {
+		mockClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(&errorReader{err: errors.New("read error")}),
+				}, nil
+			},
+		}
+		service := newTestMattermostStrategy(t, mockClient)
+
+		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mattermost returned status code 403, and failed to read response body: read error")
+	})
+
+	t.Run("Failed Template Execution", func(t *testing.T) {
+		invalidTmpl, err := template.New("mattermost").Parse(`{{.Missing}}`)
+		require.NoError(t, err)
+
+		service := newTestMattermostStrategy(t, &MockHTTPClient{})
+		service.template = invalidTmpl
+
+		err = service.Send(models.Task{Id: "task-1", Status: models.StatusInProgressMessage})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute mattermost template")
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		RepoCachePath:    serverConfig.RepoCachePath,
 		AcceptSuspended:  serverConfig.AcceptSuspendedApp,
 		WebhookConfig:    &serverConfig.Webhook,
+		MattermostConfig: &serverConfig.Mattermost,
 		Locker:           locker,
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #459.

Adds a second `NotificationStrategy` implementation: native Mattermost support via the REST API (`POST /api/v4/posts` with a bot token). The deployment start creates a root post in the configured channel; the result is posted as a reply in that post's thread instead of a second independent channel message. With `MATTERMOST_MENTION_AUTHOR=true` every post is prefixed with `@<Author>` — the mention goes into the `message` field because mentions inside attachments don't trigger notifications.

New env vars: `MATTERMOST_ENABLED`, `MATTERMOST_URL`, `MATTERMOST_TOKEN`, `MATTERMOST_CHANNEL_ID`, `MATTERMOST_FORMAT` (same template variables as `WEBHOOK_FORMAT`), `MATTERMOST_MENTION_AUTHOR`. Documented in `docs/guides/notifications.md`.

Implementation notes:

- No new dependencies; mirrors the existing `WebhookStrategy` (same `HTTPClient` interface, constructor validation style, 30s timeout, capped error body).
- Both strategies can be enabled at once; webhook behavior is unchanged.
- The root post id lives in a mutex-guarded in-memory map keyed by task id, removed once the result is sent, so memory is bounded by in-flight deployments. Known limitation: if the watcher restarts mid-deployment, the result degrades to a regular channel post without a thread. Persisting the id in the state backend would fix that; happy to do it as a follow-up if you think it's worth it.

Tested with unit tests covering the constructor validation branches and all `Send` paths (root post, threaded reply, mention on/off, missing root id, error paths), plus `ArgoStatusUpdater.Init` wiring tests. Running in our production cluster against a live Mattermost instance.