### PR TITLE
feat(argocd): surface pod-level cause in deployment failure reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enrich deployment-failure reasons with the actual root cause from ArgoCD's live
+  resource tree. When a rollout fails — both "not available" and "not healthy" —
+  the task status reason now surfaces the failing pod's condition (e.g. an
+  `ImagePullBackOff`/`ErrImagePull` or crash-loop message), which the previous
+  top-level resource summary never carried, alongside the existing failed-hook and
+  terminal sync-operation diagnostics. No new stored data — the existing
+  `status_reason` is simply more actionable, so no database migration is required.
 - Speed up GitOps write-backs by detecting whether the override file changed with a
   targeted single-file comparison instead of scanning the entire working tree. On
   large GitOps repositories this markedly reduces per-deployment commit latency,

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -212,9 +212,11 @@ func (api *ArgoApi) GetApplication(ctx context.Context, app string, refresh bool
 func (api *ArgoApi) GetResourceTree(ctx context.Context, app string) (*models.ApplicationTree, error) {
 	apiUrl := fmt.Sprintf("%s/api/v1/applications/%s/resource-tree", api.baseUrl.String(), url.PathEscape(app))
 
+	// No logging here: this call is best-effort (the caller swallows the error to enrich a
+	// failure reason), so a transport hiccup must not surface as an ERROR-level line. The caller
+	// logs at Debug. The unmarshal error is wrapped with %w so the underlying cause is preserved.
 	body, statusCode, err := api.doGet(ctx, apiUrl)
 	if err != nil {
-		slog.Error("failed to execute request", "error", err)
 		return nil, err
 	}
 
@@ -224,7 +226,7 @@ func (api *ArgoApi) GetResourceTree(ctx context.Context, app string) (*models.Ap
 
 	var tree models.ApplicationTree
 	if err = json.Unmarshal(body, &tree); err != nil {
-		return nil, fmt.Errorf("could not parse json response: %s", body)
+		return nil, fmt.Errorf("could not parse resource-tree response: %w", err)
 	}
 
 	return &tree, nil

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -23,6 +23,7 @@ type ArgoApiInterface interface {
 	Init(serverConfig *config.ServerConfig) error
 	GetUserInfo() (*models.Userinfo, error)
 	GetApplication(ctx context.Context, app string, refresh bool) (*models.Application, error)
+	GetResourceTree(ctx context.Context, app string) (*models.ApplicationTree, error)
 }
 
 type ArgoApi struct {
@@ -201,4 +202,30 @@ func (api *ArgoApi) GetApplication(ctx context.Context, app string, refresh bool
 	}
 
 	return &argoApp, nil
+}
+
+// GetResourceTree fetches the live resource tree of the named ArgoCD application. It is the only
+// source that exposes descendant resources — notably the Pods, whose health carries the actual
+// failure cause (ImagePullBackOff, CrashLoopBackOff) absent from the application's top-level
+// Status.Resources. The context bounds the request so a caller under a deadline is never blocked
+// past it. It is called only on the failure path to enrich the reported reason.
+func (api *ArgoApi) GetResourceTree(ctx context.Context, app string) (*models.ApplicationTree, error) {
+	apiUrl := fmt.Sprintf("%s/api/v1/applications/%s/resource-tree", api.baseUrl.String(), url.PathEscape(app))
+
+	body, statusCode, err := api.doGet(ctx, apiUrl)
+	if err != nil {
+		slog.Error("failed to execute request", "error", err)
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, parseArgoErrorResponse(body)
+	}
+
+	var tree models.ApplicationTree
+	if err = json.Unmarshal(body, &tree); err != nil {
+		return nil, fmt.Errorf("could not parse json response: %s", body)
+	}
+
+	return &tree, nil
 }

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -363,6 +363,58 @@ func TestArgoApiGetApplicationSuccess(t *testing.T) {
 	assert.Equal(t, app.Status.Summary.Images, result.Status.Summary.Images)
 }
 
+// TestArgoApiGetResourceTreeSuccess verifies that GetResourceTree hits the resource-tree
+// endpoint and decodes node health (the only place pod-level failure causes are exposed).
+func TestArgoApiGetResourceTreeSuccess(t *testing.T) {
+	tree := models.ApplicationTree{Nodes: []models.ApplicationTreeNode{
+		{Kind: "Pod", Name: "demo-xyz", Namespace: "demo"},
+	}}
+	tree.Nodes[0].Health.Status = "Degraded"
+	tree.Nodes[0].Health.Message = `Back-off pulling image "demo:v2": ErrImagePull`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/applications/demo/resource-tree", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(tree))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = server.Client()
+	api.maxRetries = 1
+
+	result, err := api.GetResourceTree(context.Background(), "demo")
+	require.NoError(t, err)
+	require.Len(t, result.Nodes, 1)
+	assert.Equal(t, "Degraded", result.Nodes[0].Health.Status)
+	assert.Equal(t, `Back-off pulling image "demo:v2": ErrImagePull`, result.Nodes[0].Health.Message)
+}
+
+// TestArgoApiGetResourceTreeError verifies a non-200 response surfaces as an error.
+func TestArgoApiGetResourceTreeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		require.NoError(t, json.NewEncoder(w).Encode(models.ArgoApiErrorResponse{Message: "boom"}))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = server.Client()
+	api.maxRetries = 1
+
+	_, err = api.GetResourceTree(context.Background(), "demo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
 // TestArgoApiGetApplicationEscapesAppName verifies that special characters in app names
 // are properly URL-escaped to prevent path traversal and injection attacks.
 func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -415,6 +415,44 @@ func TestArgoApiGetResourceTreeError(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
+// TestArgoApiGetResourceTreeUnmarshalError verifies a 200 with a non-JSON body surfaces a
+// wrapped parse error rather than a nil tree.
+func TestArgoApiGetResourceTreeUnmarshalError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = server.Client()
+	api.maxRetries = 1
+
+	_, err = api.GetResourceTree(context.Background(), "demo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not parse resource-tree response")
+}
+
+// TestArgoApiGetResourceTreeTransportError verifies a transport failure (unreachable server) is
+// returned as an error — the best-effort caller relies on this to fall back to a nil tree.
+func TestArgoApiGetResourceTreeTransportError(t *testing.T) {
+	// Port 1 is not listenable, so the request fails to connect.
+	parsedURL, err := url.Parse("http://127.0.0.1:1")
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = &http.Client{}
+	api.maxRetries = 1
+
+	_, err = api.GetResourceTree(context.Background(), "demo")
+	require.Error(t, err)
+}
+
 // TestArgoApiGetApplicationEscapesAppName verifies that special characters in app names
 // are properly URL-escaped to prevent path traversal and injection attacks.
 func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -67,6 +67,19 @@ func zeroDelay(_ uint, _ error, _ *retry.Config) time.Duration {
 	return 0
 }
 
+// newArgoApiMock builds an ArgoApi mock pre-loaded with the best-effort defaults every test
+// tolerates. The failure-path resource-tree fetch is best-effort, so it defaults to "no tree"
+// (GetRolloutMessage then falls back to the app's top-level resources). Only tests that assert
+// on tree-derived diagnostics register their own GetResourceTree expectation (using a raw mock).
+//
+// Register any future best-effort (optional) ArgoApi call here so adding one never has to touch
+// every test setup again — the whole point of routing mock creation through this constructor.
+func newArgoApiMock(ctrl *gomock.Controller) *mock.MockArgoApiInterface {
+	api := mock.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	return api
+}
+
 // notSupersededState returns a TaskRepository mock whose GetTask always reports an
 // in-progress task, so the poll loop's supersession check never fires. Use it when
 // a test exercises rollout polling but is not about cancellation.
@@ -111,7 +124,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application deployed", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -157,7 +170,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application deployed with Retry", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -210,7 +223,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application deployed with Registry proxy", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -254,7 +267,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application deployed without Registry proxy", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -305,7 +318,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application not found", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -336,7 +349,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - ArgoCD unavailable", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -367,7 +380,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application API error", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -398,7 +411,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application not available", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -445,7 +458,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application out of Sync", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -496,7 +509,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 	t.Run("Status Updater - Application not healthy", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -578,10 +591,12 @@ func TestDeploymentMonitorHandleDeploymentFailureHandlesStateError(t *testing.T)
 
 	metrics := mock.NewMockMetricsInterface(ctrl)
 	state := mock.NewMockTaskRepository(ctrl)
+	api := newArgoApiMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
 		metrics: metrics,
 		State:   state,
+		api:     api,
 	}, "", []retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
 
 	task := models.Task{
@@ -601,6 +616,95 @@ func TestDeploymentMonitorHandleDeploymentFailureHandlesStateError(t *testing.T)
 
 	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotHealthy, application)
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
+}
+
+// TestDeploymentMonitorHandleDeploymentFailureEnrichesReasonFromResourceTree pins the wiring:
+// the failure path fetches the live resource tree and the pod-level cause it carries lands in the
+// stored status reason. Uses a raw mock (not newArgoApiMock) so its GetResourceTree return is not
+// shadowed by the best-effort nil default.
+func TestDeploymentMonitorHandleDeploymentFailureEnrichesReasonFromResourceTree(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := mock.NewMockMetricsInterface(ctrl)
+	state := mock.NewMockTaskRepository(ctrl)
+	api := mock.NewMockArgoApiInterface(ctrl)
+
+	podNode := models.ApplicationTreeNode{Kind: "Pod", Name: "app-xyz", Namespace: "demo"}
+	podNode.Health.Status = "Degraded"
+	podNode.Health.Message = `Back-off pulling image "example.com/app:v2": ErrImagePull`
+	api.EXPECT().GetResourceTree(gomock.Any(), "demo").Return(&models.ApplicationTree{Nodes: []models.ApplicationTreeNode{podNode}}, nil)
+
+	monitor := NewDeploymentMonitor(Argo{
+		metrics: metrics,
+		State:   state,
+		api:     api,
+	}, "", []retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+
+	task := models.Task{
+		Id:     "task-id",
+		App:    "demo",
+		Images: []models.Image{{Image: "example.com/app", Tag: "v2"}},
+	}
+	application := &models.Application{}
+	application.Status.Summary.Images = []string{"example.com/app:v1"}
+
+	var capturedReason string
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application)
+
+	assert.Contains(t, capturedReason, "Unhealthy resources:")
+	assert.Contains(t, capturedReason, `Pod(app-xyz) Degraded with message Back-off pulling image "example.com/app:v2": ErrImagePull`)
+}
+
+// TestDeploymentMonitorHandleDeploymentFailureResourceTreeErrorIsNonFatal pins the best-effort
+// contract: if the resource-tree fetch errors, the deployment is still marked failed and the
+// reason falls back to the baseline message (no panic on the nil tree). A regression that made
+// the fetch fatal — propagating the error and skipping SetTaskStatus — would fail this test.
+func TestDeploymentMonitorHandleDeploymentFailureResourceTreeErrorIsNonFatal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := mock.NewMockMetricsInterface(ctrl)
+	state := mock.NewMockTaskRepository(ctrl)
+	api := mock.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), "demo").Return(nil, errors.New("resource-tree unavailable"))
+
+	monitor := NewDeploymentMonitor(Argo{
+		metrics: metrics,
+		State:   state,
+		api:     api,
+	}, "", []retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+
+	task := models.Task{
+		Id:     "task-id",
+		App:    "demo",
+		Images: []models.Image{{Image: "example.com/app", Tag: "v2"}},
+	}
+	application := &models.Application{}
+	application.Status.Summary.Images = []string{"example.com/app:v1"}
+
+	var capturedReason string
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application)
+
+	assert.Equal(t, models.StatusFailedMessage, task.Status)
+	assert.Contains(t, capturedReason, "Rollout status is not available")
+	assert.Contains(t, capturedReason, "List of expected images:")
 }
 
 func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
@@ -884,7 +988,8 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	metrics := mock.NewMockMetricsInterface(ctrl)
 	state := mock.NewMockTaskRepository(ctrl)
 	locker := lock.NewInMemoryLocker()
@@ -928,7 +1033,8 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	monitor := NewDeploymentMonitor(
 		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
@@ -966,7 +1072,8 @@ func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	monitor := NewDeploymentMonitor(
 		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
@@ -1007,7 +1114,8 @@ func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	monitor := NewDeploymentMonitor(
 		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
@@ -1046,7 +1154,8 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	monitor := NewDeploymentMonitor(
 		Argo{api: api, State: notSupersededState(ctrl)},
 		"",
@@ -1075,7 +1184,8 @@ func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -1117,7 +1227,8 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -1164,7 +1275,8 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -1216,7 +1328,8 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -1337,7 +1450,8 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 	mockLocker := lock.NewInMemoryLocker()
@@ -1423,7 +1537,8 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	apiMock := mock.NewMockArgoApiInterface(ctrl)
+	apiMock := newArgoApiMock(ctrl)
+
 	metricsMock := mock.NewMockMetricsInterface(ctrl)
 	stateMock := mock.NewMockTaskRepository(ctrl)
 	mockLocker := lock.NewInMemoryLocker()
@@ -1595,7 +1710,8 @@ func newFetchTestMonitor(t *testing.T) (*DeploymentMonitor, *mock.MockArgoApiInt
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
+
 	metrics := mock.NewMockMetricsInterface(ctrl)
 	monitor := NewDeploymentMonitor(
 		Argo{api: api, metrics: metrics},

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -23,7 +23,7 @@ func TestArgoCheck(t *testing.T) {
 
 	t.Run("Argo Watcher - Up", func(t *testing.T) {
 		// mocks
-		apiMock := mock.NewMockArgoApiInterface(ctrl)
+		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mock.NewMockMetricsInterface(ctrl)
 		stateMock := mock.NewMockTaskRepository(ctrl)
 
@@ -48,7 +48,7 @@ func TestArgoCheck(t *testing.T) {
 
 	t.Run("Argo Watcher - Down - Cannot connect to State manager", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -73,7 +73,7 @@ func TestArgoCheck(t *testing.T) {
 
 	t.Run("Argo Watcher - Down - Cannot login", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -98,7 +98,7 @@ func TestArgoCheck(t *testing.T) {
 
 	t.Run("Argo Watcher - Down - Unexpected login failure", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -124,7 +124,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo Unavailable", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -146,7 +146,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo - Image not passed", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -171,7 +171,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo - App not passed", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -200,7 +200,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo - State add failed", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -236,7 +236,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo - Task added", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -289,7 +289,7 @@ func TestArgoAddTask(t *testing.T) {
 
 	t.Run("Argo - Cancel failure does not block new deployment", func(t *testing.T) {
 		// mocks
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -316,7 +316,7 @@ func TestArgoAddTask(t *testing.T) {
 	})
 
 	t.Run("Argo - Rollback fields are computed and persisted", func(t *testing.T) {
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -351,7 +351,7 @@ func TestArgoAddTask(t *testing.T) {
 	})
 
 	t.Run("Argo - Client-supplied rollback fields are overwritten from history", func(t *testing.T) {
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -501,7 +501,7 @@ func TestArgoGetTasks(t *testing.T) {
 	// ArgoCD reachability. Verify GetTasks never calls Check()/GetUserInfo(): the
 	// mocks below would fail the run if it did, since no such calls are expected.
 	t.Run("readsFromStateWithoutCheckingArgoCD", func(t *testing.T) {
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -530,7 +530,7 @@ func TestArgoGetTasks(t *testing.T) {
 	// touches ArgoCD, which is precisely why stored history stays viewable during
 	// an outage.)
 	t.Run("makesNoArgoCDCallsRegardlessOfInput", func(t *testing.T) {
-		api := mock.NewMockArgoApiInterface(ctrl)
+		api := newArgoApiMock(ctrl)
 		metrics := mock.NewMockMetricsInterface(ctrl)
 		state := mock.NewMockTaskRepository(ctrl)
 
@@ -554,7 +554,7 @@ func TestArgoStartLivenessProbe(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	api := mock.NewMockArgoApiInterface(ctrl)
+	api := newArgoApiMock(ctrl)
 	metrics := mock.NewMockMetricsInterface(ctrl)
 	state := mock.NewMockTaskRepository(ctrl)
 

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -272,15 +272,36 @@ func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
 func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application) {
 	slog.Info("App deployment failed.", "id", task.Id)
 	monitor.argo.metrics.AddFailedDeployment(task.App)
+	tree := monitor.fetchResourceTree(task)
 	reason := fmt.Sprintf(
 		"Application deployment failed. Rollout status is %s\n\n%s",
 		status,
-		application.GetRolloutMessage(status, task.ListImages()),
+		application.GetRolloutMessage(status, task.ListImages(), tree),
 	)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, reason); err != nil {
 		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
 	}
 	task.Status = models.StatusFailedMessage
+}
+
+// resourceTreeTimeout bounds the best-effort resource-tree fetch on the failure path so
+// enriching the failure reason can never block terminal status reporting for long.
+const resourceTreeTimeout = 10 * time.Second
+
+// fetchResourceTree best-effort fetches the application's live resource tree to enrich the
+// failure reason with pod-level causes (ImagePullBackOff, CrashLoopBackOff). It is deliberately
+// non-fatal: any error yields a nil tree and GetRolloutMessage falls back to the app's top-level
+// resources, so a resource-tree hiccup never prevents the deployment from being marked failed.
+func (monitor *DeploymentMonitor) fetchResourceTree(task *models.Task) *models.ApplicationTree {
+	ctx, cancel := context.WithTimeout(context.Background(), resourceTreeTimeout)
+	defer cancel()
+
+	tree, err := monitor.argo.api.GetResourceTree(ctx, task.App)
+	if err != nil {
+		slog.Debug(fmt.Sprintf("Could not fetch resource tree for failure diagnostics: %s", err), "id", task.Id)
+		return nil
+	}
+	return tree
 }
 
 // handleApplicationFetchError ensures we don't retry for not found errors

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -51,6 +51,25 @@ type Application struct {
 	Status   ApplicationStatus   `json:"status"`
 }
 
+// ApplicationTree is the live resource tree returned by ArgoCD's
+// /api/v1/applications/{name}/resource-tree endpoint. Unlike Application.Status.Resources
+// (which lists only the app's top-level managed resources: Deployment, Service, ...), the
+// tree includes their descendants — crucially the Pods, whose health carries the actual
+// failure cause (ImagePullBackOff, CrashLoopBackOff) that the top-level resources never expose.
+type ApplicationTree struct {
+	Nodes []ApplicationTreeNode `json:"nodes"`
+}
+
+type ApplicationTreeNode struct {
+	Kind      string `json:"kind"`      // example: Pod | Job
+	Name      string `json:"name"`      // example: app-6b7f-abcde
+	Namespace string `json:"namespace"` // example: app
+	Health    struct {
+		Status  string `json:"status"`  // example: Degraded
+		Message string `json:"message"` // example: Back-off pulling image "app:v2": ErrImagePull
+	} `json:"health"`
+}
+
 type ApplicationStatus struct {
 	Health struct {
 		Status string `json:"status"`
@@ -123,15 +142,21 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 	return ArgoRolloutAppSuccess
 }
 
-// GetRolloutMessage generates rollout failure message.
-func (app *Application) GetRolloutMessage(status string, rolloutImages []string) string {
+// GetRolloutMessage generates a rollout failure message.
+//
+// tree is ArgoCD's live resource tree (optional, may be nil). When present it is the
+// preferred source for the "Unhealthy resources" section because it alone carries the
+// pod-level failure cause (ImagePullBackOff / CrashLoopBackOff); when nil the message
+// falls back to the app's top-level Status.Resources, preserving the pre-tree behaviour.
+// The actionable diagnostics (terminal sync operation, failed hooks, unhealthy resources)
+// are appended to both the "not available" and "not healthy"/"degraded" failures so on-call
+// users don't have to context-switch into the ArgoCD UI regardless of how the rollout failed.
+func (app *Application) GetRolloutMessage(status string, rolloutImages []string, tree *ApplicationTree) string {
 	// handle application sync failure
 	switch status {
 	// not all images were deployed to the application
 	case ArgoRolloutAppNotAvailable:
-		// Image-mismatch is the bare minimum we always show. We additionally append any actionable diagnostics
-		// already returned by ArgoCD (failed sync operation, failed hooks, unhealthy resources) so on-call users
-		// don't have to context-switch into the ArgoCD UI to find the root cause.
+		// Image-mismatch is the bare minimum we always show, then append any diagnostics.
 		base := fmt.Sprintf(
 			"List of current images (last app check):\n"+
 				"\t%s\n\n"+
@@ -140,10 +165,8 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string)
 			strings.Join(app.Status.Summary.Images, "\n\t"),
 			strings.Join(rolloutImages, "\n\t"),
 		)
-		if diag := app.buildNotAvailableDiagnostics(); diag != "" {
-			return base + "\n\n" + diag
-		}
-		return base
+		// Base message has no resource listing, so fall back to Status.Resources when no tree.
+		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, true))
 	// application sync status wasn't valid
 	case ArgoRolloutAppNotSynced:
 		// display sync status and last sync message
@@ -158,8 +181,10 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string)
 		)
 	// application is not in a healthy status
 	case ArgoRolloutAppNotHealthy, ArgoRolloutAppDegraded:
-		// display current health of pods
-		return fmt.Sprintf(
+		// display current health of the top-level resources, then append the same
+		// diagnostics as the "not available" path — a stalled rollout caused by a
+		// failing pod surfaces here just as often, and its cause lives in the tree.
+		base := fmt.Sprintf(
 			"App sync status \"%s\"\n"+
 				"App health status \"%s\"\n"+
 				"Resources:\n"+
@@ -168,6 +193,9 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string)
 			app.Status.Health.Status,
 			strings.Join(app.ListUnhealthyResources(), "\n\t"),
 		)
+		// Base "Resources:" already lists the top-level resources, so do NOT fall back to them
+		// again here; only tree-sourced problem nodes (the distinct pod cause) add signal.
+		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, false))
 	}
 
 	// handle unexpected status
@@ -175,6 +203,16 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string)
 		"received unexpected rollout status \"%s\"",
 		status,
 	)
+}
+
+// appendDiagnostics joins the base failure message with the optional diagnostics suffix,
+// separated by a blank line. An empty suffix leaves the base message byte-identical, so
+// failures with no extra diagnostics keep their historical format.
+func appendDiagnostics(base, diagnostics string) string {
+	if diagnostics == "" {
+		return base
+	}
+	return base + "\n\n" + diagnostics
 }
 
 // formatSyncResultResource renders a single sync-result resource line. Shared between full and filtered listings
@@ -271,10 +309,52 @@ func (app *Application) listProblemResources() []string {
 	return list
 }
 
-// buildNotAvailableDiagnostics builds the optional diagnostics suffix appended to the "not available" rollout
-// failure message. Each section is included only when it has content; the empty string is returned when no
-// diagnostics are available, preserving the legacy image-list-only output for that case.
-func (app *Application) buildNotAvailableDiagnostics() string {
+// formatTreeNode renders a single resource-tree node line, mirroring formatHealthResource so
+// tree-sourced and Status.Resources-sourced "Unhealthy resources" lines look identical.
+func formatTreeNode(n ApplicationTreeNode) string {
+	line := fmt.Sprintf("%s(%s) %s", n.Kind, n.Name, n.Health.Status)
+	if n.Health.Message != "" {
+		line += " with message " + n.Health.Message
+	}
+	return line
+}
+
+// ListProblemNodes returns formatted lines for resource-tree nodes whose health indicates a
+// problem. This is where pod-level failure causes (ImagePullBackOff, CrashLoopBackOff) surface —
+// they are carried by the Pod nodes, which never appear in Application.Status.Resources.
+func (tree *ApplicationTree) ListProblemNodes() []string {
+	var list []string
+	for index := range tree.Nodes {
+		node := tree.Nodes[index]
+		if !isProblemHealthStatus(node.Health.Status) {
+			continue
+		}
+		list = append(list, formatTreeNode(node))
+	}
+	return list
+}
+
+// problemResourceLines returns the "Unhealthy resources" lines. It always prefers the live
+// resource tree (which alone carries pod-level causes). When the tree is nil it falls back to
+// the app's top-level Status.Resources only if allowStatusFallback is set — the not-available
+// path enables the fallback (its base message has no resource listing), while the not-healthy
+// path disables it because its base "Resources:" block already lists those same resources.
+func (app *Application) problemResourceLines(tree *ApplicationTree, allowStatusFallback bool) []string {
+	if tree != nil {
+		return tree.ListProblemNodes()
+	}
+	if allowStatusFallback {
+		return app.listProblemResources()
+	}
+	return nil
+}
+
+// buildFailureDiagnostics builds the optional diagnostics suffix appended to the "not available"
+// and "not healthy"/"degraded" rollout-failure messages. Each section is included only when it
+// has content; the empty string is returned when no diagnostics are available, preserving the
+// legacy output for that case. tree is optional (see GetRolloutMessage); allowStatusFallback
+// controls whether the tree-less "Unhealthy resources" section falls back to Status.Resources.
+func (app *Application) buildFailureDiagnostics(tree *ApplicationTree, allowStatusFallback bool) string {
 	var sections []string
 
 	if isTerminalFailurePhase(app.Status.OperationState.Phase) {
@@ -289,7 +369,7 @@ func (app *Application) buildNotAvailableDiagnostics() string {
 		sections = append(sections, "Failed hooks:\n\t"+strings.Join(hooks, "\n\t"))
 	}
 
-	if resources := app.listProblemResources(); len(resources) > 0 {
+	if resources := app.problemResourceLines(tree, allowStatusFallback); len(resources) > 0 {
 		sections = append(sections, "Unhealthy resources:\n\t"+strings.Join(resources, "\n\t"))
 	}
 

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -158,7 +158,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 		images := []string{"ghcr.io/shini4i/argo-watcher:version2"}
 		assert.Equal(t,
 			"List of current images (last app check):\n\tghcr.io/shini4i/argo-watcher:version1\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:version2",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable with failed hook", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Failed hooks:\n"+
 				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable with unhealthy pod", func(t *testing.T) {
@@ -208,7 +208,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Unhealthy resources:\n"+
 				"\tPod(app-pod) Degraded with message Back-off restarting failed container",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable with failed sync operation", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Sync operation phase: Failed\n"+
 				"Sync operation message: one or more synchronization tasks completed unsuccessfully",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable with combined diagnostics", func(t *testing.T) {
@@ -275,7 +275,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit\n\n"+
 				"Unhealthy resources:\n"+
 				"\tPod(app-pod) Degraded with message Back-off restarting failed container",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable filters out healthy/successful resources", func(t *testing.T) {
@@ -317,7 +317,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 			assert.Equal(t,
 				"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
 					"List of expected images:\n\tapp:v0.0.2",
-				application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images),
+				application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil),
 				"phase=%q must produce the baseline image-only message", phase)
 		}
 		runCase("Running")
@@ -355,7 +355,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		assert.Equal(t,
 			"App status \"NotWorking\"\nApp message \"Not working test app\"\nResources:\n\tPod(app-migrations) PreSync Succeeded with message \n\tJob(app-job) PostSync Failed with message Job has reached the specified backoff limit",
-			application.GetRolloutMessage(ArgoRolloutAppNotSynced, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotHealthy", func(t *testing.T) {
@@ -383,7 +383,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		assert.Equal(t,
 			"App sync status \"Syncing\"\nApp health status \"NotHealthy\"\nResources:\n\tPod(app-pod) Synced\n\tJob(app-job) Unhealthy with message Job has reached the specified backoff limit",
-			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images, nil))
 	})
 
 	t.Run("Rollout message - default", func(t *testing.T) {
@@ -392,7 +392,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version2"}
-		assert.Equal(t, "received unexpected rollout status \"unexpected status\"", application.GetRolloutMessage("unexpected status", images))
+		assert.Equal(t, "received unexpected rollout status \"unexpected status\"", application.GetRolloutMessage("unexpected status", images, nil))
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable with failed sync operation and empty message", func(t *testing.T) {
@@ -406,8 +406,176 @@ func TestArgoRolloutMessage(t *testing.T) {
 			"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Sync operation phase: Error",
-			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images))
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
+
+	t.Run("Rollout message - ArgoRolloutAppNotAvailable surfaces pod cause from resource tree", func(t *testing.T) {
+		// The real not-available cause (ImagePullBackOff) lives on a Pod, which never appears in
+		// Status.Resources. When the live tree is supplied, its problem nodes must surface it.
+		application := Application{}
+		application.Status.Summary.Images = []string{"app:v0.0.1"}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "app-xyz", "Degraded", `Back-off pulling image "app:v0.0.2": ErrImagePull`),
+			// Progressing parent must be filtered out so it does not dilute the signal.
+			treeNode("Deployment", "app", "Progressing", "Waiting for rollout to finish"),
+		}}
+		images := []string{"app:v0.0.2"}
+		assert.Equal(t,
+			"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
+				"List of expected images:\n\tapp:v0.0.2\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(app-xyz) Degraded with message Back-off pulling image \"app:v0.0.2\": ErrImagePull",
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, tree))
+	})
+
+	t.Run("Rollout message - resource tree is preferred over Status.Resources", func(t *testing.T) {
+		// When both are present the live tree wins: it carries the pods, so it is strictly more
+		// informative than the top-level Status.Resources fallback.
+		application := Application{}
+		application.Status.Summary.Images = []string{"app:v0.0.1"}
+		application.Status.Resources = []ApplicationResource{
+			{
+				Kind: "Deployment", Name: "app", Namespace: "app",
+				Health: struct {
+					Message string `json:"message"`
+					Status  string `json:"status"`
+				}{Status: "Degraded", Message: "stale top-level status"},
+			},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "app-xyz", "Degraded", "CrashLoopBackOff: back-off restarting failed container"),
+		}}
+		images := []string{"app:v0.0.2"}
+		assert.Equal(t,
+			"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
+				"List of expected images:\n\tapp:v0.0.2\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(app-xyz) Degraded with message CrashLoopBackOff: back-off restarting failed container",
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, tree))
+	})
+
+	t.Run("Rollout message - ArgoRolloutAppNotHealthy appends pod cause from resource tree", func(t *testing.T) {
+		// A stalled rollout reported as not-healthy must also surface the pod-level cause, which the
+		// pre-existing "Resources:" listing (top-level resources only) cannot show.
+		application := Application{}
+		application.Status.Summary.Images = []string{"app:v0.0.1"}
+		application.Status.Sync.Status = "Synced"
+		application.Status.Health.Status = "Progressing"
+		application.Status.Resources = []ApplicationResource{
+			{
+				Kind: "Deployment", Name: "app", Namespace: "app",
+				Health: struct {
+					Message string `json:"message"`
+					Status  string `json:"status"`
+				}{Status: "Progressing", Message: "Waiting for rollout to finish"},
+			},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "app-xyz", "Degraded", `Back-off pulling image "app:v0.0.2": ErrImagePull`),
+		}}
+		images := []string{"app:v0.0.2"}
+		assert.Equal(t,
+			"App sync status \"Synced\"\n"+
+				"App health status \"Progressing\"\n"+
+				"Resources:\n"+
+				"\tDeployment(app) Progressing with message Waiting for rollout to finish\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(app-xyz) Degraded with message Back-off pulling image \"app:v0.0.2\": ErrImagePull",
+			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images, tree))
+	})
+
+	t.Run("Rollout message - not available combines sync, hooks, and tree pod cause", func(t *testing.T) {
+		// All three diagnostic sections must fire together when a live tree is present: a non-nil
+		// tree must not short-circuit the terminal-sync and failed-hooks sections.
+		application := Application{}
+		application.Status.Summary.Images = []string{"app:v0.0.1"}
+		application.Status.OperationState.Phase = "Failed"
+		application.Status.OperationState.Message = "one or more synchronization tasks completed unsuccessfully"
+		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
+			{HookPhase: "Failed", HookType: "PreSync", Kind: "Job", Message: "Job has reached the specified backoff limit", SyncPhase: "PreSync", Name: "app-migrations", Namespace: "app"},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "app-xyz", "Degraded", `Back-off pulling image "app:v0.0.2": ErrImagePull`),
+		}}
+		images := []string{"app:v0.0.2"}
+		assert.Equal(t,
+			"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
+				"List of expected images:\n\tapp:v0.0.2\n\n"+
+				"Sync operation phase: Failed\n"+
+				"Sync operation message: one or more synchronization tasks completed unsuccessfully\n\n"+
+				"Failed hooks:\n"+
+				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(app-xyz) Degraded with message Back-off pulling image \"app:v0.0.2\": ErrImagePull",
+			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, tree))
+	})
+
+	t.Run("Rollout message - not healthy with nil tree keeps sync+hooks and does not duplicate resources", func(t *testing.T) {
+		// With no live tree, the not-healthy path must still surface the terminal-sync and
+		// failed-hooks sections, but must NOT re-list the Degraded resource under "Unhealthy
+		// resources:" — it already appears in the base "Resources:" block.
+		application := Application{}
+		application.Status.Summary.Images = []string{"app:v0.0.1"}
+		application.Status.Sync.Status = "Synced"
+		application.Status.Health.Status = "Progressing"
+		application.Status.Resources = []ApplicationResource{
+			{
+				Kind: "Deployment", Name: "app", Namespace: "app",
+				Health: struct {
+					Message string `json:"message"`
+					Status  string `json:"status"`
+				}{Status: "Degraded", Message: "replicas unavailable"},
+			},
+		}
+		application.Status.OperationState.Phase = "Failed"
+		application.Status.OperationState.Message = "sync failed"
+		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
+			{HookPhase: "Failed", HookType: "PreSync", Kind: "Job", Message: "backoff", SyncPhase: "PreSync", Name: "app-migrations", Namespace: "app"},
+		}
+		images := []string{"app:v0.0.2"}
+		assert.Equal(t,
+			"App sync status \"Synced\"\n"+
+				"App health status \"Progressing\"\n"+
+				"Resources:\n"+
+				"\tDeployment(app) Degraded with message replicas unavailable\n\n"+
+				"Sync operation phase: Failed\n"+
+				"Sync operation message: sync failed\n\n"+
+				"Failed hooks:\n"+
+				"\tJob(app-migrations) PreSync Failed with message backoff",
+			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images, nil))
+	})
+}
+
+// treeNode builds an ApplicationTreeNode with the given health, sparing tests the anonymous
+// struct literal for the Health field.
+func treeNode(kind, name, status, message string) ApplicationTreeNode {
+	n := ApplicationTreeNode{Kind: kind, Name: name, Namespace: "app"}
+	n.Health.Status = status
+	n.Health.Message = message
+	return n
+}
+
+func TestApplicationTreeListProblemNodes(t *testing.T) {
+	tree := ApplicationTree{Nodes: []ApplicationTreeNode{
+		treeNode("Pod", "pull-fail", "Degraded", `Back-off pulling image "app:v2": ErrImagePull`),
+		treeNode("Pod", "healthy", "Healthy", ""),
+		treeNode("Deployment", "app", "Progressing", "Waiting for rollout to finish"),
+		treeNode("Job", "missing-hook", "Missing", ""),
+		treeNode("Pod", "unknown-pod", "Unknown", "lost contact with node"),
+		treeNode("Rollout", "suspended-rollout", "Suspended", "paused for manual promotion"),
+		treeNode("Service", "no-health", "", ""),
+	}}
+
+	got := tree.ListProblemNodes()
+
+	// Every status isProblemHealthStatus whitelists survives (Degraded, Missing, Unknown,
+	// Suspended); Healthy/Progressing/empty are filtered out.
+	assert.Equal(t, []string{
+		`Pod(pull-fail) Degraded with message Back-off pulling image "app:v2": ErrImagePull`,
+		"Job(missing-hook) Missing",
+		"Pod(unknown-pod) Unknown with message lost contact with node",
+		"Rollout(suspended-rollout) Suspended with message paused for manual promotion",
+	}, got)
 }
 
 func TestIsTerminalFailurePhase(t *testing.T) {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -42,6 +42,10 @@ func (m *mockArgoApi) GetApplication(_ context.Context, _ string, _ bool) (*mode
 	return &models.Application{}, nil
 }
 
+func (m *mockArgoApi) GetResourceTree(_ context.Context, _ string) (*models.ApplicationTree, error) {
+	return &models.ApplicationTree{}, nil
+}
+
 // mockTaskRepository is a minimal mock for TaskRepository used in tests.
 // Calls to GetTasks capture the last argument set so handler-level tests can
 // assert that query params are forwarded to the repository.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,7 @@ pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → smoke → failure-diagnostics → load → race → down
+task e2e     # one-shot per-release run: up → smoke → load → race → failure-diagnostics → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,7 @@ pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → smoke → load → race → down
+task e2e     # one-shot per-release run: up → smoke → failure-diagnostics → load → race → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed
@@ -29,12 +29,13 @@ run leaves the cluster up for debugging; a fully green run tears it down.
 Individual steps (for iterating or debugging):
 
 ```sh
-task up      # build the race image + boot the full lab (idempotent)
-task verify  # assert argo-watcher is up and reaching real Argo
-task smoke   # one authenticated deploy through the full write-back loop
-task load    # git-conflict soak: competitor + concurrent deploys, strict 0-failed
-task race    # same-app supersession: a newer deploy must win over an older retrying one
-task down    # destroy the cluster
+task up                   # build the race image + boot the full lab (idempotent)
+task verify               # assert argo-watcher is up and reaching real Argo
+task smoke                # one authenticated deploy through the full write-back loop
+task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
+task load                 # git-conflict soak: competitor + concurrent deploys, strict 0-failed
+task race                 # same-app supersession: a newer deploy must win over an older retrying one
+task down                 # destroy the cluster
 ```
 
 Tunable soak knobs are `Taskfile.yml` vars (`APPS`, `WORKERS`, `WS_CLIENTS`,
@@ -63,6 +64,8 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 | `values/` | pinned Helm values for argocd / argo-watcher / gitea |
 | `scripts/load-race-image.sh` | load a local image into the kind node |
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
+| `scripts/failure-diagnostics.sh` | table-driven failure-reason assertions (add a case = one table entry) |
+| `scripts/hook-fixture.sh` | add/remove a failing PreSync hook via the chart's `rawObject` |
 
 ## Gotchas (why the scripts exist)
 

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -49,15 +49,18 @@ tasks:
       - task: verify
 
   e2e:
-    desc: "One-shot per-release run: up → smoke → failure-diagnostics → load → race → down"
+    desc: "One-shot per-release run: up → smoke → load → race → failure-diagnostics → down"
     cmds:
       # Runs the whole flow. Stops on the first failing step, so a failed run
       # leaves the cluster up for debugging; a fully green run tears it down.
       - task: up
       - task: smoke
-      - task: failure-diagnostics
       - task: load
       - task: race
+      # failure-diagnostics runs LAST: it deliberately breaks apps (bad images, a failing
+      # PreSync hook injected into the SHARED chart values) and pushes directly to the gitops
+      # repo, so running it before load/race would perturb those pristine-state soak gates.
+      - task: failure-diagnostics
       - task: down
 
   cluster:

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -49,12 +49,13 @@ tasks:
       - task: verify
 
   e2e:
-    desc: "One-shot per-release run: up → smoke → load → race → down"
+    desc: "One-shot per-release run: up → smoke → failure-diagnostics → load → race → down"
     cmds:
       # Runs the whole flow. Stops on the first failing step, so a failed run
       # leaves the cluster up for debugging; a fully green run tears it down.
       - task: up
       - task: smoke
+      - task: failure-diagnostics
       - task: load
       - task: race
       - task: down
@@ -111,6 +112,11 @@ tasks:
     desc: "One authenticated end-to-end deploy proving the write-back loop"
     cmds:
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/smoke-deploy.sh
+
+  failure-diagnostics:
+    desc: "Assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks) from real ArgoCD"
+    cmds:
+      - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/failure-diagnostics.sh
 
   load:
     desc: "Git-conflict soak: competitor writer + concurrent deploys + collect/assert"

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -28,7 +28,11 @@ trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
 
 # --- helpers ----------------------------------------------------------------
-api() { curl -s -m 15 "localhost:${PORT}/api/v1/$1" "${@:2}"; }
+api() {
+  local path="$1"; shift
+  curl -s -m 15 "localhost:${PORT}/api/v1/${path}" "$@"
+  return
+}
 
 # submit_task <json> <use_token> -> task id
 submit_task() {
@@ -36,6 +40,7 @@ submit_task() {
   [[ "$use_token" == "1" ]] && hdr=(-H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}")
   # "${hdr[@]+...}" guards the empty-array expansion so it is safe under `set -u` on bash < 4.4.
   api tasks -X POST -H 'Content-Type: application/json' "${hdr[@]+"${hdr[@]}"}" -d "$payload" | jq -r '.id'
+  return
 }
 
 # wait_terminal <id> -> prints final status
@@ -43,10 +48,14 @@ wait_terminal() {
   local id="$1" st
   for _ in $(seq 1 48); do
     st=$(api "tasks/${id}" | jq -r '.status // "?"')
-    case "$st" in deployed|failed|aborted) echo "$st"; return 0 ;; esac
+    case "$st" in
+      deployed|failed|aborted) echo "$st"; return 0 ;;
+      *) ;; # non-terminal: keep polling
+    esac
     sleep 5
   done
   echo "timeout"
+  return
 }
 
 # restore_good_tag <app>: bump the app back to a pullable tag so the lab stays reusable.
@@ -54,6 +63,7 @@ restore_good_tag() {
   local app="$1" id
   id=$(submit_task "{\"app\":\"${app}\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":120,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${GOOD_TAG}\"}]}" 1)
   wait_terminal "$id" >/dev/null
+  return
 }
 
 # --- scenarios --------------------------------------------------------------
@@ -66,8 +76,9 @@ scenario_bad_image() {
   echo "expect=Pod("
   echo "expect=ErrImagePull"
   echo "teardown=teardown_bad_image"
+  return
 }
-teardown_bad_image() { restore_good_tag app1; }
+teardown_bad_image() { restore_good_tag app1; return; }
 
 # A deploy request whose image is never applied (unvalidated -> write-back skipped) stays
 # "not available" with the app green. There is nothing for ArgoCD to diagnose, so the reason
@@ -77,6 +88,7 @@ scenario_unvalidated_not_available() {
   echo "token=0"
   echo "expect=Rollout status is not available"
   echo "expect=List of expected images:"
+  return
 }
 
 # A failing PreSync hook (Helm Job) must surface as a failed hook, not just image lists.
@@ -87,9 +99,10 @@ scenario_failed_presync_hook() {
   echo "expect=PreSync Failed"
   echo "setup=setup_failed_presync_hook"
   echo "teardown=teardown_failed_presync_hook"
+  return
 }
-setup_failed_presync_hook()    { "${here}/hook-fixture.sh" add app3; }
-teardown_failed_presync_hook() { "${here}/hook-fixture.sh" remove app3; restore_good_tag app3; }
+setup_failed_presync_hook()    { "${here}/hook-fixture.sh" add app3; return; }
+teardown_failed_presync_hook() { "${here}/hook-fixture.sh" remove app3; restore_good_tag app3; return; }
 
 SCENARIOS=(
   scenario_bad_image

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Assert argo-watcher extracts an ACTIONABLE failure reason from real ArgoCD — not just the
+# image lists. Each scenario drives a deployment that is meant to fail a specific way, then
+# checks the stored task `status_reason` contains the substrings that pin the diagnosis.
+#
+# Table-driven on purpose: adding coverage is one entry in SCENARIOS plus a scenario_<name>
+# function. Each scenario echoes, on stdout, a series of "key=value" lines the runner reads:
+#   task=<json>            deploy payload POSTed to /api/v1/tasks   (required)
+#   token=<0|1>            send the deploy token (enables write-back); default 1
+#   expect=<substring>     a substring that MUST appear in status_reason (repeatable)
+#   setup / teardown       optional: names of functions run before/after the scenario
+# The runner submits the task, waits for a terminal status, and greps the reason.
+#
+# Usage: DEPLOY_TOKEN=... failure-diagnostics.sh
+set -uo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+PORT="${PORT:-18095}"
+IMAGE="${IMAGE:-traefik/whoami}"
+GOOD_TAG="${GOOD_TAG:-v1.10.1}"
+GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
+GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+
+# --- helpers ----------------------------------------------------------------
+api() { curl -s -m 15 "localhost:${PORT}/api/v1/$1" "${@:2}"; }
+
+# submit_task <json> <use_token> -> task id
+submit_task() {
+  local payload="$1" use_token="$2" hdr=()
+  [[ "$use_token" == "1" ]] && hdr=(-H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}")
+  # "${hdr[@]+...}" guards the empty-array expansion so it is safe under `set -u` on bash < 4.4.
+  api tasks -X POST -H 'Content-Type: application/json' "${hdr[@]+"${hdr[@]}"}" -d "$payload" | jq -r '.id'
+}
+
+# wait_terminal <id> -> prints final status
+wait_terminal() {
+  local id="$1" st
+  for _ in $(seq 1 48); do
+    st=$(api "tasks/${id}" | jq -r '.status // "?"')
+    case "$st" in deployed|failed|aborted) echo "$st"; return 0 ;; esac
+    sleep 5
+  done
+  echo "timeout"
+}
+
+# restore_good_tag <app>: bump the app back to a pullable tag so the lab stays reusable.
+restore_good_tag() {
+  local app="$1" id
+  id=$(submit_task "{\"app\":\"${app}\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":120,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${GOOD_TAG}\"}]}" 1)
+  wait_terminal "$id" >/dev/null
+}
+
+# --- scenarios --------------------------------------------------------------
+# Committed image tag that cannot be pulled -> pods ImagePullBackOff. The cause lives ONLY on
+# the Pod (resource tree), never in the app's top-level resources; the fix must surface it.
+scenario_bad_image() {
+  echo "task={\"app\":\"app1\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":90,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v0.0.0-nopull\"}]}"
+  echo "token=1"
+  echo "expect=Unhealthy resources:"
+  echo "expect=Pod("
+  echo "expect=ErrImagePull"
+  echo "teardown=teardown_bad_image"
+}
+teardown_bad_image() { restore_good_tag app1; }
+
+# A deploy request whose image is never applied (unvalidated -> write-back skipped) stays
+# "not available" with the app green. There is nothing for ArgoCD to diagnose, so the reason
+# must be the baseline image lists WITHOUT inventing diagnostics.
+scenario_unvalidated_not_available() {
+  echo "task={\"app\":\"app2\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":45,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v0.0.0-never\"}]}"
+  echo "token=0"
+  echo "expect=Rollout status is not available"
+  echo "expect=List of expected images:"
+}
+
+# A failing PreSync hook (Helm Job) must surface as a failed hook, not just image lists.
+scenario_failed_presync_hook() {
+  echo "task={\"app\":\"app3\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":90,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.2\"}]}"
+  echo "token=1"
+  echo "expect=Failed hooks:"
+  echo "expect=PreSync Failed"
+  echo "setup=setup_failed_presync_hook"
+  echo "teardown=teardown_failed_presync_hook"
+}
+setup_failed_presync_hook()    { "${here}/hook-fixture.sh" add app3; }
+teardown_failed_presync_hook() { "${here}/hook-fixture.sh" remove app3; restore_good_tag app3; }
+
+SCENARIOS=(
+  scenario_bad_image
+  scenario_unvalidated_not_available
+  scenario_failed_presync_hook
+)
+
+# --- runner -----------------------------------------------------------------
+overall=0
+for scenario in "${SCENARIOS[@]}"; do
+  echo "=== ${scenario#scenario_} ==="
+  spec="$($scenario)"
+  task=$(sed -n 's/^task=//p' <<<"$spec")
+  token=$(sed -n 's/^token=//p' <<<"$spec"); token="${token:-1}"
+  setup=$(sed -n 's/^setup=//p' <<<"$spec")
+  teardown=$(sed -n 's/^teardown=//p' <<<"$spec")
+  mapfile -t expects < <(sed -n 's/^expect=//p' <<<"$spec")
+
+  [[ -n "$setup" ]] && { echo "  setup: $setup"; "$setup"; }
+
+  id=$(submit_task "$task" "$token")
+  status=$(wait_terminal "$id")
+  reason=$(api "tasks/${id}" | jq -r '.status_reason // ""')
+  echo "  status=${status}"
+  echo "  reason: $(sed 's/^/    | /' <<<"$reason")"
+
+  ok=1
+  [[ "$status" == "failed" ]] || { echo "  FAIL: expected terminal 'failed', got '${status}'"; ok=0; }
+  for want in "${expects[@]}"; do
+    if grep -qF -- "$want" <<<"$reason"; then
+      echo "  OK: reason contains «${want}»"
+    else
+      echo "  FAIL: reason missing «${want}»"; ok=0
+    fi
+  done
+
+  [[ -n "$teardown" ]] && { echo "  teardown: $teardown"; "$teardown"; }
+  [[ "$ok" -eq 1 ]] || overall=1
+done
+
+if [[ "$overall" -eq 0 ]]; then echo "FAILURE-DIAGNOSTICS: PASS"; else echo "FAILURE-DIAGNOSTICS: FAIL"; exit 1; fi

--- a/test/e2e/scripts/hook-fixture.sh
+++ b/test/e2e/scripts/hook-fixture.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Add or remove a deliberately-failing PreSync hook in the shared gitops chart, so a deploy
+# through argo-watcher makes ArgoCD run (and fail) the hook — exercising the failed-hook branch
+# of the failure-reason diagnostics. The hook is injected via the `app` chart's rawObject values
+# passthrough (no chart templates needed). Shared values affect all fixture apps; callers run
+# this only around the hook scenario and remove it immediately after.
+#
+# Usage: hook-fixture.sh <add|remove> [app]
+set -euo pipefail
+
+ACTION="${1:?usage: hook-fixture.sh <add|remove> [app]}"
+ORG="${ORG:-e2e}"; REPO="${REPO:-gitops}"; PORT="${GITEA_PORT:-13030}"
+GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"; GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
+
+kubectl -n gitea port-forward svc/gitea-http "${PORT}:3000" >/dev/null 2>&1 &
+pf=$!; trap 'kill $pf 2>/dev/null || true; rm -rf "${work:-}"' EXIT
+for _ in $(seq 1 20); do curl -sf -m3 -u "${GITEA_ADMIN}:${GITEA_PW}" "http://localhost:${PORT}/api/v1/version" >/dev/null 2>&1 && break; sleep 1; done
+
+work="$(mktemp -d)"
+git -C "$work" clone -q "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${PORT}/${ORG}/${REPO}.git" r
+
+values="$work/r/chart/values.yaml"
+case "$ACTION" in
+  add)
+    cat > "$values" <<'YAML'
+app:
+  image:
+    repository: traefik/whoami
+    tag: v1.10.1
+  rawObject:
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: presync-migration
+        annotations:
+          argocd.argoproj.io/hook: PreSync
+          argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      spec:
+        backoffLimit: 0
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: migrate
+                image: busybox:1.36
+                command: ["sh", "-c", "echo running db migration; sleep 2; echo 'migration failed'; exit 1"]
+YAML
+    msg="add failing PreSync hook fixture"
+    ;;
+  remove)
+    cat > "$values" <<'YAML'
+app:
+  image:
+    repository: traefik/whoami
+    tag: v1.10.1
+YAML
+    msg="remove failing PreSync hook fixture"
+    ;;
+  *) echo "unknown action: $ACTION" >&2; exit 2 ;;
+esac
+
+# Idempotent: if the fixture is already in the target state there is nothing to commit, and
+# `git commit` under `set -e` would abort. Only commit+push when the tree actually changed.
+if git -C "$work/r" diff --quiet; then
+  echo "hook-fixture: ${ACTION} already applied (no-op)"
+else
+  git -C "$work/r" -c user.name=e2e -c user.email=e2e@e2e commit -qam "$msg"
+  git -C "$work/r" push -q origin main
+  echo "hook-fixture: ${ACTION} committed"
+fi


### PR DESCRIPTION
Deployment-failure reasons previously showed only the image lists and the app's top-level resources (Service/Deployment), which never carry the actual root cause: a failing rollout's cause lives on the Pod (ImagePullBackOff, CrashLoopBackOff), absent from Application.Status.Resources.

Fetch ArgoCD's live resource tree on the failure path and surface its problem nodes, so both "not available" and "not healthy"/"degraded" failures report the real cause. The tree is the preferred source for the unhealthy-resources section, falling back to Status.Resources only where it does not duplicate the existing listing; failed-hook and terminal sync-operation diagnostics are retained. The fetch is best-effort: a resource-tree error yields no enrichment and never blocks marking the deployment failed. status_reason is only richer text, so no schema change.

Add table-driven e2e lab coverage (task failure-diagnostics) asserting the enriched reasons against real ArgoCD, and centralize test mock creation so new ArgoCD API methods need one edit, not one per test.