### PR TITLE
perf(updater): avoid full-worktree scans on git write-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `gitops_writeback_duration_seconds` and `gitops_lock_wait_duration_seconds`
+  Prometheus histograms (label `app`) to surface slow or contended git write-backs
+  to GitOps repositories — the first measures how long a write-back holds the
+  per-repository lock (clone/commit/push plus retries), the second how long a
+  deployment waits to acquire it.
+
+### Changed
+
+- Speed up GitOps write-backs by detecting whether the override file changed with a
+  targeted single-file comparison instead of scanning the entire working tree. On
+  large GitOps repositories this markedly reduces per-deployment commit latency,
+  most noticeably when several deployments to the same repository run concurrently
+  and each must wait its turn under the per-repository lock.
+
 ### Fixed
 
 - Keep the History page filters visible when there are no matching deployments.

--- a/cmd/argo-watcher/prometheus/metrics.go
+++ b/cmd/argo-watcher/prometheus/metrics.go
@@ -14,6 +14,8 @@ type MetricsInterface interface {
 	AddInProgressTask()
 	RemoveInProgressTask()
 	ObserveRefreshDuration(app string, seconds float64)
+	ObserveGitWritebackDuration(app string, seconds float64)
+	ObserveGitLockWaitDuration(app string, seconds float64)
 }
 
 // Metrics contains all the prometheus collectors.
@@ -23,6 +25,8 @@ type Metrics struct {
 	ArgocdUnavailable    prometheus.Gauge
 	InProgressTasks      prometheus.Gauge
 	RefreshDuration      *prometheus.HistogramVec
+	GitWritebackDuration *prometheus.HistogramVec
+	GitLockWaitDuration  *prometheus.HistogramVec
 }
 
 // NewMetrics creates and registers the metrics with the provided Registerer.
@@ -49,9 +53,29 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help:    "Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"app"}),
+		// GitWritebackDuration times the whole write-back held under the per-repo lock:
+		// the clone/commit/push cycle plus any retries and inter-attempt backoff. This is
+		// the operationally meaningful number — it is how long the task blocks every other
+		// write-back to the same repo. Under push contention it can approach
+		// GIT_MAX_ATTEMPTS * GIT_OP_TIMEOUT plus backoff, so the buckets extend to 600s
+		// (the default 10s top bucket is far too low for git ops against a large repo).
+		GitWritebackDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "gitops_writeback_duration_seconds",
+			Help:    "Time the git write-back held the per-repo lock, covering the clone/commit/push cycle plus any retries and backoff.",
+			Buckets: []float64{0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+		}, []string{"app"}),
+		// GitLockWaitDuration times how long a task waited to acquire the per-repository
+		// write-back lock. Under concurrent deployments to one repo this is the dominant
+		// contributor to tail latency (the last task queues behind all the others), so the
+		// buckets extend to 300s.
+		GitLockWaitDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "gitops_lock_wait_duration_seconds",
+			Help:    "Time spent waiting to acquire the per-repository git write-back lock.",
+			Buckets: []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 180, 300},
+		}, []string{"app"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks, m.RefreshDuration)
+	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration)
 
 	return m
 }
@@ -93,4 +117,16 @@ func (m *Metrics) RemoveInProgressTask() {
 // ObserveRefreshDuration records how long an ArgoCD refresh request took for the given app.
 func (m *Metrics) ObserveRefreshDuration(app string, seconds float64) {
 	m.RefreshDuration.WithLabelValues(app).Observe(seconds)
+}
+
+// ObserveGitWritebackDuration records how long the git write-back (clone, commit, push)
+// took for the given app, measured while holding the per-repo lock.
+func (m *Metrics) ObserveGitWritebackDuration(app string, seconds float64) {
+	m.GitWritebackDuration.WithLabelValues(app).Observe(seconds)
+}
+
+// ObserveGitLockWaitDuration records how long the given app's write-back waited to acquire
+// the per-repository lock.
+func (m *Metrics) ObserveGitLockWaitDuration(app string, seconds float64) {
+	m.GitLockWaitDuration.WithLabelValues(app).Observe(seconds)
 }

--- a/cmd/argo-watcher/prometheus/metrics_test.go
+++ b/cmd/argo-watcher/prometheus/metrics_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetrics_AddProcessedDeployment(t *testing.T) {
@@ -90,6 +92,45 @@ func TestMetrics_SetArgoUnavailable(t *testing.T) {
 			assert.Equal(t, tc.expectedValue, testutil.ToFloat64(m.ArgocdUnavailable))
 		})
 	}
+}
+
+// histogramSampleForApp reads the sample count and sum recorded for a given app label
+// on a HistogramVec, so tests can assert the exact value that was observed.
+func histogramSampleForApp(t *testing.T, vec *prometheus.HistogramVec, app string) (count uint64, sum float64) {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(app)
+	require.NoError(t, err)
+	var metric dto.Metric
+	require.NoError(t, obs.(prometheus.Metric).Write(&metric))
+	return metric.GetHistogram().GetSampleCount(), metric.GetHistogram().GetSampleSum()
+}
+
+func TestMetrics_ObserveGitWritebackDuration(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+
+	// Act
+	m.ObserveGitWritebackDuration("test-app", 3.5)
+
+	// Assert: exactly one observation of the passed value for the app.
+	count, sum := histogramSampleForApp(t, m.GitWritebackDuration, "test-app")
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, 3.5, sum)
+}
+
+func TestMetrics_ObserveGitLockWaitDuration(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+
+	// Act
+	m.ObserveGitLockWaitDuration("test-app", 12)
+
+	// Assert: exactly one observation of the passed value for the app.
+	count, sum := histogramSampleForApp(t, m.GitLockWaitDuration, "test-app")
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, float64(12), sum)
 }
 
 func TestMetrics_InProgressTasks(t *testing.T) {

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -12,7 +12,7 @@ scrape_configs:
 
 ## Exposed metrics
 
-The server emits five metrics today, all defined in [`cmd/argo-watcher/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/cmd/argo-watcher/prometheus/metrics.go).
+The server emits seven metrics today, all defined in [`cmd/argo-watcher/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/cmd/argo-watcher/prometheus/metrics.go).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
@@ -21,6 +21,8 @@ The server emits five metrics today, all defined in [`cmd/argo-watcher/prometheu
 | `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. |
 | `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |
 | `argocd_refresh_duration_seconds` | histogram | `app` | Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes. Recorded only when the status check requests a refresh. |
+| `gitops_writeback_duration_seconds` | histogram | `app` | Time the git write-back held the per-repo lock, covering the clone/commit/push cycle plus any retries and backoff. |
+| `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting to acquire the per-repository git write-back lock. High values mean tasks are queued behind concurrent write-backs to the same repo. |
 
 In addition, the standard Go runtime metrics from the Prometheus client library are exposed (`go_*`, `process_*`).
 
@@ -77,6 +79,19 @@ groups:
             settles (e.g. an app with a constantly-reconciling CronJob) can stall the
             deployment check — set the per-task refresh override (or ARGO_REFRESH_APP) to
             false for such apps.
+
+      - alert: ArgoWatcherSlowGitWriteback
+        expr: histogram_quantile(0.95, sum by (app, le) (rate(gitops_writeback_duration_seconds_bucket[10m]))) > 60
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.app }} git write-back is slow"
+          description: |
+            The p95 git write-back for this application exceeds 60s, which points to push
+            contention (retries/backoff) or an expensive clone against a large GitOps repo.
+            Check gitops_lock_wait_duration_seconds for the same app to see whether it is
+            queued behind other write-backs to the same repository.
 ```
 
 ## Grafana panel queries

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.54.0
@@ -72,7 +73,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/config"
+	"github.com/shini4i/argo-watcher/cmd/argo-watcher/prometheus"
 	"github.com/shini4i/argo-watcher/internal/notifications"
 
 	"github.com/shini4i/argo-watcher/internal/helpers"
@@ -55,6 +56,9 @@ type DeploymentMonitor struct {
 type GitUpdater struct {
 	locker        lock.Locker
 	repoCachePath string
+	// metrics records lock-wait and write-back durations. May be nil in tests, in which
+	// case observation is skipped.
+	metrics prometheus.MetricsInterface
 }
 
 // NewDeploymentMonitor creates a deployment monitor with the supplied configuration.
@@ -334,11 +338,27 @@ func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, sta
 	task.Status = models.StatusFailedMessage
 }
 
-// NewGitUpdater creates a GitUpdater instance.
-func NewGitUpdater(locker lock.Locker, repoCachePath string) *GitUpdater {
+// NewGitUpdater creates a GitUpdater instance. metrics may be nil, in which case
+// duration observation is skipped.
+func NewGitUpdater(locker lock.Locker, repoCachePath string, metrics prometheus.MetricsInterface) *GitUpdater {
 	return &GitUpdater{
 		locker:        locker,
 		repoCachePath: repoCachePath,
+		metrics:       metrics,
+	}
+}
+
+// observeLockWait records how long a task waited to acquire the per-repo lock.
+func (gitUpdater *GitUpdater) observeLockWait(app string, d time.Duration) {
+	if gitUpdater.metrics != nil {
+		gitUpdater.metrics.ObserveGitLockWaitDuration(app, d.Seconds())
+	}
+}
+
+// observeWriteback records how long the git write-back took while holding the lock.
+func (gitUpdater *GitUpdater) observeWriteback(app string, d time.Duration) {
+	if gitUpdater.metrics != nil {
+		gitUpdater.metrics.ObserveGitWritebackDuration(app, d.Seconds())
 	}
 }
 
@@ -358,7 +378,14 @@ func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task model
 		return err
 	}
 
+	// Timed from just before the lock request so lock-wait captures the full queueing
+	// delay behind concurrent write-backs to the same repo, and the write-back timer
+	// captures only the work done once the lock is held.
+	lockRequested := time.Now()
 	gitUpdateFunc := func() error {
+		gitUpdater.observeLockWait(task.App, time.Since(lockRequested))
+		workStart := time.Now()
+		defer func() { gitUpdater.observeWriteback(task.App, time.Since(workStart)) }()
 		slog.Debug("Application managed by watcher. Initiating git repo update.", "id", task.Id)
 		return gitUpdater.updateGitRepo(app, &task, &gitopsRepo, isSuperseded...)
 	}
@@ -418,7 +445,7 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 	updater.monitor = NewDeploymentMonitor(argo, cfg.RegistryProxyURL, retryOptions, cfg.AcceptSuspended, cfg.RetryDelay)
 	updater.monitor.defaultAttempts = cfg.RetryAttempts
 	updater.monitor.refreshApp = cfg.RefreshApp
-	updater.gitUpdater = NewGitUpdater(cfg.Locker, cfg.RepoCachePath)
+	updater.gitUpdater = NewGitUpdater(cfg.Locker, cfg.RepoCachePath, argo.metrics)
 
 	var strategies []notifications.NotificationStrategy
 

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -647,7 +647,7 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("skipsWhenAppNotManaged", func(t *testing.T) {
 		locker := &spyLocker{}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 		err := updater.UpdateIfNeeded(makeApp(false), validTask)
 		assert.NoError(t, err)
 		assert.False(t, locker.called)
@@ -655,7 +655,7 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("skipsWhenTaskNotValidated", func(t *testing.T) {
 		locker := &spyLocker{}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 		task := validTask
 		task.Validated = false
 		err := updater.UpdateIfNeeded(makeApp(true), task)
@@ -665,7 +665,7 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("failsWhenRepoInvalid", func(t *testing.T) {
 		locker := &spyLocker{}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 		app := makeApp(true)
 		app.Spec.Source.RepoURL = ""
 
@@ -676,7 +676,7 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("returnsLockerError", func(t *testing.T) {
 		locker := &spyLocker{err: errors.New("lock failed")}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 
 		err := updater.UpdateIfNeeded(makeApp(true), validTask)
 		assert.EqualError(t, err, "lock failed")
@@ -685,7 +685,7 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("propagatesUpdateError", func(t *testing.T) {
 		locker := &spyLocker{}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 		app := makeApp(true)
 		app.Metadata.Annotations["argo-watcher/managed-images"] = "broken"
 
@@ -696,10 +696,58 @@ func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 
 	t.Run("succeedsWhenNoUpdateNeeded", func(t *testing.T) {
 		locker := &spyLocker{}
-		updater := NewGitUpdater(locker, "/tmp/cache")
+		updater := NewGitUpdater(locker, "/tmp/cache", nil)
 
 		err := updater.UpdateIfNeeded(makeApp(true), validTask)
 		assert.NoError(t, err)
+		assert.True(t, locker.called)
+	})
+
+	t.Run("observesLockWaitAndWritebackDurations", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		metrics := mock.NewMockMetricsInterface(ctrl)
+		metrics.EXPECT().ObserveGitLockWaitDuration(validTask.App, gomock.Any()).Times(1)
+		metrics.EXPECT().ObserveGitWritebackDuration(validTask.App, gomock.Any()).Times(1)
+
+		locker := &spyLocker{}
+		updater := NewGitUpdater(locker, "/tmp/cache", metrics)
+
+		err := updater.UpdateIfNeeded(makeApp(true), validTask)
+		assert.NoError(t, err)
+		assert.True(t, locker.called)
+	})
+
+	t.Run("skipsMetricsWhenLockNeverAcquired", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		// Lock acquisition fails before the closure runs, so neither duration is recorded.
+		metrics := mock.NewMockMetricsInterface(ctrl)
+
+		locker := &spyLocker{err: errors.New("lock failed")}
+		updater := NewGitUpdater(locker, "/tmp/cache", metrics)
+
+		err := updater.UpdateIfNeeded(makeApp(true), validTask)
+		assert.EqualError(t, err, "lock failed")
+	})
+
+	t.Run("observesDurationsEvenWhenWritebackFails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		// The write-back timer is deferred so a failed (and typically slow, retried)
+		// write-back — the tail-latency case the histogram exists to surface — is still
+		// measured once the lock is acquired.
+		metrics := mock.NewMockMetricsInterface(ctrl)
+		metrics.EXPECT().ObserveGitLockWaitDuration(validTask.App, gomock.Any()).Times(1)
+		metrics.EXPECT().ObserveGitWritebackDuration(validTask.App, gomock.Any()).Times(1)
+
+		locker := &spyLocker{}
+		updater := NewGitUpdater(locker, "/tmp/cache", metrics)
+		app := makeApp(true)
+		app.Metadata.Annotations["argo-watcher/managed-images"] = "broken"
+
+		err := updater.UpdateIfNeeded(app, validTask)
+		assert.Error(t, err)
 		assert.True(t, locker.called)
 	})
 }
@@ -714,7 +762,7 @@ func TestGitUpdaterUpdateGitRepo(t *testing.T) {
 	repo := &models.GitopsRepo{Path: "some/path"}
 
 	t.Run("returnsNilWhenNoOverrides", func(t *testing.T) {
-		updater := NewGitUpdater(lock.NewInMemoryLocker(), "/tmp/cache")
+		updater := NewGitUpdater(lock.NewInMemoryLocker(), "/tmp/cache", nil)
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
 
@@ -723,7 +771,7 @@ func TestGitUpdaterUpdateGitRepo(t *testing.T) {
 	})
 
 	t.Run("propagatesOverrideError", func(t *testing.T) {
-		updater := NewGitUpdater(lock.NewInMemoryLocker(), "/tmp/cache")
+		updater := NewGitUpdater(lock.NewInMemoryLocker(), "/tmp/cache", nil)
 		app := &models.Application{}
 		app.Metadata.Annotations = map[string]string{
 			"argo-watcher/managed":        "true",

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -89,13 +89,15 @@ func (m *mockTaskRepository) ProcessObsoleteTasks(_ uint) {}
 // mockMetrics is a minimal mock for MetricsInterface used in tests.
 type mockMetrics struct{}
 
-func (m *mockMetrics) AddProcessedDeployment(_ string)            {}
-func (m *mockMetrics) AddFailedDeployment(_ string)               {}
-func (m *mockMetrics) ResetFailedDeployment(_ string)             {}
-func (m *mockMetrics) SetArgoUnavailable(_ bool)                  {}
-func (m *mockMetrics) AddInProgressTask()                         {}
-func (m *mockMetrics) RemoveInProgressTask()                      {}
-func (m *mockMetrics) ObserveRefreshDuration(_ string, _ float64) {}
+func (m *mockMetrics) AddProcessedDeployment(_ string)                 {}
+func (m *mockMetrics) AddFailedDeployment(_ string)                    {}
+func (m *mockMetrics) ResetFailedDeployment(_ string)                  {}
+func (m *mockMetrics) SetArgoUnavailable(_ bool)                       {}
+func (m *mockMetrics) AddInProgressTask()                              {}
+func (m *mockMetrics) RemoveInProgressTask()                           {}
+func (m *mockMetrics) ObserveRefreshDuration(_ string, _ float64)      {}
+func (m *mockMetrics) ObserveGitWritebackDuration(_ string, _ float64) {}
+func (m *mockMetrics) ObserveGitLockWaitDuration(_ string, _ float64)  {}
 
 func TestGetVersion(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -267,42 +267,48 @@ func (repo *GitRepo) mergeOverrideFileContent(fullPath string, overrideContent *
 }
 
 // commitAndPush handles the git workflow: writing changes, adding to stage,
-// committing, and pushing to the remote. If the working tree is clean after
-// writing the file, it skips the commit and push. ctx bounds the push.
+// committing, and pushing to the remote. If the override file already contains
+// exactly the content to be written, it skips the commit and push. ctx bounds
+// the push.
 func (repo *GitRepo) commitAndPush(ctx context.Context, fullPath, commitMsg string, overrideContent *ArgoOverrideFile) error {
 	worktree, err := repo.localRepo.Worktree()
 	if err != nil {
 		return err
 	}
 
-	// Write the final merged content to the override file.
+	// Marshal the final merged content.
 	contentBytes, err := yaml.Marshal(overrideContent)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(fullPath, contentBytes, 0600); err != nil {
-		return fmt.Errorf("failed to write override file: %w", err)
-	}
 
-	// Check if writing the file actually resulted in changes.
-	status, err := worktree.Status()
-	if err != nil {
-		return fmt.Errorf("failed to get worktree status: %w", err)
-	}
-
-	// If the image tag is already correct, there will be no changes.
-	if status.IsClean() {
+	// Detect "nothing to commit" with a single-file byte compare instead of a
+	// full-worktree scan. Clone() hard-resets the worktree to origin HEAD before every
+	// attempt, and this override file is the only path argo-watcher ever writes, so the
+	// on-disk bytes equalling what we are about to write is equivalent to
+	// worktree.Status().IsClean() for our purposes — but O(1 file) instead of O(entire
+	// repo). On a large GitOps repo that whole-tree scan dominates the per-task cost, and
+	// it is paid serially for every concurrent task holding the per-repo lock in turn.
+	// #nosec G304 -- path already validated by assertInsideRoot in UpdateApp
+	if existing, readErr := os.ReadFile(fullPath); readErr == nil && bytes.Equal(existing, contentBytes) {
 		slog.Debug("No changes detected. Skipping commit.")
 		return nil
 	}
 
-	// Add the file to the staging area.
+	// Write the final merged content to the override file.
+	if err := os.WriteFile(fullPath, contentBytes, 0600); err != nil {
+		return fmt.Errorf("failed to write override file: %w", err)
+	}
+
+	// Add the file to the staging area. SkipStatus avoids the full-worktree Status()
+	// scan that worktree.Add performs internally; with an explicit single-file path
+	// go-git hashes and stages only that file (new or modified).
 	relativePath, err := filepath.Rel(repo.localRepoPath, fullPath)
 	if err != nil {
 		// This is a programmatic error, should not happen in practice.
 		return fmt.Errorf("could not determine relative path: %w", err)
 	}
-	if _, err := worktree.Add(relativePath); err != nil {
+	if err := worktree.AddWithOptions(&git.AddOptions{Path: relativePath, SkipStatus: true}); err != nil {
 		return err
 	}
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -452,6 +452,101 @@ func TestMergeOverrideFileContent(t *testing.T) {
 	})
 }
 
+func TestCommitAndPush_SkipsWhenContentUnchanged(t *testing.T) {
+	_, _, localRepo, _, localPath := setupGitForTest(t)
+
+	repo := newTestRepo(t, &GitClient{})
+	repo.localRepo = localRepo
+	repo.localRepoPath = localPath
+	appDir := filepath.Join(localPath, "apps")
+	require.NoError(t, os.Mkdir(appDir, 0755))
+	fullPath := filepath.Join(appDir, "values.yaml")
+
+	params := &ArgoOverrideFile{}
+	params.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
+
+	// First write creates the commit.
+	require.NoError(t, repo.commitAndPush(context.Background(), fullPath, "msg", params))
+
+	headBefore, err := localRepo.Head()
+	require.NoError(t, err)
+
+	// Second call with byte-identical content must skip: no new commit, no error.
+	require.NoError(t, repo.commitAndPush(context.Background(), fullPath, "msg", params))
+
+	headAfter, err := localRepo.Head()
+	require.NoError(t, err)
+	assert.Equal(t, headBefore.Hash(), headAfter.Hash(), "expected no new commit when content is unchanged")
+}
+
+func TestCommitAndPush_RestagesModifiedTrackedFile(t *testing.T) {
+	_, remoteRepo, localRepo, _, localPath := setupGitForTest(t)
+
+	repo := newTestRepo(t, &GitClient{})
+	repo.localRepo = localRepo
+	repo.localRepoPath = localPath
+	appDir := filepath.Join(localPath, "apps")
+	require.NoError(t, os.Mkdir(appDir, 0755))
+	fullPath := filepath.Join(appDir, "values.yaml")
+
+	// First commit tracks the file at v1.
+	v1 := &ArgoOverrideFile{}
+	v1.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v1.0.0"}}
+	require.NoError(t, repo.commitAndPush(context.Background(), fullPath, "v1", v1))
+	headV1, err := localRepo.Head()
+	require.NoError(t, err)
+
+	// Second commit modifies the already-tracked file to v2. SkipStatus must still
+	// stage the modified content and advance HEAD with the new blob.
+	v2 := &ArgoOverrideFile{}
+	v2.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
+	require.NoError(t, repo.commitAndPush(context.Background(), fullPath, "v2", v2))
+
+	headV2, err := localRepo.Head()
+	require.NoError(t, err)
+	assert.NotEqual(t, headV1.Hash(), headV2.Hash(), "modifying a tracked file must produce a new commit")
+
+	commit, err := remoteRepo.CommitObject(headV2.Hash())
+	require.NoError(t, err)
+	file, err := commit.File("apps/values.yaml")
+	require.NoError(t, err)
+	contents, err := file.Contents()
+	require.NoError(t, err)
+	assert.Contains(t, contents, "v2.0.0")
+	assert.NotContains(t, contents, "v1.0.0")
+}
+
+func TestCommitAndPush_StagesOnlyTargetFile(t *testing.T) {
+	_, remoteRepo, localRepo, _, localPath := setupGitForTest(t)
+
+	repo := newTestRepo(t, &GitClient{})
+	repo.localRepo = localRepo
+	repo.localRepoPath = localPath
+	appDir := filepath.Join(localPath, "apps")
+	require.NoError(t, os.Mkdir(appDir, 0755))
+	fullPath := filepath.Join(appDir, "values.yaml")
+
+	// An unrelated, untracked file sitting in the worktree must never be swept into
+	// our commit — we stage exactly the override file and nothing else.
+	require.NoError(t, os.WriteFile(filepath.Join(localPath, "stray.txt"), []byte("junk"), 0600))
+
+	params := &ArgoOverrideFile{}
+	params.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
+	require.NoError(t, repo.commitAndPush(context.Background(), fullPath, "msg", params))
+
+	head, err := remoteRepo.Head()
+	require.NoError(t, err)
+	commit, err := remoteRepo.CommitObject(head.Hash())
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+
+	_, err = tree.File("apps/values.yaml")
+	require.NoError(t, err, "override file should be committed")
+	_, err = tree.File("stray.txt")
+	assert.Error(t, err, "unrelated untracked file must not be committed")
+}
+
 func TestCommitAndPush_WriteFileError(t *testing.T) {
 	localPath := t.TempDir()
 	r, err := git.PlainInit(localPath, false)


### PR DESCRIPTION
### **User description**
Concurrent deployments to the same GitOps repo are serialized by the per-repo advisory lock, so each write-back's cost is paid in series. On a large repo that cost was dominated by two full-worktree go-git scans: worktree.Status().IsClean() for change detection, and worktree.Add(), which runs Status() internally. Both are O(entire repo).

Detect whether the override file changed with a single-file byte compare and stage it with AddWithOptions{SkipStatus:true}, which hashes only that file. This is equivalent to the old IsClean() check because Clone() hard- resets the worktree to origin HEAD before every attempt and the override file is the only path ever written, so the worktree is never otherwise dirty.

Add gitops_writeback_duration_seconds and gitops_lock_wait_duration_seconds histograms (label app) to distinguish per-task write-back cost from time spent queued behind other write-backs, and document both metrics plus a write-back latency alert.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Optimize git write-back: replace full-worktree scans with single-file byte compare and `SkipStatus` add, reducing per-deployment latency.

- Add `gitops_writeback_duration_seconds` and `gitops_lock_wait_duration_seconds` histograms to monitor write-back performance and lock contention.

- Test new optimization behavior (skip on unchanged, correct staging of modified/untracked files) and metric observation.

- Update observability documentation and changelog with new metrics, alert rule, and dependency.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Write-back request"] --> B["Acquire per-repo lock\n(lock wait timer)"]
    B --> C{"Override file\nbyte compare"}
    C -- "unchanged" --> D["Skip commit"]
    C -- "changed" --> E["Write file &\nstage with SkipStatus"]
    E --> F["Commit & push"]
    D --> G["Release lock"]
    F --> G
    G --> H["Writeback duration\nobserved"]
    B --> I["Lock wait duration\nobserved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>metrics.go</strong><dd><code>Add git writeback and lock wait histogram metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-f60c78b7383828b0c7362d212d99cfcd640a55e88141c6472c0f0b43be912de0">+37/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_status_updater.go</strong><dd><code>Instrument git writeback with duration metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-ed22c343f4b6ed3704cd98d39d200754d2474f7829d30e102464e213ac23eab3">+30/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updater.go</strong><dd><code>Optimize commit detection with file byte compare and SkipStatus</code></dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-6f575e683c5fe1eb9301f314392e63c56a00e7b09ae9663adf4c3e4d67f81c70">+22/-16</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>metrics_test.go</strong><dd><code>Test new git writeback and lock wait histogram metrics</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-2b4d509a755853ac7397840c6a8628fa80377dcb688a229f51801df88a0e9ba2">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>argo_status_updater_test.go</strong><dd><code>Test metric observation in git update scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-09b297447b7e2fbfea57e00fa6d493a1ffd2757f47fcc08456ad96a8c8a1e5e3">+56/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router_test.go</strong><dd><code>Update mockMetrics to implement new interface methods</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-0e7d3d9b9adc77e35d95609d14f1d1f255b669d8d89589080b2c6da28c6760c5">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updater_test.go</strong><dd><code>Add tests for optimized commit detection behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-4d0d383650a20cd840b7a63253208729bc0cba059db6d4b39d1cc45af249ca2e">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document new metrics and performance improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>observability.md</strong><dd><code>Document new gitops metrics and add alerting rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-f5e8a887e00f003769578d91f8786e8fb1a7529185d5c202ac47e677af582cfc">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Add prometheus/client_model as direct dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/472/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

