### PR TITLE
feat(argocd): add per-task refresh override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cancelled and marked with the new `cancelled` status instead of continuing to
   poll Argo CD until it times out. The CLI client reports the cancellation and
   the status is filterable in the Web UI (#353).
+- Per-task Argo CD refresh override: set `TASK_REFRESH=true`/`false` on the CLI
+  client (or `refresh` in the task JSON) to override the server's instance-wide
+  `ARGO_REFRESH_APP` default for a single deployment. Setting it to `false` for
+  applications that never settle a refresh (e.g. one with a constantly
+  reconciling CronJob) avoids the status check timing out (#334).
+- New `argocd_refresh_duration_seconds` Prometheus histogram (label `app`) to
+  surface slow or stuck Argo CD refreshes.
 
 ### Changed
 

--- a/cmd/argo-watcher/prometheus/metrics.go
+++ b/cmd/argo-watcher/prometheus/metrics.go
@@ -13,6 +13,7 @@ type MetricsInterface interface {
 	SetArgoUnavailable(unavailable bool)
 	AddInProgressTask()
 	RemoveInProgressTask()
+	ObserveRefreshDuration(app string, seconds float64)
 }
 
 // Metrics contains all the prometheus collectors.
@@ -21,6 +22,7 @@ type Metrics struct {
 	ProcessedDeployments *prometheus.CounterVec
 	ArgocdUnavailable    prometheus.Gauge
 	InProgressTasks      prometheus.Gauge
+	RefreshDuration      *prometheus.HistogramVec
 }
 
 // NewMetrics creates and registers the metrics with the provided Registerer.
@@ -42,9 +44,14 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "in_progress_tasks",
 			Help: "The number of tasks currently in progress.",
 		}),
+		RefreshDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "argocd_refresh_duration_seconds",
+			Help:    "Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"app"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks)
+	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks, m.RefreshDuration)
 
 	return m
 }
@@ -81,4 +88,9 @@ func (m *Metrics) AddInProgressTask() {
 // RemoveInProgressTask decrements the InProgressTasks gauge.
 func (m *Metrics) RemoveInProgressTask() {
 	m.InProgressTasks.Dec()
+}
+
+// ObserveRefreshDuration records how long an ArgoCD refresh request took for the given app.
+func (m *Metrics) ObserveRefreshDuration(app string, seconds float64) {
+	m.RefreshDuration.WithLabelValues(app).Observe(seconds)
 }

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -12,7 +12,7 @@ scrape_configs:
 
 ## Exposed metrics
 
-The server emits four metrics today, all defined in [`cmd/argo-watcher/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/cmd/argo-watcher/prometheus/metrics.go).
+The server emits five metrics today, all defined in [`cmd/argo-watcher/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/cmd/argo-watcher/prometheus/metrics.go).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
@@ -20,6 +20,7 @@ The server emits four metrics today, all defined in [`cmd/argo-watcher/prometheu
 | `processed_deployments` | counter | `app` | Total deployments processed since server startup, per application. |
 | `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. |
 | `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |
+| `argocd_refresh_duration_seconds` | histogram | `app` | Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes. Recorded only when the status check requests a refresh. |
 
 In addition, the standard Go runtime metrics from the Prometheus client library are exposed (`go_*`, `process_*`).
 
@@ -63,6 +64,19 @@ groups:
           description: |
             More than 50 tasks have been in progress for over 15 minutes.
             Check Argo CD sync performance and DEPLOYMENT_TIMEOUT.
+
+      - alert: ArgoWatcherSlowRefresh
+        expr: histogram_quantile(0.95, sum by (app, le) (rate(argocd_refresh_duration_seconds_bucket[10m]))) > 30
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.app }} ArgoCD refresh is slow"
+          description: |
+            The p95 ArgoCD refresh for this application exceeds 30s. A refresh that never
+            settles (e.g. an app with a constantly-reconciling CronJob) can stall the
+            deployment check — set the per-task refresh override (or ARGO_REFRESH_APP) to
+            false for such apps.
 ```
 
 ## Grafana panel queries

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -21,6 +21,7 @@ The Argo Watcher client is a lightweight CLI tool distributed as a Docker image 
 | `BEARER_TOKEN`              | JWT token for authentication (prefix with `Bearer `, e.g. `Bearer <token>`)                     |
 | `TIMEOUT`                   | HTTP request timeout (e.g. `60s`, `2m`)                                                         |
 | `TASK_TIMEOUT`              | Maximum time (in seconds) to wait for a task to complete                                        |
+| `TASK_REFRESH`              | Override the server's refresh setting for this deployment (`true`/`false`); unset keeps the server default |
 | `RETRY_INTERVAL`            | Interval between status polling attempts (e.g. `15s`, `1m`)                                    |
 | `EXPECTED_DEPLOY_TIME`      | Expected deployment duration; affects polling behavior (e.g. `15m`, `30m`)                     |
 | `DEBUG`                     | Enable verbose debug output                                                                      |

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -21,13 +21,12 @@ import (
 type ArgoApiInterface interface {
 	Init(serverConfig *config.ServerConfig) error
 	GetUserInfo() (*models.Userinfo, error)
-	GetApplication(ctx context.Context, app string) (*models.Application, error)
+	GetApplication(ctx context.Context, app string, refresh bool) (*models.Application, error)
 }
 
 type ArgoApi struct {
 	baseUrl    url.URL
 	client     *http.Client
-	refreshApp bool
 	maxRetries uint
 	// requestFn allows injecting a custom HTTP request constructor for testing.
 	requestFn func(method, url string, body io.Reader) (*http.Request, error)
@@ -74,10 +73,6 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 	}
 
 	log.Debug().Msgf("Timeout for ArgoCD API calls set to: %s", api.client.Timeout)
-
-	// whether to refresh the app during status check
-	api.refreshApp = serverConfig.ArgoRefreshApp
-	log.Debug().Msgf("Refresh app set to: %t", api.refreshApp)
 
 	// configure retry attempts for transient transport errors
 	api.maxRetries = serverConfig.ArgoApiRetries
@@ -183,12 +178,13 @@ func (api *ArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	return &userInfo, nil
 }
 
-// GetApplication fetches the named ArgoCD application. The context bounds the request and its
+// GetApplication fetches the named ArgoCD application. When refresh is true the request asks
+// ArgoCD to reconcile the app first (?refresh=normal). The context bounds the request and its
 // retry loop so a caller polling under a deadline is never blocked past that deadline.
-func (api *ArgoApi) GetApplication(ctx context.Context, app string) (*models.Application, error) {
+func (api *ArgoApi) GetApplication(ctx context.Context, app string, refresh bool) (*models.Application, error) {
 	apiUrl := fmt.Sprintf("%s/api/v1/applications/%s", api.baseUrl.String(), url.PathEscape(app))
 
-	if api.refreshApp {
+	if refresh {
 		apiUrl += "?refresh=normal"
 	}
 

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -86,7 +86,6 @@ func TestArgoApiInit(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, transport.TLSClientConfig)
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.True(t, api.refreshApp)
 	assert.Equal(t, uint(5), api.maxRetries)
 
 	t.Run("returnsErrorWhenCookieJarFails", func(t *testing.T) {
@@ -356,7 +355,7 @@ func TestArgoApiGetApplicationSuccess(t *testing.T) {
 	api.baseUrl = *parsedURL
 	api.client = server.Client()
 	api.maxRetries = 1
-	result, err := api.GetApplication(context.Background(), "demo")
+	result, err := api.GetApplication(context.Background(), "demo", false)
 	require.NoError(t, err)
 	assert.Equal(t, app.Status.Health.Status, result.Status.Health.Status)
 	assert.Equal(t, app.Status.Sync.Status, result.Status.Sync.Status)
@@ -393,32 +392,44 @@ func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {
 			api.baseUrl = *parsedURL
 			api.client = server.Client()
 			api.maxRetries = 1
-			_, err = api.GetApplication(context.Background(), tc.appName)
+			_, err = api.GetApplication(context.Background(), tc.appName, false)
 			assert.NoError(t, err)
 		})
 	}
 }
 
 // TestArgoApiGetApplicationAddsRefreshQuery verifies that the refresh query parameter
-// is added when refreshApp is enabled.
+// is added when refresh is requested, and omitted otherwise.
 func TestArgoApiGetApplicationAddsRefreshQuery(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "refresh=normal", r.URL.RawQuery)
-		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.Application{}))
-	}))
-	defer server.Close()
+	tests := []struct {
+		name      string
+		refresh   bool
+		wantQuery string
+	}{
+		{name: "refresh requested", refresh: true, wantQuery: "refresh=normal"},
+		{name: "refresh not requested", refresh: false, wantQuery: ""},
+	}
 
-	parsedURL, err := url.Parse(server.URL)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tc.wantQuery, r.URL.RawQuery)
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(models.Application{}))
+			}))
+			defer server.Close()
 
-	api := NewArgoApi()
-	api.baseUrl = *parsedURL
-	api.client = server.Client()
-	api.maxRetries = 1
-	api.refreshApp = true
-	_, err = api.GetApplication(context.Background(), "demo")
-	assert.NoError(t, err)
+			parsedURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			api := NewArgoApi()
+			api.baseUrl = *parsedURL
+			api.client = server.Client()
+			api.maxRetries = 1
+			_, err = api.GetApplication(context.Background(), "demo", tc.refresh)
+			assert.NoError(t, err)
+		})
+	}
 }
 
 // TestArgoApiGetApplicationErrors verifies error handling for various failure scenarios
@@ -612,7 +623,7 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(t, tc.api)
 			}
-			app, err := tc.api.GetApplication(context.Background(), "demo")
+			app, err := tc.api.GetApplication(context.Background(), "demo", false)
 			if tc.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, app)

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -46,6 +46,9 @@ type DeploymentMonitor struct {
 	acceptSuspended  bool
 	retryDelay       time.Duration
 	defaultAttempts  uint
+	// refreshApp is the instance-wide default for requesting an ArgoCD refresh during status checks.
+	// A per-task Refresh override takes precedence (see resolveRefresh).
+	refreshApp bool
 }
 
 // GitUpdater encapsulates the logic required to update Git repositories watched by ArgoCD.
@@ -75,10 +78,31 @@ func (monitor *DeploymentMonitor) EndTracking() {
 	monitor.argo.metrics.RemoveInProgressTask()
 }
 
+// resolveRefresh reports whether this task's status check should request an ArgoCD refresh.
+// A per-task Refresh override wins over the instance-wide default; a nil override (field omitted
+// by the client) keeps the default, so old clients behave exactly as before (issue #334).
+func (monitor *DeploymentMonitor) resolveRefresh(task models.Task) bool {
+	if task.Refresh != nil {
+		return *task.Refresh
+	}
+	return monitor.refreshApp
+}
+
 // FetchApplication retrieves the ArgoCD application by name. The context bounds the underlying
 // API call so callers polling under a deadline are not blocked past it.
-func (monitor *DeploymentMonitor) FetchApplication(ctx context.Context, appName string) (*models.Application, error) {
-	return monitor.argo.api.GetApplication(ctx, appName)
+//
+// When a refresh is requested, the call is timed and its duration recorded (argocd_refresh_duration_seconds)
+// so slow or stuck refreshes are diagnosable. A stuck refresh is avoided operationally, not here: set the
+// per-task Refresh override (or ARGO_REFRESH_APP) to false for apps that never settle (issue #334).
+func (monitor *DeploymentMonitor) FetchApplication(ctx context.Context, appName string, refresh bool) (*models.Application, error) {
+	if !refresh {
+		return monitor.argo.api.GetApplication(ctx, appName, false)
+	}
+
+	start := time.Now()
+	app, err := monitor.argo.api.GetApplication(ctx, appName, true)
+	monitor.argo.metrics.ObserveRefreshDuration(appName, time.Since(start).Seconds())
+	return app, err
 }
 
 // StoreInitialAppStatus caches the initial rollout status for comparison during monitoring.
@@ -117,6 +141,7 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 	// cannot clobber the last-known-good status we want to report on timeout.
 	var application *models.Application
 
+	refresh := monitor.resolveRefresh(task)
 	retryOptions, deadline := monitor.configureRetryOptions(task)
 
 	ctx, cancel := context.WithTimeout(context.Background(), deadline)
@@ -135,7 +160,7 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 			return retry.Unrecoverable(errTaskSuperseded)
 		}
 
-		app, fetchErr := monitor.FetchApplication(ctx, task.App)
+		app, fetchErr := monitor.FetchApplication(ctx, task.App, refresh)
 		if fetchErr != nil {
 			return handleApplicationFetchError(task, fetchErr)
 		}
@@ -370,6 +395,7 @@ type ArgoStatusUpdaterConfig struct {
 	RegistryProxyURL string
 	RepoCachePath    string
 	AcceptSuspended  bool
+	RefreshApp       bool
 	WebhookConfig    *config.WebhookConfig
 	MattermostConfig *config.MattermostConfig
 	Locker           lock.Locker
@@ -388,6 +414,7 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 
 	updater.monitor = NewDeploymentMonitor(argo, cfg.RegistryProxyURL, retryOptions, cfg.AcceptSuspended, cfg.RetryDelay)
 	updater.monitor.defaultAttempts = cfg.RetryAttempts
+	updater.monitor.refreshApp = cfg.RefreshApp
 	updater.gitUpdater = NewGitUpdater(cfg.Locker, cfg.RepoCachePath)
 
 	var strategies []notifications.NotificationStrategy
@@ -465,7 +492,7 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 
 	// Fetch initial app state. This single call happens before the timed polling loop, so it is
 	// bounded only by the HTTP client's per-request timeout rather than the rollout deadline.
-	app, err := updater.monitor.FetchApplication(context.Background(), task.App)
+	app, err := updater.monitor.FetchApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -144,7 +144,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -196,8 +196,8 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		healthyApp.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&healthyApp, nil).Times(1)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -241,7 +241,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(2).MaxTimes(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -287,7 +287,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "Healthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -323,7 +323,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -354,7 +354,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -385,7 +385,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, fmt.Errorf("unexpected failure"))
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("unexpected failure"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -427,7 +427,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Summary.Images = []string{"test-image:v0.0.1"}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -478,7 +478,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.OperationState.Message = "Not working test app"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -527,7 +527,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.Health.Status = "NotHealthy"
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).Times(3)
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -853,13 +853,13 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 	task := models.Task{App: "demo", Validated: true}
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
-		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, errors.New("network")).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errors.New("network")).Times(1)
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
-		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, nil).Times(1)
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
@@ -868,7 +868,7 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
 		app.Spec.Source.RepoURL = ""
-		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(app, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
 		_, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
@@ -892,7 +892,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 	t.Run("handlesFireAndForget", func(t *testing.T) {
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{"argo-watcher/fire-and-forget": "true"}
-		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(app, nil).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
 		received, err := monitor.WaitRollout(task)
 		require.NoError(t, err)
@@ -901,7 +901,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 
 	t.Run("wrapsApplicationFetchErrors", func(t *testing.T) {
 		errNotFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
-		api.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, errNotFound).Times(1)
+		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errNotFound).Times(1)
 
 		_, err := monitor.WaitRollout(task)
 		require.Error(t, err)
@@ -935,8 +935,8 @@ func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
 	app.Status.Sync.Status = "OutOfSync"
 	app.Status.Health.Status = "Progressing"
 
-	api.EXPECT().GetApplication(gomock.Any(), task.App).DoAndReturn(
-		func(_ context.Context, _ string) (*models.Application, error) {
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ bool) (*models.Application, error) {
 			time.Sleep(40 * time.Millisecond)
 			return app, nil
 		}).MinTimes(1).MaxTimes(3)
@@ -973,8 +973,8 @@ func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.
 	goodApp.Status.Health.Status = "Progressing"
 
 	firstDone := false
-	api.EXPECT().GetApplication(gomock.Any(), task.App).DoAndReturn(
-		func(ctx context.Context, _ string) (*models.Application, error) {
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ string, _ bool) (*models.Application, error) {
 			if !firstDone {
 				firstDone = true
 				return goodApp, nil
@@ -1007,7 +1007,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	)
 	task := models.Task{Id: "test-id", App: "demo", Timeout: 1}
 
-	api.EXPECT().GetApplication(gomock.Any(), task.App).
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 		Return(nil, errors.New(argoUnavailableErrorMessage)).MinTimes(1)
 
 	received, err := monitor.WaitRollout(task)
@@ -1089,7 +1089,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	application.Status.Summary.Images = []string{"test-registry/ghcr.io/shini4i/argo-watcher:dev"}
 	application.Status.Sync.Status = "OutOfSync"
 	application.Status.Health.Status = "Progressing"
-	apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).AnyTimes()
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).AnyTimes()
 
 	// First status read (initial supersession check) reports in-progress; the next
 	// read — at the top of the first poll iteration — reports cancelled.
@@ -1142,9 +1142,9 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 
 	gomock.InOrder(
 		// Initial check and first poll succeed: the app is present but still progressing.
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&inProgress, nil).Times(2),
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&inProgress, nil).Times(2),
 		// The app is then deleted mid-rollout; every subsequent fetch reports not found.
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(nil, notFound).MinTimes(1),
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, notFound).MinTimes(1),
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
@@ -1190,7 +1190,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 
 	// Every supersession check fails to read the status; the rollout must carry on.
 	stateMock.EXPECT().GetTask(task.Id).Return(nil, errors.New("db unavailable")).AnyTimes()
-	apiMock.EXPECT().GetApplication(gomock.Any(), task.App).Return(&application, nil).MinTimes(1)
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(1)
 	metricsMock.EXPECT().AddInProgressTask()
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
@@ -1632,4 +1632,88 @@ func TestDeploymentMonitor_configureRetryOptions(t *testing.T) {
 		assert.Equal(t, 5, attempts, "Should use the configured defaultAttempts when timeout is zero")
 		assert.Equal(t, 5*ArgoSyncRetryDelay, deadline, "Default-attempts deadline should be attempts*delay")
 	})
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestDeploymentMonitorResolveRefresh verifies the per-task refresh override precedence (issue #334):
+// an explicit Refresh wins over the instance default, and a nil override (old clients) keeps the default.
+func TestDeploymentMonitorResolveRefresh(t *testing.T) {
+	tests := []struct {
+		name            string
+		instanceDefault bool
+		taskRefresh     *bool
+		want            bool
+	}{
+		{name: "nil override keeps instance default (true)", instanceDefault: true, taskRefresh: nil, want: true},
+		{name: "nil override keeps instance default (false)", instanceDefault: false, taskRefresh: nil, want: false},
+		{name: "explicit false overrides default true", instanceDefault: true, taskRefresh: boolPtr(false), want: false},
+		{name: "explicit true overrides default false", instanceDefault: false, taskRefresh: boolPtr(true), want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := &DeploymentMonitor{refreshApp: tc.instanceDefault}
+			got := monitor.resolveRefresh(models.Task{Refresh: tc.taskRefresh})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// newFetchTestMonitor builds a monitor wired to mock API + metrics for FetchApplication tests.
+func newFetchTestMonitor(t *testing.T) (*DeploymentMonitor, *mock.MockArgoApiInterface, *mock.MockMetricsInterface) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	api := mock.NewMockArgoApiInterface(ctrl)
+	metrics := mock.NewMockMetricsInterface(ctrl)
+	monitor := NewDeploymentMonitor(
+		Argo{api: api, metrics: metrics},
+		"",
+		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	return monitor, api, metrics
+}
+
+// TestDeploymentMonitorFetchApplicationRefreshRecordsDuration verifies that a refresh request is
+// forwarded with refresh=true and its duration recorded (argocd_refresh_duration_seconds), so slow or
+// stuck refreshes are diagnosable (issue #334). The API error is surfaced unchanged.
+func TestDeploymentMonitorFetchApplicationRefreshRecordsDuration(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		monitor, api, metrics := newFetchTestMonitor(t)
+		wantApp := &models.Application{}
+		api.EXPECT().GetApplication(gomock.Any(), "demo", true).Return(wantApp, nil)
+		metrics.EXPECT().ObserveRefreshDuration("demo", gomock.Any())
+
+		app, err := monitor.FetchApplication(context.Background(), "demo", true)
+		require.NoError(t, err)
+		assert.Same(t, wantApp, app)
+	})
+
+	t.Run("error is surfaced, duration still recorded", func(t *testing.T) {
+		monitor, api, metrics := newFetchTestMonitor(t)
+		api.EXPECT().GetApplication(gomock.Any(), "demo", true).Return(nil, errors.New("connection refused"))
+		metrics.EXPECT().ObserveRefreshDuration("demo", gomock.Any())
+
+		app, err := monitor.FetchApplication(context.Background(), "demo", true)
+		require.Error(t, err)
+		assert.Nil(t, app)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+}
+
+// TestDeploymentMonitorFetchApplicationNoRefresh verifies that when refresh is not requested, the call
+// is forwarded with refresh=false and no refresh duration is recorded.
+func TestDeploymentMonitorFetchApplicationNoRefresh(t *testing.T) {
+	monitor, api, _ := newFetchTestMonitor(t)
+	wantApp := &models.Application{}
+	// No ObserveRefreshDuration expectation: the mock controller fails the test if it is called.
+	api.EXPECT().GetApplication(gomock.Any(), "demo", false).Return(wantApp, nil)
+
+	app, err := monitor.FetchApplication(context.Background(), "demo", false)
+	require.NoError(t, err)
+	assert.Same(t, wantApp, app)
 }

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -28,6 +28,10 @@ type Task struct {
 	Validated    bool    `json:"validated,omitempty"`
 	Timeout      int     `json:"timeout,omitempty"`
 	IsRollback   bool    `json:"is_rollback,omitempty"`
+	// Refresh optionally overrides the instance-wide ARGO_REFRESH_APP setting for this task.
+	// A nil pointer (field omitted) keeps the instance default, so old clients are unaffected;
+	// an explicit true/false forces a refresh on or off for this deployment (issue #334).
+	Refresh *bool `json:"refresh,omitempty" example:"false"`
 	// RollbackTargetId is the ID of the most recent earlier task whose image set
 	// this deployment returns to. Empty when the deployment is not a rollback.
 	RollbackTargetId string         `json:"rollback_target_id,omitempty"`

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -1,11 +1,54 @@
 package models
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestTask_RefreshUnmarshal verifies the per-task refresh override (issue #334) is optional and
+// backward compatible: a payload from an old client (no "refresh" field) yields a nil pointer, while
+// explicit true/false round-trip as set. A nil pointer lets the server fall back to its instance default.
+func TestTask_RefreshUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		assert  func(t *testing.T, refresh *bool)
+	}{
+		{
+			name:    "field omitted (old client)",
+			payload: `{"app":"demo","author":"ci","project":"Demo","images":[]}`,
+			assert:  func(t *testing.T, refresh *bool) { assert.Nil(t, refresh) },
+		},
+		{
+			name:    "explicit false",
+			payload: `{"app":"demo","author":"ci","project":"Demo","images":[],"refresh":false}`,
+			assert: func(t *testing.T, refresh *bool) {
+				require.NotNil(t, refresh)
+				assert.False(t, *refresh)
+			},
+		},
+		{
+			name:    "explicit true",
+			payload: `{"app":"demo","author":"ci","project":"Demo","images":[],"refresh":true}`,
+			assert: func(t *testing.T, refresh *bool) {
+				require.NotNil(t, refresh)
+				assert.True(t, *refresh)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var task Task
+			require.NoError(t, json.Unmarshal([]byte(tc.payload), &task))
+			tc.assert(t, task.Refresh)
+		})
+	}
+}
 
 func TestTask_ListImages(t *testing.T) {
 	task := Task{

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -38,7 +38,7 @@ func (m *mockArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	return &models.Userinfo{LoggedIn: true, Username: "test"}, nil
 }
 
-func (m *mockArgoApi) GetApplication(_ context.Context, _ string) (*models.Application, error) {
+func (m *mockArgoApi) GetApplication(_ context.Context, _ string, _ bool) (*models.Application, error) {
 	return &models.Application{}, nil
 }
 
@@ -89,12 +89,13 @@ func (m *mockTaskRepository) ProcessObsoleteTasks(_ uint) {}
 // mockMetrics is a minimal mock for MetricsInterface used in tests.
 type mockMetrics struct{}
 
-func (m *mockMetrics) AddProcessedDeployment(_ string) {}
-func (m *mockMetrics) AddFailedDeployment(_ string)    {}
-func (m *mockMetrics) ResetFailedDeployment(_ string)  {}
-func (m *mockMetrics) SetArgoUnavailable(_ bool)       {}
-func (m *mockMetrics) AddInProgressTask()              {}
-func (m *mockMetrics) RemoveInProgressTask()           {}
+func (m *mockMetrics) AddProcessedDeployment(_ string)            {}
+func (m *mockMetrics) AddFailedDeployment(_ string)               {}
+func (m *mockMetrics) ResetFailedDeployment(_ string)             {}
+func (m *mockMetrics) SetArgoUnavailable(_ bool)                  {}
+func (m *mockMetrics) AddInProgressTask()                         {}
+func (m *mockMetrics) RemoveInProgressTask()                      {}
+func (m *mockMetrics) ObserveRefreshDuration(_ string, _ float64) {}
 
 func TestGetVersion(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,6 +81,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		RegistryProxyURL: serverConfig.RegistryProxyUrl,
 		RepoCachePath:    serverConfig.RepoCachePath,
 		AcceptSuspended:  serverConfig.AcceptSuspendedApp,
+		RefreshApp:       serverConfig.ArgoRefreshApp,
 		WebhookConfig:    &serverConfig.Webhook,
 		MattermostConfig: &serverConfig.Mattermost,
 		Locker:           locker,

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -9,16 +9,20 @@ import (
 )
 
 type Config struct {
-	Url                    string        `env:"ARGO_WATCHER_URL,required"`
-	Images                 []string      `env:"IMAGES,required"`
-	Tag                    string        `env:"IMAGE_TAG,required"`
-	App                    string        `env:"ARGO_APP,required"`
-	Author                 string        `env:"COMMIT_AUTHOR,required"`
-	Project                string        `env:"PROJECT_NAME,required"`
-	Token                  string        `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
-	JsonWebToken           string        `env:"BEARER_TOKEN"`
-	Timeout                time.Duration `env:"TIMEOUT" envDefault:"60s"`
-	TaskTimeout            int           `env:"TASK_TIMEOUT"`
+	Url          string        `env:"ARGO_WATCHER_URL,required"`
+	Images       []string      `env:"IMAGES,required"`
+	Tag          string        `env:"IMAGE_TAG,required"`
+	App          string        `env:"ARGO_APP,required"`
+	Author       string        `env:"COMMIT_AUTHOR,required"`
+	Project      string        `env:"PROJECT_NAME,required"`
+	Token        string        `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
+	JsonWebToken string        `env:"BEARER_TOKEN"`
+	Timeout      time.Duration `env:"TIMEOUT" envDefault:"60s"`
+	TaskTimeout  int           `env:"TASK_TIMEOUT"`
+	// Refresh optionally overrides the server's instance-wide refresh setting for this deployment.
+	// Left unset it stays nil and the field is omitted from the request, so the server keeps its
+	// default; set TASK_REFRESH=true/false to force a refresh on or off for this task (issue #334).
+	Refresh                *bool         `env:"TASK_REFRESH"`
 	RetryInterval          time.Duration `env:"RETRY_INTERVAL" envDefault:"15s"`
 	ExpectedDeploymentTime time.Duration `env:"EXPECTED_DEPLOY_TIME" envDefault:"15m"`
 	Debug                  bool          `env:"DEBUG"`

--- a/pkg/client/utility.go
+++ b/pkg/client/utility.go
@@ -149,6 +149,7 @@ func createTask(config *Config) models.Task {
 		Project: config.Project,
 		Images:  images,
 		Timeout: config.TaskTimeout,
+		Refresh: config.Refresh,
 	}
 }
 

--- a/pkg/client/utility_test.go
+++ b/pkg/client/utility_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestWatcher builds a Watcher pointing at the given URL with retries enabled
@@ -374,6 +375,37 @@ func TestCreateTask(t *testing.T) {
 
 		assert.Equal(t, expectedTask, task)
 		assert.Zero(t, task.Timeout)
+	})
+
+	t.Run("RefreshOverride", func(t *testing.T) {
+		refresh := false
+		config := &Config{
+			App:     "test-app",
+			Author:  "test-author",
+			Project: "test-project",
+			Images:  []string{"image1"},
+			Tag:     "test-tag",
+			Refresh: &refresh,
+		}
+
+		task := createTask(config)
+
+		require.NotNil(t, task.Refresh, "an explicit TASK_REFRESH must propagate to the task")
+		assert.False(t, *task.Refresh)
+	})
+
+	t.Run("RefreshUnset", func(t *testing.T) {
+		config := &Config{
+			App:     "test-app",
+			Author:  "test-author",
+			Project: "test-project",
+			Images:  []string{"image1"},
+			Tag:     "test-tag",
+		}
+
+		task := createTask(config)
+
+		assert.Nil(t, task.Refresh, "an omitted TASK_REFRESH must leave the server default in effect")
 	})
 }
 


### PR DESCRIPTION
### **User description**
Allow a deployment task to override the instance-wide ARGO_REFRESH_APP setting via a new optional `refresh` field (client env TASK_REFRESH). Omitting it keeps the server default, so existing clients are unaffected. Setting it to false for apps that never settle a refresh (e.g. one with a constantly reconciling CronJob) avoids the status check timing out.

Also expose an argocd_refresh_duration_seconds histogram to surface slow or stuck refreshes (closes #334).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Allow per-task Argo CD refresh override via optional `refresh` field.
  - Uses `TASK_REFRESH` client env; omitting keeps server default.

- Expose `argocd_refresh_duration_seconds` histogram for slow refresh detection.

- Update `GetApplication` to accept a per-call refresh boolean.

- Add tests for refresh resolution and metric recording.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client sets TASK_REFRESH"] --> B["Task.Refresh field"]
  B --> C["resolveRefresh()"]
  D["Instance default ARGO_REFRESH_APP"] --> C
  C -- "refresh bool" --> E["FetchApplication()"]
  E --> F["ArgoCD API call"]
  F --> G["if refresh: observe duration"]
  G --> H["argocd_refresh_duration_seconds histogram"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>metrics.go</strong><dd><code>Add `argocd_refresh_duration_seconds` histogram metric</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-f60c78b7383828b0c7362d212d99cfcd640a55e88141c6472c0f0b43be912de0">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_api.go</strong><dd><code>Accept per-call refresh bool, remove instance-wide refresh toggle</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-258db12fc8cb94622298e5c370dee0bd14489f19fd8d1fcf875eab84a21871c9">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_status_updater.go</strong><dd><code>Add resolveRefresh, record refresh duration, per-task override</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-ed22c343f4b6ed3704cd98d39d200754d2474f7829d30e102464e213ac23eab3">+31/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task.go</strong><dd><code>Add optional Refresh field to Task struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-6f0c139732cdc86a8357d4bb1f5d83c1f17da9e49294747fb1173967703b8956">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.go</strong><dd><code>Add TASK_REFRESH env var for client refresh override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-4c6c39be3c960ef6149f9248a8ac51387be1fdb382869d9c68fef688735ebb69">+14/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>utility.go</strong><dd><code>Propagate Refresh config to task creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-14128409dc784e5179825fca2f57cde9e4950851c7260c94b16cc7288b4d27a5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>argo_api_test.go</strong><dd><code>Update tests to pass refresh flag; add query parameter tests</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-52eef6e90e9c7a7be700e7bb9ed2bab565a62dc247dec3b885ac6c9f7db31add">+31/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>argo_status_updater_test.go</strong><dd><code>Add tests for resolveRefresh, FetchApplication refresh, metrics</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-09b297447b7e2fbfea57e00fa6d493a1ffd2757f47fcc08456ad96a8c8a1e5e3">+109/-25</a></td>

</tr>

<tr>
  <td><strong>task_test.go</strong><dd><code>Test JSON unmarshalling of per-task refresh field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-5342f20a679df7b1015acd28d514b426afbfa92546c903c376359b9fdeebd786">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router_test.go</strong><dd><code>Update mock signatures and add ObserveRefreshDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-0e7d3d9b9adc77e35d95609d14f1d1f255b669d8d89589080b2c6da28c6760c5">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utility_test.go</strong><dd><code>Test that TASK_REFRESH propagates correctly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-860b0c566509573a86c19587af80fe376d7e6d38a67164fba124b475f52bd6c8">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server.go</strong><dd><code>Pass RefreshApp config to status updater</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document per-task refresh override and new metric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>observability.md</strong><dd><code>Add refresh duration metric to monitoring docs and alert</code>&nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-f5e8a887e00f003769578d91f8786e8fb1a7529185d5c202ac47e677af582cfc">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client-env.md</strong><dd><code>Add TASK_REFRESH environment variable documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/462/files#diff-ef45e5367935b89d45a93d9e63233d73eaaa25070428a30124810dd572a80847">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

