### PR TITLE
fix(auth): prevent log injection in keycloak group logging

### DIFF
--- a/internal/auth/keycloak.go
+++ b/internal/auth/keycloak.go
@@ -118,11 +118,11 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 func (k *KeycloakAuthService) allowedToRollback(username string, groups []string) bool {
 	for _, group := range groups {
 		if slices.Contains(k.PrivilegedGroups, group) {
-			slog.Debug(fmt.Sprintf("%s is a member of the privileged group: %v", username, group))
+			slog.Debug("user is a member of a privileged group", "username", username, "group", group)
 			return true
 		}
 	}
 
-	slog.Debug(fmt.Sprintf("%s is not a member of any of the privileged groups: %v", username, k.PrivilegedGroups))
+	slog.Debug("user is not a member of any privileged group", "username", username, "privileged_groups", k.PrivilegedGroups)
 	return false
 }


### PR DESCRIPTION
### **User description**
The Keycloak username (derived from the presented token) was interpolated into the debug log message via fmt.Sprintf, so a crafted username containing CRLF/control characters could forge log entries.

Pass the username and groups as structured slog attributes with a constant message instead; the slog handler encodes the values, so the tainted input can no longer break out of its field. Clears gosec G706 (CWE-117) on both group-membership debug lines.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent log injection in Keycloak group debug logging

- Use structured slog attributes instead of message formatting

- Fix CWE-117 (gosec G706) vulnerability


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keycloak.go</strong><dd><code>Use structured logging to prevent log injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/auth/keycloak.go

<ul><li>Replace fmt.Sprintf debug log messages with structured slog attributes<br> <li> Pass username and groups as separate log fields to prevent injection</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/469/files#diff-515cf5b5f4a0e77009426a928f3690a85a8d27cfa70387acd1d70d234517cb16">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

