### PR TITLE
fix(server): guard stale locked notification after lock release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stop sending a stale "locked" WebSocket notification after a manual lock
+  release. Releasing a manual lock during an active scheduled window suppresses
+  that window for 15 minutes; when the timer expired the server always told
+  clients the system was "locked" again, even if the scheduled window had ended
+  in the meantime — leaving the Web UI showing a lockdown that was no longer in
+  effect. It now re-notifies only when the system is genuinely still locked.
 - Never show React-admin's built-in username/password login form. The Web UI
   authenticates only through a top-level Keycloak redirect, but the stock login
   form could still surface as a misleading fallback when Keycloak was

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -153,15 +153,25 @@ func (l *Lockdown) ReleaseLock() {
 	l.mu.Unlock()
 
 	if isLocked {
-		go func() {
-			time.Sleep(15 * time.Minute)
-			l.mu.Lock()
-			l.OverrideMode = false
-			l.mu.Unlock()
+		go l.expireOverride(15*time.Minute, notifyWebSocketClients)
+	}
+}
 
-			// we need to re-notify clients that the lock is in action again
-			notifyWebSocketClients("locked")
-		}()
+// expireOverride waits for d, then clears the temporary override that ReleaseLock
+// enabled. It re-notifies clients with "locked" only when the system is genuinely
+// still locked once the override ends; if the scheduled window closed during the
+// wait, the system is now unlocked and no stale "locked" message is sent. The
+// duration and notifier are parameters so the guard can be unit-tested.
+func (l *Lockdown) expireOverride(d time.Duration, notify func(string)) {
+	time.Sleep(d)
+
+	l.mu.Lock()
+	l.OverrideMode = false
+	stillLocked := l.isLockedInternal()
+	l.mu.Unlock()
+
+	if stillLocked {
+		notify("locked")
 	}
 }
 

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -418,8 +418,9 @@ func TestLockdown_ExpireOverride(t *testing.T) {
 	// The wide margins keep the window on the correct side of "now" across
 	// hour/day/week boundaries.
 	scheduleAround := func(startOffset, endOffset time.Duration) LockdownSchedule {
-		start := time.Now().Add(startOffset)
-		end := time.Now().Add(endOffset)
+		now := time.Now()
+		start := now.Add(startOffset)
+		end := now.Add(endOffset)
 		return LockdownSchedule{
 			StartDay:  start.Weekday(),
 			StartHour: start.Hour(),

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -409,6 +409,68 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 	})
 }
 
+// TestLockdown_ExpireOverride verifies that once the override window ends, the
+// system re-notifies clients with "locked" only when it is genuinely still
+// locked, and stays silent when the lock has meanwhile been lifted.
+func TestLockdown_ExpireOverride(t *testing.T) {
+	// scheduleAround builds a one-off schedule window offset from now, so tests
+	// can reproduce a scheduled lockdown that is still open or already closed.
+	// The wide margins keep the window on the correct side of "now" across
+	// hour/day/week boundaries.
+	scheduleAround := func(startOffset, endOffset time.Duration) LockdownSchedule {
+		start := time.Now().Add(startOffset)
+		end := time.Now().Add(endOffset)
+		return LockdownSchedule{
+			StartDay:  start.Weekday(),
+			StartHour: start.Hour(),
+			StartMin:  start.Minute(),
+			EndDay:    end.Weekday(),
+			EndHour:   end.Hour(),
+			EndMin:    end.Minute(),
+		}
+	}
+
+	t.Run("notifies locked when the scheduled window is still open", func(t *testing.T) {
+		// Mirrors the production path: ReleaseLock clears ManualLock, so the only
+		// way the system is still locked after the override expires is an active
+		// schedule window. Once OverrideMode clears, that window must re-notify.
+		l := &Lockdown{OverrideMode: true, Schedules: []LockdownSchedule{
+			scheduleAround(-2*time.Minute, 2*time.Minute),
+		}}
+
+		msgs := make(chan string, 1)
+		l.expireOverride(time.Millisecond, func(m string) { msgs <- m })
+
+		assert.False(t, l.OverrideMode, "override should be cleared")
+		select {
+		case m := <-msgs:
+			assert.Equal(t, "locked", m)
+		case <-time.After(time.Second):
+			t.Fatal("expected a 'locked' notification")
+		}
+	})
+
+	t.Run("stays silent when the scheduled window closed during the override", func(t *testing.T) {
+		// The exact bug scenario: the schedule window elapsed while the override
+		// was active, so once OverrideMode clears the system is unlocked and no
+		// stale "locked" message must be sent.
+		l := &Lockdown{OverrideMode: true, Schedules: []LockdownSchedule{
+			scheduleAround(-4*time.Minute, -2*time.Minute),
+		}}
+
+		msgs := make(chan string, 1)
+		l.expireOverride(time.Millisecond, func(m string) { msgs <- m })
+
+		assert.False(t, l.OverrideMode, "override should be cleared")
+		select {
+		case m := <-msgs:
+			t.Fatalf("unexpected notification: %q", m)
+		case <-time.After(50 * time.Millisecond):
+			// no notification is the expected outcome
+		}
+	})
+}
+
 // TestLockdown_IsLockedInternal tests the internal lock checking logic.
 func TestLockdown_IsLockedInternal(t *testing.T) {
 	t.Run("returns true when ManualLock is set", func(t *testing.T) {


### PR DESCRIPTION
ReleaseLock's override-expiry goroutine sent an unconditional "locked" WebSocket notification when the 15-minute override elapsed. If the scheduled lockdown window had ended during those 15 minutes, clients were wrongly told the system was locked while it was actually unlocked.

Extract the goroutine body into expireOverride, which clears the override and re-notifies "locked" only when the system is genuinely still locked. The duration and notifier are parameters so both branches of the guard are unit-tested against real schedule windows.