### PR TITLE
fix(web): disable react-admin built-in login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Never show React-admin's built-in username/password login form. The Web UI
+  authenticates only through a top-level Keycloak redirect, but the stock login
+  form could still surface as a misleading fallback when Keycloak was
+  misconfigured; it is now disabled outright.
 - Keep the History page filters visible when there are no matching deployments.
   Previously, with no deployments in the default time window the empty-state
   message replaced the whole view, hiding the date-range and application

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -106,6 +106,7 @@ describe('App', () => {
     expect(adminProps.authProvider).toBe(authProviderStub);
     expect(adminProps.notification).toBe(AppNotificationStub);
     expect(adminProps.disableTelemetry).toBe(true);
+    expect(adminProps.loginPage).toBe(false);
     expect(adminProps.theme).toEqual({ paletteMode: 'dark' });
 
     expect(resourceCalls).toHaveLength(1);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,11 @@ import { useThemeMode } from './theme';
 
 /**
  * Root React-admin application wiring data/auth providers, resources, and custom routes.
+ *
+ * `loginPage={false}` disables React-admin's built-in username/password login form.
+ * This app authenticates exclusively via a top-level Keycloak redirect (see
+ * authProvider), so the stock form is never a valid entry point; leaving it enabled
+ * only surfaced it as a misleading fallback when Keycloak was misconfigured.
  */
 export const App = () => {
   const { theme } = useThemeMode();
@@ -21,6 +26,7 @@ export const App = () => {
       dataProvider={dataProvider}
       authProvider={authProvider}
       notification={AppNotification}
+      loginPage={false}
       disableTelemetry
       theme={theme}
     >


### PR DESCRIPTION
The Web UI authenticates only via a top-level Keycloak redirect, but react-admin's default MUI username/password form could still surface at /login as a misleading fallback when Keycloak was misconfigured. Pass loginPage={false} so the /login route is never registered.