### PR TITLE
fix(server): return 500 not 404 on task lookup backend failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Return `500 Internal Server Error` instead of `404 Not Found` when looking up a
+  task by id fails for a backend reason (e.g. the database is unreachable).
+  Previously every error from the task lookup was reported as `404`, so a database
+  outage masqueraded as a missing task — hiding the failure from metrics and
+  alerting and leaking the raw backend error to the client. Genuine "no such task"
+  (including a malformed task id) still returns `404`; the `500` response body no
+  longer exposes internal error detail.
 - Wait for in-flight WebSocket upgrades during graceful shutdown. The shutdown
   routine only tracked established connections, not handshakes still being
   negotiated, which left a data race between an in-progress upgrade and shutdown

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -181,7 +181,7 @@ func (env *Env) getTaskStatus(c *gin.Context) {
 		// unreachable). Return 500 so it surfaces in metrics and alerting
 		// instead of masquerading as a missing task, and keep the internal
 		// detail out of the client response.
-		slog.Error(fmt.Sprintf("failed to retrieve task %s: %s", id, err))
+		slog.Error("failed to retrieve task", "id", id, "error", err)
 		c.JSON(http.StatusInternalServerError, models.TaskStatus{
 			Id:    id,
 			Error: "internal server error",

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 var version = "local"
@@ -161,15 +163,28 @@ func (env *Env) getState(c *gin.Context) {
 // @Produce json
 // @Success 200 {object} models.TaskStatus
 // @Failure 404 {object} models.TaskStatus
+// @Failure 500 {object} models.TaskStatus
 // @Router /api/v1/tasks/{id} [get]
 func (env *Env) getTaskStatus(c *gin.Context) {
 	id := c.Param("id")
 	task, err := env.argo.State.GetTask(id)
 
 	if err != nil {
-		c.JSON(http.StatusNotFound, models.TaskStatus{
+		if errors.Is(err, state.ErrTaskNotFound) {
+			c.JSON(http.StatusNotFound, models.TaskStatus{
+				Id:    id,
+				Error: "task not found",
+			})
+			return
+		}
+		// Any other error is a backend failure (e.g. the database is
+		// unreachable). Return 500 so it surfaces in metrics and alerting
+		// instead of masquerading as a missing task, and keep the internal
+		// detail out of the client response.
+		slog.Error(fmt.Sprintf("failed to retrieve task %s: %s", id, err))
+		c.JSON(http.StatusInternalServerError, models.TaskStatus{
 			Id:    id,
-			Error: err.Error(),
+			Error: "internal server error",
 		})
 	} else {
 		c.JSON(http.StatusOK, models.TaskStatus{

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/config"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/prometheus"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 // mockArgoApi is a minimal mock for ArgoApiInterface used in tests.
@@ -1771,11 +1772,11 @@ func TestGetTaskStatusEndpoint(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "test-app")
 	})
 
-	t.Run("returns error when task not found", func(t *testing.T) {
+	t.Run("returns 404 when task not found", func(t *testing.T) {
 		argo := &argocd.Argo{}
 		argo.Init(&mockTaskRepositoryWithHealth{
 			healthy:   true,
-			taskError: fmt.Errorf("task not found"),
+			taskError: state.ErrTaskNotFound,
 		}, &mockArgoApi{}, &mockMetrics{})
 
 		env := &Env{argo: argo}
@@ -1790,6 +1791,29 @@ func TestGetTaskStatusEndpoint(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 		assert.Contains(t, w.Body.String(), "nonexistent")
 		assert.Contains(t, w.Body.String(), "task not found")
+	})
+
+	t.Run("returns 500 on backend failure", func(t *testing.T) {
+		argo := &argocd.Argo{}
+		argo.Init(&mockTaskRepositoryWithHealth{
+			healthy:   true,
+			taskError: fmt.Errorf("connection refused"),
+		}, &mockArgoApi{}, &mockMetrics{})
+
+		env := &Env{argo: argo}
+
+		router := gin.New()
+		router.GET("/api/v1/tasks/:id", env.getTaskStatus)
+
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/tasks/some-id", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "some-id")
+		assert.Contains(t, w.Body.String(), "internal server error")
+		// The internal error detail must not leak to the client.
+		assert.NotContains(t, w.Body.String(), "connection refused")
 	})
 }
 

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -122,7 +122,7 @@ func (state *InMemoryState) GetTasks(startTime float64, endTime float64, app str
 // GetTask retrieves a task from the in-memory state based on the provided task ID.
 // It takes a string parameter for the task ID.
 // The method iterates over the tasks in the in-memory state and returns the task if a matching ID is found.
-// If no task with the given ID is found, it returns an error indicating that the task was not found.
+// If no task with the given ID is found, it returns ErrTaskNotFound.
 func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
@@ -132,7 +132,7 @@ func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 			return &task, nil
 		}
 	}
-	return nil, errors.New("task not found")
+	return nil, ErrTaskNotFound
 }
 
 // SetTaskStatus updates the status and status reason of a task in the in-memory state based on the provided task ID.

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -96,8 +96,7 @@ func TestInMemoryState_GetTask_NotFound(t *testing.T) {
 	state := InMemoryState{}
 	task, err := state.GetTask("non-existent-id")
 	assert.Nil(t, task)
-	assert.Error(t, err)
-	assert.Equal(t, "task not found", err.Error())
+	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
 // TestInMemoryState_GetTasks verifies that tasks can be retrieved within a time range
@@ -407,8 +406,7 @@ func TestInMemoryState_ProcessObsoleteTasks_RemovesAppNotFound(t *testing.T) {
 
 	// Verify "app not found" task was removed
 	_, err = state.GetTask(appNotFoundTask.Id)
-	assert.Error(t, err)
-	assert.Equal(t, "task not found", err.Error())
+	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
 // TestInMemoryState_Check verifies that the Check method returns true for in-memory state.

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -111,12 +111,24 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 }
 
 // GetTask retrieves a task from the PostgreSQL database based on the provided task ID.
-// It returns the task as a pointer to models.Task and an error if the task is not found or an error occurs during retrieval.
+// It returns ErrTaskNotFound when the id is malformed or no matching row exists,
+// and a wrapped error for any other retrieval failure so callers can distinguish
+// 404 from 500.
 // The method executes a SELECT query with the given task ID and scans the result into the task struct.
 // It handles converting the created and updated timestamps to float64 values and unmarshalling the images from the database.
 func (state *PostgresState) GetTask(id string) (*models.Task, error) {
+	// The id column is a uuid, so a malformed id can never match a row. Treat it
+	// as not-found instead of letting Postgres raise a syntax error, which would
+	// otherwise surface as a client-triggerable HTTP 500 and ERROR-log noise.
+	if _, err := uuid.Parse(id); err != nil {
+		return nil, ErrTaskNotFound
+	}
+
 	var ormTask state_models.TaskModel
 	if err := state.orm.Take(&ormTask, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrTaskNotFound
+		}
 		return nil, fmt.Errorf("error retrieving task with ID %s: %w", id, err)
 	}
 	return ormTask.ConvertToExternalTask(), nil

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -141,6 +141,46 @@ func TestPostgresState_GetTask(t *testing.T) {
 	assert.Equal(t, models.StatusInProgressMessage, task.Status)
 }
 
+// TestPostgresState_GetTask_NotFound verifies that GetTask returns the
+// ErrTaskNotFound sentinel (not a generic error) when no row matches, so the
+// HTTP layer can map it to 404 while other failures surface as 500.
+func TestPostgresState_GetTask_NotFound(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	// Valid UUID that was never inserted -> gorm.ErrRecordNotFound.
+	task, err := env.state.GetTask("00000000-0000-0000-0000-000000000000")
+	assert.Nil(t, task)
+	assert.ErrorIs(t, err, ErrTaskNotFound)
+}
+
+// TestPostgresState_GetTask_MalformedID verifies that a non-UUID id is mapped to
+// ErrTaskNotFound (HTTP 404) rather than reaching the uuid-typed column and
+// producing a client-triggerable backend error (HTTP 500). The parse guard runs
+// before any query, so this does not need a live database.
+func TestPostgresState_GetTask_MalformedID(t *testing.T) {
+	state := &PostgresState{}
+	task, err := state.GetTask("not-a-uuid")
+	assert.Nil(t, task)
+	assert.ErrorIs(t, err, ErrTaskNotFound)
+}
+
+// TestPostgresState_GetTask_BackendError verifies that a non-not-found backend
+// failure (here: a closed connection pool) is returned as a wrapped error and
+// NOT the ErrTaskNotFound sentinel, so a database outage keeps mapping to HTTP
+// 500 instead of masquerading as a missing task.
+func TestPostgresState_GetTask_BackendError(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	db, err := env.state.orm.DB()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	task, err := env.state.GetTask("00000000-0000-0000-0000-000000000000")
+	assert.Nil(t, task)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrTaskNotFound)
+}
+
 func TestPostgresState_SetTaskStatus(t *testing.T) {
 	env := newPostgresTestEnv(t)
 	inserted := env.addTask(t, sampleTask("Test"))

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -11,6 +11,12 @@ import (
 
 var errDesiredRetry = errors.New("desired retry error")
 
+// ErrTaskNotFound is returned by TaskRepository.GetTask when no task exists for
+// the requested id. Callers use errors.Is to distinguish a genuine "not found"
+// (HTTP 404) from a backend failure (HTTP 500), so a database outage is not
+// silently reported as a missing task.
+var ErrTaskNotFound = errors.New("task not found")
+
 // imageNamesOverlap reports whether the two image slices share at least one
 // image name (the repository, ignoring the tag). It is used to decide whether a
 // new deployment supersedes an in-progress one for the same app.

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -92,8 +92,16 @@ scenario_unvalidated_not_available() {
 }
 
 # A failing PreSync hook (Helm Job) must surface as a failed hook, not just image lists.
+#
+# The tag MUST differ from app3's current live tag. argo-watcher only drives a sync when the
+# write-back actually changes the override file (unchanged tags are a no-op since #472); a sync
+# is what makes ArgoCD run the PreSync hook. The SOAK phase deterministically (fixed RNG seed)
+# leaves app3 at one of ${TAGS} (v1.10.1/2/3), so we deploy a tag OUTSIDE that set to guarantee
+# a real write-back regardless of which SOAK tag app3 ended on. The tag is never pulled: a failing
+# PreSync hook aborts the sync before the main wave applies the Deployment — so the image stays at
+# the old tag, the expected image is "not available", and the failure diagnostics carry the hook.
 scenario_failed_presync_hook() {
-  echo "task={\"app\":\"app3\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":90,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.2\"}]}"
+  echo "task={\"app\":\"app3\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":90,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v0.0.0-hookfail\"}]}"
   echo "token=1"
   echo "expect=Failed hooks:"
   echo "expect=PreSync Failed"


### PR DESCRIPTION
GET /api/v1/tasks/{id} mapped every GetTask error to 404, so a database outage masqueraded as a missing task (hiding the failure from metrics and alerting) and leaked the raw backend error to the client.

Introduce a state.ErrTaskNotFound sentinel returned by both repository backends for genuine not-found; the handler now maps it to 404 and any other error to 500 with a sanitized body. A malformed (non-UUID) id is treated as 404 via an early parse guard so client input stays off the 500 path and out of the error log.