### PR TITLE
test(e2e): cover generic webhook notifications

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,7 @@ pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → smoke → load → race → failure-diagnostics → down
+task e2e     # one-shot per-release run: up → smoke → notifications → load → race → failure-diagnostics → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed
@@ -32,6 +32,7 @@ Individual steps (for iterating or debugging):
 task up                   # build the race image + boot the full lab (idempotent)
 task verify               # assert argo-watcher is up and reaching real Argo
 task smoke                # one authenticated deploy through the full write-back loop
+task notifications        # assert the generic webhook fires (start + result) with the correct payload
 task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
 task load                 # git-conflict soak: competitor + concurrent deploys, strict 0-failed
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
@@ -61,11 +62,12 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 |---|---|
 | `Dockerfile.server.race` | argo-watcher built with `-race` on a glibc distroless base |
 | `kind-config.yaml` | single-node cluster |
-| `values/` | pinned Helm values for argocd / argo-watcher / gitea |
+| `values/` | pinned Helm values for argocd / argo-watcher / gitea / webhook-tester |
 | `scripts/load-race-image.sh` | load a local image into the kind node |
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
 | `scripts/failure-diagnostics.sh` | table-driven failure-reason assertions (add a case = one table entry) |
 | `scripts/hook-fixture.sh` | add/remove a failing PreSync hook via the chart's `rawObject` |
+| `scripts/notifications.sh` | assert the generic webhook fires start + result with the templated payload and auth header |
 
 ## Gotchas (why the scripts exist)
 
@@ -77,6 +79,16 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
   `CGO_ENABLED=1` and dynamic linking, so `Dockerfile.server.race` uses
   `gcr.io/distroless/base-debian12` — the production `distroless/static` base
   cannot run it.
+- **Webhook notifications are enabled globally, not just for `notifications`.**
+  The webhook is env-configured at install (`values/argo-watcher.yaml`
+  `extraEnvs`) pointing at the in-cluster `webhook-tester` receiver, so *every*
+  task fires start + result webhooks — the soak/race phases exercise the
+  notifier under `-race` for free. `notifications.sh` still gets a deterministic
+  assertion by running on a clean state and filtering the receiver's capture on
+  its own task id. The receiver is the generic `app` chart running
+  `tarampampam/webhook-tester` (in-memory, single container, no DB/Redis); its
+  `AUTO_CREATE_SESSIONS` makes the fixed-UUID `WEBHOOK_URL` work with no startup
+  wiring (the `WEBHOOK_UUID` in `Taskfile.yml` and the URL must match).
 
 ## Topology note
 

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -18,6 +18,12 @@ vars:
   GITEA_CHART_VERSION: 12.6.0
   AW_CHART_VERSION: 1.0.8
   AW_CHART_REPO: https://shini4i.github.io/charts/
+  # Generic app chart (same repo/family as argo-watcher) used to run the
+  # in-cluster webhook receiver for the notifications phase.
+  APP_CHART_VERSION: 0.2.1
+  # Fixed session UUID the webhook receiver auto-creates on first POST; the
+  # WEBHOOK_URL in values/argo-watcher.yaml and notifications.sh must agree.
+  WEBHOOK_UUID: 11111111-1111-1111-1111-111111111111
   # Number of fixture apps (all share one gitops repo → push contention).
   APPS: 5
   # Deploy token gating git write-back; the driver/smoke sends it in the
@@ -44,6 +50,7 @@ tasks:
       - task: load-race-image
       - task: gitea
       - task: seed
+      - task: webhook-tester
       - task: argo-watcher
       - task: apply-apps
       - task: verify
@@ -55,6 +62,7 @@ tasks:
       # leaves the cluster up for debugging; a fully green run tears it down.
       - task: up
       - task: smoke
+      - task: notifications
       - task: load
       - task: race
       # failure-diagnostics runs LAST: it deliberately breaks apps (bad images, a failing
@@ -101,6 +109,17 @@ tasks:
         --version {{.GITEA_CHART_VERSION}} -n gitea -f values/gitea.yaml
       - kubectl -n gitea rollout status deploy/gitea --timeout=300s
 
+  webhook-tester:
+    desc: "Install the in-cluster webhook receiver (generic app chart) used by the notifications phase"
+    cmds:
+      # Installed BEFORE argo-watcher so the receiver is reachable the moment the
+      # first task fires a webhook. Uses the generic shini4i `app` chart to avoid
+      # a bespoke manifest.
+      - helm upgrade --install webhook-tester app --repo {{.AW_CHART_REPO}}
+        --version {{.APP_CHART_VERSION}} -n webhook-tester --create-namespace
+        -f values/webhook-tester.yaml
+      - kubectl -n webhook-tester rollout status deploy/webhook-tester --timeout=120s
+
   seed:
     desc: "Seed Gitea (fixture repo + deploy key) and wire argo-watcher SSH"
     cmds:
@@ -115,6 +134,14 @@ tasks:
     desc: "One authenticated end-to-end deploy proving the write-back loop"
     cmds:
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/smoke-deploy.sh
+
+  notifications:
+    desc: "Assert the generic webhook fires (start + result) with the correct payload against a real receiver"
+    cmds:
+      # Runs on a clean state (right after smoke, before load/race dirty things)
+      # and asserts on its own uniquely-tagged deploy, so later soak traffic to
+      # the shared receiver is irrelevant to the assertion.
+      - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} WEBHOOK_UUID={{.WEBHOOK_UUID}} ./scripts/notifications.sh
 
   failure-diagnostics:
     desc: "Assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks) from real ArgoCD"

--- a/test/e2e/scripts/notifications.sh
+++ b/test/e2e/scripts/notifications.sh
@@ -32,8 +32,14 @@ WHT_PORT="${WHT_PORT:-18097}"
 kubectl -n "$NS_AW"  port-forward svc/argo-watcher   "${AW_PORT}:80"  >/dev/null 2>&1 &
 kubectl -n "$NS_WHT" port-forward svc/webhook-tester "${WHT_PORT}:80" >/dev/null 2>&1 &
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
-for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${AW_PORT}/healthz"  && break; sleep 1; done
-for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${WHT_PORT}/healthz" && break; sleep 1; done
+# Wait for each port-forward to actually answer; fail loudly if it never does,
+# so a forwarding problem does not masquerade as a later "no task id" error.
+wait_ready() { # <name> <healthz-url>
+  for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "$2" && return 0; sleep 1; done
+  echo "FAIL: port-forward to $1 not ready"; exit 1
+}
+wait_ready argo-watcher   "localhost:${AW_PORT}/healthz"
+wait_ready webhook-tester "localhost:${WHT_PORT}/healthz"
 
 wht="localhost:${WHT_PORT}/api/session/${WEBHOOK_UUID}"
 

--- a/test/e2e/scripts/notifications.sh
+++ b/test/e2e/scripts/notifications.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Assert argo-watcher's generic webhook notifications fire correctly against a
+# REAL in-cluster receiver (tarampampam/webhook-tester). One authenticated
+# deploy must produce TWO deliveries — the "in progress" start event and the
+# terminal "deployed" result — each carrying the templated JSON body and the
+# configured authorization header.
+#
+# Runs on a clean state (right after smoke, before load/race) and asserts only
+# on THIS deploy's task id, so unrelated soak traffic to the shared receiver
+# does not affect the result. The receiver captures every request and serves it
+# back over GET /api/session/<uuid>/requests (body base64-encoded).
+#
+# Usage: DEPLOY_TOKEN=... WEBHOOK_UUID=... notifications.sh
+set -uo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+NS_WHT="${NS_WHT:-webhook-tester}"
+DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+# Must match the fixed UUID baked into WEBHOOK_URL (values/argo-watcher.yaml).
+WEBHOOK_UUID="${WEBHOOK_UUID:-11111111-1111-1111-1111-111111111111}"
+APP="${APP:-app1}"
+IMAGE="${IMAGE:-traefik/whoami}"
+# A pullable tag that differs from smoke's (v1.10.2) so this forces a real
+# rollout to "deployed" rather than a no-op.
+TAG="${TAG:-v1.10.1}"
+# Must match WEBHOOK_AUTHORIZATION_HEADER_* in values/argo-watcher.yaml.
+AUTH_HEADER="${AUTH_HEADER:-X-E2E-Token}"
+AUTH_VALUE="${AUTH_VALUE:-e2e-webhook-secret}"
+AW_PORT="${AW_PORT:-18096}"
+WHT_PORT="${WHT_PORT:-18097}"
+
+kubectl -n "$NS_AW"  port-forward svc/argo-watcher   "${AW_PORT}:80"  >/dev/null 2>&1 &
+kubectl -n "$NS_WHT" port-forward svc/webhook-tester "${WHT_PORT}:80" >/dev/null 2>&1 &
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${AW_PORT}/healthz"  && break; sleep 1; done
+for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${WHT_PORT}/healthz" && break; sleep 1; done
+
+wht="localhost:${WHT_PORT}/api/session/${WEBHOOK_UUID}"
+
+# Start from a clean session so we assert on this deploy alone. A no-op if the
+# session does not exist yet (the first webhook auto-creates it).
+curl -s -m10 -X DELETE "${wht}/requests" >/dev/null 2>&1 || true
+
+# Fire one authenticated deploy: validated -> real write-back -> "deployed".
+id=$(curl -s -m15 -X POST "localhost:${AW_PORT}/api/v1/tasks" \
+  -H 'Content-Type: application/json' -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
+  -d "{\"app\":\"${APP}\",\"author\":\"e2e\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\"}]}" \
+  | jq -r '.id')
+echo "task ${id}: deploying ${APP} -> ${IMAGE}:${TAG}"
+[[ -n "$id" && "$id" != "null" ]] || { echo "FAIL: no task id returned"; exit 1; }
+
+# Wait for the terminal result so both webhooks (start + result) have fired.
+status=""
+for _ in $(seq 1 48); do
+  status=$(curl -s -m10 "localhost:${AW_PORT}/api/v1/tasks/${id}" | jq -r '.status // "?"')
+  case "$status" in deployed|failed|aborted) break ;; esac
+  sleep 5
+done
+echo "task status=${status}"
+[[ "$status" == "deployed" ]] || { echo "FAIL: expected terminal 'deployed', got '${status}'"; exit 1; }
+
+# Pull captured requests for THIS task id. The capture-API shape below
+# (GET .../requests, body in .request_payload_base64, headers as [{name,value}])
+# matches webhook-tester v2.3.0 — the tag pinned in values/webhook-tester.yaml;
+# re-verify it if that image is bumped. Body is base64 JSON; the auth header
+# match is case-insensitive (Go canonicalizes header names on send/receive).
+# Retry briefly — the result webhook lands right around terminal status.
+events='[]'
+for _ in $(seq 1 15); do
+  events=$(curl -s -m10 "${wht}/requests" | jq -c --arg id "$id" --arg hdr "$AUTH_HEADER" '
+    [ .[]
+      | . as $r
+      | (try ($r.request_payload_base64 | @base64d | fromjson) catch null) as $b
+      | select($b != null and $b.id == $id)
+      | { status: $b.status, app: $b.app, tag: ($b.images[0].tag // ""),
+          auth: ([ $r.headers[] | select((.name|ascii_downcase) == ($hdr|ascii_downcase)) | .value ] | first // "") } ]')
+  [[ "$(jq 'length' <<<"$events")" -ge 2 ]] && break
+  sleep 2
+done
+echo "captured events for task ${id}: ${events}"
+
+fail() { echo "FAIL: $1"; exit 1; }
+count=$(jq 'length' <<<"$events")
+[[ "$count" -ge 2 ]] || fail "expected >=2 webhook deliveries (start + result), got ${count}"
+jq -e --arg a "$APP" 'any(.[]; .status == "in progress" and .app == $a)' <<<"$events" >/dev/null \
+  || fail "missing 'in progress' start event for app=${APP}"
+jq -e --arg a "$APP" --arg t "$TAG" 'any(.[]; .status == "deployed" and .app == $a and .tag == $t)' <<<"$events" >/dev/null \
+  || fail "missing 'deployed' result event for app=${APP} tag=${TAG}"
+jq -e --arg v "$AUTH_VALUE" 'all(.[]; .auth == $v)' <<<"$events" >/dev/null \
+  || fail "authorization header ${AUTH_HEADER} missing or wrong on a delivery"
+
+echo "NOTIFICATIONS: PASS"

--- a/test/e2e/scripts/notifications.sh
+++ b/test/e2e/scripts/notifications.sh
@@ -35,8 +35,9 @@ trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 # Wait for each port-forward to actually answer; fail loudly if it never does,
 # so a forwarding problem does not masquerade as a later "no task id" error.
 wait_ready() { # <name> <healthz-url>
-  for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "$2" && return 0; sleep 1; done
-  echo "FAIL: port-forward to $1 not ready"; exit 1
+  local name="$1" url="$2"
+  for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "$url" && return 0; sleep 1; done
+  echo "FAIL: port-forward to ${name} not ready"; exit 1
 }
 wait_ready argo-watcher   "localhost:${AW_PORT}/healthz"
 wait_ready webhook-tester "localhost:${WHT_PORT}/healthz"
@@ -59,7 +60,7 @@ echo "task ${id}: deploying ${APP} -> ${IMAGE}:${TAG}"
 status=""
 for _ in $(seq 1 48); do
   status=$(curl -s -m10 "localhost:${AW_PORT}/api/v1/tasks/${id}" | jq -r '.status // "?"')
-  case "$status" in deployed|failed|aborted) break ;; esac
+  case "$status" in deployed|failed|aborted) break ;; *) ;; esac # non-terminal: keep polling
   sleep 5
 done
 echo "task status=${status}"
@@ -85,14 +86,14 @@ for _ in $(seq 1 15); do
 done
 echo "captured events for task ${id}: ${events}"
 
-fail() { echo "FAIL: $1"; exit 1; }
 count=$(jq 'length' <<<"$events")
-[[ "$count" -ge 2 ]] || fail "expected >=2 webhook deliveries (start + result), got ${count}"
+[[ "$count" -ge 2 ]] \
+  || { echo "FAIL: expected >=2 webhook deliveries (start + result), got ${count}"; exit 1; }
 jq -e --arg a "$APP" 'any(.[]; .status == "in progress" and .app == $a)' <<<"$events" >/dev/null \
-  || fail "missing 'in progress' start event for app=${APP}"
+  || { echo "FAIL: missing 'in progress' start event for app=${APP}"; exit 1; }
 jq -e --arg a "$APP" --arg t "$TAG" 'any(.[]; .status == "deployed" and .app == $a and .tag == $t)' <<<"$events" >/dev/null \
-  || fail "missing 'deployed' result event for app=${APP} tag=${TAG}"
+  || { echo "FAIL: missing 'deployed' result event for app=${APP} tag=${TAG}"; exit 1; }
 jq -e --arg v "$AUTH_VALUE" 'all(.[]; .auth == $v)' <<<"$events" >/dev/null \
-  || fail "authorization header ${AUTH_HEADER} missing or wrong on a delivery"
+  || { echo "FAIL: authorization header ${AUTH_HEADER} missing or wrong on a delivery"; exit 1; }
 
 echo "NOTIFICATIONS: PASS"

--- a/test/e2e/values/argo-watcher.yaml
+++ b/test/e2e/values/argo-watcher.yaml
@@ -30,3 +30,28 @@ updater:
 postgres:
   enabled: false
 replicaCount: 1
+
+# Generic-webhook notifications, pointed at the in-cluster webhook-tester
+# receiver (installed by `task webhook-tester` before this release). Config is
+# entirely env-var driven, so we wire it through the chart's extraEnvs — no
+# chart change needed. Enabled globally: every task fires start + result
+# webhooks, giving the soak/race phases free notifier-under-race coverage while
+# scripts/notifications.sh asserts on a clean, uniquely-tagged deploy.
+#
+# The URL's fixed UUID must match WEBHOOK_UUID in Taskfile.yml; the receiver
+# auto-creates the session on the first POST (AUTO_CREATE_SESSIONS).
+extraEnvs:
+  - name: WEBHOOK_ENABLED
+    value: "true"
+  - name: WEBHOOK_URL
+    value: "http://webhook-tester.webhook-tester/11111111-1111-1111-1111-111111111111"
+  # Emit the fields notifications.sh asserts on. Rendered by Go text/template
+  # against models.Task; passed through verbatim (Helm toYaml does not evaluate
+  # the {{ }}).
+  - name: WEBHOOK_FORMAT
+    value: '{"id":"{{.Id}}","app":"{{.App}}","status":"{{.Status}}","author":"{{.Author}}","project":"{{.Project}}","images":[{{range $i,$img := .Images}}{{if $i}},{{end}}{"image":"{{$img.Image}}","tag":"{{$img.Tag}}"}{{end}}]}'
+  # Prove auth-header passthrough end to end (asserted on the captured request).
+  - name: WEBHOOK_AUTHORIZATION_HEADER_NAME
+    value: "X-E2E-Token"
+  - name: WEBHOOK_AUTHORIZATION_HEADER_VALUE
+    value: "e2e-webhook-secret"

--- a/test/e2e/values/webhook-tester.yaml
+++ b/test/e2e/values/webhook-tester.yaml
@@ -35,7 +35,9 @@ app:
     - name: PUBSUB_DRIVER
       value: memory
     # Default is a 128-entry ring buffer; the soak fires two webhooks per task,
-    # so keep everything to avoid our asserted deploy being evicted.
+    # so keep everything to avoid our asserted deploy being evicted. 0 disables
+    # the cap (unlimited) — the in-memory store only trims when maxRequests > 0
+    # (verified in webhook-tester v2.3.0 internal/storage/inmemory.go).
     - name: MAX_REQUESTS
       value: "0"
   livenessProbe:

--- a/test/e2e/values/webhook-tester.yaml
+++ b/test/e2e/values/webhook-tester.yaml
@@ -1,0 +1,52 @@
+# In-cluster webhook receiver for the notifications e2e phase, deployed with the
+# generic shini4i `app` chart (the same chart family the lab already uses) so we
+# add no bespoke manifests.
+#
+# tarampampam/webhook-tester is a single-binary, in-memory, open-source
+# webhook.site clone: it captures incoming HTTP requests and serves them back
+# over a JSON API, so notifications.sh can assert on exactly what argo-watcher
+# delivered. Storage and pub/sub both default to memory (wiped on restart —
+# fine for a disposable per-release lab); no database or Redis needed.
+#
+# AUTO_CREATE_SESSIONS lets argo-watcher POST to a fixed-UUID URL
+# (http://webhook-tester.webhook-tester/<uuid>) with zero startup wiring: the
+# session is created on first request and read back via
+# GET /api/session/<uuid>/requests.
+fullnameOverride: webhook-tester
+
+image:
+  repository: ghcr.io/tarampampam/webhook-tester
+  # Pinned for reproducibility (latest release at time of writing).
+  tag: "2.3.0"
+
+service:
+  type: ClusterIP
+  ports:
+    - port: 80
+      containerPort: 8080
+      name: http
+
+app:
+  env:
+    - name: AUTO_CREATE_SESSIONS
+      value: "true"
+    - name: STORAGE_DRIVER
+      value: memory
+    - name: PUBSUB_DRIVER
+      value: memory
+    # Default is a 128-entry ring buffer; the soak fires two webhooks per task,
+    # so keep everything to avoid our asserted deploy being evicted.
+    - name: MAX_REQUESTS
+      value: "0"
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 2
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 2
+    periodSeconds: 5


### PR DESCRIPTION
Add a notifications phase to the e2e lab that exercises the generic webhook path end to end against a real in-cluster receiver.

- Run tarampampam/webhook-tester via the generic shini4i/app chart as an in-memory capture endpoint (no bespoke manifests, no DB/Redis).
- Enable the webhook globally through the argo-watcher chart extraEnvs so every task fires start + result events; the soak/race phases get notifier-under-race coverage for free.
- notifications.sh fires one authenticated deploy and asserts both deliveries (start "in progress" + result "deployed") carry the templated payload and auth header, filtered by task id so shared receiver traffic is irrelevant.
- Wire it into the up and e2e flows and document it.