### PR TITLE
fix(client): accept raw JWT so BEARER_TOKEN is CI-maskable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `401`/`403`, hints which token variables govern authentication
   (`ARGO_WATCHER_DEPLOY_TOKEN` / `BEARER_TOKEN`), replacing the previous
   status-code-only message.
+- `BEARER_TOKEN` can now be set to the raw JWT with no `Bearer ` prefix, so the
+  value is maskable as a GitLab CI variable (the space in `Bearer ` blocked
+  masking). The `Bearer <jwt>` form is still accepted for backward
+  compatibility — the client strips the prefix before sending.
 - Update backend and frontend dependencies to their latest releases. The bundled
   web UI now runs on React 19 and Material UI 9, and building from source
   requires Go 1.26.

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -180,7 +180,8 @@ export ARGO_WATCHER_DEPLOY_TOKEN=your_deploy_token
 **Using JWT (recommended):**
 
 ```bash
-export BEARER_TOKEN="Bearer your_jwt_token"
+# Set the raw token — no "Bearer " prefix — so it can be masked as a CI variable.
+export BEARER_TOKEN="your_jwt_token"
 ```
 
 See the [Installation](install.md#client-setup) guide for complete CI/CD pipeline examples.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -64,7 +64,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 **How to verify:**
 - Check the Argo CD UI to confirm the application is syncing and the new image is being deployed.
 - Verify that the image tag annotation was correctly set: `kubectl describe app <ARGO_APP> -o yaml | grep -A5 argo-watcher`.
-- Confirm the CI job actually supplied `ARGO_WATCHER_DEPLOY_TOKEN` or a `Bearer` JWT; with `LOG_LEVEL=debug` a skipped write-back logs "Skipping git repo update".
+- Confirm the CI job actually supplied `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`; with `LOG_LEVEL=debug` a skipped write-back logs "Skipping git repo update".
 - Check if the application is locked: `curl -H "Authorization: Bearer $BEARER_TOKEN" $ARGO_WATCHER_URL/api/v1/locks | jq '.[] | select(.app == "<ARGO_APP>")'`.
 
 **Fix:**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -15,7 +15,7 @@ https://argo-watcher.example.com/api/v1
 Authentication is only required to authorize the built-in [GitOps Updater](../guides/gitops-updater.md)'s git write-back. Provide one of:
 
 - **Deploy token** — Pass the `ARGO_WATCHER_DEPLOY_TOKEN` value as a query parameter or header.
-- **JWT token** — Include a `Bearer` token in the `Authorization` header.
+- **JWT token** — Pass the JWT in the `Authorization` header. The raw token is accepted directly (e.g. `Authorization: eyJhbGci...`); a `Bearer <token>` value is also accepted for backward compatibility.
 
 A task submitted **without** a credential is still accepted (`202 Accepted`) and its rollout is monitored normally — argo-watcher simply does not perform the git write-back. This is the expected setup when the image tag is updated by other means (e.g. Argo CD Image Updater or your CI pipeline) and argo-watcher only tracks the resulting rollout. If you instead rely on the built-in updater to commit the tag and omit the credential, the write-back is skipped and the deployment times out waiting for an image change that never arrives. A token that is **present but invalid or expired** returns `401 Unauthorized`.
 

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -18,7 +18,7 @@ The Argo Watcher client is a lightweight CLI tool distributed as a Docker image 
 | Variable                    | Description                                                                                       |
 |-----------------------------|---------------------------------------------------------------------------------------------------|
 | `ARGO_WATCHER_DEPLOY_TOKEN` | Deploy token for Git image override (required when using the built-in GitOps updater)            |
-| `BEARER_TOKEN`              | JWT token for authentication (prefix with `Bearer `, e.g. `Bearer <token>`)                     |
+| `BEARER_TOKEN`              | JWT for authentication. Set the raw token (e.g. `eyJhbGci...`) so it is maskable as a GitLab CI variable; a legacy `Bearer <token>` value is still accepted. |
 | `TIMEOUT`                   | HTTP request timeout (e.g. `60s`, `2m`)                                                         |
 | `TASK_TIMEOUT`              | Maximum time (in seconds) to wait for a task to complete                                        |
 | `TASK_REFRESH`              | Override the server's refresh setting for this deployment (`true`/`false`); unset keeps the server default |

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -264,6 +266,38 @@ func TestAuthenticatorValidateBearerOnlyPrefix(t *testing.T) {
 	valid, validateErr := authenticator.Validate(request)
 	assert.False(t, valid)
 	assert.NoError(t, validateErr)
+}
+
+// TestAuthenticatorValidateJWTWithAndWithoutBearerPrefix proves that the
+// "Bearer " prefix is optional: a raw JWT on the Authorization header
+// validates identically to a "Bearer <jwt>" value. The raw form is what makes
+// the token maskable as a GitLab CI variable (no space in the value).
+func TestAuthenticatorValidateJWTWithAndWithoutBearerPrefix(t *testing.T) {
+	secret := "test_secret_key"
+	claims := jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+	assert.NoError(t, err)
+
+	cases := map[string]string{
+		"raw JWT (maskable)":       signed,
+		"Bearer-prefixed (legacy)": "Bearer " + signed,
+	}
+
+	for name, headerValue := range cases {
+		t.Run(name, func(t *testing.T) {
+			authenticator := NewAuthenticator(map[string]AuthStrategy{
+				"Authorization": NewJWTAuthService(secret),
+			})
+
+			request, reqErr := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
+			assert.NoError(t, reqErr)
+			request.Header.Set("Authorization", headerValue)
+
+			valid, validateErr := authenticator.Validate(request)
+			assert.True(t, valid)
+			assert.NoError(t, validateErr)
+		})
+	}
 }
 
 func TestNewAuthenticatorSkipsNilStrategies(t *testing.T) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -72,7 +72,12 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 	if authMethod != "" && token != "" {
 		switch authMethod {
 		case "JWT":
-			request.Header.Set("Authorization", token)
+			// Send the raw JWT so the value is maskable as a GitLab CI variable
+			// (a "Bearer " prefix contains a space, which GitLab refuses to mask).
+			// A legacy "Bearer <jwt>" value is still accepted: strip the prefix
+			// here so the wire header is consistent regardless of how the user
+			// set BEARER_TOKEN.
+			request.Header.Set("Authorization", strings.TrimPrefix(token, "Bearer "))
 		case "DeployToken":
 			request.Header.Set("ARGO_WATCHER_DEPLOY_TOKEN", token)
 		}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -211,6 +211,76 @@ func TestAddTask(t *testing.T) {
 	assert.Equal(t, expected.Id, taskId)
 }
 
+// TestAddTaskJWTHeader verifies the Authorization header the client puts on the
+// wire for a JWT. A raw JWT (the maskable GitLab CI form) and a legacy
+// "Bearer <jwt>" value must both yield a clean, unprefixed Authorization value
+// so backward compatibility is preserved while the raw form is maskable. A
+// prefix-only value ("Bearer ") is a misconfiguration that collapses to an
+// empty header rather than being sent verbatim — pinned here so the behavior
+// cannot change undetected.
+func TestAddTaskJWTHeader(t *testing.T) {
+	const jwtValue = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjF9.signature"
+
+	cases := []struct {
+		name     string
+		input    string
+		wantAuth string
+	}{
+		{"raw JWT (maskable)", jwtValue, jwtValue},
+		{"Bearer-prefixed (legacy)", "Bearer " + jwtValue, jwtValue},
+		{"prefix only (misconfiguration)", "Bearer ", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_ = json.NewEncoder(w).Encode(models.TaskStatus{Status: models.StatusAccepted, Id: taskId})
+			}))
+			defer srv.Close()
+
+			watcher := NewWatcher(srv.URL, false, 30*time.Second)
+			_, err := watcher.addTask(models.Task{App: "test"}, "JWT", tc.input)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantAuth, gotAuth, "Authorization header must carry the raw JWT without a Bearer prefix")
+		})
+	}
+}
+
+// TestAddTaskDeployTokenHeader guards that the deploy-token path is unaffected
+// by the JWT "Bearer " normalization: the ARGO_WATCHER_DEPLOY_TOKEN header must
+// carry the token verbatim, even for a value that happens to start with
+// "Bearer ", proving no stripping leaks onto this branch.
+func TestAddTaskDeployTokenHeader(t *testing.T) {
+	cases := map[string]string{
+		"plain token":            "s3cr3t-deploy-token",
+		"Bearer-looking literal": "Bearer not-a-jwt",
+	}
+
+	for name, tokenInput := range cases {
+		t.Run(name, func(t *testing.T) {
+			var gotToken string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotToken = r.Header.Get("ARGO_WATCHER_DEPLOY_TOKEN")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_ = json.NewEncoder(w).Encode(models.TaskStatus{Status: models.StatusAccepted, Id: taskId})
+			}))
+			defer srv.Close()
+
+			watcher := NewWatcher(srv.URL, false, 30*time.Second)
+			_, err := watcher.addTask(models.Task{App: "test"}, "DeployToken", tokenInput)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tokenInput, gotToken, "deploy token must be sent verbatim, never prefix-stripped")
+		})
+	}
+}
+
 func TestGetTaskStatus(t *testing.T) {
 	t.Run("received deployed status", func(t *testing.T) {
 		task, err := client.getTaskStatus(taskId)


### PR DESCRIPTION
### **User description**
The "Bearer " prefix was never a functional requirement: auth is routed by header name and the server already strips an optional prefix. Setting BEARER_TOKEN to "Bearer <jwt>" produced a value with a space, which GitLab CI refuses to mask.

Strip an optional leading "Bearer " in the client before setting the Authorization header, so a raw (maskable) token and a legacy prefixed value both send a clean, unprefixed JWT. The deploy-token path is left verbatim. Docs now recommend the raw token and note the prefix stays accepted for backward compatibility.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Client strips optional "Bearer " prefix from JWT token before setting Authorization header.

- Raw JWT tokens (without prefix) are accepted, enabling GitLab CI variable masking.

- Added tests for prefix stripping and server-side validation of both raw and prefixed tokens.

- Updated documentation to recommend raw token and note backward compatibility.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    token["BEARER_TOKEN: raw JWT or 'Bearer <jwt>'"] --> client["Client (strings.TrimPrefix)"]
    client --> header["Authorization: clean JWT"]
    header --> server["Server accepts both forms"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>auth_test.go</strong><dd><code>Add test for JWT validation with and without Bearer prefix</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-20af7dffb0864afe8e7d4c663407f75d3a34831a91957e6f0e8c12d98957a25a">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client_test.go</strong><dd><code>Add tests for JWT header normalization and deploy token verbatim</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-2dad64e28ce5e2eddf0adf303052d38e3b5b4fcba6b32fc4ca26d5e4d6b8fa4a">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>client.go</strong><dd><code>Strip optional 'Bearer ' prefix from JWT token before setting </code><br><code>Authorization header</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-2895f30116602d8fe6b0545c186d4f81247fa4eaab049dab174c6c91c0036e08">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document raw JWT acceptance in CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gitops-updater.md</strong><dd><code>Update GitOps updater guide to recommend raw JWT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-e1e8d9dd9a673694905f05a76210f88733008a51bfa12c6a27f850110ec4fd17">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting.md</strong><dd><code>Fix troubleshooting doc to reference BEARER_TOKEN instead of Bearer </code><br><code>JWT</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-2883c5b585966e4ab99e6cc2e9b9edd162f20bbae4d6a573a6f77f8dfd237ba2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.md</strong><dd><code>Update API documentation to reflect raw JWT acceptance</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client-env.md</strong><dd><code>Update client environment variable docs for raw JWT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/468/files#diff-ef45e5367935b89d45a93d9e63233d73eaaa25070428a30124810dd572a80847">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

