### PR TITLE
fix: harden deploy-lock and correct deployment status reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously, with no deployments in the default time window the empty-state
   message replaced the whole view, hiding the date-range and application
   filters so users had no way to widen the range.
+- Report the correct final status in failure notifications. When a deployment
+  failed (Argo CD unreachable, application not found), the stored task status
+  was correct but the outgoing result notification still carried "in progress",
+  so webhook consumers never saw the failure and Mattermost posted it as a new
+  "started" message instead of a threaded result.
+- Fail a deployment when a watcher-managed image is missing its image-tag
+  annotation, instead of silently skipping the git write-back and reporting
+  success. Previously an application whose `argo-watcher/managed-images` listed
+  an image without a matching `*.helm.image-tag` annotation logged an error,
+  wrote nothing to git, and still marked the deployment successful.
+
+### Security
+
+- Only expose the manual deploy-lock endpoints (`POST`/`DELETE
+  /api/v1/deploy-lock`) when Keycloak is enabled. Without an authentication
+  backend these state-changing endpoints were reachable unauthenticated,
+  letting anyone able to reach the server freeze or release all deployments;
+  they are now registered only when Keycloak is enabled, and the Web UI hides
+  the manual lock toggle to match. The read-only lock status and scheduled
+  lockdown are unaffected.
 
 ## [0.11.0] - 2026-07-13
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -217,6 +217,9 @@ The Web UI lockdown banner updates automatically (within about a minute) when a 
 
 ### Manual Lockdown
 
+!!! note
+    Manual locking requires Keycloak (`KEYCLOAK_ENABLED=true`). Without an auth backend the server does not register the `POST`/`DELETE /api/v1/deploy-lock` endpoints (requests return `404 Not Found`) and the Web UI does not show the lock toggle. The read-only lock status and scheduled lockdown (above) work regardless of Keycloak.
+
 #### Via API
 
 Set a lock:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,7 +19,7 @@ Authentication is only required to authorize the built-in [GitOps Updater](../gu
 
 A task submitted **without** a credential is still accepted (`202 Accepted`) and its rollout is monitored normally — argo-watcher simply does not perform the git write-back. This is the expected setup when the image tag is updated by other means (e.g. Argo CD Image Updater or your CI pipeline) and argo-watcher only tracks the resulting rollout. If you instead rely on the built-in updater to commit the tag and omit the credential, the write-back is skipped and the deployment times out waiting for an image change that never arrives. A token that is **present but invalid or expired** returns `401 Unauthorized`.
 
-If [Keycloak](../guides/keycloak.md) is enabled, additional endpoints (such as deploy lock) require a valid Keycloak session.
+The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [Keycloak](../guides/keycloak.md) is enabled, and require a valid Keycloak session; when Keycloak is disabled these endpoints are not exposed (`404 Not Found`). The read-only `GET /api/v1/deploy-lock` is always available regardless of Keycloak.
 
 ## Conventions
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -304,15 +304,19 @@ func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 }
 
 // HandleArgoAPIFailure processes API errors and updates task status accordingly.
-func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task models.Task, err error) {
+// task is taken by pointer so the resolved terminal status is reflected back to
+// the caller, keeping the outgoing failure notification in sync with the stored
+// status (mirroring handleDeploymentSuccess/handleDeploymentFailure).
+func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error) {
 	monitor.argo.metrics.AddFailedDeployment(task.App)
-	finalStatus := determineFailureStatus(task, err)
+	finalStatus := determineFailureStatus(*task, err)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
 	slog.Warn(fmt.Sprintf("Deployment failed with status \"%s\". Aborting with error: %s", finalStatus, reason), "id", task.Id)
 
 	if err := monitor.argo.State.SetTaskStatus(task.Id, finalStatus, reason); err != nil {
 		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
 	}
+	task.Status = finalStatus
 }
 
 func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
@@ -501,7 +505,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 		task.Status = models.StatusCancelledMessage
 	case err != nil:
 		// handle application failure
-		updater.monitor.HandleArgoAPIFailure(task, err)
+		updater.monitor.HandleArgoAPIFailure(&task, err)
 	default:
 		// process deployment result
 		updater.monitor.ProcessDeploymentResult(&task, application)

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -621,7 +621,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
 		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
 		Return(errors.New("persist failed"))
 
-	monitor.HandleArgoAPIFailure(task, fmt.Errorf("boom"))
+	monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"))
 }
 
 func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
@@ -1440,7 +1440,11 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any())
 
-		updater.monitor.HandleArgoAPIFailure(task, err)
+		updater.monitor.HandleArgoAPIFailure(&task, err)
+
+		// The resolved terminal status must be reflected back onto the task so the
+		// result notification does not report a stale "in progress" for a failure.
+		assert.Equal(t, models.StatusFailedMessage, task.Status)
 	})
 }
 

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -335,15 +335,20 @@ func (app *Application) generateOverrideFileContent(annotations map[string]strin
 	for _, image := range task.Images {
 		for appAlias, appImage := range managedImages {
 			if image.Image == appImage {
-				if tagPath, exists := annotations[fmt.Sprintf(managedImageTagPattern, appAlias)]; exists {
-					overrideFileContent.Helm.Parameters = append(overrideFileContent.Helm.Parameters, updater.ArgoParameterOverride{
-						Name:        tagPath,
-						Value:       image.Tag,
-						ForceString: true,
-					})
-				} else {
-					slog.Error(fmt.Sprintf("%s annotation not found, skipping image %s update", fmt.Sprintf(managedImageTagPattern, appAlias), image.Image))
+				tagAnnotation := fmt.Sprintf(managedImageTagPattern, appAlias)
+				tagPath, exists := annotations[tagAnnotation]
+				if !exists {
+					// The image is declared managed but has no tag-path annotation, so
+					// we cannot know which Helm value to override. Silently skipping here
+					// would let the write-back report success while never updating git;
+					// fail loudly so the misconfiguration surfaces on the task instead.
+					return nil, fmt.Errorf("managed image %q (alias %q) is missing its %s annotation", appImage, appAlias, tagAnnotation)
 				}
+				overrideFileContent.Helm.Parameters = append(overrideFileContent.Helm.Parameters, updater.ArgoParameterOverride{
+					Name:        tagPath,
+					Value:       image.Tag,
+					ForceString: true,
+				})
 			}
 		}
 	}

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -700,6 +700,76 @@ func computeRepoCachePath(base, repoURL, branch string) string {
 	return filepath.Join(base, strconv.FormatUint(hasher.Sum64(), 16))
 }
 
+func TestGenerateOverrideFileContent(t *testing.T) {
+	t.Run("Builds override when managed image has its tag annotation", func(t *testing.T) {
+		app := newAppWithImages("app")
+		task := newImageTask()
+
+		override, err := app.generateOverrideFileContent(app.Metadata.Annotations, task)
+
+		require.NoError(t, err)
+		require.NotNil(t, override)
+		require.Len(t, override.Helm.Parameters, 1)
+		assert.Equal(t, "image.tag", override.Helm.Parameters[0].Name)
+		assert.Equal(t, "v1.0.0", override.Helm.Parameters[0].Value)
+	})
+
+	t.Run("Errors when a managed image is missing its tag annotation", func(t *testing.T) {
+		app := &Application{
+			Metadata: ApplicationMetadata{
+				Name: "app",
+				Annotations: map[string]string{
+					// managed-images references "myimage" but the matching
+					// app.helm.image-tag annotation is absent — a misconfiguration
+					// that must fail loudly instead of silently no-op'ing the write-back.
+					"argo-watcher/managed-images": "app=myimage",
+				},
+			},
+		}
+		task := newImageTask()
+
+		override, err := app.generateOverrideFileContent(app.Metadata.Annotations, task)
+
+		require.Error(t, err)
+		assert.Nil(t, override)
+		assert.Contains(t, err.Error(), "image-tag")
+	})
+
+	t.Run("Errors when only some managed images have their tag annotation", func(t *testing.T) {
+		// Two managed images, but only "img1" has its tag annotation. The whole
+		// write-back must abort (fail loud) rather than emitting a partial override
+		// for the correctly-configured image and silently dropping the other.
+		app := &Application{
+			Metadata: ApplicationMetadata{
+				Name: "app",
+				Annotations: map[string]string{
+					"argo-watcher/managed-images":   "a=img1,b=img2",
+					"argo-watcher/a.helm.image-tag": "img1.tag",
+					// argo-watcher/b.helm.image-tag deliberately absent
+				},
+			},
+		}
+		task := &Task{Id: "test-id", Images: []Image{{Image: "img1", Tag: "v1"}, {Image: "img2", Tag: "v2"}}}
+
+		override, err := app.generateOverrideFileContent(app.Metadata.Annotations, task)
+
+		require.Error(t, err)
+		assert.Nil(t, override)
+		assert.Contains(t, err.Error(), "img2")
+	})
+
+	t.Run("Skips images that do not match any managed image", func(t *testing.T) {
+		app := newAppWithImages("app")
+		task := &Task{Id: "test-id", Images: []Image{{Image: "unmanaged", Tag: "v1"}}}
+
+		override, err := app.generateOverrideFileContent(app.Metadata.Annotations, task)
+
+		require.NoError(t, err)
+		require.NotNil(t, override)
+		assert.Empty(t, override.Helm.Parameters)
+	})
+}
+
 func TestUpdateGitImageTag(t *testing.T) {
 	t.Run("Returns nil when path is empty", func(t *testing.T) {
 		app := &Application{}
@@ -722,6 +792,27 @@ func TestUpdateGitImageTag(t *testing.T) {
 
 		err := app.UpdateGitImageTag(context.Background(), task, gitopsRepo, nil)
 		assert.NoError(t, err)
+	})
+
+	t.Run("Returns error when a managed image lacks its tag annotation", func(t *testing.T) {
+		// End-to-end guarantee: the misconfiguration must abort the write-back
+		// (surface as a task failure), not silently report success. The error is
+		// raised before any git access, so no repo/handler is needed.
+		app := &Application{
+			Metadata: ApplicationMetadata{
+				Name: "test-app",
+				Annotations: map[string]string{
+					"argo-watcher/managed-images": "app=myimage",
+					// argo-watcher/app.helm.image-tag deliberately absent
+				},
+			},
+		}
+		task := &Task{Id: "test-id", Images: []Image{{Image: "myimage", Tag: "v1.0.0"}}}
+		gitopsRepo := &GitopsRepo{Path: "/some/path"}
+
+		err := app.UpdateGitImageTag(context.Background(), task, gitopsRepo, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "image-tag")
 	})
 
 	t.Run("Returns error when NewGitRepo fails (no SSH_KEY_PATH)", func(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -272,8 +272,15 @@ func (env *Env) CreateRouter() *gin.Engine {
 		v1.GET("/tasks/:id", env.getTaskStatus)
 		v1.GET("/version", env.getVersion)
 		v1.GET("/config", env.getConfig)
-		v1.POST(deployLockEndpoint, env.SetDeployLock)
-		v1.DELETE(deployLockEndpoint, env.ReleaseDeployLock)
+		// The state-changing deploy-lock endpoints are only registered when Keycloak
+		// is enabled: without an auth backend they cannot be protected, so exposing
+		// them would leave an unauthenticated deploy-freeze switch reachable by anyone
+		// who can reach the server (including via a victim's browser). The read-only
+		// GET stays available so the banner and scheduled lockdown keep working.
+		if env.config.Keycloak.Enabled {
+			v1.POST(deployLockEndpoint, env.SetDeployLock)
+			v1.DELETE(deployLockEndpoint, env.ReleaseDeployLock)
+		}
 		v1.GET(deployLockEndpoint, env.isDeployLockSet)
 	}
 
@@ -674,7 +681,7 @@ func (env *Env) requireKeycloakAuth(c *gin.Context) bool {
 
 // SetDeployLock godoc
 // @Summary Set deploy lock
-// @Description Set deploy lock
+// @Description Set deploy lock. Only available when Keycloak is enabled; requires a valid Keycloak session.
 // @Tags frontend
 // @Success 200 {string} string
 // @Failure 401 {object} models.TaskStatus
@@ -695,7 +702,7 @@ func (env *Env) SetDeployLock(c *gin.Context) {
 
 // ReleaseDeployLock godoc
 // @Summary Release deploy lock
-// @Description Release deploy lock
+// @Description Release deploy lock. Only available when Keycloak is enabled; requires a valid Keycloak session.
 // @Tags frontend
 // @Success 200 {string} string
 // @Failure 401 {object} models.TaskStatus

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -177,6 +177,55 @@ func TestDeployLock(t *testing.T) {
 	})
 }
 
+// TestDeployLockEndpointRegistration verifies that the state-changing deploy-lock
+// endpoints only exist when Keycloak is enabled. Without an auth backend they cannot
+// be protected, so they must not be exposed; the read-only GET stays available so the
+// banner and scheduled lockdown keep working.
+func TestDeployLockEndpointRegistration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hasRoute := func(routes gin.RoutesInfo, method, path string) bool {
+		for _, r := range routes {
+			if r.Method == method && r.Path == path {
+				return true
+			}
+		}
+		return false
+	}
+
+	newRouter := func(t *testing.T, keycloakEnabled bool) *gin.Engine {
+		t.Helper()
+		serverConfig := &config.ServerConfig{
+			StaticFilePath: t.TempDir(),
+			Keycloak:       config.KeycloakConfig{Enabled: keycloakEnabled},
+		}
+		env := &Env{config: serverConfig}
+		var err error
+		env.lockdown, err = NewLockdown("")
+		require.NoError(t, err)
+		return env.CreateRouter()
+	}
+
+	const lockPath = "/api/v1/deploy-lock"
+
+	t.Run("registers lock write endpoints when Keycloak is enabled", func(t *testing.T) {
+		routes := newRouter(t, true).Routes()
+		assert.True(t, hasRoute(routes, http.MethodPost, lockPath))
+		assert.True(t, hasRoute(routes, http.MethodDelete, lockPath))
+		assert.True(t, hasRoute(routes, http.MethodGet, lockPath))
+	})
+
+	t.Run("omits lock write endpoints when Keycloak is disabled", func(t *testing.T) {
+		routes := newRouter(t, false).Routes()
+		assert.False(t, hasRoute(routes, http.MethodPost, lockPath),
+			"POST deploy-lock must not be registered without an auth backend")
+		assert.False(t, hasRoute(routes, http.MethodDelete, lockPath),
+			"DELETE deploy-lock must not be registered without an auth backend")
+		assert.True(t, hasRoute(routes, http.MethodGet, lockPath),
+			"read-only GET deploy-lock must stay available")
+	})
+}
+
 func TestRemoveWebSocketConnection(t *testing.T) {
 	conn := &websocket.Conn{}
 	connectionsMutex.Lock()

--- a/web/src/layout/components/ConfigDrawer.test.tsx
+++ b/web/src/layout/components/ConfigDrawer.test.tsx
@@ -105,6 +105,24 @@ describe('ConfigDrawer', () => {
     expect(toggles[0]).toBeDisabled();
   });
 
+  it('hides the deploy lock toggle when Keycloak is disabled', async () => {
+    keycloakEnabledMock.mockReturnValue(false);
+    renderDrawer();
+
+    expect(screen.queryByRole('switch', { name: /toggle deploy lock/i })).toBeNull();
+    expect(screen.getByText(/manual deploy lock requires keycloak/i)).toBeInTheDocument();
+  });
+
+  it('hides the deploy lock toggle while Keycloak status is unknown', async () => {
+    // Default-deny during the config-loading / request-failed window: the toggle
+    // must not be rendered until Keycloak status is known.
+    keycloakEnabledMock.mockReturnValue(null);
+    renderDrawer();
+
+    expect(screen.queryByRole('switch', { name: /toggle deploy lock/i })).toBeNull();
+    expect(screen.getByText(/checking permissions/i)).toBeInTheDocument();
+  });
+
   it('calls deploy lock service when toggled', async () => {
     renderDrawer();
     await screen.findByRole('switch', { name: /toggle deploy lock/i });

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -44,15 +44,18 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
   const privilegedGroups: readonly string[] =
     (permissions as { privilegedGroups?: string[] })?.privilegedGroups ?? [];
   const privileged = hasPrivilegedAccess(groups, privilegedGroups);
-  // Default-deny while keycloakEnabled is unknown (null = config still loading
-  // or the /api/v1/config request failed) so a non-privileged user cannot
-  // toggle the lock during the brief startup window or on a transient error.
-  const canToggleLock =
-    keycloakEnabled === false || (keycloakEnabled === true && privileged);
+  // The manual toggle is only shown when Keycloak is enabled: without an auth
+  // backend the server does not expose the deploy-lock write endpoints, so there
+  // is nothing to toggle (mirrors the rollback button). Default-deny while
+  // keycloakEnabled is unknown (null = config still loading or the request failed).
+  const showLockToggle = keycloakEnabled === true;
+  const canToggleLock = keycloakEnabled === true && privileged;
   let lockHelperText: string | null = null;
   if (keycloakEnabled === null) {
     lockHelperText = 'Checking permissions…';
-  } else if (keycloakEnabled === true && !privileged) {
+  } else if (keycloakEnabled === false) {
+    lockHelperText = 'Manual deploy lock requires Keycloak.';
+  } else if (!privileged) {
     lockHelperText = 'Deploy lock requires privileged access.';
   }
 
@@ -171,12 +174,14 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
                   {deployLock ? 'Lock engaged' : 'Lock released'}
                 </Typography>
               </Stack>
-              <Switch
-                checked={deployLock}
-                onChange={handleDeployLockToggle}
-                disabled={!canToggleLock || lockUpdating}
-                slotProps={{ input: { 'aria-label': 'Toggle deploy lock' } }}
-              />
+              {showLockToggle && (
+                <Switch
+                  checked={deployLock}
+                  onChange={handleDeployLockToggle}
+                  disabled={!canToggleLock || lockUpdating}
+                  slotProps={{ input: { 'aria-label': 'Toggle deploy lock' } }}
+                />
+              )}
             </Stack>
             {lockHelperText && (
               <Typography variant="body2" sx={{


### PR DESCRIPTION
- Register the state-changing deploy-lock endpoints (POST/DELETE /api/v1/deploy-lock) only when Keycloak is enabled, and hide the manual lock toggle in the Web UI to match. Without an auth backend these endpoints were reachable unauthenticated, letting anyone able to reach the server freeze or release all deployments. The read-only lock status and scheduled lockdown are unaffected.
- Reflect the resolved terminal status back onto the task in HandleArgoAPIFailure so failure notifications report the actual result instead of a stale "in progress".
- Fail a deployment when a watcher-managed image is missing its image-tag annotation instead of silently skipping the git write-back and reporting success.