### PR TITLE
fix(argocd): scope superseded-task cancel to matching images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the task detail page links to the earlier task the deployment rolls back to.
 - Expose `IsRollback` and `RollbackTargetId` as webhook notification template
   variables so alerts can highlight rollbacks.
-- Cancel superseded deployments: when a new deployment for an application is
-  triggered while a previous one is still in progress, the older deployment is
-  cancelled and marked with the new `cancelled` status instead of continuing to
-  poll Argo CD until it times out. The CLI client reports the cancellation and
-  the status is filterable in the Web UI (#353).
+- Cancel superseded deployments: when a new deployment is triggered while a
+  previous in-progress one for the same application targets one of the same
+  images, the older deployment is cancelled and marked with the new `cancelled`
+  status instead of continuing to poll Argo CD until it times out. Matching on
+  image name (not just the application) lets independent per-image deployments of
+  the same application run concurrently without cancelling each other. The CLI
+  client reports the cancellation and the status is filterable in the Web UI
+  (#353).
 - Per-task Argo CD refresh override: set `TASK_REFRESH=true`/`false` on the CLI
   client (or `refresh` in the task JSON) to override the server's instance-wide
   `ARGO_REFRESH_APP` default for a single deployment. Setting it to `false` for

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -26,7 +26,7 @@ A task in Argo Watcher moves through the following states:
 2. **In Progress** — Image detected in Argo CD, deployment is syncing or running.
 3. **Deployed** — Deployment succeeded; application is healthy and synced.
 4. **Failed** — Deployment failed due to health/sync issues or timeout.
-5. **Cancelled** — Superseded by a newer deployment for the same application before reaching a final state; polling stops. Unlike Failed, a cancelled task is not counted as a deployment failure.
+5. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. Unlike Failed, a cancelled task is not counted as a deployment failure.
 
 ## Deployment Locking
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -33,7 +33,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - The `ARGO_APP` name does not match an application in Argo CD.
 - The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
 - The client timed out waiting for the deployment to complete.
-- A newer deployment for the same application was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
+- A newer deployment of one of the same images was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). Only tasks sharing an image with the newer deployment are cancelled; independent per-image deployments of the same application do not cancel each other. This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
 
 **How to verify:**
 - Check the client logs in the CI output.

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -32,8 +32,8 @@ const (
 	// argoUnavailableErrorMessage is the specific error message for a refused connection.
 	argoUnavailableErrorMessage = "connect: connection refused"
 	// supersededTaskReason is the status reason stored on a deployment that was
-	// cancelled because a newer deployment for the same app superseded it.
-	supersededTaskReason = "superseded by a newer deployment for the same application"
+	// cancelled because a newer deployment of the same image superseded it.
+	supersededTaskReason = "superseded by a newer deployment for the same image"
 )
 
 // Argo is the primary controller for watcher operations.
@@ -94,12 +94,14 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	task.RollbackTargetId = argo.detectRollback(task)
 	task.IsRollback = task.RollbackTargetId != ""
 
-	// Supersede any in-flight deployment for this app before starting a new one, so
-	// the watcher stops polling ArgoCD for a rollout nobody is waiting on anymore
-	// (issue #353). This runs against the shared state, so in an HA setup it also
-	// cancels rollouts being watched by other replicas. Best-effort: a failure here
-	// must not block the new deployment.
-	if cancelled, err := argo.State.CancelInProgressTasks(task.App, supersededTaskReason); err != nil {
+	// Supersede any in-flight deployment for this app that targets one of the same
+	// images before starting a new one, so the watcher stops polling ArgoCD for a
+	// rollout nobody is waiting on anymore (issue #353). Matching on image name
+	// (not just the app) keeps independent per-image deployments of the same app
+	// from cancelling each other. This runs against the shared state, so in an HA
+	// setup it also cancels rollouts being watched by other replicas. Best-effort:
+	// a failure here must not block the new deployment.
+	if cancelled, err := argo.State.CancelInProgressTasks(task.App, task.Images, supersededTaskReason); err != nil {
 		log.Warn().Str("app", task.App).Msgf("Failed to cancel in-progress deployments for the app: %s", err)
 	} else if cancelled > 0 {
 		log.Info().Str("app", task.App).Msgf("Cancelled %d in-progress deployment(s) superseded by the new task", cancelled)

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -213,7 +213,7 @@ func TestArgoAddTask(t *testing.T) {
 		// mock calls to add task
 		stateError := fmt.Errorf("database error")
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
-		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).Return(nil, stateError)
 
 		// argo manager
@@ -267,7 +267,9 @@ func TestArgoAddTask(t *testing.T) {
 		// match the cancel filter and cancel itself. gomock.InOrder locks that.
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
 		gomock.InOrder(
-			state.EXPECT().CancelInProgressTasks("test-app", supersededTaskReason).Return(int64(0), nil),
+			// The task's images MUST be forwarded to the cancel call so superseding
+			// is scoped to matching images, not the whole app.
+			state.EXPECT().CancelInProgressTasks("test-app", gomock.Eq(task.Images), supersededTaskReason).Return(int64(0), nil),
 			state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil),
 		)
 
@@ -300,7 +302,7 @@ func TestArgoAddTask(t *testing.T) {
 		// Cancelling prior in-progress tasks is best-effort: a failure here must not
 		// block the new deployment from being persisted.
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
-		state.EXPECT().CancelInProgressTasks("test-app", supersededTaskReason).Return(int64(0), fmt.Errorf("cancel failed"))
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), supersededTaskReason).Return(int64(0), fmt.Errorf("cancel failed"))
 		state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil)
 
 		argo := &Argo{}
@@ -330,7 +332,7 @@ func TestArgoAddTask(t *testing.T) {
 
 		// Capture the task actually handed to the repository.
 		var captured models.Task
-		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
 			captured = task
 			task.Id = uuid.NewString()
@@ -363,7 +365,7 @@ func TestArgoAddTask(t *testing.T) {
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return(deployed, int64(len(deployed)))
 
 		var captured models.Task
-		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any()).Return(int64(0), nil)
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
 			captured = task
 			task.Id = uuid.NewString()

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -76,7 +76,7 @@ func (m *mockTaskRepository) SetTaskStatus(_, _, _ string) error {
 	return nil
 }
 
-func (m *mockTaskRepository) CancelInProgressTasks(_, _ string) (int64, error) {
+func (m *mockTaskRepository) CancelInProgressTasks(_ string, _ []models.Image, _ string) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -153,17 +153,20 @@ func (state *InMemoryState) SetTaskStatus(id string, status string, reason strin
 	return errors.New("task not found")
 }
 
-// CancelInProgressTasks marks every in-progress task for the given app as
-// cancelled and returns how many were updated. It is used to supersede an older
-// deployment when a newer one for the same app is triggered.
-func (state *InMemoryState) CancelInProgressTasks(app, reason string) (int64, error) {
+// CancelInProgressTasks marks in-progress tasks for the given app as cancelled
+// and returns how many were updated. A task is only cancelled when it shares at
+// least one image name with the supplied images (tags ignored), so independent
+// per-image deployments of the same app do not cancel each other.
+func (state *InMemoryState) CancelInProgressTasks(app string, images []models.Image, reason string) (int64, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
 	var count int64
 	now := float64(time.Now().Unix())
 	for idx := range state.tasks {
-		if state.tasks[idx].App == app && state.tasks[idx].Status == models.StatusInProgressMessage {
+		if state.tasks[idx].App == app &&
+			state.tasks[idx].Status == models.StatusInProgressMessage &&
+			imageNamesOverlap(state.tasks[idx].Images, images) {
 			state.tasks[idx].Status = models.StatusCancelledMessage
 			state.tasks[idx].StatusReason = reason
 			state.tasks[idx].Updated = now

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -28,6 +28,38 @@ func createTestTask(app string) models.Task {
 	}
 }
 
+// taskWithImage returns an in-progress task for the given app deploying a single
+// named image, used to exercise image-aware cancellation.
+func taskWithImage(app, image string) models.Task {
+	task := createTestTask(app)
+	task.Images = []models.Image{{Image: image, Tag: "v0.0.1"}}
+	return task
+}
+
+// TestImageNamesOverlap locks the boundary contract of the overlap helper:
+// empty/nil inputs never match, tags are ignored, and a single shared image
+// name (even within larger disjoint sets) counts as an overlap.
+func TestImageNamesOverlap(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []models.Image
+		b    []models.Image
+		want bool
+	}{
+		{"both nil", nil, nil, false},
+		{"first empty", nil, []models.Image{{Image: "image-a", Tag: "v1"}}, false},
+		{"second empty", []models.Image{{Image: "image-a", Tag: "v1"}}, nil, false},
+		{"fully disjoint", []models.Image{{Image: "image-a"}}, []models.Image{{Image: "image-b"}}, false},
+		{"same name different tags", []models.Image{{Image: "image-a", Tag: "v1"}}, []models.Image{{Image: "image-a", Tag: "v2"}}, true},
+		{"partial overlap in larger sets", []models.Image{{Image: "image-a"}, {Image: "image-b"}}, []models.Image{{Image: "image-b"}, {Image: "image-c"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, imageNamesOverlap(tt.a, tt.b))
+		})
+	}
+}
+
 // TestInMemoryState_AddTask verifies that tasks can be added to the in-memory state
 // and receive unique IDs.
 func TestInMemoryState_AddTask(t *testing.T) {
@@ -207,30 +239,42 @@ func TestInMemoryState_SetTaskStatus_NotFound(t *testing.T) {
 	assert.Equal(t, "task not found", err.Error())
 }
 
-// TestInMemoryState_CancelInProgressTasks verifies that only the in-progress
-// tasks for the target app are switched to cancelled, and that already-finished
-// tasks and tasks for other apps are left untouched.
+// TestInMemoryState_CancelInProgressTasks verifies that only in-progress tasks
+// for the target app that share an image name with the new deployment are
+// switched to cancelled, and that same-app-different-image tasks, already-
+// finished tasks, and tasks for other apps are left untouched.
 func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
 	state := InMemoryState{}
 
-	inProgress, err := state.AddTask(createTestTask("app-a"))
+	inProgress, err := state.AddTask(taskWithImage("app-a", "image-a"))
 	require.NoError(t, err)
 
-	otherApp, err := state.AddTask(createTestTask("app-b"))
+	// Same app, but a different image deployed independently.
+	sameAppOtherImage, err := state.AddTask(taskWithImage("app-a", "image-b"))
 	require.NoError(t, err)
 
-	finished, err := state.AddTask(createTestTask("app-a"))
+	otherApp, err := state.AddTask(taskWithImage("app-b", "image-a"))
+	require.NoError(t, err)
+
+	finished, err := state.AddTask(taskWithImage("app-a", "image-a"))
 	require.NoError(t, err)
 	require.NoError(t, state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
 
-	count, err := state.CancelInProgressTasks("app-a", "superseded")
+	// A new deployment of image-a for app-a supersedes only the in-progress
+	// image-a task.
+	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded")
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), count, "only the in-progress app-a task should be cancelled")
+	assert.Equal(t, int64(1), count, "only the in-progress app-a task sharing image-a should be cancelled")
 
 	got, err := state.GetTask(inProgress.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusCancelledMessage, got.Status)
 	assert.Equal(t, "superseded", got.StatusReason)
+
+	// Same app but a different image is untouched.
+	gotSameApp, err := state.GetTask(sameAppOtherImage.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotSameApp.Status)
 
 	// A different app is untouched.
 	gotOther, err := state.GetTask(otherApp.Id)
@@ -241,6 +285,66 @@ func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
 	gotFinished, err := state.GetTask(finished.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusDeployedMessage, gotFinished.Status)
+}
+
+// TestInMemoryState_CancelInProgressTasks_MultiImageOverlap verifies the "any
+// shared image name" semantics: a multi-image in-progress task is cancelled when
+// the new deployment shares only one of its images, while a task sharing none is
+// left alone. This is what distinguishes overlap from set-equality matching.
+func TestInMemoryState_CancelInProgressTasks_MultiImageOverlap(t *testing.T) {
+	state := InMemoryState{}
+
+	overlapping := createTestTask("app-a")
+	overlapping.Images = []models.Image{{Image: "image-a", Tag: "v1"}, {Image: "image-b", Tag: "v1"}}
+	overlappingTask, err := state.AddTask(overlapping)
+	require.NoError(t, err)
+
+	disjoint := createTestTask("app-a")
+	disjoint.Images = []models.Image{{Image: "image-c", Tag: "v1"}, {Image: "image-d", Tag: "v1"}}
+	disjointTask, err := state.AddTask(disjoint)
+	require.NoError(t, err)
+
+	// New deployment shares only image-b with the first task and nothing with the second.
+	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-b", Tag: "v2"}, {Image: "image-e", Tag: "v1"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "only the task sharing an image name should be cancelled")
+
+	gotOverlapping, err := state.GetTask(overlappingTask.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotOverlapping.Status)
+
+	gotDisjoint, err := state.GetTask(disjointTask.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotDisjoint.Status)
+}
+
+// TestInMemoryState_CancelInProgressTasks_Count verifies the returned count:
+// every matching in-progress task is cancelled (aggregation), and a deployment
+// that overlaps nothing in flight cancels nothing.
+func TestInMemoryState_CancelInProgressTasks_Count(t *testing.T) {
+	state := InMemoryState{}
+
+	first, err := state.AddTask(taskWithImage("app-a", "image-a"))
+	require.NoError(t, err)
+	second, err := state.AddTask(taskWithImage("app-a", "image-a"))
+	require.NoError(t, err)
+
+	// No overlap: nothing is cancelled and both tasks stay in progress.
+	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-z", Tag: "v1"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "a deployment sharing no image should cancel nothing")
+
+	// Overlap: both in-progress tasks sharing image-a are cancelled.
+	count, err = state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count, "every matching in-progress task must be cancelled")
+
+	gotFirst, err := state.GetTask(first.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotFirst.Status)
+	gotSecond, err := state.GetTask(second.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotSecond.Status)
 }
 
 // TestInMemoryState_ProcessObsoleteTasks verifies that stale in-progress tasks

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -143,12 +143,35 @@ func (state *PostgresState) SetTaskStatus(id string, status string, reason strin
 	return nil
 }
 
-// CancelInProgressTasks marks every in-progress task for the given app as
-// cancelled in a single atomic UPDATE and returns how many rows were affected.
-// It supersedes older deployments when a newer one for the same app arrives.
-func (state *PostgresState) CancelInProgressTasks(app, reason string) (int64, error) {
-	result := state.orm.Model(&state_models.TaskModel{}).
+// CancelInProgressTasks marks in-progress tasks for the given app as cancelled
+// and returns how many rows were affected. A task is only cancelled when it
+// shares at least one image name with the supplied images (tags ignored), so
+// independent per-image deployments of the same app do not cancel each other.
+// Because the image match is evaluated in Go, the in-progress tasks are first
+// fetched, filtered by image overlap, then updated by id. The UPDATE re-checks
+// the in-progress status so a task that finished between the two queries is not
+// clobbered.
+func (state *PostgresState) CancelInProgressTasks(app string, images []models.Image, reason string) (int64, error) {
+	var candidates []state_models.TaskModel
+	if err := state.orm.Model(&state_models.TaskModel{}).
 		Where(`"tasks"."app" = ?`, app).
+		Where(whereStatusEquals, models.StatusInProgressMessage).
+		Find(&candidates).Error; err != nil {
+		return 0, err
+	}
+
+	var ids []uuid.UUID
+	for _, candidate := range candidates {
+		if imageNamesOverlap(candidate.Images, images) {
+			ids = append(ids, candidate.Id)
+		}
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	result := state.orm.Model(&state_models.TaskModel{}).
+		Where("id IN ?", ids).
 		Where(whereStatusEquals, models.StatusInProgressMessage).
 		Updates(state_models.TaskModel{
 			Status:       models.StatusCancelledMessage,

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -158,19 +158,25 @@ func TestPostgresState_SetTaskStatus(t *testing.T) {
 func TestPostgresState_CancelInProgressTasks(t *testing.T) {
 	env := newPostgresTestEnv(t)
 
-	inProgress := env.addTask(t, sampleTask("app-a"))
-	otherApp := env.addTask(t, sampleTask("app-b"))
-	finished := env.addTask(t, sampleTask("app-a"))
+	inProgress := env.addTask(t, taskWithImage("app-a", "image-a"))
+	sameAppOtherImage := env.addTask(t, taskWithImage("app-a", "image-b"))
+	otherApp := env.addTask(t, taskWithImage("app-b", "image-a"))
+	finished := env.addTask(t, taskWithImage("app-a", "image-a"))
 	require.NoError(t, env.state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
 
-	count, err := env.state.CancelInProgressTasks("app-a", "superseded")
+	count, err := env.state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded")
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), count, "only the in-progress app-a task should be cancelled")
+	assert.Equal(t, int64(1), count, "only the in-progress app-a task sharing image-a should be cancelled")
 
 	got, err := env.state.GetTask(inProgress.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusCancelledMessage, got.Status)
 	assert.Equal(t, "superseded", got.StatusReason)
+
+	// Same app but a different image is untouched.
+	gotSameApp, err := env.state.GetTask(sameAppOtherImage.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotSameApp.Status)
 
 	gotOther, err := env.state.GetTask(otherApp.Id)
 	require.NoError(t, err)
@@ -179,6 +185,58 @@ func TestPostgresState_CancelInProgressTasks(t *testing.T) {
 	gotFinished, err := env.state.GetTask(finished.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusDeployedMessage, gotFinished.Status)
+}
+
+// TestPostgresState_CancelInProgressTasks_MultiImageOverlap mirrors the
+// in-memory multi-image test: a task sharing one image name is cancelled while a
+// fully disjoint task is left alone, exercising overlap (not equality) matching.
+func TestPostgresState_CancelInProgressTasks_MultiImageOverlap(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	overlapping := sampleTask("app-a")
+	overlapping.Images = []models.Image{{Image: "image-a", Tag: "v1"}, {Image: "image-b", Tag: "v1"}}
+	overlappingTask := env.addTask(t, overlapping)
+
+	disjoint := sampleTask("app-a")
+	disjoint.Images = []models.Image{{Image: "image-c", Tag: "v1"}, {Image: "image-d", Tag: "v1"}}
+	disjointTask := env.addTask(t, disjoint)
+
+	count, err := env.state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-b", Tag: "v2"}, {Image: "image-e", Tag: "v1"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "only the task sharing an image name should be cancelled")
+
+	gotOverlapping, err := env.state.GetTask(overlappingTask.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotOverlapping.Status)
+
+	gotDisjoint, err := env.state.GetTask(disjointTask.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusInProgressMessage, gotDisjoint.Status)
+}
+
+// TestPostgresState_CancelInProgressTasks_Count mirrors the in-memory count test
+// for CI: no-overlap returns 0 (the len(ids) == 0 early return) and an
+// overlapping deployment cancels every matching in-progress task.
+func TestPostgresState_CancelInProgressTasks_Count(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	first := env.addTask(t, taskWithImage("app-a", "image-a"))
+	second := env.addTask(t, taskWithImage("app-a", "image-a"))
+
+	count, err := env.state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-z", Tag: "v1"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "a deployment sharing no image should cancel nothing")
+
+	count, err = env.state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count, "every matching in-progress task must be cancelled")
+
+	gotFirst, err := env.state.GetTask(first.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotFirst.Status)
+	gotSecond, err := env.state.GetTask(second.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, gotSecond.Status)
 }
 
 func TestPostgresState_ProcessObsoleteTasks(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -11,6 +11,22 @@ import (
 
 var errDesiredRetry = errors.New("desired retry error")
 
+// imageNamesOverlap reports whether the two image slices share at least one
+// image name (the repository, ignoring the tag). It is used to decide whether a
+// new deployment supersedes an in-progress one for the same app.
+func imageNamesOverlap(a, b []models.Image) bool {
+	names := make(map[string]struct{}, len(a))
+	for _, img := range a {
+		names[img.Image] = struct{}{}
+	}
+	for _, img := range b {
+		if _, ok := names[img.Image]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // TaskRepository defines the contract for task persistence.
 // Implementations are responsible for connecting to the underlying storage and
 // offering CRUD-like operations for deployment tasks.
@@ -20,12 +36,15 @@ type TaskRepository interface {
 	GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) ([]models.Task, int64)
 	GetTask(id string) (*models.Task, error)
 	SetTaskStatus(id string, status string, reason string) error
-	// CancelInProgressTasks marks every in-progress task for the given app as
-	// cancelled and returns how many were affected. It is used to supersede an
-	// older deployment when a newer one for the same app arrives (issue #353).
-	// Operating on the shared state makes the cancellation visible to every
-	// replica, not just the one handling the new deployment.
-	CancelInProgressTasks(app, reason string) (int64, error)
+	// CancelInProgressTasks marks in-progress tasks for the given app as
+	// cancelled and returns how many were affected. A task is only cancelled when
+	// it shares at least one image name with the supplied images, so independent
+	// per-image deployments of the same app do not cancel each other (issue #353).
+	// Tags are ignored on purpose: a newer tag of the same image must still
+	// supersede the older in-flight rollout. Operating on the shared state makes
+	// the cancellation visible to every replica, not just the one handling the new
+	// deployment.
+	CancelInProgressTasks(app string, images []models.Image, reason string) (int64, error)
 	Check() bool
 	ProcessObsoleteTasks(retryTimes uint)
 }


### PR DESCRIPTION
Cancelling in-progress deployments on supersede matched by app name alone, so deploying one image cancelled unrelated in-flight watches for other images of the same app. Match on app plus a shared image name instead; tags are ignored so a newer tag of the same image still supersedes the older rollout.

CancelInProgressTasks now takes the new task's images. The Postgres path selects in-progress rows for the app, filters by image-name overlap in Go, then updates by id with an in-progress status re-check to avoid clobbering a task that finished between the two queries.