### PR TITLE
perf(updater): clone GitOps repos shallowly to cap write-back cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   large GitOps repositories this markedly reduces per-deployment commit latency,
   most noticeably when several deployments to the same repository run concurrently
   and each must wait its turn under the per-repository lock.
+- Clone and fetch GitOps repositories shallowly (depth 1, no tags) instead of pulling
+  full history. On a repository with a deep history (100k+ commits) a full clone could
+  take minutes while holding the per-repository write-back lock, blocking every other
+  deployment to that repository; the shallow clone caps this to seconds. Commit, push,
+  retry/self-heal, and the persistent on-disk cache behave exactly as before.
 
 ### Fixed
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -89,9 +89,10 @@ groups:
           summary: "{{ $labels.app }} git write-back is slow"
           description: |
             The p95 git write-back for this application exceeds 60s, which points to push
-            contention (retries/backoff) or an expensive clone against a large GitOps repo.
-            Check gitops_lock_wait_duration_seconds for the same app to see whether it is
-            queued behind other write-backs to the same repository.
+            contention (retries/backoff) or, on a repo with an unusually large working tree,
+            slow transfer of that tree (history depth is not a factor — clone and fetch are
+            shallow). Check gitops_lock_wait_duration_seconds for the same app to see whether
+            it is queued behind other write-backs to the same repository.
 ```
 
 ## Grafana panel queries

--- a/internal/models/push_race_integration_test.go
+++ b/internal/models/push_race_integration_test.go
@@ -137,6 +137,13 @@ func TestIntegration_PushRaceRecovery_WithLatencyInjection(t *testing.T) {
 		select {
 		case err := <-aDone:
 			require.NoError(t, err, "UpdateGitImageTag should succeed after recovery (attempt %d)", attempt)
+			// Recovery must fast-forward onto the competitor's commit, never clobber
+			// it: after A succeeds, the commit the external writer landed mid-flight
+			// must still be present on the remote. This is the correctness guarantee
+			// for the common case of the branch moving outside argo-watcher's flow.
+			_, competitorContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", "competitor.txt")
+			assert.Contains(t, competitorContent, "race-injection",
+				"recovery must preserve the competitor's commit, not force-push over it (attempt %d)", attempt)
 		case <-time.After(90 * time.Second):
 			t.Fatalf("UpdateGitImageTag did not complete in 90s (attempt %d)", attempt)
 		}

--- a/internal/models/shallow_clone_integration_test.go
+++ b/internal/models/shallow_clone_integration_test.go
@@ -123,6 +123,97 @@ func localTagCount(t *testing.T, localRepoPath string) int {
 	return count
 }
 
+// seedFullClone creates a NON-shallow clone of the remote at exactly the cache
+// path GitRepo.Clone will use, simulating a cache left behind by a pre-upgrade
+// (full-history) version of argo-watcher.
+func seedFullClone(t *testing.T, repoURL, sshKeyPath, branch, cachePath, localRepoPath string) {
+	t.Helper()
+	auth, err := gogitssh.NewPublicKeysFromFile("git", sshKeyPath, "")
+	require.NoError(t, err)
+	auth.HostKeyCallback = cryptossh.InsecureIgnoreHostKey()
+	require.NoError(t, os.MkdirAll(cachePath, 0o755))
+	_, err = gogit.PlainCloneContext(context.Background(), localRepoPath, false, &gogit.CloneOptions{
+		URL:           repoURL,
+		ReferenceName: plumbing.ReferenceName("refs/heads/" + branch),
+		SingleBranch:  true,
+		Auth:          auth,
+	})
+	require.NoError(t, err)
+	require.NoFileExists(t, filepath.Join(localRepoPath, ".git", "shallow"),
+		"precondition: the seeded cache must be a full (non-shallow) clone")
+}
+
+// TestIntegration_ShallowClone_UpgradeFromFullCache is the migration test: an
+// existing FULL-history cache on a persistent volume, left by a pre-upgrade
+// argo-watcher, must keep working after the switch to shallow fetch.
+//
+// Verified behavior (this test locks it in): a Depth:1 fetch does NOT
+// retroactively shallow an existing full repo. The write-back succeeds and the
+// commit lands, the cache is handled IN PLACE (no self-heal re-clone — the .git
+// sentinel survives), and the cache stays full. So a pre-upgrade full cache is
+// grandfathered: correct and no slower on the warm path (the expensive full
+// clone already happened and does not recur), it just keeps its larger on-disk
+// footprint until independently invalidated — at which point the self-heal path
+// re-clones it shallow (see TestIntegration_ShallowClone_SelfHealFreshClone).
+func TestIntegration_ShallowClone_UpgradeFromFullCache(t *testing.T) {
+	waitForGitea(t, 60*time.Second)
+	env := setupGitea(t)
+
+	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	// 2 so attempt 1 exercises the warm path on the pre-seeded full cache; if it
+	// fails, attempt 2 (final) self-heals via InvalidateCache + fresh clone.
+	t.Setenv("GIT_MAX_ATTEMPTS", "2")
+
+	const app = "upgrade-app"
+	cachePath := t.TempDir()
+	overrideRel := fmt.Sprintf("apps/.argocd-source-%s.yaml", app)
+	localRepoPath := computeRepoCachePath(cachePath, env.DirectRepoURL, "master")
+
+	// Give the remote some real history so "full" is meaningful, then seed a
+	// full-history cache at the code's cache path.
+	competitorPush(t, env.DirectRepoURL, env.SSHKeyPath, "hist1")
+	competitorPush(t, env.DirectRepoURL, env.SSHKeyPath, "hist2")
+	seedFullClone(t, env.DirectRepoURL, env.SSHKeyPath, "master", cachePath, localRepoPath)
+
+	// Sentinel in .git: survives the in-place warm path; removed by a self-heal
+	// (InvalidateCache does os.RemoveAll on the whole cache dir).
+	sentinel := filepath.Join(localRepoPath, ".git", "UPGRADE_SENTINEL")
+	require.NoError(t, os.WriteFile(sentinel, []byte("pre-upgrade cache"), 0o600))
+
+	gitopsRepo := &GitopsRepo{
+		RepoUrl:       env.DirectRepoURL,
+		BranchName:    "master",
+		Path:          "apps",
+		RepoCachePath: cachePath,
+	}
+	err := newAppWithImages(app).UpdateGitImageTag(
+		context.Background(),
+		&Task{Id: "task-upgrade", Images: []Image{{Image: "myimage", Tag: "v1"}}},
+		gitopsRepo,
+		testGitHandler{},
+	)
+
+	// Invariant 1: the write-back succeeds against a pre-existing full cache.
+	require.NoError(t, err, "write-back must succeed against a pre-upgrade full-history cache")
+
+	// Invariant 2: the commit lands correctly on the remote.
+	_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	assert.Contains(t, content, "v1", "the upgrade write-back must commit the tag")
+
+	// Invariant 3: the full cache was reused IN PLACE — no self-heal re-clone was
+	// needed (the sentinel in .git survives only if the cache dir was never wiped).
+	assert.FileExists(t, sentinel,
+		"a pre-upgrade full cache must be reused in place, not wiped and re-cloned")
+
+	// Invariant 4 (characterization): a Depth:1 fetch does NOT retroactively
+	// shallow an existing full repo — the grandfathered cache stays full. If a
+	// future go-git version changes this, update the migration note in the
+	// docstring rather than treating it as a regression.
+	assert.NoFileExists(t, filepath.Join(localRepoPath, ".git", "shallow"),
+		"Depth:1 fetch is not expected to shallow an already-full cache")
+}
+
 // TestIntegration_ShallowClone_WarmFetchOfExternallyAdvancedTip covers the case
 // the plain warm-cache test cannot: a Depth:1 warm fetch must retrieve a branch
 // tip that an EXTERNAL writer advanced by more than one commit, and our commit

--- a/internal/models/shallow_clone_integration_test.go
+++ b/internal/models/shallow_clone_integration_test.go
@@ -1,0 +1,326 @@
+//go:build integration
+
+package models
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	gogitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	cryptossh "golang.org/x/crypto/ssh"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cloneRemoteState clones the remote directly (full history, bypassing any
+// cache) into a throwaway dir and returns the current HEAD hash plus the
+// contents of the given repo-relative path. Tests use it to observe what
+// actually landed on the server, independent of the system-under-test's cache.
+func cloneRemoteState(t *testing.T, repoURL, sshKeyPath, branch, relPath string) (headHash string, fileContent string) {
+	t.Helper()
+
+	auth, err := gogitssh.NewPublicKeysFromFile("git", sshKeyPath, "")
+	require.NoError(t, err)
+	auth.HostKeyCallback = cryptossh.InsecureIgnoreHostKey()
+
+	dir := t.TempDir()
+	repo, err := gogit.PlainCloneContext(context.Background(), dir, false, &gogit.CloneOptions{
+		URL:           repoURL,
+		ReferenceName: plumbing.ReferenceName("refs/heads/" + branch),
+		SingleBranch:  true,
+		Auth:          auth,
+	})
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, relPath)) // #nosec G304 -- test-controlled path
+	if err != nil {
+		return head.Hash().String(), ""
+	}
+	return head.Hash().String(), string(content)
+}
+
+// localPresentCommitCount opens the on-disk cache and counts commits actually
+// present locally, walking from HEAD until the walk runs off the shallow
+// boundary (go-git surfaces the missing parent as an "object not found" error
+// rather than stopping cleanly — that error IS the boundary, so we stop and
+// return the count gathered so far). On a shallow cache this stays small; a
+// repo silently deepened to full history would walk its entire commit graph.
+func localPresentCommitCount(t *testing.T, localRepoPath string) int {
+	t.Helper()
+	repo, err := gogit.PlainOpen(localRepoPath)
+	require.NoError(t, err)
+	iter, err := repo.Log(&gogit.LogOptions{})
+	require.NoError(t, err)
+	count := 0
+	walkErr := iter.ForEach(func(_ *object.Commit) error {
+		count++
+		return nil
+	})
+	// The ONLY tolerated terminal error is running off the shallow boundary
+	// (the parent commit is absent locally). Any other error is a real failure
+	// that must not be silently swallowed into a falsely-low count.
+	if walkErr != nil {
+		require.ErrorIs(t, walkErr, plumbing.ErrObjectNotFound,
+			"commit walk failed for a reason other than the shallow boundary")
+	}
+	return count
+}
+
+// remoteCommitCount full-clones the remote (complete history, so the walk never
+// hits a shallow boundary) and counts commits reachable from the branch HEAD.
+// Tests use it to prove that write-backs stack linearly on the remote — a
+// clobbering force-push would leave the count flat or lower instead of growing
+// by one per commit.
+func remoteCommitCount(t *testing.T, repoURL, sshKeyPath, branch string) int {
+	t.Helper()
+	auth, err := gogitssh.NewPublicKeysFromFile("git", sshKeyPath, "")
+	require.NoError(t, err)
+	auth.HostKeyCallback = cryptossh.InsecureIgnoreHostKey()
+
+	dir := t.TempDir()
+	repo, err := gogit.PlainCloneContext(context.Background(), dir, false, &gogit.CloneOptions{
+		URL:           repoURL,
+		ReferenceName: plumbing.ReferenceName("refs/heads/" + branch),
+		SingleBranch:  true,
+		Auth:          auth,
+	})
+	require.NoError(t, err)
+	iter, err := repo.Log(&gogit.LogOptions{})
+	require.NoError(t, err)
+	count := 0
+	require.NoError(t, iter.ForEach(func(_ *object.Commit) error {
+		count++
+		return nil
+	}))
+	return count
+}
+
+// localTagCount opens the on-disk cache and counts local tag references. A
+// shallow clone/fetch with Tags:NoTags must never populate any, regardless of
+// how many tags the remote carries.
+func localTagCount(t *testing.T, localRepoPath string) int {
+	t.Helper()
+	repo, err := gogit.PlainOpen(localRepoPath)
+	require.NoError(t, err)
+	iter, err := repo.Tags()
+	require.NoError(t, err)
+	count := 0
+	require.NoError(t, iter.ForEach(func(_ *plumbing.Reference) error {
+		count++
+		return nil
+	}))
+	return count
+}
+
+// TestIntegration_ShallowClone_WarmFetchOfExternallyAdvancedTip covers the case
+// the plain warm-cache test cannot: a Depth:1 warm fetch must retrieve a branch
+// tip that an EXTERNAL writer advanced by more than one commit, and our commit
+// must stack on that advanced tip as a fast-forward — never clobber the
+// intervening commits. This is the correctness property that most matters for a
+// shallow cache: it must not silently rewrite history it cannot see.
+func TestIntegration_ShallowClone_WarmFetchOfExternallyAdvancedTip(t *testing.T) {
+	waitForGitea(t, 60*time.Second)
+	env := setupGitea(t)
+
+	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	t.Setenv("GIT_MAX_ATTEMPTS", "2") // keep the warm cache; no self-heal reclone
+
+	const app = "advanced-tip-app"
+	cachePath := t.TempDir()
+	overrideRel := fmt.Sprintf("apps/.argocd-source-%s.yaml", app)
+	gitopsRepo := &GitopsRepo{
+		RepoUrl:       env.DirectRepoURL,
+		BranchName:    "master",
+		Path:          "apps",
+		RepoCachePath: cachePath,
+	}
+	writeBack := func(tag string) error {
+		return newAppWithImages(app).UpdateGitImageTag(
+			context.Background(),
+			&Task{Id: "task-" + tag, Images: []Image{{Image: "myimage", Tag: tag}}},
+			gitopsRepo,
+			testGitHandler{},
+		)
+	}
+	localRepoPath := computeRepoCachePath(cachePath, env.DirectRepoURL, "master")
+
+	// (1) Cold shallow clone + commit v1, seeding the warm cache.
+	require.NoError(t, writeBack("v1"), "cold write-back should succeed")
+
+	// (2) An external writer advances master by TWO commits while our cache sits
+	// at the old tip. Our next warm fetch must jump the full distance.
+	competitorPush(t, env.DirectRepoURL, env.SSHKeyPath, "c1")
+	competitorPush(t, env.DirectRepoURL, env.SSHKeyPath, "c2")
+
+	// (3) Warm write-back v2: Depth:1 fetch of the moved tip + hard reset + commit + push.
+	require.NoError(t, writeBack("v2"),
+		"warm write-back must succeed against an externally-advanced tip")
+
+	// The pushed HEAD's tree must contain BOTH our v2 override AND the
+	// competitor's file — proving we committed on top of their tip rather than
+	// force-pushing over it.
+	_, overrideContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	_, competitorContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", "competitor.txt")
+	assert.Contains(t, overrideContent, "v2", "our v2 tag must be committed")
+	assert.Contains(t, competitorContent, "c2",
+		"competitor commits must survive — our write-back must fast-forward, not clobber")
+
+	require.FileExists(t, filepath.Join(localRepoPath, ".git", "shallow"),
+		"cache must stay shallow after fetching a multi-commit advance")
+}
+
+// TestIntegration_ShallowClone_SelfHealFreshClone exercises the final-attempt
+// self-heal path: with GIT_MAX_ATTEMPTS=1 every write-back invalidates the cache
+// and performs a fresh shallow clone before committing. Successive write-backs
+// must still produce correctly-parented commits that stack on the remote, i.e.
+// the fresh shallow re-clone must not lose or rewrite prior history.
+func TestIntegration_ShallowClone_SelfHealFreshClone(t *testing.T) {
+	waitForGitea(t, 60*time.Second)
+	env := setupGitea(t)
+
+	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	// 1 => invalidateCacheOnFinalAttempt fires on the (only) attempt, so every
+	// write-back wipes the cache and re-clones shallow from scratch.
+	t.Setenv("GIT_MAX_ATTEMPTS", "1")
+
+	const app = "selfheal-app"
+	cachePath := t.TempDir()
+	overrideRel := fmt.Sprintf("apps/.argocd-source-%s.yaml", app)
+	gitopsRepo := &GitopsRepo{
+		RepoUrl:       env.DirectRepoURL,
+		BranchName:    "master",
+		Path:          "apps",
+		RepoCachePath: cachePath,
+	}
+	writeBack := func(tag string) error {
+		return newAppWithImages(app).UpdateGitImageTag(
+			context.Background(),
+			&Task{Id: "task-" + tag, Images: []Image{{Image: "myimage", Tag: tag}}},
+			gitopsRepo,
+			testGitHandler{},
+		)
+	}
+	localRepoPath := computeRepoCachePath(cachePath, env.DirectRepoURL, "master")
+
+	base := remoteCommitCount(t, env.DirectRepoURL, env.SSHKeyPath, "master")
+
+	require.NoError(t, writeBack("v1"), "first self-heal write-back should succeed")
+	require.NoError(t, writeBack("v2"), "second self-heal write-back should succeed")
+
+	// Two commits landed, stacked linearly on top of the base — the fresh
+	// re-clone between them neither lost v1 nor rewrote history.
+	assert.Equal(t, base+2, remoteCommitCount(t, env.DirectRepoURL, env.SSHKeyPath, "master"),
+		"each self-heal write-back must add exactly one commit, preserving prior history")
+
+	_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	assert.Contains(t, content, "v2", "latest self-heal commit must carry v2")
+
+	require.FileExists(t, filepath.Join(localRepoPath, ".git", "shallow"),
+		"the self-heal re-clone must itself be shallow")
+}
+
+// TestIntegration_ShallowClone_WarmCacheWriteBacks is the gating test for
+// switching GitRepo.Clone to a shallow (Depth:1) clone. It exercises the exact
+// production sequence that a shallow cache must survive on a persistent volume:
+// a cold clone followed by repeated warm write-backs (fetch + hard reset +
+// commit + push) against the SAME cache directory.
+//
+// It asserts two independent things:
+//   - correctness: every write-back's commit lands on the remote, and an
+//     unchanged write-back is skipped — the warm path must work on a shallow repo;
+//   - shallowness: the cache is shallow after the cold clone AND stays shallow
+//     across warm fetches (go-git must not silently deepen to full history,
+//     which would defeat the whole point on a 100k-commit repo).
+//
+// Before Depth:1 is implemented this fails on the shallowness assertion (a full
+// clone has no shallow boundary); after, all assertions must hold, or shallow
+// clone does not fit our flow and must not ship.
+func TestIntegration_ShallowClone_WarmCacheWriteBacks(t *testing.T) {
+	waitForGitea(t, 60*time.Second)
+	env := setupGitea(t)
+
+	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	// >=2 so a successful first attempt never hits invalidateCacheOnFinalAttempt;
+	// otherwise every call would wipe the cache and re-clone, defeating the
+	// warm-cache reuse this test exists to exercise.
+	t.Setenv("GIT_MAX_ATTEMPTS", "2")
+
+	// Seed a tag on the remote so the Tags:NoTags half of the change has teeth:
+	// a regression re-enabling tag fetching would pull this tag into the cache.
+	giteaAPIPost(t, env.User, env.Password,
+		fmt.Sprintf("/api/v1/repos/%s/%s/tags", env.User, env.RepoName),
+		map[string]any{"tag_name": "seed-tag", "target": "master"})
+
+	const app = "shallow-app"
+	// One shared cache across every write-back — the persistent-volume model.
+	cachePath := t.TempDir()
+	overrideRel := fmt.Sprintf("apps/.argocd-source-%s.yaml", app)
+
+	// Direct SSH URL (no toxiproxy): this test injects no latency, so it needs
+	// only Gitea. Keeping the SUT on the direct URL avoids a toxiproxy dependency.
+	gitopsRepo := &GitopsRepo{
+		RepoUrl:       env.DirectRepoURL,
+		BranchName:    "master",
+		Path:          "apps",
+		RepoCachePath: cachePath,
+	}
+
+	writeBack := func(tag string) error {
+		return newAppWithImages(app).UpdateGitImageTag(
+			context.Background(),
+			&Task{Id: "task-" + tag, Images: []Image{{Image: "myimage", Tag: tag}}},
+			gitopsRepo,
+			testGitHandler{},
+		)
+	}
+
+	// The deterministic on-disk cache path the code will actually use.
+	localRepoPath := computeRepoCachePath(cachePath, env.DirectRepoURL, "master")
+
+	// (1) Cold clone + commit v1.
+	require.NoError(t, writeBack("v1"), "cold write-back should succeed")
+
+	shallowMarker := filepath.Join(localRepoPath, ".git", "shallow")
+	require.FileExists(t, shallowMarker,
+		"cache must be a shallow clone (.git/shallow present) after the cold clone")
+	assert.Zero(t, localTagCount(t, localRepoPath),
+		"cold clone must not fetch tags (Tags:NoTags), even though the remote has one")
+
+	head1, content1 := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	assert.Contains(t, content1, "v1", "v1 tag must be committed to the remote")
+
+	// (2) Warm write-back on the shallow cache: fetch + hard reset + commit v2 + push.
+	// This is the path go-git shallow support must not break.
+	require.NoError(t, writeBack("v2"), "warm write-back on a shallow cache must succeed")
+
+	head2, content2 := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	assert.NotEqual(t, head1, head2, "warm write-back must advance the remote branch")
+	assert.Contains(t, content2, "v2", "v2 tag must be committed to the remote")
+
+	require.FileExists(t, shallowMarker,
+		"cache must STAY shallow after a warm fetch (go-git must not deepen to full history)")
+	assert.LessOrEqual(t, localPresentCommitCount(t, localRepoPath), 3,
+		"warm fetch must not pull full remote history into the shallow cache")
+	assert.Zero(t, localTagCount(t, localRepoPath),
+		"warm fetch must not fetch tags (Tags:NoTags)")
+
+	// (3) Identical content is a no-op: byte-compare skip must still work on the
+	// shallow warm cache.
+	require.NoError(t, writeBack("v2"), "no-op write-back should succeed")
+	head3, _ := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
+	assert.Equal(t, head2, head3, "unchanged content must not create a new commit")
+}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -89,6 +89,12 @@ func (repo *GitRepo) getRepoCachePath() string {
 //     the function assumes the cache is invalid. It safely removes the directory and then
 //     performs a fresh, single-branch clone from the remote.
 //
+// Both the fresh clone and the warm-cache fetch are shallow (Depth:1, no tags):
+// argo-watcher only reads the branch tip and commits one file on top of it, so
+// the repository's history is never needed. This keeps the clone/fetch cost off
+// the deep-history path, which matters because the whole operation runs under
+// the distributed per-repo advisory lock.
+//
 // The provided ctx bounds all network I/O; callers typically derive ctx from a
 // total-budget context for the whole update flow so that one stuck operation
 // cannot hold the per-repo lock past that budget.
@@ -123,10 +129,20 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 			}
 		}
 
+		// Depth:1 makes this a shallow clone: only the branch tip commit is
+		// fetched, not the repository's full history. argo-watcher only ever reads
+		// the tip and commits one file on top of it, so history is dead weight. On a
+		// deep-history GitOps repo (100k+ commits) a full clone is minutes of work,
+		// and it runs while holding the distributed per-repo advisory lock — so it
+		// blocks every other replica's write-back to that repo. A shallow clone caps
+		// that to seconds. Tags:NoTags likewise skips fetching tag refs, which a
+		// large repo may have thousands of and which are never used here.
 		repo.localRepo, err = repo.GitHandler.PlainClone(ctx, repo.localRepoPath, false, &git.CloneOptions{
 			URL:           repo.RepoURL,
 			ReferenceName: plumbing.ReferenceName("refs/heads/" + repo.BranchName),
 			SingleBranch:  true,
+			Depth:         1,
+			Tags:          git.NoTags,
 			Auth:          repo.sshAuth,
 		})
 		return err
@@ -134,10 +150,16 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 
 	// If we get here, the cache is valid and has an 'origin' remote.
 	slog.Debug(fmt.Sprintf("Successfully opened cached repository at %s", repo.localRepoPath))
+	// Depth:1 keeps the cache shallow across warm fetches too: only the new tip
+	// is fetched, never the intervening history. Without it go-git would deepen
+	// the shallow clone toward full history on the first fetch, undoing the cold
+	// clone's win on a deep-history repo. Tags:NoTags mirrors the clone.
 	err = repo.localRepo.FetchContext(ctx, &git.FetchOptions{
 		RemoteName: "origin",
 		Auth:       repo.sshAuth,
 		Force:      true,
+		Depth:      1,
+		Tags:       git.NoTags,
 	})
 	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("failed to fetch repo: %w", err)

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -228,7 +229,19 @@ func TestClone(t *testing.T) {
 
 	t.Run("Cache Not Exists", func(t *testing.T) {
 		mockHandler.EXPECT().PlainOpen(gomock.Any()).Return(nil, git.ErrRepositoryNotExists)
-		mockHandler.EXPECT().PlainClone(gomock.Any(), gomock.Any(), false, gomock.Any()).Return(nil, nil)
+		// Capture the CloneOptions to assert the fresh clone is shallow. This is the
+		// only cheap (non-integration) guard against a regression that drops Depth:1
+		// or Tags:NoTags — `task test` excludes the integration suite, so without this
+		// such a revert would ship green. The corrupt-cache reclone path shares this
+		// call, so asserting once covers both.
+		mockHandler.EXPECT().PlainClone(gomock.Any(), gomock.Any(), false, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ bool, o *git.CloneOptions) (*git.Repository, error) {
+				assert.Equal(t, 1, o.Depth, "fresh clone must be shallow (Depth:1)")
+				assert.Equal(t, git.NoTags, o.Tags, "fresh clone must not fetch tags")
+				assert.True(t, o.SingleBranch, "fresh clone must be single-branch")
+				assert.Equal(t, plumbing.ReferenceName("refs/heads/"+repo.BranchName), o.ReferenceName)
+				return nil, nil
+			})
 		err := repo.Clone(context.Background())
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
### **User description**
The write-back clone/fetch runs under the distributed per-repo advisory lock, so on a deep-history repo (100k+ commits) a full clone held the lock for minutes and blocked every other replica's write-back to that repo. The fresh clone and the warm-cache fetch now use Depth:1 with no tags, capping that to seconds. Commit, push, retry/self-heal and the persistent cache behave exactly as before.

Add integration coverage for the shallow warm path against real Gitea (fetch of an externally-advanced tip, self-heal re-clone, no-op skip, no tag fetch, push no-clobber) plus a unit assertion that Clone requests the shallow options, so a revert is caught without the integration suite.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Make fresh clone and warm fetch use Depth=1 and Tags=NoTags to cap write-back lock duration from minutes to seconds on deep-history repos.

- Add integration tests verifying shallow clone works with externally advanced tip, self-heal re-clone, no tag fetch, and no-op skip.

- Update unit test to assert shallow clone options are passed.

- Enhance existing push race recovery test to check competitor commit preservation.

- Document the change in changelog and observability alert.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitRepo.Clone()"] --> B{"Cache exists?"}
  B -- "Yes" --> C["Warm fetch (Depth:1, NoTags)"]
  B -- "No" --> D["Fresh clone (Depth:1, NoTags)"]
  C --> E["Fast-forward to tip"]
  D --> E
  E --> F["Commit & push"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push_race_integration_test.go</strong><dd><code>Verify competitor commit preservation in race recovery test</code></dd></summary>
<hr>

internal/models/push_race_integration_test.go

<ul><li>Added assertion that after push race recovery, the competitor's commit <br>is still present on the remote.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-fe211eb8813935b2b9c858e8181673ee703681ce37797ec8322b5c3094119b89">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shallow_clone_integration_test.go</strong><dd><code>Integration tests for shallow clone scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/models/shallow_clone_integration_test.go

<ul><li>New integration tests for shallow clone behavior: warm fetch of <br>externally advanced tip, self-heal fresh re-clone, no tag fetching, <br>and no-op skip.<br> <li> Helper functions to inspect remote state, local commit count, and tag <br>count.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-7ff200a359452912c8b78c2333b252c5e5e105a74924f23f2cfa5fab6cf6590b">+326/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>updater_test.go</strong><dd><code>Unit test asserting shallow clone options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/updater/updater_test.go

<ul><li>Updated unit test to capture CloneOptions and assert Depth:1, NoTags, <br>and SingleBranch flags are set.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-4d0d383650a20cd840b7a63253208729bc0cba059db6d4b39d1cc45af249ca2e">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>updater.go</strong><dd><code>Shallow clone and fetch for GitOps repos</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/updater/updater.go

<ul><li>Added Depth:1 and Tags:NoTags to both fresh clone and warm fetch <br>operations.<br> <li> Comments explain rationale: reduces per-repo lock time on deep-history <br>repos.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-6f575e683c5fe1eb9301f314392e63c56a00e7b09ae9663adf4c3e4d67f81c70">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for shallow clone improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry describing the shallow clone optimization and its impact <br>on write-back lock time.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>observability.md</strong><dd><code>Observability doc update for shallow clone</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/operations/observability.md

<ul><li>Updated slow write-back alert description to note that history depth <br>is no longer a bottleneck due to shallow cloning.</ul>


</details>


  </td>
  <td><a href="https://github.com/shini4i/argo-watcher/pull/473/files#diff-f5e8a887e00f003769578d91f8786e8fb1a7529185d5c202ac47e677af582cfc">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

