### PR TITLE
fix(server): wait for in-flight WebSocket upgrades on shutdown

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,22 @@ jobs:
           POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
         run: task test
 
+      # task test runs the whole tree without -race; run the server package under
+      # the race detector so goroutine/shutdown races (e.g. the WebSocket hijack
+      # path) fail CI instead of staying hidden. These tests are untagged and
+      # self-contained, so no integration services are required.
+      - name: Race-detect the server package
+        env:
+          DB_HOST: localhost
+          DB_USER: postgres
+          DB_NAME: postgres
+          DB_PASSWORD: postgres
+          DB_PORT: 5432
+          STATE_TYPE: in-memory
+          ARGO_URL: http://localhost:8081
+          POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+        run: go test -race -count=1 -timeout=5m ./internal/server/...
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wait for in-flight WebSocket upgrades during graceful shutdown. The shutdown
+  routine only tracked established connections, not handshakes still being
+  negotiated, which left a data race between an in-progress upgrade and shutdown
+  (surfaced by the race detector). Handshakes are now accounted for, so shutdown
+  drains them cleanly.
 - Stop sending a stale "locked" WebSocket notification after a manual lock
   release. Releasing a manual lock during an active scheduled window suppresses
   that window for 15 minutes; when the timer expired the server always told

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -680,6 +680,12 @@ func TestWebSocketInterceptor(t *testing.T) {
 	})
 }
 
+// TestWebSocketConnectionIntegration establishes a real WebSocket connection and
+// then triggers env.Shutdown during cleanup. Besides asserting the pre-hijack
+// upgrade works, it is the regression guard for the WebSocket hijack/shutdown
+// data race: it only detects that race when the suite runs under `go test -race`
+// (wired in .github/workflows/run-tests.yml), since a plain run cannot observe
+// it. Keep the -race CI step if you touch this test.
 func TestWebSocketConnectionIntegration(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -110,6 +110,17 @@ func (env *Env) handleWebSocketConnection(c *gin.Context) {
 		return
 	}
 
+	// Track the in-flight upgrade so graceful shutdown waits for handshakes that
+	// are still in progress, not only for connections that are already
+	// established. Bracketing the rest of the handler also gives Shutdown's
+	// connWg.Wait a happens-before edge over the handshake's response writes
+	// (websocket.Accept -> WriteHeader below); without it the only
+	// synchronization between this handler and shutdown is the underlying TCP
+	// socket, which the race detector cannot observe. Registered only after a
+	// successful hijack, so non-WebSocket early returns never touch connWg.
+	env.connWg.Add(1)
+	defer env.connWg.Done()
+
 	// Create wrapper with pre-hijacked connection
 	wrappedWriter := &wsResponseWriter{
 		ResponseWriter: c.Writer,


### PR DESCRIPTION
Env.Shutdown drains env.connWg, but connWg only tracked the spawned checkConnection goroutine, not the handshake work in handleWebSocketConnection (websocket.Accept then WriteHeader). The request-handler goroutine and the shutdown goroutine synchronized only through the TCP socket, which the race detector cannot observe as a happens-before edge, so it reported a data race on memory reused after the handler finished.

Bracket handleWebSocketConnection with connWg.Add/Done right after a successful hijack. Graceful shutdown now waits for in-flight upgrades and the WaitGroup establishes the missing happens-before edge, clearing the race. Add a CI step running the server package under -race so this class of regression fails CI, which previously never exercised it.