### PR TITLE
fix(web): restore layout broken by MUI v9 upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       timeout: 30s
       retries: 3
     volumes:
-      - ./db/data:/var/lib/postgresql/data
+      - ./db/data:/var/lib/postgresql
     ports:
       - "5432:5432"
   migrations:

--- a/web/src/features/tasks/components/ActiveFilterBar.tsx
+++ b/web/src/features/tasks/components/ActiveFilterBar.tsx
@@ -25,18 +25,17 @@ const FilterChip = ({ chip }: { chip: FilterChipDescriptor }) => {
   return (
     <Stack
       direction="row"
-      alignItems="center"
       spacing={0.5}
       sx={{
+        alignItems: 'center',
         height: 28,
         px: 1.25,
         borderRadius: tokens.radiusPill,
         border: `1px solid ${theme.palette.divider}`,
         backgroundColor: bg,
         color: theme.palette.text.primary,
-        fontSize: 12,
-      }}
-    >
+        fontSize: 12
+      }}>
       {chip.labelPrefix && (
         <Box component="span" sx={{ color: theme.palette.text.secondary, fontWeight: 500 }}>
           {chip.labelPrefix}:
@@ -78,10 +77,12 @@ export const ActiveFilterBar = ({ chips, onClearAll }: ActiveFilterBarProps) => 
     <Stack
       direction="row"
       spacing={1}
-      alignItems="center"
-      flexWrap="wrap"
-      sx={{ minHeight: 44, py: 0.5 }}
-    >
+      sx={{
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        minHeight: 44,
+        py: 0.5
+      }}>
       {chips.map(chip => (
         <FilterChip key={chip.key} chip={chip} />
       ))}

--- a/web/src/features/tasks/components/AppCell.tsx
+++ b/web/src/features/tasks/components/AppCell.tsx
@@ -61,7 +61,13 @@ export const AppCell = ({ app }: AppCellProps) => {
   const swatch = swatches[hashIndex(app, swatches.length)];
 
   return (
-    <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{
+        alignItems: 'center',
+        minWidth: 0
+      }}>
       <Box
         aria-hidden
         sx={{

--- a/web/src/features/tasks/components/EmptyState.tsx
+++ b/web/src/features/tasks/components/EmptyState.tsx
@@ -32,11 +32,18 @@ export const EmptyState = ({ icon = 'inbox', title, description, cta }: EmptySta
       px: 3,
     }}
   >
-    <Stack spacing={1.5} alignItems="center" sx={{ maxWidth: 420 }}>
+    <Stack
+      spacing={1.5}
+      sx={{
+        alignItems: 'center',
+        maxWidth: 420
+      }}>
       {ICONS[icon]}
       <Typography variant="h6">{title}</Typography>
       {description && (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: 'text.secondary'
+        }}>
           {description}
         </Typography>
       )}

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -21,7 +21,13 @@ interface ImageRowProps {
 
 /** Single repo + tag-chip row, rendered identically for primary and expanded entries. */
 const ImageRow = ({ image }: ImageRowProps) => (
-  <Stack direction="row" spacing={0.75} alignItems="center" sx={{ minWidth: 0 }}>
+  <Stack
+    direction="row"
+    spacing={0.75}
+    sx={{
+      alignItems: 'center',
+      minWidth: 0
+    }}>
     <Typography
       component="span"
       sx={{

--- a/web/src/features/tasks/components/ListToolbar.tsx
+++ b/web/src/features/tasks/components/ListToolbar.tsx
@@ -15,24 +15,29 @@ export const ListToolbar = ({ left, right }: ListToolbarProps) => (
   <Stack
     direction={{ xs: 'column', md: 'row' }}
     spacing={{ xs: 1.5, md: 2 }}
-    alignItems={{ xs: 'stretch', md: 'center' }}
-    justifyContent="space-between"
-    sx={{ width: '100%', minHeight: 48, py: 0.5 }}
-  >
+    sx={{
+      alignItems: { xs: 'stretch', md: 'center' },
+      justifyContent: 'space-between',
+      width: '100%',
+      minHeight: 48,
+      py: 0.5
+    }}>
     <Stack
       direction="row"
       spacing={1}
-      alignItems="center"
-      sx={{ flexShrink: 0 }}
-    >
+      sx={{
+        alignItems: 'center',
+        flexShrink: 0
+      }}>
       {left}
     </Stack>
     <Stack
       direction="row"
       spacing={1}
-      alignItems="center"
-      sx={{ flexShrink: 0 }}
-    >
+      sx={{
+        alignItems: 'center',
+        flexShrink: 0
+      }}>
       {right}
     </Stack>
   </Stack>

--- a/web/src/features/tasks/components/RefreshControl.tsx
+++ b/web/src/features/tasks/components/RefreshControl.tsx
@@ -139,23 +139,25 @@ export const RefreshControl = ({ onRefresh, storageKey = 'recentTasks.refreshInt
   return (
     <Stack
       direction="row"
-      alignItems="center"
       role="group"
       aria-label="Refresh control"
       sx={{
+        alignItems: 'center',
         height: 34,
         borderRadius: `${tokens.radiusMd}px`,
         border: `1px solid ${theme.palette.divider}`,
         backgroundColor: theme.palette.background.paper,
-        overflow: 'hidden',
-      }}
-    >
+        overflow: 'hidden'
+      }}>
       <Stack
         direction="row"
-        alignItems="center"
         spacing={0.75}
-        sx={{ px: 1.25, height: '100%', minWidth: 110 }}
-      >
+        sx={{
+          alignItems: 'center',
+          px: 1.25,
+          height: '100%',
+          minWidth: 110
+        }}>
         <Box
           aria-hidden
           sx={{

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -307,7 +307,7 @@ const StatusReasonContent = ({ record }: { record?: Task | null }) => {
 
   if (!record.status_reason) {
     return (
-      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+      <Typography variant="body2" sx={{ color: 'text.secondary', p: 2 }}>
         No additional status reason provided.
       </Typography>
     );

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -331,7 +331,6 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
             justifyContent: 'space-between',
             padding: 1.5,
             borderTop: `1px solid ${theme.palette.divider}`,
-
             backgroundColor:
               theme.palette.mode === 'dark' ? tokens.surface2Dark : tokens.surface2
           }}>

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -256,7 +256,13 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
             })}
           </Stack>
           <Stack sx={{ flex: 1, padding: 1.5 }}>
-            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+            <Stack
+              direction="row"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                mb: 1
+              }}>
               <IconButton size="small" onClick={goPrevMonth} aria-label="Previous month">
                 <ChevronLeftIcon fontSize="small" />
               </IconButton>
@@ -320,15 +326,15 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
         </Stack>
         <Stack
           direction="row"
-          alignItems="center"
-          justifyContent="space-between"
           sx={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
             padding: 1.5,
             borderTop: `1px solid ${theme.palette.divider}`,
+
             backgroundColor:
-              theme.palette.mode === 'dark' ? tokens.surface2Dark : tokens.surface2,
-          }}
-        >
+              theme.palette.mode === 'dark' ? tokens.surface2Dark : tokens.surface2
+          }}>
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
             {timezone === 'utc' ? 'UTC' : 'Local'}
             {spanLabel}

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -337,7 +337,9 @@ export const TaskShow = () => {
       <Card>
         <CardContent>
           <Typography variant="h6">Task not specified</Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{
+            color: 'text.secondary'
+          }}>
             The requested task cannot be located because the identifier is missing from the URL.
           </Typography>
         </CardContent>
@@ -347,7 +349,12 @@ export const TaskShow = () => {
 
   if (isLoading) {
     return (
-      <Stack spacing={2} alignItems="center" sx={{ py: 6 }}>
+      <Stack
+        spacing={2}
+        sx={{
+          alignItems: 'center',
+          py: 6
+        }}>
         <CircularProgress />
         <Typography variant="body1">Loading task details…</Typography>
       </Stack>
@@ -359,7 +366,9 @@ export const TaskShow = () => {
       <Card>
         <CardContent>
           <Typography variant="h6">Task not found</Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{
+            color: 'text.secondary'
+          }}>
             The task with identifier <strong>{id}</strong> could not be located.
           </Typography>
         </CardContent>
@@ -369,8 +378,12 @@ export const TaskShow = () => {
 
   return (
     <Stack spacing={3} sx={{ mt: { xs: 1.5, sm: 2 }, px: { xs: 1, md: 0 } }}>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems="center">
-        <Stack direction="row" spacing={1} flexWrap="wrap">
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{
+        alignItems: 'center'
+      }}>
+        <Stack direction="row" spacing={1} sx={{
+          flexWrap: 'wrap'
+        }}>
           <Button onClick={handleBack} startIcon={<ArrowBackIcon />} variant="text">
             Back
           </Button>
@@ -379,13 +392,14 @@ export const TaskShow = () => {
           </Button>
         </Stack>
       </Stack>
-
       <Card elevation={3}>
         <CardHeader
           title={`Task ${data.id?.slice(0, 8) ?? '—'}`}
           subheader="UTC"
           action={
-            <Stack direction="row" spacing={1} alignItems="center">
+            <Stack direction="row" spacing={1} sx={{
+              alignItems: 'center'
+            }}>
               <RollbackIndicator isRollback={data.is_rollback} />
               <Chip label={descriptor.label} color={descriptor.chipColor} size="medium" icon={descriptor.icon} />
             </Stack>
@@ -394,7 +408,7 @@ export const TaskShow = () => {
         <CardContent>
           <Stack spacing={3}>
             <Grid container spacing={3}>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Stack spacing={1.5}>
                   <InfoField label="Application" value={data.app ?? 'Unknown'} />
                   <InfoField label="Project" value={<ProjectReference project={data.project} />} />
@@ -415,7 +429,7 @@ export const TaskShow = () => {
                   )}
                 </Stack>
               </Grid>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Stack spacing={1.5}>
                   <InfoField label="Task ID" value={data.id} />
                   <InfoField label="Created" value={formatDate(createdTimestamp ?? null)} />
@@ -427,7 +441,9 @@ export const TaskShow = () => {
                       ) : (
                         <Stack spacing={0.5}>
                           <Typography variant="body1">{formatDate(updatedTimestamp)}</Typography>
-                          <Typography variant="caption" color="text.secondary">
+                          <Typography variant="caption" sx={{
+                            color: 'text.secondary'
+                          }}>
                             {formatRelativeTime(updatedTimestamp)}
                           </Typography>
                         </Stack>
@@ -445,7 +461,9 @@ export const TaskShow = () => {
             {timelineEntries.length > 0 && (
               <Stack spacing={2}>
                 <Divider />
-                <Typography variant="subtitle2" color="text.secondary">
+                <Typography variant="subtitle2" sx={{
+                  color: 'text.secondary'
+                }}>
                   Timeline
                 </Typography>
                 <Stack spacing={2}>
@@ -463,7 +481,6 @@ export const TaskShow = () => {
           </Stack>
         </CardContent>
       </Card>
-
       <Card elevation={3}>
         <CardHeader title="Actions" />
         <CardContent>
@@ -505,7 +522,6 @@ export const TaskShow = () => {
           </Stack>
         </CardContent>
       </Card>
-
       {data.status_reason && (
         <Alert severity={descriptor.reasonSeverity}>
           <output aria-live="polite" style={{ display: 'block' }}>
@@ -515,7 +531,6 @@ export const TaskShow = () => {
           </output>
         </Alert>
       )}
-
       <Card>
         <CardContent>
           <Typography variant="h6" gutterBottom>
@@ -563,9 +578,12 @@ const InfoField = ({ label, value }: InfoFieldProps) => (
   <Box>
     <Typography
       variant="caption"
-      color="text.secondary"
-      sx={{ textTransform: 'uppercase', letterSpacing: 0.6, fontWeight: 600 }}
-    >
+      sx={{
+        color: 'text.secondary',
+        textTransform: 'uppercase',
+        letterSpacing: 0.6,
+        fontWeight: 600
+      }}>
       {label}
     </Typography>
     {typeof value === 'string' || typeof value === 'number' ? (
@@ -623,10 +641,14 @@ const TimelineRow = ({
     </Box>
     <Stack spacing={0.25}>
       <Typography variant="subtitle2">{entry.label}</Typography>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" sx={{
+        color: 'text.secondary'
+      }}>
         {formattedTimestamp}
       </Typography>
-      <Typography variant="caption" color="text.secondary">
+      <Typography variant="caption" sx={{
+        color: 'text.secondary'
+      }}>
         {formatRelativeTime(entry.timestamp)}
       </Typography>
     </Stack>
@@ -644,7 +666,7 @@ const ImagesList = ({
   const list = images ?? [];
   if (!list.length) {
     return (
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
         No container images were reported for this task.
       </Typography>
     );
@@ -657,7 +679,9 @@ const ImagesList = ({
           key={`${image.image}:${image.tag}`}
           direction={{ xs: 'column', sm: 'row' }}
           spacing={1}
-          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          sx={{
+            alignItems: { xs: 'flex-start', sm: 'center' }
+          }}
         >
           <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
             {image.image}
@@ -666,7 +690,9 @@ const ImagesList = ({
         </Stack>
       ))}
       {hasAdditional && (
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" sx={{
+          color: 'text.secondary'
+        }}>
           Showing the first {MAX_IMAGES_RENDERED} images.
         </Typography>
       )}

--- a/web/src/layout/components/AppTopBar.tsx
+++ b/web/src/layout/components/AppTopBar.tsx
@@ -109,10 +109,13 @@ export const AppTopBar = (props: AppBarProps) => {
         <Toolbar sx={{ minHeight: { xs: 56, md: 64 }, px: { xs: 1, md: 2 } }}>
           <Stack
             direction="row"
-            alignItems="center"
             spacing={1}
-            sx={{ width: '100%', flexWrap: { xs: 'wrap', md: 'nowrap' }, rowGap: { xs: 0.75, md: 0 } }}
-          >
+            sx={{
+              alignItems: 'center',
+              width: '100%',
+              flexWrap: { xs: 'wrap', md: 'nowrap' },
+              rowGap: { xs: 0.75, md: 0 }
+            }}>
             <IconButton
               size="small"
               color="inherit"
@@ -143,9 +146,12 @@ export const AppTopBar = (props: AppBarProps) => {
             <Stack
               direction="row"
               spacing={2}
-              alignItems="center"
-              sx={{ ml: { xs: 0, md: 2 }, flexGrow: 1, justifyContent: { xs: 'center', md: 'flex-start' } }}
-            >
+              sx={{
+                alignItems: 'center',
+                ml: { xs: 0, md: 2 },
+                flexGrow: 1,
+                justifyContent: { xs: 'center', md: 'flex-start' }
+              }}>
               {navigationButtons.map(button => {
                 const active = routeIsActive(location.pathname, button.to);
                 return (
@@ -164,7 +170,14 @@ export const AppTopBar = (props: AppBarProps) => {
               })}
             </Stack>
 
-            <Stack direction="row" spacing={2} alignItems="center" sx={{ flexWrap: 'wrap', rowGap: 0.5 }}>
+            <Stack
+              direction="row"
+              spacing={2}
+              sx={{
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                rowGap: 0.5
+              }}>
               <Chip
                 size="small"
                 color="secondary"
@@ -217,11 +230,15 @@ export const AppTopBar = (props: AppBarProps) => {
                   aria-label={`Open GitHub tag ${version}`}
                 >
                   <GitHubIcon sx={{ fontSize: '1.7em' }} />
-                  <Stack spacing={0.5} alignItems="flex-start">
+                  <Stack spacing={0.5} sx={{
+                    alignItems: 'flex-start'
+                  }}>
                     <Typography sx={{ fontSize: 14, lineHeight: 1 }}>
                       GitHub
                     </Typography>
-                    <Stack direction="row" alignItems="center" spacing={0.5}>
+                    <Stack direction="row" spacing={0.5} sx={{
+                      alignItems: 'center'
+                    }}>
                       <LocalOfferIcon sx={{ fontSize: 12 }} />
                       <Typography sx={{ fontSize: 11, lineHeight: 1 }}>
                         {version}

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -89,19 +89,35 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
     >
       <Stack spacing={2} sx={{ height: '100%' }}>
         <Stack spacing={2} sx={{ flexGrow: 1 }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Stack
+            direction="row"
+            sx={{
+              alignItems: 'center',
+              justifyContent: 'space-between'
+            }}>
             <Typography variant="h6">Workspace Controls</Typography>
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{
+              color: 'text.secondary'
+            }}>
               v{version}
             </Typography>
           </Stack>
 
           <Stack spacing={1.5} component="section" aria-labelledby="drawer-appearance">
-            <Typography variant="subtitle2" color="text.secondary">
+            <Typography variant="subtitle2" sx={{
+              color: 'text.secondary'
+            }}>
               <span id="drawer-appearance">Appearance</span>
             </Typography>
-            <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center">
+            <Stack
+              direction="row"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'space-between'
+              }}>
+              <Stack direction="row" spacing={1} sx={{
+                alignItems: 'center'
+              }}>
                 {mode === 'light' ? <LightModeIcon fontSize="small" /> : <NightlightIcon fontSize="small" />}
                 <Typography variant="body2">Theme mode</Typography>
               </Stack>
@@ -109,8 +125,15 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
                 Switch to {mode === 'light' ? 'dark' : 'light'}
               </Button>
             </Stack>
-            <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center">
+            <Stack
+              direction="row"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'space-between'
+              }}>
+              <Stack direction="row" spacing={1} sx={{
+                alignItems: 'center'
+              }}>
                 <Typography variant="body2">Timezone</Typography>
               </Stack>
               <ToggleButtonGroup
@@ -129,11 +152,20 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
           <Divider />
 
           <Stack spacing={1.5} component="section" aria-labelledby="drawer-lock">
-            <Typography variant="subtitle2" color="text.secondary">
+            <Typography variant="subtitle2" sx={{
+              color: 'text.secondary'
+            }}>
               <span id="drawer-lock">Deploy Lock</span>
             </Typography>
-            <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center">
+            <Stack
+              direction="row"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'space-between'
+              }}>
+              <Stack direction="row" spacing={1} sx={{
+                alignItems: 'center'
+              }}>
                 {deployLock ? <LockIcon fontSize="small" /> : <LockOpenIcon fontSize="small" />}
                 <Typography variant="body2">
                   {deployLock ? 'Lock engaged' : 'Lock released'}
@@ -147,7 +179,9 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
               />
             </Stack>
             {lockHelperText && (
-              <Typography variant="body2" color="text.secondary">
+              <Typography variant="body2" sx={{
+                color: 'text.secondary'
+              }}>
                 {lockHelperText}
               </Typography>
             )}
@@ -165,7 +199,9 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
             textAlign: 'center',
           }}
         >
-          <Typography variant="caption" color="text.secondary">
+          <Typography variant="caption" sx={{
+            color: 'text.secondary'
+          }}>
             © 2022 - {new Date().getFullYear()} Vadim Gedz
           </Typography>
         </Box>

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -188,9 +188,6 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
           </Stack>
         </Stack>
 
-        <Box sx={{ textAlign: 'right' }}>
-          <Button onClick={onClose}>Close</Button>
-        </Box>
         <Box
           sx={{
             mt: 'auto',


### PR DESCRIPTION
### **User description**
A recent dependency bump moved @mui/material from v5 to v9. MUI v6+ removed
  "system props" from components, so `alignItems`, `justifyContent`, `flexWrap`,
  and `color` props stopped emitting CSS — every Stack lost its alignment
  (empty-state icons and header rows drifted left).

  Changes:
  - Move the affected system props into the `sx` prop across the web components
    (via the official `@mui/codemod v6.0.0/system-props`).
  - Migrate the task-detail Grid to the MUI v9 `size` API.
  - Remove the redundant "Close" button from the workspace drawer — it already
    dismisses on backdrop click and Escape.
  - Fix the Postgres 18 data volume mount in docker-compose so the local dev
    stack starts.


___

### **PR Type**
Bug fix


___

### **Description**
- Restore layouts by moving MUI system props into `sx` prop and migrating Grid to v9 API.
  - Move `alignItems`, `justifyContent`, `flexWrap`, `color` inside `sx`.
  - Migrate Grid from `item`/`xs` to new `size` API.

- Remove redundant "Close" button from workspace configuration drawer.

- Fix Postgres 18 data volume mount in docker-compose.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MUIv9["MUI v9 upgrade"] -- "removed system props" --> SystemProps["Move alignItems, justifyContent, color, flexWrap into sx"]
  MUIv9 -- "deprecated old Grid API" --> GridAPI["Migrate Grid to size API"]
  SystemProps --> LayoutFix["Restore layouts"]
  GridAPI --> LayoutFix
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>ActiveFilterBar.tsx</strong><dd><code>Move alignItems and flexWrap into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-691719b6b58c83d151da91ecce4b07f5af33dd01b446abdaafd0a2d436951c30">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AppCell.tsx</strong><dd><code>Move alignItems into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-4ce880c16c15a37a6d7647e0ea2b12ef7d809e6d1ebaab109503b835e754024b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EmptyState.tsx</strong><dd><code>Move alignItems and color into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-f42c693e5173d0c1a8b4b24d3760fae74552aa80545702f53ad0e5c4d173cf86">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ImagesCell.tsx</strong><dd><code>Move alignItems into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-9bf93a7c3a48eb9276d4ac330aa4a3176f905dc9f881bb0c6f4e8467028ae541">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ListToolbar.tsx</strong><dd><code>Move alignItems and justifyContent into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-600e7055f24a629d4236faa85d2abd2f126eabba5a5523cc0dd03985a21029e3">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RefreshControl.tsx</strong><dd><code>Move alignItems into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-542bf5b9e8c1e8840f6f3541af6019b1135bde1518122c327b119932981af428">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TasksDatagrid.tsx</strong><dd><code>Move color into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-591ca5be6c4283b49760078f2deeaa42105aa64a96e7b2be554c7d271979d3c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DateRangePicker.tsx</strong><dd><code>Move alignItems and justifyContent into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-17adb0663020b20bfe475795bb9b12861e4e3f8986156cd00d34e03a2752cdf2">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskShow.tsx</strong><dd><code>Migrate Grid to size API and move system props into sx</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-1d4b92abc8f1378fb4bc1e59c9417a70e764cb1f86824243b5c0c6f04ce599e7">+48/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AppTopBar.tsx</strong><dd><code>Move alignItems and flexWrap into sx prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-e456f01edcbc5e578474cbe9834ffd2f52a4e53a378911d42eeefb0b6f4d7062">+26/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConfigDrawer.tsx</strong><dd><code>Move color and alignItems into sx, remove redundant Close button</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-e3d17af0fded6e7e0b62f66e28e958c7ddd5ce1147c32066dd7e43c4a4ac5990">+48/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Fix Postgres 18 data volume mount path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/461/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

