### PR TITLE
fix(client): redact auth credentials from debug cURL log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they are now registered only when Keycloak is enabled, and the Web UI hides
   the manual lock toggle to match. The read-only lock status and scheduled
   lockdown are unaffected.
+- Redact the authorization credential from the client's debug output. With debug
+  mode enabled the client logged an equivalent cURL command that included the
+  `Authorization` (JWT) and `ARGO_WATCHER_DEPLOY_TOKEN` header values in clear
+  text, leaking the deploy credential into CI job logs and log aggregators. Those
+  header values are now replaced with `<redacted>` while the header names remain
+  visible for troubleshooting.
 
 ## [0.11.0] - 2026-07-13
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -83,8 +83,10 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 		}
 	}
 
-	// Print the equivalent cURL command for troubleshooting
-	if curlCommand, err := helpers.CurlCommandFromRequest(request); err != nil {
+	// Print the equivalent cURL command for troubleshooting. Redact the auth
+	// headers so the JWT / deploy token is never written to logs (e.g. CI job
+	// output), which are often persisted and widely readable.
+	if curlCommand, err := helpers.CurlCommandFromRequest(request, "Authorization", "ARGO_WATCHER_DEPLOY_TOKEN"); err != nil {
 		log.Printf("Couldn't get cURL command. Got the following error: %s", err)
 	} else if watcher.debugMode {
 		log.Printf("Adding task to argo-watcher. Equivalent cURL command: %s\n", curlCommand)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -277,6 +279,47 @@ func TestAddTaskDeployTokenHeader(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tokenInput, gotToken, "deploy token must be sent verbatim, never prefix-stripped")
+		})
+	}
+}
+
+// TestAddTaskDebugLogRedactsToken guards the actual leak site fixed for the
+// go/clear-text-logging alert: with debug mode on, addTask logs an equivalent
+// cURL command, and the auth credential (JWT or deploy token) must be redacted
+// there. This pins the redaction arguments at the call site so dropping them
+// (which would silently reintroduce the leak) fails the suite.
+func TestAddTaskDebugLogRedactsToken(t *testing.T) {
+	cases := []struct {
+		name       string
+		authMethod string
+		token      string
+	}{
+		{"JWT", "JWT", "eyJhbGciOiJIUzI1NiJ9.super-secret-jwt.signature"},
+		{"DeployToken", "DeployToken", "s3cr3t-deploy-token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_ = json.NewEncoder(w).Encode(models.TaskStatus{Status: models.StatusAccepted, Id: taskId})
+			}))
+			defer srv.Close()
+
+			var logBuf bytes.Buffer
+			originalOutput := log.Writer()
+			log.SetOutput(&logBuf)
+			t.Cleanup(func() { log.SetOutput(originalOutput) })
+
+			watcher := NewWatcher(srv.URL, true, 30*time.Second)
+			_, err := watcher.addTask(models.Task{App: "test"}, tc.authMethod, tc.token)
+			assert.NoError(t, err)
+
+			logged := logBuf.String()
+			assert.Contains(t, logged, "Equivalent cURL command", "debug mode must log the cURL command")
+			assert.NotContains(t, logged, tc.token, "auth credential must not appear in logs")
+			assert.Contains(t, logged, "<redacted>", "auth header value must be redacted")
 		})
 	}
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -27,8 +27,11 @@ func ImagesContains(images []string, image string, registryProxy string) bool {
 
 // CurlCommandFromRequest generates a cURL command string from an HTTP request,
 // including the request method, headers, request body, and URL.
+// The value of any header whose name matches redactHeaders (case-insensitively)
+// is replaced with "<redacted>" so secrets such as auth tokens are not written
+// to logs; the header name itself is kept for troubleshooting.
 // It handles any errors during the process and returns the formatted cURL command or an error if encountered.
-func CurlCommandFromRequest(request *http.Request) (string, error) {
+func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (string, error) {
 	clonedRequest, err := httputil.DumpRequest(request, true)
 	if err != nil {
 		return "", err
@@ -38,6 +41,10 @@ func CurlCommandFromRequest(request *http.Request) (string, error) {
 
 	// Iterate over request headers and add them to the cURL command
 	for key, values := range request.Header {
+		if headerMatches(key, redactHeaders) {
+			cmd += fmt.Sprintf(" -H '%s: <redacted>'", shellEscapeSingleQuote(key))
+			continue
+		}
 		for _, value := range values {
 			cmd += fmt.Sprintf(" -H '%s: %s'", shellEscapeSingleQuote(key), shellEscapeSingleQuote(value))
 		}
@@ -61,8 +68,19 @@ func CurlCommandFromRequest(request *http.Request) (string, error) {
 	return cmd, nil
 }
 
+// headerMatches reports whether the given header name matches any entry in
+// names, comparing case-insensitively to tolerate HTTP header canonicalization.
+func headerMatches(name string, names []string) bool {
+	for _, candidate := range names {
+		if strings.EqualFold(name, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
 // shellEscapeSingleQuote escapes single quotes for use inside single-quoted shell strings.
-// It replaces each single quote with the sequence '\'' which ends the current single-quoted
+// It replaces each single quote with the sequence '\” which ends the current single-quoted
 // string, adds an escaped single quote, and starts a new single-quoted string.
 func shellEscapeSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", `'\''`)

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -80,8 +80,10 @@ func headerMatches(name string, names []string) bool {
 }
 
 // shellEscapeSingleQuote escapes single quotes for use inside single-quoted shell strings.
-// It replaces each single quote with the sequence '\” which ends the current single-quoted
-// string, adds an escaped single quote, and starts a new single-quoted string.
+// Each single quote is replaced with the following four-character sequence, which ends the
+// current single-quoted string, adds an escaped single quote, and starts a new one:
+//
+//	'\''
 func shellEscapeSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", `'\''`)
 }

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -135,7 +135,9 @@ func TestCurlCommandFromRequest_ShellEscaping(t *testing.T) {
 }
 
 // TestShellEscapeSingleQuote verifies that shellEscapeSingleQuote correctly escapes
-// single quotes using the '\” pattern for safe shell string interpolation.
+// single quotes for safe shell string interpolation, using the sequence:
+//
+//	'\''
 func TestShellEscapeSingleQuote(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -75,6 +75,47 @@ func TestCurlCommandFromRequest(t *testing.T) {
 	assert.Equal(t, sortedExpectedCurl, sortedActualCurl)
 }
 
+// TestCurlCommandFromRequest_RedactsHeaders verifies that the values of the
+// named sensitive headers are replaced with a placeholder while non-sensitive
+// headers are emitted verbatim, and that matching is case-insensitive.
+func TestCurlCommandFromRequest_RedactsHeaders(t *testing.T) {
+	request, _ := http.NewRequest("POST", "https://example.com/api", strings.NewReader(""))
+	request.Header.Add("Authorization", "super-secret-jwt")
+	request.Header.Add("ARGO_WATCHER_DEPLOY_TOKEN", "super-secret-token")
+	request.Header.Add("Content-Type", "application/json")
+
+	actualCurl, err := CurlCommandFromRequest(request, "authorization", "ARGO_WATCHER_DEPLOY_TOKEN")
+	assert.NoError(t, err)
+
+	// Secret values must not appear anywhere in the command.
+	assert.NotContains(t, actualCurl, "super-secret-jwt", "JWT value must be redacted")
+	assert.NotContains(t, actualCurl, "super-secret-token", "deploy token value must be redacted")
+
+	// Header names stay visible with a redacted placeholder value.
+	assert.Contains(t, actualCurl, "-H 'Authorization: <redacted>'")
+	assert.Contains(t, actualCurl, "-H 'Argo_watcher_deploy_token: <redacted>'")
+
+	// Non-sensitive headers are unchanged.
+	assert.Contains(t, actualCurl, "-H 'Content-Type: application/json'")
+}
+
+// TestCurlCommandFromRequest_RedactsMultiValueHeader verifies that a sensitive
+// header carrying multiple values collapses to a single redacted entry and never
+// emits any of the raw values.
+func TestCurlCommandFromRequest_RedactsMultiValueHeader(t *testing.T) {
+	request, _ := http.NewRequest("POST", "https://example.com/api", strings.NewReader(""))
+	request.Header.Add("Authorization", "secret-a")
+	request.Header.Add("Authorization", "secret-b")
+
+	actualCurl, err := CurlCommandFromRequest(request, "Authorization")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, actualCurl, "secret-a")
+	assert.NotContains(t, actualCurl, "secret-b")
+	assert.Equal(t, 1, strings.Count(actualCurl, "-H 'Authorization: <redacted>'"),
+		"multi-value sensitive header must collapse to exactly one redacted entry")
+}
+
 // TestCurlCommandFromRequest_ShellEscaping verifies that single quotes in headers,
 // body, and URL are properly escaped to prevent shell injection.
 func TestCurlCommandFromRequest_ShellEscaping(t *testing.T) {
@@ -94,7 +135,7 @@ func TestCurlCommandFromRequest_ShellEscaping(t *testing.T) {
 }
 
 // TestShellEscapeSingleQuote verifies that shellEscapeSingleQuote correctly escapes
-// single quotes using the '\'' pattern for safe shell string interpolation.
+// single quotes using the '\” pattern for safe shell string interpolation.
 func TestShellEscapeSingleQuote(t *testing.T) {
 	testCases := []struct {
 		input    string


### PR DESCRIPTION
With debug mode enabled the client logged an equivalent cURL command built from the outgoing request, which included the Authorization (JWT) and ARGO_WATCHER_DEPLOY_TOKEN header values in clear text. In CI these logs are persisted and widely readable, leaking the deploy credential (CodeQL go/clear-text-logging).

CurlCommandFromRequest now takes a variadic list of header names to redact and replaces their values with <redacted> while keeping the header name visible for troubleshooting; the client passes the two auth headers. Matching is case-insensitive to tolerate HTTP header canonicalization, and a multi-value sensitive header collapses to a single redacted entry.