### PR TITLE
ci(release): sign checksums with cosign v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,13 +101,15 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    # cosign v3 defaults to the new bundle format: the separate .sig/.pem
+    # outputs are gone, replaced by a single .sigstore.json bundle written via
+    # --bundle. Verify with: cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt
+    signature: "${artifact}.sigstore.json"
     output: true
     artifacts: checksum
     args:
       - "sign-blob"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
 


### PR DESCRIPTION
### **User description**
cosign v3 defaults to the new bundle format, where --output-signature and --output-certificate are ignored and a --bundle path is required. The old signs block passed an empty bundle path, failing the release with "create bundle file: open : no such file or directory". Switch to a single .sigstore.json bundle written via --bundle.


___

### **PR Type**
Bug fix


___

### **Description**
- Switch cosign signing to the v3 bundle format

- Replace separate .sig and .pem outputs with a single .sigstore.json bundle

- Update goreleaser configuration to use `--bundle` instead of `--output-signature` and `--output-certificate`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cosign sign-blob with separate outputs"] --> B["Replaced by"]
  B --> C["cosign sign-blob with --bundle"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.goreleaser.yaml</strong><dd><code>Switch cosign signing to v3 bundle format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.goreleaser.yaml

<ul><li>Replaced <code>--output-signature</code> and <code>--output-certificate</code> with <code>--bundle</code><br> <li> Changed the signature file to use the <code>.sigstore.json</code> bundle extension<br> <li> Added a comment explaining the cosign v3 bundle format verification</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/463/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

