### PR TITLE
ci(release): prune superseded pre-releases after a stable release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,3 +120,21 @@ jobs:
           chart_name: argo-watcher
           app_version: ${{ github.ref_name }}
           update_chart_annotations: true
+
+      - name: Prune superseded pre-releases
+        # Once a stable vX.Y.Z ships, the date-stamped vX.Y.Z-pre.* snapshots
+        # that led to it are obsolete. Delete those releases and their tags so
+        # the Releases page keeps only shipped versions. Runs last and tolerates
+        # per-tag failures so a cleanup hiccup can't fail an otherwise-good
+        # release; skipped failures surface as workflow annotations.
+        if: (!contains(github.ref, 'pre'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release list --limit 200 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease and (.tagName | startswith(env.GITHUB_REF_NAME + "-pre."))) | .tagName' \
+          | while read -r tag; do
+              echo "Deleting superseded pre-release: $tag"
+              gh release delete "$tag" --cleanup-tag --yes \
+                || echo "::warning::failed to delete pre-release $tag"
+            done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,7 +127,11 @@ jobs:
         # the Releases page keeps only shipped versions. Runs last and tolerates
         # per-tag failures so a cleanup hiccup can't fail an otherwise-good
         # release; skipped failures surface as workflow annotations.
-        if: (!contains(github.ref, 'pre'))
+        #
+        # Guard on the tag ref (matching the helm step) so this destructive
+        # delete can never run against a branch/dispatch ref if a future trigger
+        # is added — GITHUB_REF_NAME would then be a branch name, not a version.
+        if: startsWith(github.ref, 'refs/tags/v') && (!contains(github.ref, 'pre'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
### **User description**
goreleaser only manages the current release, so the date-stamped vX.Y.Z-pre.* snapshots pile up on the Releases page. Add a final step to the stable release path that deletes the pre-releases (and their tags) for the version just shipped via `gh release delete --cleanup-tag`.

The step runs last and tolerates per-tag failures (logged as workflow annotations) so a cleanup hiccup cannot fail an otherwise-good release. It reuses the existing `contents: write` permission and GITHUB_TOKEN, so no new dependency or secret is required.


___

### **PR Type**
Enhancement


___

### **Description**
- Add a final step to the stable release workflow that deletes superseded pre-releases and their tags via `gh release delete --cleanup-tag`.

- The step runs only for non-pre-release tags, uses the existing `GITHUB_TOKEN` and `contents: write` permission.

- Failures per tag are logged as workflow annotations, preventing a cleanup error from failing the entire release.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Helm Chart Update Step"] --> B["Prune Superseded Pre-releases"]
  B --> C["gh release delete --cleanup-tag"]
  C -- "on failure" --> D["Workflow Annotation Warning"]
  C -- "on success" --> E["Cleanup Complete"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yaml</strong><dd><code>Add pre-release cleanup after stable release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yaml

<ul><li>Added a new job step named "Prune superseded pre-releases" that runs <br>after the Helm chart update step.<br> <li> The step fetches all pre-releases with <code>gh release list</code> and deletes <br>those matching the current stable version's pre-release pattern.<br> <li> Uses <code>gh release delete --cleanup-tag --yes</code> to remove both the release <br>and its tag.<br> <li> Failures are caught with a <code>|| echo "::warning::..."</code> so that a single <br>deletion failure does not fail the entire workflow.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/470/files#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

