### PR TITLE
refactor(logging): replace zerolog with stdlib log/slog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application now aborts its write-back (re-checked before every attempt) rather
   than committing a stale image tag, so the larger retry budget cannot let an
   older deployment overwrite a newer one.
+- Switch server and mock logging from zerolog to Go's standard library
+  `log/slog`. Log output is still JSON on stderr, but level names are now
+  uppercase (e.g. `INFO`), the message field key is `msg` (previously
+  `message`), timestamps carry nanosecond precision, and durations are reported
+  in nanoseconds — update any log processing that keys on the old field names or
+  values. `LOG_LEVEL` still accepts `debug`/`info`/`warn`/`error` (default
+  `info`); the previously-accepted, undocumented `disabled` value is no longer
+  recognized and now falls back to `info`.
 
 ### Fixed
 

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 
 	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
@@ -60,20 +61,20 @@ func mockReturnAppStatus(c *gin.Context) {
 	appStatus.Status.Summary.Images = []string{"app:v0.0.1", "nginx:1.21.6", "migrations:v0.0.1"}
 
 	if app == "app4" && requestsCount < 5 {
-		log.Info().Msgf("app4 requests count %d", requestsCount)
+		slog.Info(fmt.Sprintf("app4 requests count %d", requestsCount))
 		requestsCount++
 		if requestsCount < 2 {
 			appStatus.Status.Summary.Images = []string{"app:v0.0.1-rc1", "nginx:1.21.6", "migrations:v0.0.1"}
 		}
 		appStatus.Status.Health.Status = "UhHealthy"
-		log.Info().Msgf("app4 sync status is %s", appStatus.Status.Sync.Status)
-		log.Info().Msgf("app4 health status is %s", appStatus.Status.Health.Status)
+		slog.Info(fmt.Sprintf("app4 sync status is %s", appStatus.Status.Sync.Status))
+		slog.Info(fmt.Sprintf("app4 health status is %s", appStatus.Status.Health.Status))
 	} else if app == "app4" {
 		requestsCount = 0
 		appStatus.Status.Health.Status = "Healthy"
 		appStatus.Status.Sync.Status = "Synced"
-		log.Info().Msgf("app4 sync status is %s", appStatus.Status.Sync.Status)
-		log.Info().Msgf("app4 health status is %s", appStatus.Status.Health.Status)
+		slog.Info(fmt.Sprintf("app4 sync status is %s", appStatus.Status.Sync.Status))
+		slog.Info(fmt.Sprintf("app4 health status is %s", appStatus.Status.Health.Status))
 	} else {
 		appStatus.Status.Health.Status = "Healthy"
 	}
@@ -82,12 +83,13 @@ func mockReturnAppStatus(c *gin.Context) {
 }
 
 func main() {
-	log.Info().Msg("Starting mock web server")
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+	slog.Info("Starting mock web server")
 
 	router := setupRouter()
 
 	err := router.Run(":8081")
 	if err != nil {
-		log.Error().Msg(err.Error())
+		slog.Error(err.Error())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.54.0
@@ -63,7 +62,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,6 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
 github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
-github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy0/jY=
-github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
@@ -201,8 +199,6 @@ github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+
 github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
-github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -3,14 +3,13 @@ package argocd
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
 	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/state"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 )
@@ -102,9 +101,9 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// setup it also cancels rollouts being watched by other replicas. Best-effort:
 	// a failure here must not block the new deployment.
 	if cancelled, err := argo.State.CancelInProgressTasks(task.App, task.Images, supersededTaskReason); err != nil {
-		log.Warn().Str("app", task.App).Msgf("Failed to cancel in-progress deployments for the app: %s", err)
+		slog.Warn(fmt.Sprintf("Failed to cancel in-progress deployments for the app: %s", err), "app", task.App)
 	} else if cancelled > 0 {
-		log.Info().Str("app", task.App).Msgf("Cancelled %d in-progress deployment(s) superseded by the new task", cancelled)
+		slog.Info(fmt.Sprintf("Cancelled %d in-progress deployment(s) superseded by the new task", cancelled), "app", task.App)
 	}
 
 	newTask, err := argo.State.AddTask(task)
@@ -112,13 +111,13 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 		return nil, err
 	}
 
-	log.Info().Str("id", newTask.Id).Msgf("A new task was triggered")
+	slog.Info("A new task was triggered", "id", newTask.Id)
 	for index, value := range newTask.Images {
-		log.Info().Str("id", newTask.Id).Msgf("Task image [%d] expecting tag %s in app %s.",
+		slog.Info(fmt.Sprintf("Task image [%d] expecting tag %s in app %s.",
 			index,
 			value.Tag,
 			task.App,
-		)
+		), "id", newTask.Id)
 	}
 
 	argo.metrics.AddProcessedDeployment(task.App)

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"time"
 
 	retry "github.com/avast/retry-go/v4"
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
@@ -43,7 +43,7 @@ func NewArgoApi() *ArgoApi {
 }
 
 func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
-	log.Debug().Msg("Initializing argo-watcher client...")
+	slog.Debug("Initializing argo-watcher client...")
 	// set base url
 	api.baseUrl = serverConfig.ArgoUrl
 
@@ -72,11 +72,11 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 		Timeout:   time.Duration(serverConfig.ArgoApiTimeout) * time.Second,
 	}
 
-	log.Debug().Msgf("Timeout for ArgoCD API calls set to: %s", api.client.Timeout)
+	slog.Debug(fmt.Sprintf("Timeout for ArgoCD API calls set to: %s", api.client.Timeout))
 
 	// configure retry attempts for transient transport errors
 	api.maxRetries = serverConfig.ArgoApiRetries
-	log.Debug().Msgf("Max API retries set to: %d", api.maxRetries)
+	slog.Debug(fmt.Sprintf("Max API retries set to: %d", api.maxRetries))
 
 	return nil
 }
@@ -115,11 +115,7 @@ func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, erro
 		retry.DelayType(retry.BackOffDelay),
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(n uint, err error) {
-			log.Debug().
-				Err(err).
-				Uint("retry", n+1).
-				Str("url", reqURL).
-				Msg("retrying ArgoCD API request")
+			slog.Debug("retrying ArgoCD API request", "error", err, "retry", n+1, "url", reqURL)
 		}),
 	)
 	if err != nil {
@@ -127,7 +123,7 @@ func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, erro
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			log.Error().Err(closeErr).Msg("failed to close response body")
+			slog.Error("failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -190,7 +186,7 @@ func (api *ArgoApi) GetApplication(ctx context.Context, app string, refresh bool
 
 	body, statusCode, err := api.doGet(ctx, apiUrl)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to execute request")
+		slog.Error("failed to execute request", "error", err)
 		return nil, err
 	}
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/helpers"
 
 	"github.com/avast/retry-go/v4"
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/pkg/updater"
@@ -148,7 +148,7 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 	defer cancel()
 	retryOptions = append(retryOptions, retry.Context(ctx))
 
-	log.Debug().Str("id", task.Id).Dur("deadline", deadline).Msg("Waiting for rollout")
+	slog.Debug("Waiting for rollout", "id", task.Id, "deadline", deadline)
 
 	err := retry.Do(func() error {
 		// Stop before hitting ArgoCD if a newer deployment superseded this task.
@@ -168,7 +168,7 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 
 		// Early return for fire and forget mode
 		if app.IsFireAndForgetModeActive() {
-			log.Debug().Str("id", task.Id).Msg("Fire and forget mode is active, skipping checks...")
+			slog.Debug("Fire and forget mode is active, skipping checks...", "id", task.Id)
 			return nil
 		}
 
@@ -255,19 +255,19 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 	}
 
 	if task.Timeout <= 0 {
-		log.Debug().Str("id", task.Id).Msgf("Task timeout is non-positive, defaulting to %d attempts", defaultAttempts)
+		slog.Debug(fmt.Sprintf("Task timeout is non-positive, defaulting to %d attempts", defaultAttempts), "id", task.Id)
 		return append(retryOptions, retry.Attempts(defaultAttempts)), mulDurationSaturating(defaultAttempts, delay)
 	}
 
 	attempts := safeIntToUint(int64(task.Timeout)/delaySeconds + 1)
 
-	log.Debug().Str("id", task.Id).Msgf(
+	slog.Debug(fmt.Sprintf(
 		"Overriding task timeout to %ds with retry delay %s (~%d second step, %d attempts)",
 		task.Timeout,
 		delay,
 		delaySeconds,
 		attempts,
-	)
+	), "id", task.Id)
 
 	return append(retryOptions, retry.Attempts(attempts)), mulDurationSaturating(attempts, delay)
 }
@@ -293,7 +293,7 @@ func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, app
 func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 	current, err := monitor.argo.State.GetTask(id)
 	if err != nil {
-		log.Warn().Str("id", id).Msgf("Could not read task status to check for supersession: %s", err)
+		slog.Warn(fmt.Sprintf("Could not read task status to check for supersession: %s", err), "id", id)
 		return false
 	}
 	return current.Status == models.StatusCancelledMessage
@@ -304,24 +304,24 @@ func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task models.Task, err err
 	monitor.argo.metrics.AddFailedDeployment(task.App)
 	finalStatus := determineFailureStatus(task, err)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
-	log.Warn().Str("id", task.Id).Msgf("Deployment failed with status \"%s\". Aborting with error: %s", finalStatus, reason)
+	slog.Warn(fmt.Sprintf("Deployment failed with status \"%s\". Aborting with error: %s", finalStatus, reason), "id", task.Id)
 
 	if err := monitor.argo.State.SetTaskStatus(task.Id, finalStatus, reason); err != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, err)
+		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
 	}
 }
 
 func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
-	log.Info().Str("id", task.Id).Msg("App is running on the expected version.")
+	slog.Info("App is running on the expected version.", "id", task.Id)
 	monitor.argo.metrics.ResetFailedDeployment(task.App)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""); err != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, err)
+		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
 	}
 	task.Status = models.StatusDeployedMessage
 }
 
 func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application) {
-	log.Info().Str("id", task.Id).Msg("App deployment failed.")
+	slog.Info("App deployment failed.", "id", task.Id)
 	monitor.argo.metrics.AddFailedDeployment(task.App)
 	reason := fmt.Sprintf(
 		"Application deployment failed. Rollout status is %s\n\n%s",
@@ -329,7 +329,7 @@ func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, sta
 		application.GetRolloutMessage(status, task.ListImages()),
 	)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, reason); err != nil {
-		log.Error().Str("id", task.Id).Msgf(failedToUpdateTaskStatusTemplate, err)
+		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
 	}
 	task.Status = models.StatusFailedMessage
 }
@@ -348,24 +348,24 @@ func NewGitUpdater(locker lock.Locker, repoCachePath string) *GitUpdater {
 // newer deployment aborts instead of committing a stale image tag.
 func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task models.Task, isSuperseded ...func() bool) error {
 	if !app.IsManagedByWatcher() || !task.Validated {
-		log.Debug().Str("id", task.Id).Msg("Skipping git repo update: application not managed by watcher or task not validated.")
+		slog.Debug("Skipping git repo update: application not managed by watcher or task not validated.", "id", task.Id)
 		return nil
 	}
 
 	gitopsRepo, err := models.NewGitopsRepo(app, gitUpdater.repoCachePath)
 	if err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to get gitops repo info for app %s: %s", task.App, err)
+		slog.Error(fmt.Sprintf("Failed to get gitops repo info for app %s: %s", task.App, err), "id", task.Id)
 		return err
 	}
 
 	gitUpdateFunc := func() error {
-		log.Debug().Str("id", task.Id).Msg("Application managed by watcher. Initiating git repo update.")
+		slog.Debug("Application managed by watcher. Initiating git repo update.", "id", task.Id)
 		return gitUpdater.updateGitRepo(app, &task, &gitopsRepo, isSuperseded...)
 	}
 
 	err = gitUpdater.locker.WithLock(gitopsRepo.RepoUrl, gitUpdateFunc)
 	if err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed git repo update for app %s: %s", task.App, err)
+		slog.Error(fmt.Sprintf("Failed git repo update for app %s: %s", task.App, err), "id", task.Id)
 		return err
 	}
 
@@ -378,7 +378,7 @@ func (gitUpdater *GitUpdater) updateGitRepo(app *models.Application, task *model
 	// WaitForRollout is a future improvement.
 	err := app.UpdateGitImageTag(context.Background(), task, gitopsRepo, updater.GitClient{}, isSuperseded...)
 	if err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to update git repo. Error: %s", err.Error())
+		slog.Error(fmt.Sprintf("Failed to update git repo. Error: %s", err.Error()), "id", task.Id)
 		return err
 	}
 	return nil
@@ -470,7 +470,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 		// A newer deployment for the same app already marked this task "cancelled"
 		// in the shared state (possibly on another replica). Stop without writing a
 		// status so we do not overwrite it; reflect it locally for the notification.
-		log.Info().Str("id", task.Id).Msg("Deployment superseded by a newer deployment for the same app; stopping.")
+		slog.Info("Deployment superseded by a newer deployment for the same app; stopping.", "id", task.Id)
 		task.Status = models.StatusCancelledMessage
 	case err != nil:
 		// handle application failure
@@ -527,7 +527,7 @@ func handleApplicationFetchError(task models.Task, err error) error {
 	if task.IsAppNotFoundError(err) {
 		return retry.Unrecoverable(err)
 	}
-	log.Debug().Str("id", task.Id).Msgf("Failed fetching application status. Error: %s", err.Error())
+	slog.Debug(fmt.Sprintf("Failed fetching application status. Error: %s", err.Error()), "id", task.Id)
 	return err
 }
 
@@ -537,17 +537,17 @@ func checkRolloutStatus(task models.Task, application *models.Application, regis
 
 	switch status {
 	case models.ArgoRolloutAppDegraded:
-		log.Debug().Str("id", task.Id).Msgf("Application is degraded")
+		slog.Debug("Application is degraded", "id", task.Id)
 		normalizedImages := helpers.NormalizeImages(application.Status.Summary.Images)
 		hash := helpers.GenerateHash(strings.Join(normalizedImages, ","))
 		if !bytes.Equal(task.SavedAppStatus.ImagesHash, hash) {
 			return retry.Unrecoverable(errors.New("application has degraded"))
 		}
 	case models.ArgoRolloutAppSuccess:
-		log.Debug().Str("id", task.Id).Msgf("Application rollout finished")
+		slog.Debug("Application rollout finished", "id", task.Id)
 		return nil
 	default:
-		log.Debug().Str("id", task.Id).Msgf("Application status is not final. Status received \"%s\"", status)
+		slog.Debug(fmt.Sprintf("Application status is not final. Status received \"%s\"", status), "id", task.Id)
 	}
 	return errForceRetry
 }
@@ -570,6 +570,6 @@ func sendNotification(task models.Task, notifier *notifications.Notifier) {
 	}
 
 	if err := notifier.Send(task); err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to dispatch notification. Error: %s", err.Error())
+		slog.Error(fmt.Sprintf("Failed to dispatch notification. Error: %s", err.Error()), "id", task.Id)
 	}
 }

--- a/internal/auth/keycloak.go
+++ b/internal/auth/keycloak.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 type KeycloakResponse struct {
@@ -74,32 +73,32 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 	if err != nil {
 		// Transport/internal failure details (URLs, hostnames) stay in the
 		// server log; the public-facing error must not leak them.
-		log.Error().Err(err).Msg("keycloak: error creating userinfo request")
+		slog.Error("keycloak: error creating userinfo request", "error", err)
 		return false, errors.New("token validation failed")
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
 	resp, err := k.client.Do(req) // #nosec G704 - URL is validated in Init()
 	if err != nil {
-		log.Error().Err(err).Msg("keycloak: userinfo request failed")
+		slog.Error("keycloak: userinfo request failed", "error", err)
 		return false, errors.New("token validation failed")
 	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			log.Error().Msgf("error closing response body: %v", err)
+			slog.Error(fmt.Sprintf("error closing response body: %v", err))
 		}
 	}(resp.Body)
 
 	// Read and parse the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error().Err(err).Msg("keycloak: error reading userinfo response body")
+		slog.Error("keycloak: error reading userinfo response body", "error", err)
 		return false, errors.New("token validation failed")
 	}
 
 	if err := json.Unmarshal(bodyBytes, &keycloakResponse); err != nil {
-		log.Error().Err(err).Msg("keycloak: error unmarshalling userinfo response")
+		slog.Error("keycloak: error unmarshalling userinfo response", "error", err)
 		return false, errors.New("token validation failed")
 	}
 
@@ -119,11 +118,11 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 func (k *KeycloakAuthService) allowedToRollback(username string, groups []string) bool {
 	for _, group := range groups {
 		if slices.Contains(k.PrivilegedGroups, group) {
-			log.Debug().Msgf("%s is a member of the privileged group: %v", username, group)
+			slog.Debug(fmt.Sprintf("%s is a member of the privileged group: %v", username, group))
 			return true
 		}
 	}
 
-	log.Debug().Msgf("%s is not a member of any of the privileged groups: %v", username, k.PrivilegedGroups)
+	slog.Debug(fmt.Sprintf("%s is not a member of any of the privileged groups: %v", username, k.PrivilegedGroups))
 	return false
 }

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/pkg/updater"
 )
@@ -328,7 +328,7 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 	}
 
 	if len(managedImages) == 0 {
-		log.Error().Msgf("%s annotation not found, skipping image update", managedImagesAnnotation)
+		slog.Error(fmt.Sprintf("%s annotation not found, skipping image update", managedImagesAnnotation))
 		return nil, nil
 	}
 
@@ -342,7 +342,7 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 						ForceString: true,
 					})
 				} else {
-					log.Error().Msgf("%s annotation not found, skipping image %s update", fmt.Sprintf(managedImageTagPattern, appAlias), image.Image)
+					slog.Error(fmt.Sprintf("%s annotation not found, skipping image %s update", fmt.Sprintf(managedImageTagPattern, appAlias), image.Image))
 				}
 			}
 		}
@@ -365,7 +365,7 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 // same app is never overwritten by an older one that keeps retrying.
 func (app *Application) UpdateGitImageTag(ctx context.Context, task *Task, gitopsRepo *GitopsRepo, gitHandler updater.GitHandler, isSuperseded ...func() bool) error {
 	if gitopsRepo.Path == "" {
-		log.Warn().Str("id", task.Id).Msgf("No path found for app %s, unsupported Application configuration", app.Metadata.Name)
+		slog.Warn(fmt.Sprintf("No path found for app %s, unsupported Application configuration", app.Metadata.Name), "id", task.Id)
 		return nil
 	}
 
@@ -380,13 +380,13 @@ func (app *Application) UpdateGitImageTag(ctx context.Context, task *Task, gitop
 	}
 
 	if releaseOverrides == nil {
-		log.Warn().Str("id", task.Id).Msgf("No release overrides found for app %s", app.Metadata.Name)
+		slog.Warn(fmt.Sprintf("No release overrides found for app %s", app.Metadata.Name), "id", task.Id)
 		return nil
 	}
 
 	repo, err := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, gitopsRepo.RepoCachePath, gitHandler)
 	if err != nil {
-		log.Error().Str("id", task.Id).Msgf("Failed to create git repo instance for %s: %s", gitopsRepo.RepoUrl, err)
+		slog.Error(fmt.Sprintf("Failed to create git repo instance for %s: %s", gitopsRepo.RepoUrl, err), "id", task.Id)
 		return err
 	}
 
@@ -449,7 +449,7 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 		// on top of a newer one — the correctness guard that makes a larger retry
 		// budget safe.
 		if isSuperseded != nil && isSuperseded() {
-			log.Info().Str("id", task.Id).Msgf("Git update aborted at attempt %d/%d: task superseded by a newer deployment", attempt, maxAttempts)
+			slog.Info(fmt.Sprintf("Git update aborted at attempt %d/%d: task superseded by a newer deployment", attempt, maxAttempts), "id", task.Id)
 			return ErrDeploymentSuperseded
 		}
 
@@ -458,14 +458,14 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 		err := runGitUpdateAttempt(parentCtx, repo, opTimeout, appName, releaseOverrides, task)
 		if err == nil {
 			if attempt > 1 {
-				log.Info().Str("id", task.Id).Msgf("Git update succeeded on attempt %d/%d", attempt, maxAttempts)
+				slog.Info(fmt.Sprintf("Git update succeeded on attempt %d/%d", attempt, maxAttempts), "id", task.Id)
 			}
 			return nil
 		}
 		lastErr = err
 
 		if updater.IsPermanent(err) {
-			log.Error().Err(err).Str("id", task.Id).Msgf("Git update failed with permanent error on attempt %d/%d; not retrying", attempt, maxAttempts)
+			slog.Error(fmt.Sprintf("Git update failed with permanent error on attempt %d/%d; not retrying", attempt, maxAttempts), "error", err, "id", task.Id)
 			return err
 		}
 
@@ -484,12 +484,12 @@ func invalidateCacheOnFinalAttempt(repo *updater.GitRepo, task *Task, attempt, m
 	if attempt != maxAttempts {
 		return
 	}
-	log.Warn().Str("id", task.Id).Msgf(
+	slog.Warn(fmt.Sprintf(
 		"Final attempt %d/%d: invalidating cache and performing fresh clone",
 		attempt, maxAttempts,
-	)
+	), "id", task.Id)
 	if invErr := repo.InvalidateCache(); invErr != nil {
-		log.Warn().Err(invErr).Str("id", task.Id).Msg("Failed to invalidate cache before final attempt; proceeding anyway")
+		slog.Warn("Failed to invalidate cache before final attempt; proceeding anyway", "error", invErr, "id", task.Id)
 	}
 }
 
@@ -501,10 +501,10 @@ func backoffBeforeRetry(parentCtx context.Context, task *Task, attemptErr error,
 		return nil
 	}
 	backoff := gitUpdateBackoff(attempt)
-	log.Warn().Err(attemptErr).Str("id", task.Id).Msgf(
+	slog.Warn(fmt.Sprintf(
 		"Git update attempt %d/%d failed; retrying after %s",
 		attempt, maxAttempts, backoff,
-	)
+	), "error", attemptErr, "id", task.Id)
 	select {
 	case <-parentCtx.Done():
 		return fmt.Errorf("git update cancelled during backoff: %w", parentCtx.Err())

--- a/internal/notifications/mattermost.go
+++ b/internal/notifications/mattermost.go
@@ -7,13 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"text/template"
 	"time"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
@@ -139,7 +138,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 		return "", fmt.Errorf("failed to marshal mattermost post: %w", err)
 	}
 
-	log.Debug().Msgf("Sending mattermost post: %s", string(payload))
+	slog.Debug(fmt.Sprintf("Sending mattermost post: %s", string(payload)))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/api/v4/posts", bytes.NewReader(payload))
 	if err != nil {
@@ -155,7 +154,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Warn().Err(err).Msg("Failed to close mattermost response body")
+			slog.Warn("Failed to close mattermost response body", "error", err)
 		}
 	}()
 
@@ -177,7 +176,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 	}
 
 	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-		log.Warn().Err(err).Msg("Failed to discard mattermost response body")
+		slog.Warn("Failed to discard mattermost response body", "error", err)
 	}
 
 	return created.Id, nil

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
 	"text/template"
 	"time"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
@@ -120,7 +119,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 		return fmt.Errorf("failed to execute webhook template: %w", err)
 	}
 
-	log.Debug().Str("id", task.Id).Msgf("Sending webhook payload: %s", payload.String())
+	slog.Debug(fmt.Sprintf("Sending webhook payload: %s", payload.String()), "id", task.Id)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.url, &payload)
 	if err != nil {
@@ -138,7 +137,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Warn().Err(err).Str("id", task.Id).Msg("Failed to close response body")
+			slog.Warn("Failed to close response body", "error", err, "id", task.Id)
 		}
 	}()
 
@@ -153,7 +152,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 
 	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
-		log.Warn().Err(err).Str("id", task.Id).Msg("Failed to discard response body on success")
+		slog.Warn("Failed to discard response body on success", "error", err, "id", task.Id)
 	}
 
 	return nil

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -2,12 +2,11 @@ package server
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 type Lockdown struct {
@@ -96,7 +95,7 @@ func (l *Lockdown) Parse(schedules string) error {
 		l.Schedules = append(l.Schedules, schedule)
 	}
 
-	log.Debug().Msgf("Parsed lockdown schedules: %v", l.Schedules)
+	slog.Debug(fmt.Sprintf("Parsed lockdown schedules: %v", l.Schedules))
 
 	return nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -19,7 +20,6 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
 	"github.com/shini4i/argo-watcher/internal/argocd"
@@ -72,11 +72,10 @@ func (fs safeFileSystem) validatePath(name string) (string, error) {
 	// Verify the cleaned path is still within the base directory
 	// Check for exact match (root directory) or proper prefix with separator
 	if cleanedFull != fs.basePath && !strings.HasPrefix(cleanedFull, fs.basePath+string(filepath.Separator)) {
-		log.Debug().
-			Str("requested_path", name).
-			Str("resolved_path", cleanedFull).
-			Str("base_path", fs.basePath).
-			Msg("blocked path traversal attempt")
+		slog.Debug("blocked path traversal attempt",
+			"requested_path", name,
+			"resolved_path", cleanedFull,
+			"base_path", fs.basePath)
 		return "", os.ErrPermission
 	}
 
@@ -111,11 +110,10 @@ func (fs safeFileSystem) Open(name string) (http.File, error) {
 	}
 
 	if !strings.HasPrefix(realPath, fs.basePath+string(filepath.Separator)) && realPath != fs.basePath {
-		log.Debug().
-			Str("requested_path", name).
-			Str("resolved_path", realPath).
-			Str("base_path", fs.basePath).
-			Msg("blocked symlink escape attempt")
+		slog.Debug("blocked symlink escape attempt",
+			"requested_path", name,
+			"resolved_path", realPath,
+			"base_path", fs.basePath)
 		_ = f.Close() // #nosec G104 - best effort cleanup
 		return nil, os.ErrPermission
 	}
@@ -165,24 +163,24 @@ func (w *wsResponseWriter) WriteHeader(code int) {
 	w.headerWritten = true
 
 	if w.brw == nil {
-		log.Error().Msg("buffered writer not available during WriteHeader")
+		slog.Error("buffered writer not available during WriteHeader")
 		return
 	}
 	statusLine := fmt.Sprintf("HTTP/1.1 %d %s\r\n", code, http.StatusText(code))
 	if _, err := w.brw.WriteString(statusLine); err != nil {
-		log.Error().Err(err).Msg("failed to write status line during WebSocket upgrade")
+		slog.Error("failed to write status line during WebSocket upgrade", "error", err)
 		return
 	}
 	if err := w.Header().Write(w.brw); err != nil {
-		log.Error().Err(err).Msg("failed to write headers during WebSocket upgrade")
+		slog.Error("failed to write headers during WebSocket upgrade", "error", err)
 		return
 	}
 	if _, err := w.brw.WriteString("\r\n"); err != nil {
-		log.Error().Err(err).Msg("failed to write header terminator during WebSocket upgrade")
+		slog.Error("failed to write header terminator during WebSocket upgrade", "error", err)
 		return
 	}
 	if err := w.brw.Flush(); err != nil {
-		log.Error().Err(err).Msg("failed to flush WebSocket upgrade response")
+		slog.Error("failed to flush WebSocket upgrade response", "error", err)
 	}
 }
 
@@ -227,11 +225,10 @@ func (env *Env) CreateRouter() *gin.Engine {
 	// CORS middleware writes headers that interfere with WebSocket hijacking
 	router.Use(func(c *gin.Context) {
 		if c.Request.URL.Path == "/ws" {
-			log.Debug().
-				Str("upgrade", c.Request.Header.Get("Upgrade")).
-				Str("connection", c.Request.Header.Get("Connection")).
-				Bool("written", c.Writer.Written()).
-				Msg("WebSocket request received")
+			slog.Debug("WebSocket request received",
+				"upgrade", c.Request.Header.Get("Upgrade"),
+				"connection", c.Request.Header.Get("Connection"),
+				"written", c.Writer.Written())
 
 			if strings.EqualFold(c.Request.Header.Get("Upgrade"), "websocket") {
 				env.handleWebSocketConnection(c)
@@ -255,7 +252,8 @@ func (env *Env) CreateRouter() *gin.Engine {
 	swaggerPath := filepath.Join(env.config.StaticFilePath, "swagger")
 	absSwaggerPath, err := filepath.Abs(swaggerPath)
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to resolve swagger files path")
+		slog.Error("failed to resolve swagger files path", "error", err)
+		os.Exit(1)
 	}
 	resolvedSwaggerPath, err := filepath.EvalSymlinks(absSwaggerPath)
 	if err != nil {
@@ -282,14 +280,13 @@ func (env *Env) CreateRouter() *gin.Engine {
 	// Static file serving - use NoRoute to handle unmatched paths
 	// This prevents static middleware from interfering with API and WebSocket routes
 	staticFilesPath := env.config.StaticFilePath
-	log.Debug().
-		Str("static_path", staticFilesPath).
-		Msg("serving frontend assets")
+	slog.Debug("serving frontend assets", "static_path", staticFilesPath)
 
 	// Get absolute path for security validation
 	absStaticPath, err := filepath.Abs(staticFilesPath)
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to resolve static files path")
+		slog.Error("failed to resolve static files path", "error", err)
+		os.Exit(1)
 	}
 
 	// Resolve symlinks in the base path to ensure consistent path comparison
@@ -349,7 +346,7 @@ func tryServeStaticFile(c *gin.Context, fs safeFileSystem) bool {
 // The caller is responsible for starting the server and handling graceful shutdown.
 func (env *Env) StartRouter(router *gin.Engine) *http.Server {
 	routerBind := fmt.Sprintf("%s:%s", env.config.Host, env.config.Port)
-	log.Debug().Msgf("Listening on %s", routerBind)
+	slog.Debug(fmt.Sprintf("Listening on %s", routerBind))
 	return &http.Server{
 		Addr:              routerBind,
 		Handler:           router,
@@ -401,9 +398,9 @@ func (env *Env) Shutdown() {
 
 	select {
 	case <-done:
-		log.Debug().Msg("All WebSocket connections closed gracefully")
+		slog.Debug("All WebSocket connections closed gracefully")
 	case <-time.After(shutdownTimeout):
-		log.Warn().Msg("Shutdown timeout reached, some WebSocket goroutines may still be running")
+		slog.Warn("Shutdown timeout reached, some WebSocket goroutines may still be running")
 	}
 }
 
@@ -469,7 +466,7 @@ func (env *Env) addTask(c *gin.Context) {
 
 	err := c.ShouldBindJSON(&task)
 	if err != nil {
-		log.Error().Msgf("couldn't process new task, got the following error: %s", err)
+		slog.Error(fmt.Sprintf("couldn't process new task, got the following error: %s", err))
 		c.JSON(http.StatusNotAcceptable, models.TaskStatus{
 			Status: "invalid payload",
 			Error:  err.Error(),
@@ -479,7 +476,7 @@ func (env *Env) addTask(c *gin.Context) {
 
 	// we need to handle cases when deploy lock is set either manually or by cron
 	if env.lockdown.IsLocked() {
-		log.Warn().Msgf("deploy lock is set, rejecting the task")
+		slog.Warn("deploy lock is set, rejecting the task")
 		c.JSON(http.StatusNotAcceptable, models.TaskStatus{
 			Status: "rejected",
 			Error:  "lockdown is active, deployments are not accepted",
@@ -492,7 +489,7 @@ func (env *Env) addTask(c *gin.Context) {
 		// A non-nil error means the strategy was invoked and rejected the
 		// token: a client mistake, not a server failure. Return 401 with
 		// the reason so the client can show something actionable.
-		log.Warn().Msgf("rejecting task: %s", err)
+		slog.Warn(fmt.Sprintf("rejecting task: %s", err))
 		c.JSON(http.StatusUnauthorized, models.TaskStatus{
 			Status: unauthorizedMessage,
 			Error:  err.Error(),
@@ -504,7 +501,7 @@ func (env *Env) addTask(c *gin.Context) {
 
 	newTask, err := env.argo.AddTask(task)
 	if err != nil {
-		log.Error().Msgf("Couldn't process new task. Got the following error: %s", err)
+		slog.Error(fmt.Sprintf("Couldn't process new task. Got the following error: %s", err))
 		c.JSON(http.StatusServiceUnavailable, models.TaskStatus{
 			Status: "down",
 			Error:  err.Error(),
@@ -537,11 +534,11 @@ func (env *Env) addTask(c *gin.Context) {
 func (env *Env) getState(c *gin.Context) {
 	startTime, err := strconv.ParseFloat(c.Query("from_timestamp"), 64)
 	if err != nil && c.Query("from_timestamp") != "" {
-		log.Debug().Str("from_timestamp", c.Query("from_timestamp")).Msg("invalid from_timestamp, defaulting to 0")
+		slog.Debug("invalid from_timestamp, defaulting to 0", "from_timestamp", c.Query("from_timestamp"))
 	}
 	endTime, err := strconv.ParseFloat(c.Query("to_timestamp"), 64)
 	if err != nil && c.Query("to_timestamp") != "" {
-		log.Debug().Str("to_timestamp", c.Query("to_timestamp")).Msg("invalid to_timestamp, defaulting to current time")
+		slog.Debug("invalid to_timestamp, defaulting to current time", "to_timestamp", c.Query("to_timestamp"))
 	}
 	if endTime == 0 {
 		endTime = float64(time.Now().Unix())
@@ -555,11 +552,11 @@ func (env *Env) getState(c *gin.Context) {
 
 	limit, err := strconv.Atoi(c.Query("limit"))
 	if err != nil && c.Query("limit") != "" {
-		log.Debug().Str("limit", c.Query("limit")).Msg("invalid limit, defaulting to 0")
+		slog.Debug("invalid limit, defaulting to 0", "limit", c.Query("limit"))
 	}
 	offset, err := strconv.Atoi(c.Query("offset"))
 	if err != nil && c.Query("offset") != "" {
-		log.Debug().Str("offset", c.Query("offset")).Msg("invalid offset, defaulting to 0")
+		slog.Debug("invalid offset, defaulting to 0", "offset", c.Query("offset"))
 	}
 	if limit <= 0 || limit > maxTaskListLimit {
 		limit = maxTaskListLimit
@@ -657,8 +654,8 @@ func (env *Env) requireKeycloakAuth(c *gin.Context) bool {
 
 	if err != nil {
 		// Strategy was invoked and rejected the token. Surface the reason.
-		log.Warn().Msgf("User tried %s %s with invalid token: %s",
-			c.Request.Method, c.Request.URL, err)
+		slog.Warn(fmt.Sprintf("User tried %s %s with invalid token: %s",
+			c.Request.Method, c.Request.URL, err))
 		c.JSON(http.StatusUnauthorized, models.TaskStatus{
 			Status: unauthorizedMessage,
 			Error:  err.Error(),
@@ -667,7 +664,7 @@ func (env *Env) requireKeycloakAuth(c *gin.Context) bool {
 	}
 
 	// (false, nil): no auth header sent at all.
-	log.Warn().Msgf("User tried %s %s without authentication", c.Request.Method, c.Request.URL)
+	slog.Warn(fmt.Sprintf("User tried %s %s without authentication", c.Request.Method, c.Request.URL))
 	c.JSON(http.StatusUnauthorized, models.TaskStatus{
 		Status: unauthorizedMessage,
 		Error:  "authentication required (set " + keycloakHeader + " header)",
@@ -689,7 +686,7 @@ func (env *Env) SetDeployLock(c *gin.Context) {
 
 	env.lockdown.SetLock()
 
-	log.Debug().Msg("deploy lock is set")
+	slog.Debug("deploy lock is set")
 
 	notifyWebSocketClients("locked")
 
@@ -710,7 +707,7 @@ func (env *Env) ReleaseDeployLock(c *gin.Context) {
 
 	env.lockdown.ReleaseLock()
 
-	log.Debug().Msg("deploy lock is released")
+	slog.Debug("deploy lock is released")
 
 	notifyWebSocketClients("unlocked")
 
@@ -752,14 +749,14 @@ func (env *Env) handleWebSocketConnection(c *gin.Context) {
 	// gin's ResponseWriter fails Hijack after WriteHeader, so we hijack first
 	hijacker, ok := c.Writer.(http.Hijacker)
 	if !ok {
-		log.Error().Msg("ResponseWriter does not support hijacking")
+		slog.Error("ResponseWriter does not support hijacking")
 		c.String(http.StatusInternalServerError, "WebSocket not supported")
 		return
 	}
 
 	netConn, brw, err := hijacker.Hijack()
 	if err != nil {
-		log.Error().Err(err).Msg("failed to hijack connection for WebSocket")
+		slog.Error("failed to hijack connection for WebSocket", "error", err)
 		// After a failed hijack, the connection state is unknown and we cannot reliably
 		// write a response. The client connection will eventually timeout.
 		return
@@ -774,7 +771,7 @@ func (env *Env) handleWebSocketConnection(c *gin.Context) {
 
 	conn, err := websocket.Accept(wrappedWriter, c.Request, options)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to accept websocket connection")
+		slog.Error("failed to accept websocket connection", "error", err)
 		_ = netConn.Close() // #nosec G104 - best effort cleanup, already in error path
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,16 +3,16 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	prom "github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
 	"github.com/shini4i/argo-watcher/internal/argocd"
@@ -67,10 +67,10 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 			return nil, fmt.Errorf("could not get a valid DB connection from the postgres state")
 		}
 		locker = lock.NewPostgresLocker(db)
-		log.Info().Msg("Using Postgres advisory locks for distributed locking.")
+		slog.Info("Using Postgres advisory locks for distributed locking.")
 	} else {
 		locker = lock.NewInMemoryLocker()
-		log.Warn().Msg("Using in-memory lock. This is not suitable for HA setups.")
+		slog.Warn("Using in-memory lock. This is not suitable for HA setups.")
 	}
 
 	// initialize argo updater
@@ -111,7 +111,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 
 // Run starts the HTTP server and handles graceful shutdown on SIGINT/SIGTERM.
 func (s *Server) Run() {
-	log.Info().Msg("Starting web server")
+	slog.Info("Starting web server")
 
 	srv := s.env.StartRouter(s.router)
 
@@ -122,7 +122,8 @@ func (s *Server) Run() {
 	// Start server in goroutine
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal().Err(err).Msg("failed to start server")
+			slog.Error("failed to start server", "error", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -131,7 +132,7 @@ func (s *Server) Run() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
-	log.Info().Msg("shutting down server...")
+	slog.Info("shutting down server...")
 
 	// Trigger WebSocket connection shutdown
 	s.env.Shutdown()
@@ -141,18 +142,43 @@ func (s *Server) Run() {
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Error().Err(err).Msg("server forced to shutdown")
+		slog.Error("server forced to shutdown", "error", err)
 	}
 
-	log.Info().Msg("server exited")
+	slog.Info("server exited")
 }
 
-// initLogs initializes the logging configuration.
+// logLevelVar holds the active log level for the default logger so initLogs can
+// adjust it at runtime.
+var logLevelVar = new(slog.LevelVar)
+
+// initLogs configures the global slog logger to emit JSON to stderr at the
+// level parsed from logLevel. An unparseable level is logged as a warning and
+// leaves the logger at its default (info) level.
 func initLogs(logLevel string) {
-	if lvl, err := zerolog.ParseLevel(logLevel); err != nil {
-		log.Warn().Msgf("Couldn't parse log level. Got the following error: %s", err)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: logLevelVar})))
+	if lvl, err := parseLogLevel(logLevel); err != nil {
+		slog.Warn(fmt.Sprintf("Couldn't parse log level. Got the following error: %s", err))
 	} else {
-		zerolog.SetGlobalLevel(lvl)
-		log.Debug().Msgf("Configured log level: %s", lvl)
+		logLevelVar.Set(lvl)
+		slog.Debug(fmt.Sprintf("Configured log level: %s", lvl))
+	}
+}
+
+// parseLogLevel maps a textual log level to its slog equivalent. It accepts the
+// level names previously handled by zerolog (including the trace/fatal/panic
+// aliases) so existing LOG_LEVEL values keep working; unknown values error.
+func parseLogLevel(level string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "trace", "debug":
+		return slog.LevelDebug, nil
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error", "fatal", "panic":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q", level)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log/slog"
 	"net/url"
 	"testing"
 
@@ -75,10 +76,47 @@ func TestNewServer_PostgresConnectionFailure(t *testing.T) {
 }
 
 func TestInitLogs(t *testing.T) {
-	assert.NotPanics(t, func() {
-		initLogs("debug")
-	})
-	assert.NotPanics(t, func() {
-		initLogs("invalid-level")
-	})
+	// A valid level is parsed and applied to the shared logLevelVar.
+	initLogs("debug")
+	assert.Equal(t, slog.LevelDebug, logLevelVar.Level())
+
+	initLogs("warn")
+	assert.Equal(t, slog.LevelWarn, logLevelVar.Level())
+
+	// An unparseable level is a no-op on the level: it logs a warning and
+	// leaves the previously configured level (warn) untouched.
+	initLogs("invalid-level")
+	assert.Equal(t, slog.LevelWarn, logLevelVar.Level())
+}
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input     string
+		want      slog.Level
+		expectErr bool
+	}{
+		{"trace", slog.LevelDebug, false},
+		{"debug", slog.LevelDebug, false},
+		{"info", slog.LevelInfo, false},
+		{"", slog.LevelInfo, false},
+		{"WARN", slog.LevelWarn, false},
+		{"warning", slog.LevelWarn, false},
+		{"error", slog.LevelError, false},
+		{"fatal", slog.LevelError, false},
+		{"panic", slog.LevelError, false},
+		{" Info ", slog.LevelInfo, false},
+		{"bogus", slog.LevelInfo, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseLogLevel(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -2,13 +2,14 @@ package state
 
 import (
 	"errors"
+	"fmt"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
@@ -34,7 +35,7 @@ var _ TaskRepository = (*InMemoryState)(nil)
 // It logs a debug message indicating that the InMemoryState does not connect to anything and skips the connection process.
 // This method exists to fulfill the TaskRepository interface requirement and has no functional value.
 func (state *InMemoryState) Connect(serverConfig *config.ServerConfig) error {
-	log.Debug().Msg("InMemoryState does not connect to anything. Skipping.")
+	slog.Debug("InMemoryState does not connect to anything. Skipping.")
 	return nil
 }
 
@@ -187,7 +188,7 @@ func (state *InMemoryState) Check() bool {
 // It starts a process to watch for obsolete tasks by invoking the `processInMemoryObsoleteTasks` function.
 // The function uses the `retry` package to periodically retry the task processing with a fixed delay of 60 minutes.
 func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
-	log.Debug().Msg("Starting watching for obsolete tasks...")
+	slog.Debug("Starting watching for obsolete tasks...")
 	err := retry.Do(
 		func() error {
 			state.mu.Lock()
@@ -200,7 +201,7 @@ func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
 		retry.Attempts(retryTimes),
 	)
 	if err != nil {
-		log.Error().Msgf("Couldn't process obsolete tasks. Got the following error: %s", err)
+		slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
 	}
 }
 

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -4,12 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
-	"github.com/rs/zerolog/log"
 	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -54,7 +54,7 @@ func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 	}
 
 	if err := state.orm.Create(&ormTask).Error; err != nil {
-		log.Error().Msgf("Failed to create task database record with error: %s", err.Error())
+		slog.Error(fmt.Sprintf("Failed to create task database record with error: %s", err.Error()))
 		return nil, fmt.Errorf("failed to create task in database")
 	}
 
@@ -83,7 +83,7 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 	countQuery := query.Session(&gorm.Session{})
 	var total int64
 	if err := countQuery.Count(&total).Error; err != nil {
-		log.Error().Msg(err.Error())
+		slog.Error(err.Error())
 		return []models.Task{}, 0
 	}
 
@@ -98,7 +98,7 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 
 	var ormTasks []state_models.TaskModel
 	if err := query.Find(&ormTasks).Error; err != nil {
-		log.Error().Msg(err.Error())
+		slog.Error(err.Error())
 		return []models.Task{}, 0
 	}
 
@@ -189,12 +189,12 @@ func (state *PostgresState) CancelInProgressTasks(app string, images []models.Im
 func (state *PostgresState) Check() bool {
 	connection, err := state.orm.DB()
 	if err != nil {
-		log.Error().Msgf("Failed to retrieve DB connection: %s", err.Error())
+		slog.Error(fmt.Sprintf("Failed to retrieve DB connection: %s", err.Error()))
 		return false
 	}
 
 	if err = connection.Ping(); err != nil {
-		log.Error().Msgf("Failed to ping DB: %s", err.Error())
+		slog.Error(fmt.Sprintf("Failed to ping DB: %s", err.Error()))
 		return false
 	}
 
@@ -206,11 +206,11 @@ func (state *PostgresState) Check() bool {
 // The function utilizes retry logic to handle potential errors and retry the process if necessary.
 // The retry interval is set to 60 minutes, and the retry attempts are set to 0 (no limit).
 func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
-	log.Debug().Msg("Starting watching for obsolete tasks...")
+	slog.Debug("Starting watching for obsolete tasks...")
 	err := retry.Do(
 		func() error {
 			if err := state.doProcessPostgresObsoleteTasks(); err != nil {
-				log.Error().Msgf("Couldn't process obsolete tasks. Got the following error: %s", err)
+				slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
 				return err
 			}
 			return errDesiredRetry
@@ -221,7 +221,7 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	)
 
 	if err != nil {
-		log.Error().Msgf("Couldn't process obsolete tasks. Got the following error: %s", err)
+		slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
 	}
 }
 
@@ -230,14 +230,14 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 // The function expects a valid *sql.DB connection to the PostgreSQL database.
 // It returns an error if any database operation encounters an error; otherwise, it returns nil.
 func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
-	log.Debug().Msg("Removing obsolete tasks...")
+	slog.Debug("Removing obsolete tasks...")
 
-	log.Debug().Msg("Removing app not found tasks older than 1 hour from the database...")
+	slog.Debug("Removing app not found tasks older than 1 hour from the database...")
 	if err := state.orm.Where(whereStatusEquals, models.StatusAppNotFoundMessage).Where("created < now() - interval '1 hour'").Delete(&state_models.TaskModel{}).Error; err != nil {
 		return err
 	}
 
-	log.Debug().Msg("Marking in progress tasks older than 1 hour as aborted...")
+	slog.Debug("Marking in progress tasks older than 1 hour as aborted...")
 	if err := state.orm.Where(whereStatusEquals, models.StatusInProgressMessage).Where("created < now() - interval '1 hour'").Updates(&state_models.TaskModel{Status: models.StatusAborted}).Error; err != nil {
 		return err
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,8 +3,8 @@ package state
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
@@ -53,14 +53,14 @@ type TaskRepository interface {
 // It initializes the appropriate repository according to the StateType field and
 // ensures that the returned implementation is already connected to the storage backend.
 func NewState(serverConfig *config.ServerConfig) (TaskRepository, error) {
-	log.Debug().Msg("Initializing argo-watcher state...")
+	slog.Debug("Initializing argo-watcher state...")
 	var state TaskRepository
 	switch name := serverConfig.StateType; name {
 	case "postgres":
-		log.Debug().Msg("Created postgres state..")
+		slog.Debug("Created postgres state..")
 		state = &PostgresState{}
 	case "in-memory":
-		log.Debug().Msg("Created in-memory state..")
+		slog.Debug("Created in-memory state..")
 		state = &InMemoryState{}
 	default:
 		return nil, fmt.Errorf("unexpected state type received: %s", name)

--- a/pkg/updater/config.go
+++ b/pkg/updater/config.go
@@ -2,11 +2,11 @@ package updater
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
 	envConfig "github.com/caarlos0/env/v11"
-	"github.com/rs/zerolog/log"
 )
 
 // GitConfig holds runtime configuration for the git updater, parsed from
@@ -86,7 +86,7 @@ func applyLegacyGitTimeout(config *GitConfig) error {
 	}
 
 	if _, newSet := os.LookupEnv("GIT_OP_TIMEOUT"); newSet {
-		log.Warn().Msgf("GIT_TIMEOUT is deprecated and was ignored because GIT_OP_TIMEOUT is set. Remove GIT_TIMEOUT to silence this warning.")
+		slog.Warn("GIT_TIMEOUT is deprecated and was ignored because GIT_OP_TIMEOUT is set. Remove GIT_TIMEOUT to silence this warning.")
 		return nil
 	}
 
@@ -94,10 +94,10 @@ func applyLegacyGitTimeout(config *GitConfig) error {
 	// (default 5, validated > 0); its conversion to time.Duration is only used
 	// to format a warning-log message and crosses no security boundary.
 	worstCaseWallClock := legacy * time.Duration(config.GitMaxAttempts)
-	log.Warn().Msgf(
+	slog.Warn(fmt.Sprintf(
 		"GIT_TIMEOUT is deprecated; using %s as GIT_OP_TIMEOUT directly. With GIT_MAX_ATTEMPTS=%d retries enabled, the worst-case total wall clock is %s. Set GIT_OP_TIMEOUT explicitly to silence this warning.",
 		legacy, config.GitMaxAttempts, worstCaseWallClock,
-	)
+	))
 	config.GitOpTimeout = legacy
 	return nil
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +23,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -115,9 +115,9 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 	if err != nil {
 		// Differentiate between a simple "not found" and a real corruption issue for logging.
 		if errors.Is(err, git.ErrRepositoryNotExists) {
-			log.Debug().Msgf("No cache found for repo %s at %s. Cloning fresh.", repo.RepoURL, repo.localRepoPath)
+			slog.Debug(fmt.Sprintf("No cache found for repo %s at %s. Cloning fresh.", repo.RepoURL, repo.localRepoPath))
 		} else {
-			log.Warn().Msgf("Cached repo at %s is invalid or missing remote (%s). Re-cloning.", repo.localRepoPath, err)
+			slog.Warn(fmt.Sprintf("Cached repo at %s is invalid or missing remote (%s). Re-cloning.", repo.localRepoPath, err))
 			if err := os.RemoveAll(repo.localRepoPath); err != nil {
 				return fmt.Errorf("failed to remove invalid cache directory: %w", err)
 			}
@@ -133,7 +133,7 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 	}
 
 	// If we get here, the cache is valid and has an 'origin' remote.
-	log.Debug().Msgf("Successfully opened cached repository at %s", repo.localRepoPath)
+	slog.Debug(fmt.Sprintf("Successfully opened cached repository at %s", repo.localRepoPath))
 	err = repo.localRepo.FetchContext(ctx, &git.FetchOptions{
 		RemoteName: "origin",
 		Auth:       repo.sshAuth,
@@ -183,13 +183,13 @@ func (repo *GitRepo) generateCommitMessage(appName string, tmplData any) string 
 
 	tmpl, err := template.New("commitMsg").Parse(repo.gitConfig.CommitMessageFormat)
 	if err != nil {
-		log.Warn().Err(err).Msg("COMMIT_MESSAGE_FORMAT parse error; using default commit message")
+		slog.Warn("COMMIT_MESSAGE_FORMAT parse error; using default commit message", "error", err)
 		return commitMsg
 	}
 
 	var message bytes.Buffer
 	if err = tmpl.Execute(&message, tmplData); err != nil {
-		log.Warn().Err(err).Msg("COMMIT_MESSAGE_FORMAT execute error; using default commit message")
+		slog.Warn("COMMIT_MESSAGE_FORMAT execute error; using default commit message", "error", err)
 		return commitMsg
 	}
 
@@ -210,7 +210,7 @@ func (repo *GitRepo) UpdateApp(ctx context.Context, appName string, overrideCont
 
 	commitMsg := repo.generateCommitMessage(appName, tmplData)
 
-	log.Debug().Msgf("Updating override file: %s", fullPath)
+	slog.Debug(fmt.Sprintf("Updating override file: %s", fullPath))
 
 	finalContent, err := repo.mergeOverrideFileContent(fullPath, overrideContent)
 	if err != nil {
@@ -292,7 +292,7 @@ func (repo *GitRepo) commitAndPush(ctx context.Context, fullPath, commitMsg stri
 
 	// If the image tag is already correct, there will be no changes.
 	if status.IsClean() {
-		log.Debug().Msg("No changes detected. Skipping commit.")
+		slog.Debug("No changes detected. Skipping commit.")
 		return nil
 	}
 
@@ -423,4 +423,3 @@ func (repo *GitRepo) InvalidateCache() error {
 	}
 	return os.RemoveAll(repo.localRepoPath)
 }
-


### PR DESCRIPTION
### **User description**
Migrate all logging from github.com/rs/zerolog to the standard library log/slog across the server, updater, and mock. Structured fields become slog key/value pairs, Msgf calls are preserved via fmt.Sprintf, and the three Fatal calls become slog.Error followed by os.Exit(1). Logging is configured through a slog.LevelVar-gated JSON handler with a new parseLogLevel helper.

Output stays JSON on stderr, but level names are now uppercase, the message key is msg instead of message, and timestamps and durations gain nanosecond units. LOG_LEVEL no longer accepts the undocumented "disabled" value and falls back to info. Drops the zerolog dependency and its go-colorable indirect.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Migrate all logging from zerolog to Go stdlib log/slog across server, updater, mock, and clients

- Replace structured fields with slog key/value pairs; preserve Msgf calls via fmt.Sprintf

- Configure logging with a slog.LevelVar-gated JSON handler and new parseLogLevel helper

- Update LOG_LEVEL handling: drop undocumented "disabled" value, accept trace alias, fallback to info

- Adjust log output: uppercase level names, message key "msg", nanosecond timestamps and durations

- Remove zerolog and indirect go-colorable dependencies

- Add tests for log level parsing and initialization


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Switch mock server logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-fdd96a2a4308bc229473e39749ad9503f69a461020ea9df868902997531ec48f">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo.go</strong><dd><code>Replace zerolog calls in Argo task manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-abdd9cfc4f9a1578b5df9240910b2d7dfd1307abc014b204ec753b8489ae3026">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_api.go</strong><dd><code>Migrate ArgoCD API client logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-258db12fc8cb94622298e5c370dee0bd14489f19fd8d1fcf875eab84a21871c9">+7/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_status_updater.go</strong><dd><code>Convert status updater and rollout monitor logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-ed22c343f4b6ed3704cd98d39d200754d2474f7829d30e102464e213ac23eab3">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>keycloak.go</strong><dd><code>Replace zerolog in Keycloak auth service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-515cf5b5f4a0e77009426a928f3690a85a8d27cfa70387acd1d70d234517cb16">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo.go</strong><dd><code>Update application model and git update logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-18192c0eee18db04ef18aac44b6c8c5e543b5547e9c674c82a70c2e4d055b1b4">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mattermost.go</strong><dd><code>Switch Mattermost notification logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-378fc38776fb8f47c0b0c4e729d713fff1be809371af0cd209128b96b6c902e0">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>webhook.go</strong><dd><code>Replace zerolog in webhook notification strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-bf80818fc0f4c2a9841716d4cad87eba7b67c626647941893a9de85642948cd3">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lockdown.go</strong><dd><code>Migrate lockdown schedule logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-13aa8da54e1b3578eb6b9f4d4372224c034489e909039fd15628f30792a38aa1">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.go</strong><dd><code>Replace logging in router, static files, and WebSocket handlers</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-9f58d31f48b31a1fa23cfee5460796fc34ce5461fb6277f40107bc0dff6b204c">+42/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Add slog init with parseLogLevel, replace logger and fatal handling</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23">+40/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>in_memory_state.go</strong><dd><code>Replace zerolog in in-memory state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-57016f2d3ed9f115be8fd25f13f1404ea2b4d45d5837521c3b91a76921cd17cd">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>postgres_state.go</strong><dd><code>Migrate PostgreSQL state logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-b6167798edbbb49ad97445e15c9823a0d491e835843da606fbda81a3091a0701">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>state.go</strong><dd><code>Update state factory logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-126cf2e8c0a673a17979060f3f74335ad847c8706001f0a679d600df5d82131d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.go</strong><dd><code>Replace zerolog in git config deprecation warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-80c4f746f97ba2334011e1f62e903dd1ab2dfb28eeff911a3fb4e27f8352116d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updater.go</strong><dd><code>Switch git updater operations logging to slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-6f575e683c5fe1eb9301f314392e63c56a00e7b09ae9663adf4c3e4d67f81c70">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server_test.go</strong><dd><code>Add tests for log level parsing and initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92">+44/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for logging migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Remove zerolog and go-colorable dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/467/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

