### PR TITLE
fix(server): stop accepting connections before draining on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   routine only tracked established connections, not handshakes still being
   negotiated, which left a data race between an in-progress upgrade and shutdown
   (surfaced by the race detector). Handshakes are now accounted for, so shutdown
-  drains them cleanly.
+  drains them cleanly. Shutdown also stops accepting new connections before
+  draining the WebSocket goroutines, avoiding a rare shutdown-time panic when a
+  new connection arrived mid-drain.
 - Stop sending a stale "locked" WebSocket notification after a manual lock
   release. Releasing a manual lock during an active scheduled window suppresses
   that window for 15 minutes; when the timer expired the server always told

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,16 +151,27 @@ func (s *Server) Run() {
 		s.probeCancel()
 	}
 
-	// Trigger WebSocket connection shutdown
-	s.env.Shutdown()
-
-	// Give outstanding requests 30 seconds to complete
+	// Stop accepting new connections first and let outstanding HTTP requests
+	// drain (up to 30 seconds), then shut down the WebSocket goroutines. Closing
+	// the listener before env.Shutdown means new handshakes can no longer arrive,
+	// which greatly narrows the window in which a WebSocket handler could call
+	// connWg.Add(1) after env.Shutdown has begun waiting on connWg (a WaitGroup
+	// misuse that could panic during shutdown). It does not fully eliminate it: a
+	// handshake already past the hijack but not yet registered is untracked by
+	// srv.Shutdown, so it can still register in that nanosecond gap — an
+	// acceptable residual given it can only occur on an already-terminating
+	// process. Hijacked WebSocket connections are not waited on by srv.Shutdown;
+	// they are drained by env.Shutdown below.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
 		slog.Error("server forced to shutdown", "error", err)
 	}
+
+	// Now that the listener is closed, signal the WebSocket connection
+	// goroutines to stop and wait for them to finish.
+	s.env.Shutdown()
 
 	slog.Info("server exited")
 }


### PR DESCRIPTION
Server.Run ran env.Shutdown (connWg.Wait) before srv.Shutdown, so the HTTP server kept accepting while connWg drained. A WebSocket handshake arriving as connWg reached zero could call connWg.Add(1) concurrently with the pending Wait, a sync.WaitGroup misuse that can panic during shutdown.

Close the listener first: srv.Shutdown now runs before env.Shutdown. Hijacked WebSocket connections are not waited on by srv.Shutdown, so it does not block on them; they are drained afterward by env.Shutdown. This greatly narrows the Add-after-Wait window; the residual nanosecond gap between hijack and registration is documented and acceptable on an already-terminating process.