### PR TITLE
fix(tasks): decouple task list from ArgoCD reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   success. Previously an application whose `argo-watcher/managed-images` listed
   an image without a matching `*.helm.image-tag` annotation logged an error,
   wrote nothing to git, and still marked the deployment successful.
+- Keep the task list responsive and populated when Argo CD is unreachable.
+  Listing tasks performed a live Argo CD login check on every read, so a DNS or
+  network outage made the list hang for the full API retry budget and then
+  render empty — hiding task history that was sitting untouched in the state
+  store. Listing now reads straight from the state backend; the Argo CD check is
+  retained only on the deployment-creation path, which genuinely requires it.
+- Show an explicit, retryable error in the Web UI when the task list fails to
+  load, instead of leaving it stuck in the loading skeleton or rendering a
+  misleading "no tasks" placeholder. Web UI requests are now bounded by a
+  30-second client-side timeout, so a hung backend can no longer pin the table
+  in its skeleton state indefinitely.
 
 ### Security
 

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,6 +18,9 @@ import (
 var (
 	// ArgoSyncRetryDelay is the delay between ArgoCD sync status retries.
 	ArgoSyncRetryDelay = 15 * time.Second
+	// ArgoLivenessProbeInterval is how often the background liveness probe
+	// refreshes the argocd_unavailable metric (see Argo.StartLivenessProbe).
+	ArgoLivenessProbeInterval = 30 * time.Second
 )
 
 // rollbackHistoryWindow bounds how many of an app's most recent successfully
@@ -71,6 +75,30 @@ func (argo *Argo) Check() (string, error) {
 
 	argo.metrics.SetArgoUnavailable(false)
 	return "up", nil
+}
+
+// StartLivenessProbe periodically runs Check() so the argocd_unavailable metric
+// keeps reflecting ArgoCD reachability even during read-only periods (no new
+// deployments). Check() refreshes that gauge as a side effect; the probe's
+// return value is intentionally discarded. This is the single ambient refresher:
+// it lives here, off every request path, so listing tasks never blocks on a
+// live ArgoCD call (see GetTasks). It runs until ctx is cancelled and is meant
+// to be launched in its own goroutine.
+func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration) {
+	// Probe once immediately so the gauge is populated at startup instead of
+	// only after the first interval elapses.
+	_, _ = argo.Check()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_, _ = argo.Check()
+		}
+	}
 }
 
 // AddTask validates a new deployment task and adds it to the task repository.
@@ -163,14 +191,17 @@ func imageSignature(task models.Task) string {
 }
 
 // GetTasks retrieves tasks from the state within a given time range and optional app/status filters and pagination window.
+//
+// Listing is a pure read from the state store and is deliberately NOT gated on
+// ArgoCD reachability. Stored task history must stay viewable even when ArgoCD
+// is unavailable (e.g. a DNS/network outage): coupling the read to a live
+// ArgoCD `session/userinfo` call would otherwise make the whole list hang on the
+// API retry budget and then hide existing tasks behind an error. Write paths
+// (AddTask) keep the Check() gate because creating a deployment genuinely
+// requires ArgoCD to be up; that gate — not this read — is now the only place
+// the argocd_unavailable metric is refreshed. Note the /healthz endpoint probes
+// only the state backend (SimpleHealthCheck), not ArgoCD.
 func (argo *Argo) GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) models.TasksResponse {
-	if _, err := argo.Check(); err != nil {
-		return models.TasksResponse{
-			Tasks: []models.Task{},
-			Error: err.Error(),
-		}
-	}
-
 	tasks, total := argo.State.GetTasks(startTime, endTime, app, status, limit, offset)
 
 	return models.TasksResponse{

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -86,8 +86,12 @@ func (argo *Argo) Check() (string, error) {
 // to be launched in its own goroutine.
 func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration) {
 	// Probe once immediately so the gauge is populated at startup instead of
-	// only after the first interval elapses.
-	_, _ = argo.Check()
+	// only after the first interval elapses. Check() updates the metric itself;
+	// log at debug so an outage leaves a correlatable trace without spamming
+	// logs every interval.
+	if _, err := argo.Check(); err != nil {
+		slog.Debug("ArgoCD liveness probe failed", "error", err)
+	}
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -96,7 +100,9 @@ func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			_, _ = argo.Check()
+			if _, err := argo.Check(); err != nil {
+				slog.Debug("ArgoCD liveness probe failed", "error", err)
+			}
 		}
 	}
 }

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -1,9 +1,11 @@
 package argocd
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/shini4i/argo-watcher/cmd/argo-watcher/mock"
@@ -495,7 +497,10 @@ func TestArgoGetTasks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	t.Run("returnsTasksWhenDependenciesAreHealthy", func(t *testing.T) {
+	// Listing tasks is a pure read from the state store and must NOT be gated on
+	// ArgoCD reachability. Verify GetTasks never calls Check()/GetUserInfo(): the
+	// mocks below would fail the run if it did, since no such calls are expected.
+	t.Run("readsFromStateWithoutCheckingArgoCD", func(t *testing.T) {
 		api := mock.NewMockArgoApiInterface(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
@@ -503,9 +508,6 @@ func TestArgoGetTasks(t *testing.T) {
 		start := 10.0
 		end := 20.0
 
-		state.EXPECT().Check().Return(true)
-		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 		expectedTasks := []models.Task{
 			{Id: "task-1", App: "demo", Images: []models.Image{{Image: "example.com/app", Tag: "v1.0.0"}}},
 		}
@@ -521,23 +523,66 @@ func TestArgoGetTasks(t *testing.T) {
 		assert.Empty(t, response.Error)
 	})
 
-	t.Run("returnsErrorWhenHealthCheckFails", func(t *testing.T) {
+	// The invariant "GetTasks issues no ArgoCD/metrics calls" must hold for every
+	// input, not just the one above — this case pins it on a distinct filter and
+	// time window. The api/metrics mocks expect zero interactions, so any ArgoCD
+	// call regresses. (There is no reachability to simulate: the read never
+	// touches ArgoCD, which is precisely why stored history stays viewable during
+	// an outage.)
+	t.Run("makesNoArgoCDCallsRegardlessOfInput", func(t *testing.T) {
 		api := mock.NewMockArgoApiInterface(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
-		state.EXPECT().Check().Return(false)
-		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
-		metrics.EXPECT().SetArgoUnavailable(true)
+		expectedTasks := []models.Task{
+			{Id: "task-1", App: "demo"},
+		}
+		state.EXPECT().GetTasks(0.0, 100.0, "demo", "", 0, 0).Return(expectedTasks, int64(len(expectedTasks)))
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 
 		response := argo.GetTasks(0, 100, "demo", "", 0, 0)
 
-		assert.Empty(t, response.Tasks)
-		assert.Equal(t, models.StatusConnectionUnavailable, response.Error)
+		assert.Equal(t, expectedTasks, response.Tasks)
+		assert.Equal(t, int64(len(expectedTasks)), response.Total)
+		assert.Empty(t, response.Error)
 	})
+}
+
+func TestArgoStartLivenessProbe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := mock.NewMockArgoApiInterface(ctrl)
+	metrics := mock.NewMockMetricsInterface(ctrl)
+	state := mock.NewMockTaskRepository(ctrl)
+
+	// Cancel before starting: the immediate probe still runs Check() exactly
+	// once (refreshing the metric), then the loop returns on ctx.Done() without
+	// waiting for a tick. This proves the ambient refresh + clean-exit contract
+	// deterministically, with no reliance on timer scheduling.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	state.EXPECT().Check().Return(true)
+	api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
+	metrics.EXPECT().SetArgoUnavailable(false)
+
+	argo := &Argo{}
+	argo.Init(state, api, metrics)
+
+	done := make(chan struct{})
+	go func() {
+		argo.StartLivenessProbe(ctx, time.Hour)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartLivenessProbe did not return after context cancellation")
+	}
 }
 
 func TestArgoSimpleHealthCheck(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,11 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	argo := &argocd.Argo{}
 	argo.Init(s, api, metrics)
 
+	// Keep the argocd_unavailable metric fresh via a background probe. The task
+	// list read path no longer performs an ArgoCD check (so it can't hang on an
+	// outage), so this is the only ambient refresher of that gauge.
+	go argo.StartLivenessProbe(context.Background(), argocd.ArgoLivenessProbeInterval)
+
 	// Create the locker instance based on the state type
 	var locker lock.Locker
 	if serverConfig.StateType == "postgres" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,12 +22,13 @@ import (
 )
 
 type Server struct {
-	router  *gin.Engine
-	config  *config.ServerConfig
-	argo    *argocd.Argo
-	metrics *prom.Metrics
-	updater *argocd.ArgoStatusUpdater
-	env     *Env
+	router      *gin.Engine
+	config      *config.ServerConfig
+	argo        *argocd.Argo
+	metrics     *prom.Metrics
+	updater     *argocd.ArgoStatusUpdater
+	env         *Env
+	probeCancel context.CancelFunc
 }
 
 // NewServer creates a new server instance with the given configuration and prometheus registerer.
@@ -55,11 +56,6 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	// initialize argo client
 	argo := &argocd.Argo{}
 	argo.Init(s, api, metrics)
-
-	// Keep the argocd_unavailable metric fresh via a background probe. The task
-	// list read path no longer performs an ArgoCD check (so it can't hang on an
-	// outage), so this is the only ambient refresher of that gauge.
-	go argo.StartLivenessProbe(context.Background(), argocd.ArgoLivenessProbeInterval)
 
 	// Create the locker instance based on the state type
 	var locker lock.Locker
@@ -105,13 +101,23 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	// create router
 	router := env.CreateRouter()
 
+	// Keep the argocd_unavailable metric fresh via a background probe. The task
+	// list read path no longer performs an ArgoCD check (so it can't hang on an
+	// outage), so this is the only ambient refresher of that gauge. Tie it to a
+	// cancellable context so graceful shutdown (and test teardown) can stop the
+	// goroutine instead of leaking it. Launched last, past every early-return
+	// error path, so the cancel is always owned by the returned Server.
+	probeCtx, probeCancel := context.WithCancel(context.Background())
+	go argo.StartLivenessProbe(probeCtx, argocd.ArgoLivenessProbeInterval)
+
 	return &Server{
-		router:  router,
-		config:  serverConfig,
-		argo:    argo,
-		metrics: metrics,
-		updater: updater,
-		env:     env,
+		router:      router,
+		config:      serverConfig,
+		argo:        argo,
+		metrics:     metrics,
+		updater:     updater,
+		env:         env,
+		probeCancel: probeCancel,
 	}, nil
 }
 
@@ -139,6 +145,11 @@ func (s *Server) Run() {
 	<-quit
 
 	slog.Info("shutting down server...")
+
+	// Stop the background ArgoCD liveness probe.
+	if s.probeCancel != nil {
+		s.probeCancel()
+	}
 
 	// Trigger WebSocket connection shutdown
 	s.env.Shutdown()

--- a/web/src/data/httpClient.test.ts
+++ b/web/src/data/httpClient.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpError } from 'react-admin';
-import { buildQueryString, httpClient } from './httpClient';
+import { buildQueryString, httpClient, REQUEST_TIMEOUT_MS } from './httpClient';
 
 const { getAccessTokenMock } = vi.hoisted(() => ({
   getAccessTokenMock: vi.fn(() => 'token-abc'),
@@ -90,6 +90,71 @@ describe('httpClient', () => {
   it('throws HttpError on network failure', async () => {
     mockFetch.mockRejectedValue(new Error('dns'));
     await expect(httpClient('/status')).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it('passes an AbortSignal to fetch so a hung request cannot wait forever', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await httpClient('/status');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts a hung request after REQUEST_TIMEOUT_MS and rejects as a timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      // fetch never settles on its own; it rejects only once its signal aborts,
+      // so the rejection can come solely from httpClient's own timeout wiring.
+      mockFetch.mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            const signal = init?.signal as AbortSignal;
+            signal?.addEventListener('abort', () =>
+              reject(new DOMException('The operation was aborted.', 'AbortError')),
+            );
+          }),
+      );
+
+      const promise = httpClient('/status');
+      // Attach the rejection assertion before advancing so there is no window
+      // where the rejection is unhandled.
+      const assertion = expect(promise).rejects.toThrow(/timed out/i);
+      await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS);
+      await assertion;
+
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      expect((init.signal as AbortSignal).aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the timeout on the success path so no late abort fires', async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const response = await httpClient<{ status: string }>('/status');
+      expect(response.data).toEqual({ status: 'ok' });
+
+      // Advancing past the timeout must not abort the already-completed request.
+      const init = mockFetch.mock.calls[0][1] as RequestInit;
+      await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS * 2);
+      expect((init.signal as AbortSignal).aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns undefined when response is not JSON', async () => {

--- a/web/src/data/httpClient.ts
+++ b/web/src/data/httpClient.ts
@@ -7,6 +7,15 @@ const DEFAULT_HEADERS: Record<string, string> = {
   Accept: 'application/json',
 };
 
+/**
+ * Hard ceiling on how long a single request may stay in flight before it is
+ * aborted. Without it a degraded backend (e.g. a task list blocked behind an
+ * upstream dependency that is retrying against a dead resolver) leaves the UI
+ * stuck in its loading skeleton indefinitely. Aborting surfaces the failure to
+ * react-admin so the caller can render an honest error state instead.
+ */
+export const REQUEST_TIMEOUT_MS = 30_000;
+
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 export interface HttpClientOptions {
@@ -111,6 +120,11 @@ export const httpClient = async <T>(path: string, options: HttpClientOptions = {
   const url = joinUrl(API_BASE_URL, path);
   const requestInit = buildRequestInit(options);
 
+  // Bound the request so a hung backend cannot pin the UI in its loading state.
+  const controller = new AbortController();
+  requestInit.signal = controller.signal;
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
   let response: Response;
   try {
     response = await fetch(url, requestInit);
@@ -119,7 +133,13 @@ export const httpClient = async <T>(path: string, options: HttpClientOptions = {
       throw error;
     }
 
+    if (error && typeof error === 'object' && (error as { name?: string }).name === 'AbortError') {
+      throw new HttpError('Request timed out', 0, { cause: error });
+    }
+
     throw new HttpError('Network error', 0, { cause: error });
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   const data = await parseJson<T>(response);

--- a/web/src/features/tasks/components/EmptyState.test.tsx
+++ b/web/src/features/tasks/components/EmptyState.test.tsx
@@ -17,6 +17,12 @@ describe('EmptyState', () => {
     expect(container.querySelector('p')).toBeNull();
   });
 
+  it('renders the error icon variant', () => {
+    const { container } = render(<EmptyState icon="error" title="Couldn't load" />);
+    expect(screen.getByText("Couldn't load")).toBeInTheDocument();
+    expect(container.querySelector('svg[data-testid="ErrorOutlinedIcon"]')).not.toBeNull();
+  });
+
   it('renders the supplied CTA', () => {
     const onClick = vi.fn();
     render(

--- a/web/src/features/tasks/components/EmptyState.tsx
+++ b/web/src/features/tasks/components/EmptyState.tsx
@@ -2,8 +2,9 @@ import { type ReactNode } from 'react';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import InboxOutlinedIcon from '@mui/icons-material/InboxOutlined';
 import FilterAltOutlinedIcon from '@mui/icons-material/FilterAltOutlined';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
 
-type EmptyStateIcon = 'inbox' | 'filter';
+type EmptyStateIcon = 'inbox' | 'filter' | 'error';
 
 interface EmptyStateProps {
   readonly icon?: EmptyStateIcon;
@@ -15,6 +16,7 @@ interface EmptyStateProps {
 const ICONS: Record<EmptyStateIcon, ReactNode> = {
   inbox: <InboxOutlinedIcon sx={{ fontSize: 36, color: 'text.disabled' }} />,
   filter: <FilterAltOutlinedIcon sx={{ fontSize: 36, color: 'text.disabled' }} />,
+  error: <ErrorOutlineIcon sx={{ fontSize: 36, color: 'error.main' }} />,
 };
 
 /**

--- a/web/src/features/tasks/components/TaskListLayout.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.test.tsx
@@ -9,6 +9,7 @@ interface StubListContext {
   isPending?: boolean;
   filterValues?: Record<string, unknown>;
   error?: unknown;
+  refetch?: () => void;
 }
 
 const {
@@ -169,14 +170,16 @@ describe('TaskListLayout', () => {
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 
-  it('defers to the datagrid (not the layout placeholder) when a fetch error leaves zero rows', () => {
+  it('shows an honest error state (not the empty placeholder or datagrid) when a fetch fails', () => {
     readPersistentPerPageMock.mockReturnValue(25);
+    const refetch = vi.fn();
     listContextRef.current = {
       data: [],
       total: 0,
       isPending: false,
       filterValues: {},
       error: new Error('backend unreachable'),
+      refetch,
     };
 
     render(
@@ -189,9 +192,67 @@ describe('TaskListLayout', () => {
       </TaskListLayout>,
     );
 
-    // A backend error must not be misattributed to genuine emptiness.
+    // The header/filters stay mounted so the user can adjust the query and retry.
     expect(screen.getByText('Date filter')).toBeInTheDocument();
+    // A backend error must never masquerade as genuine emptiness.
+    expect(screen.getByText('Couldn’t load tasks')).toBeInTheDocument();
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+
+    screen.getByRole('button', { name: 'Retry' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the populated grid (not the error panel) when a refetch fails with rows already loaded', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    // react-admin keeps the previously loaded rows across a refetch, so a
+    // transient auto-refresh error with total > 0 must not blank the grid.
+    listContextRef.current = {
+      data: [{ id: 1 }, { id: 2 }],
+      total: 2,
+      isPending: false,
+      filterValues: {},
+      error: new Error('transient refetch failure'),
+      refetch: vi.fn(),
+    };
+
+    render(
+      <TaskListLayout
+        perPageStorageKey="history.perPage"
+        emptyComponent={<div data-testid="empty-state" />}
+      >
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
     expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+    expect(screen.queryByText('Couldn’t load tasks')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('keeps showing the skeleton (defers to children) while a request is pending', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    // isPending must win over an error left over from a prior fetch so a refetch
+    // shows the loading state rather than flashing the error panel.
+    listContextRef.current = {
+      data: [],
+      total: 0,
+      isPending: true,
+      filterValues: {},
+      error: new Error('stale error from previous attempt'),
+    };
+
+    render(
+      <TaskListLayout
+        perPageStorageKey="history.perPage"
+        emptyComponent={<div data-testid="empty-state" />}
+      >
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+    expect(screen.queryByText('Couldn’t load tasks')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -2,6 +2,7 @@ import { Children, isValidElement, type ReactNode } from 'react';
 import { Box, Stack } from '@mui/material';
 import { List, Pagination, useListContext, type ListProps } from 'react-admin';
 import { PerPagePersistence, readPersistentPerPage } from '../../../shared/hooks/usePersistentPerPage';
+import { EmptyState, EmptyStateCta } from './EmptyState';
 import { SearchFilteredView } from './SearchFilteredView';
 import { TaskListProvider } from './TaskListContext';
 
@@ -27,9 +28,18 @@ interface TaskListLayoutProps {
  * body keeps the header/filters mounted above it. When filters are active we
  * defer to the datagrid's own filtered empty state (with its "Clear filters"
  * CTA), matching react-admin's original `shouldRenderEmptyPage` condition
- * (`!error && !isPending && total === 0 && !filterValues`). The `!error` guard
- * matters: on a fetch error after an empty load `total` is still 0, and we must
- * defer to the list body rather than misattribute the error to genuine emptiness.
+ * (`!error && !isPending && total === 0 && !filterValues`).
+ *
+ * A fetch error (a 5xx, a network drop, or the request timing out — see
+ * REQUEST_TIMEOUT_MS in httpClient) is rendered as an explicit error state with
+ * a retry, NOT as the empty placeholder or the datagrid's "no tasks" message: a
+ * load failure must never masquerade as genuine emptiness. The header/filters
+ * stay mounted above it so the user can still adjust the query and retry.
+ *
+ * The error panel is gated on `total === 0` so it only replaces the body when
+ * there is nothing to show. react-admin keeps the previously loaded rows across
+ * a refetch, so a transient auto-refresh failure keeps the populated grid (the
+ * error is surfaced via react-admin's notification) instead of blanking it.
  */
 const ListBody = ({
   emptyComponent,
@@ -38,10 +48,21 @@ const ListBody = ({
   emptyComponent: ReactNode | false;
   children: ReactNode;
 }) => {
-  const { isPending, total, filterValues, error } = useListContext();
+  const { isPending, total, filterValues, error, refetch } = useListContext();
   const hasFilters = Object.keys(filterValues ?? {}).length > 0;
 
-  if (emptyComponent && !error && !isPending && total === 0 && !hasFilters) {
+  if (error && !isPending && total === 0) {
+    return (
+      <EmptyState
+        icon="error"
+        title="Couldn’t load tasks"
+        description="The request failed or timed out. Check that the server is reachable, then try again."
+        cta={<EmptyStateCta label="Retry" onClick={() => refetch()} />}
+      />
+    );
+  }
+
+  if (emptyComponent && !isPending && total === 0 && !hasFilters) {
     return <>{emptyComponent}</>;
   }
 

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -70,9 +70,9 @@ const ListBody = ({
 };
 
 /**
- * Shared wrapper for task list pages handling pagination persistence, headers, and empty states.
+ * Shared scaffold for task list pages: wraps React-admin's <List> with the
+ * toolbar/header, pagination persistence, and the empty/error body states.
  */
-/** Shared list scaffold wrapping React-admin's List with toolbar/header handling. */
 export const TaskListLayout = ({
   title,
   perPageStorageKey,


### PR DESCRIPTION
Listing tasks (GET /api/v1/tasks) performed a live ArgoCD login check on every read. When ArgoCD was unreachable (e.g. a DNS/network outage), that call sat in the API retry loop, so the list hung for the full retry budget and then returned empty -- hiding task history that was untouched in the state store and leaving the Web UI stuck in its loading skeleton.

Read the task list straight from the state store; keep the ArgoCD check only on the deployment-creation path (AddTask), which genuinely requires it. Add a background liveness probe (StartLivenessProbe) so the argocd_unavailable metric stays fresh now that reads no longer refresh it.

Harden the Web UI so a slow or failing backend can no longer pin it: bound every request with a 30s AbortController timeout, and render an explicit, retryable error state on load failure instead of an endless skeleton or a misleading empty-state placeholder (kept only when there are genuinely no rows to show).