### PR TITLE
fix(web): keep history filters visible when list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the History page filters visible when there are no matching deployments.
+  Previously, with no deployments in the default time window the empty-state
+  message replaced the whole view, hiding the date-range and application
+  filters so users had no way to widen the range.
+
 ## [0.11.0] - 2026-07-13
 
 ### Added

--- a/web/src/features/tasks/components/TaskListLayout.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.test.tsx
@@ -3,13 +3,23 @@ import type { ReactElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskListLayout } from './TaskListLayout';
 
+interface StubListContext {
+  data: unknown[];
+  total?: number;
+  isPending?: boolean;
+  filterValues?: Record<string, unknown>;
+  error?: unknown;
+}
+
 const {
   listCalls,
+  listContextRef,
   ListMock,
   PaginationMock,
   PerPagePersistenceMock,
 } = vi.hoisted(() => {
   const listCallsInternal: Array<Record<string, unknown>> = [];
+  const contextRef: { current: StubListContext } = { current: { data: [] } };
 
   const list = ({ children, ...props }: Record<string, unknown>) => {
     listCallsInternal.push(props);
@@ -26,6 +36,7 @@ const {
 
   return {
     listCalls: listCallsInternal,
+    listContextRef: contextRef,
     ListMock: list,
     PaginationMock: pagination,
     PerPagePersistenceMock: perPage,
@@ -35,10 +46,9 @@ const {
 vi.mock('react-admin', () => ({
   List: ListMock,
   Pagination: PaginationMock,
-  // SearchFilteredView pulls useListContext + ListContextProvider through this
-  // mock; with the test's stubbed <List> not providing ListContext, we just
-  // hand back a passthrough that exposes empty data.
-  useListContext: () => ({ data: [] }),
+  // SearchFilteredView + TaskListLayout body both read useListContext; expose a
+  // mutable stub so individual tests can drive the empty/populated branches.
+  useListContext: () => listContextRef.current,
   ListContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
@@ -52,11 +62,14 @@ vi.mock('../../../shared/hooks/usePersistentPerPage', () => ({
 describe('TaskListLayout', () => {
   beforeEach(() => {
     listCalls.length = 0;
+    listContextRef.current = { data: [] };
     readPersistentPerPageMock.mockReset();
   });
 
   it('fills react-admin list props and renders header content when provided', () => {
     readPersistentPerPageMock.mockReturnValue(40);
+    // Non-empty result so the body renders children rather than the empty state.
+    listContextRef.current = { data: [{ id: 1 }], total: 1 };
 
     render(
       <TaskListLayout
@@ -94,7 +107,7 @@ describe('TaskListLayout', () => {
       pagination: ReactElement;
       actions: ReactElement;
       storeKey: string;
-      empty: ReactElement;
+      empty: unknown;
     };
 
     expect(props.title).toBe('Recent Tasks');
@@ -104,11 +117,87 @@ describe('TaskListLayout', () => {
     expect(props.pagination.props['data-testid']).toBe('custom-pagination');
     expect(props.actions.props['data-testid']).toBe('actions');
     expect(props.storeKey).toBe('customStore');
-    expect(props.empty.props['data-testid']).toBe('empty-state');
+    // The layout must NOT delegate the empty state to react-admin's <List empty>,
+    // because react-admin renders it *instead of* the list, dropping the filter
+    // toolbar. The empty placeholder is rendered inside the body instead.
+    expect(props.empty).toBe(false);
+  });
+
+  it('renders the empty placeholder alongside the header when there are no rows and no filters', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    listContextRef.current = { data: [], total: 0, isPending: false, filterValues: {} };
+
+    render(
+      <TaskListLayout
+        perPageStorageKey="history.perPage"
+        header={[<button key="filters">Date filter</button>]}
+        emptyComponent={<div data-testid="empty-state" />}
+      >
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    // The header (filters) stays mounted so the user can still pick a date range.
+    expect(screen.getByText('Date filter')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    // The datagrid children are replaced by the placeholder.
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
+  });
+
+  it('keeps rendering the datagrid (not the layout placeholder) when filters are active', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    listContextRef.current = {
+      data: [],
+      total: 0,
+      isPending: false,
+      filterValues: { start: 1, end: 2 },
+    };
+
+    render(
+      <TaskListLayout
+        perPageStorageKey="history.perPage"
+        header={[<button key="filters">Date filter</button>]}
+        emptyComponent={<div data-testid="empty-state" />}
+      >
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    // With active filters, defer to the datagrid's own filtered empty state.
+    expect(screen.getByText('Date filter')).toBeInTheDocument();
+    expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('defers to the datagrid (not the layout placeholder) when a fetch error leaves zero rows', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    listContextRef.current = {
+      data: [],
+      total: 0,
+      isPending: false,
+      filterValues: {},
+      error: new Error('backend unreachable'),
+    };
+
+    render(
+      <TaskListLayout
+        perPageStorageKey="history.perPage"
+        header={[<button key="filters">Date filter</button>]}
+        emptyComponent={<div data-testid="empty-state" />}
+      >
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    // A backend error must not be misattributed to genuine emptiness.
+    expect(screen.getByText('Date filter')).toBeInTheDocument();
+    expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 
   it('falls back to default pagination options and empty header placeholder', () => {
     readPersistentPerPageMock.mockReturnValue(15);
+    listContextRef.current = { data: [{ id: 1 }], total: 1 };
 
     render(
       <TaskListLayout title="History" perPageStorageKey="history.perPage">

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -1,6 +1,6 @@
 import { Children, isValidElement, type ReactNode } from 'react';
 import { Box, Stack } from '@mui/material';
-import { List, Pagination, type ListProps } from 'react-admin';
+import { List, Pagination, useListContext, type ListProps } from 'react-admin';
 import { PerPagePersistence, readPersistentPerPage } from '../../../shared/hooks/usePersistentPerPage';
 import { SearchFilteredView } from './SearchFilteredView';
 import { TaskListProvider } from './TaskListContext';
@@ -15,6 +15,38 @@ interface TaskListLayoutProps {
   listProps?: Partial<ListProps>;
   emptyComponent?: ReactNode | false;
 }
+
+/**
+ * Renders the list body: the children (datagrid) normally, or the page-specific
+ * empty placeholder when the backend returned zero rows and no filters are active.
+ *
+ * This gate lives here — inside <List> — rather than on <List empty>, because
+ * react-admin renders the `empty` element *instead of* the entire list, which
+ * drops the filter toolbar with it. Users would then land on an empty history
+ * page with no way to widen the date range. Rendering the placeholder in the
+ * body keeps the header/filters mounted above it. When filters are active we
+ * defer to the datagrid's own filtered empty state (with its "Clear filters"
+ * CTA), matching react-admin's original `shouldRenderEmptyPage` condition
+ * (`!error && !isPending && total === 0 && !filterValues`). The `!error` guard
+ * matters: on a fetch error after an empty load `total` is still 0, and we must
+ * defer to the list body rather than misattribute the error to genuine emptiness.
+ */
+const ListBody = ({
+  emptyComponent,
+  children,
+}: {
+  emptyComponent: ReactNode | false;
+  children: ReactNode;
+}) => {
+  const { isPending, total, filterValues, error } = useListContext();
+  const hasFilters = Object.keys(filterValues ?? {}).length > 0;
+
+  if (emptyComponent && !error && !isPending && total === 0 && !hasFilters) {
+    return <>{emptyComponent}</>;
+  }
+
+  return <>{children}</>;
+};
 
 /**
  * Shared wrapper for task list pages handling pagination persistence, headers, and empty states.
@@ -65,7 +97,7 @@ export const TaskListLayout = ({
       pagination={resolvedPagination}
       actions={actions}
       storeKey={storeKey}
-      empty={emptyComponent}
+      empty={false}
       {...rest}
     >
       <PerPagePersistence storageKey={perPageStorageKey} />
@@ -83,7 +115,9 @@ export const TaskListLayout = ({
           <Box sx={{ width: '100%' }} />
         )}
       </Stack>
-      <SearchFilteredView>{children}</SearchFilteredView>
+      <ListBody emptyComponent={emptyComponent}>
+        <SearchFilteredView>{children}</SearchFilteredView>
+      </ListBody>
     </List>
     </TaskListProvider>
   );


### PR DESCRIPTION
### **User description**
The page empty-state placeholder was passed to react-admin's <List empty> prop, which renders it instead of the entire list body. The filter toolbar (date-range picker and application filter) lives in the body, so an empty result with no active filters — the default when there are no deployments in the last 24h — dropped the filters and left no way to widen the date range.

Render the placeholder inside the list body via a ListBody gate that keeps the header mounted, using the same no-rows/no-filter/no-error condition react-admin used. When filters are active, defer to the datagrid's own filtered empty state.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Render empty placeholder inside list body to preserve filter visibility.

- Show placeholder only when no rows, no active filters, and no error.

- Defer to datagrid for filtered-empty or fetch-error states.

- Update tests with mutable list context to verify all paths.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["List renders header and ListBody"] --> B["ListBody checks context"]
    B --> C{"no rows, no filters, no error?"}
    C -- yes --> D["Show empty placeholder"]
    C -- no --> E["Show datagrid children"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskListLayout.test.tsx</strong><dd><code>Add tests for empty placeholder behavior in TaskListLayout</code></dd></summary>
<hr>

web/src/features/tasks/components/TaskListLayout.test.tsx

<ul><li>Stub list context via a mutable ref to drive different data states.<br> <li> Add tests verifying placeholder appears only when there are no rows <br>and no filters.<br> <li> Ensure the filter toolbar remains visible alongside the empty <br>placeholder.<br> <li> Assert that error-states and active filters defer to the datagrid <br>children.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/471/files#diff-46a2e7571437537b97f680c8e0248603feaa9c1347ebe97a7335e6d57b973323">+95/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskListLayout.tsx</strong><dd><code>Render empty placeholder inside list body to preserve filters</code></dd></summary>
<hr>

web/src/features/tasks/components/TaskListLayout.tsx

<ul><li>Introduce a <code>ListBody</code> gate to render empty placeholder inside the list <br>body.<br> <li> Use <code>useListContext</code> to check for no rows, no filters, and no error <br>before showing placeholder.<br> <li> Set <code><List empty={false}></code> to prevent react-admin from replacing the <br>entire list.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/471/files#diff-5f1e7848695a65498144572d7edd9075a20ab68a9ccd88000cab6f5e18e246cd">+37/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for history filter visibility fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add entry documenting the fix for hidden history page filters.


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/471/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

