### PR TITLE
test(e2e): cover scheduled lockdown and graceful WS-drain

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,7 +27,7 @@ the competitor writer. All pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → notifications → load → race → failure-diagnostics → down
+task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → race → failure-diagnostics → shutdown-drain → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed
@@ -47,10 +47,12 @@ task commit-format        # assert COMMIT_MESSAGE_FORMAT renders into the git wr
 task multi-image          # assert a multi-image deploy bumps and writes back both images in one commit
 task accept-suspended     # assert ACCEPT_SUSPENDED_APP treats a paused argo-rollouts Rollout (Suspended) as deployed
 task docker-proxy         # assert DOCKER_IMAGES_PROXY matches a bare image name against the proxy-prefixed running image
+task lockdown             # assert LOCKDOWN_SCHEDULE freezes deploys in-window (406) and the watcher broadcasts "locked"
 task notifications        # assert the generic webhook fires (start + result) with the correct payload
-task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
 task load                 # git-conflict soak: competitor + concurrent deploys, strict 0-failed
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
+task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
+task shutdown-drain       # assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic
 task down                 # destroy the cluster
 ```
 
@@ -98,6 +100,9 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 | `fixtures/rollout-chart/` + `fixtures/suspended-app.yaml` | `suspendapp`: a managed argo-rollouts Rollout (canary pause step); the write-back bump pauses it mid-rollout so ArgoCD reports it Suspended |
 | `scripts/docker-proxy.sh` | assert `DOCKER_IMAGES_PROXY` matches a bare image against the proxy-prefixed running image |
 | `fixtures/proxy-app.yaml` | `proxyapp`: reuses the shared chart with the image repository overridden to `mirror.gcr.io/traefik/whoami` |
+| `scripts/lockdown.sh` | assert scheduled lockdown: toggles `LOCKDOWN_SCHEDULE` on the release (window opening ~3 min out) and reverts, asserting in-window deploys are rejected (406), `GET /deploy-lock` reports `true`, and the watcher broadcasts `"locked"` on the transition |
+| `scripts/shutdown-drain.sh` | assert graceful shutdown: hold WebSocket clients open, delete the pod, and assert every client sees a `1001 "server shutdown"` close and the logs show the ordered drain with no data race / panic / drain timeout |
+| `tools/wsprobe/` | tiny Go WebSocket probe used by `lockdown` (grep for the `"locked"` broadcast) and `shutdown-drain` (assert the graceful GoingAway close), streaming `MSG`/`CLOSED` events one per line |
 
 ## Gotchas (why the scripts exist)
 
@@ -120,6 +125,22 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
   `AUTO_CREATE_SESSIONS` makes the fixed-UUID `WEBHOOK_URL` work with no startup
   wiring (the `WEBHOOK_UUID` in `Taskfile.yml` and the URL must match).
 
+- **`LOCKDOWN_SCHEDULE` is toggled in place, not set globally.** It is a
+  server-global freeze, so enabling it in the shared install would block every
+  other deploy phase. `lockdown.sh` instead helm-upgrades the live release with a
+  schedule whose window *opens ~3 minutes in the future* and reverts before it
+  returns. The future start is deliberate: the pod boots unlocked and then
+  crosses into the window while a `wsprobe` client watches, which is the only way
+  to observe a *scheduled* `"locked"` broadcast (the watcher notifies on state
+  change, not at boot, and polls at minute granularity). The 406 + `GET`-true +
+  revert-accepts checks are deterministic; the WS-transition sub-check is skipped
+  (not failed) if a slow rollout boots in-window. Manual (Keycloak) lock/unlock
+  WS notifications are a separate, deterministic trigger left to the heavy tier.
+- **`shutdown-drain` follows the pod's logs before deleting it.** A recreated
+  StatefulSet pod is a new object, so `kubectl logs --previous` would not have the
+  terminated instance's shutdown logs; the script streams `logs -f` to a file
+  first, then deletes the pod with `--grace-period=60` so the full drain
+  (`srv.Shutdown` 30s + WS drain 10s) completes before SIGKILL.
 - **Several config toggles are set globally via `values/argo-watcher.yaml`
   `extraEnvs`** so a single boot can assert them: `JWT_SECRET` (jwt-auth),
   `COMMIT_MESSAGE_FORMAT` (commit-format), `ACCEPT_SUSPENDED_APP` +

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -62,7 +62,7 @@ tasks:
       - task: verify
 
   e2e:
-    desc: "One-shot per-release run: up → smoke → load → race → failure-diagnostics → down"
+    desc: "One-shot per-release run: boot the lab, run every phase in order, tear it down (see README Usage for the full step list)"
     cmds:
       # Runs the whole flow. Stops on the first failing step, so a failed run
       # leaves the cluster up for debugging; a fully green run tears it down.
@@ -76,13 +76,20 @@ tasks:
       - task: multi-image
       - task: accept-suspended
       - task: docker-proxy
+      # lockdown toggles LOCKDOWN_SCHEDULE on the release and reverts before it
+      # returns (ending unlocked), so it must run BEFORE the soak but is otherwise
+      # self-contained; placed here after the light deploy phases.
+      - task: lockdown
       - task: notifications
       - task: load
       - task: race
-      # failure-diagnostics runs LAST: it deliberately breaks apps (bad images, a failing
-      # PreSync hook injected into the SHARED chart values) and pushes directly to the gitops
-      # repo, so running it before load/race would perturb those pristine-state soak gates.
+      # failure-diagnostics runs after the soak: it deliberately breaks apps (bad images, a
+      # failing PreSync hook injected into the SHARED chart values) and pushes directly to the
+      # gitops repo, so running it before load/race would perturb those pristine-state soak gates.
       - task: failure-diagnostics
+      # shutdown-drain runs LAST (before down): it deletes the argo-watcher pod to exercise
+      # graceful shutdown, so nothing but `down` should depend on the server afterwards.
+      - task: shutdown-drain
       - task: down
 
   cluster:
@@ -198,6 +205,18 @@ tasks:
     desc: "Assert DOCKER_IMAGES_PROXY: a bare image name matches the proxy-prefixed running image"
     cmds:
       - ./scripts/docker-proxy.sh
+
+  lockdown:
+    desc: "Assert LOCKDOWN_SCHEDULE freezes deploys in-window (406) and the watcher broadcasts 'locked'"
+    cmds:
+      # Toggles LOCKDOWN_SCHEDULE on the live release for its own duration and
+      # reverts before returning; needs the chart coordinates to helm-upgrade.
+      - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}} ./scripts/lockdown.sh
+
+  shutdown-drain:
+    desc: "Assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic"
+    cmds:
+      - ./scripts/shutdown-drain.sh
 
   notifications:
     desc: "Assert the generic webhook fires (start + result) with the correct payload against a real receiver"

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -83,9 +83,11 @@ schedule="${start_day} ${start_hm} - ${end_day} ${end_hm}"
 echo "lockdown window: ${schedule} (opens ~180s from now)"
 
 # Append LOCKDOWN_SCHEDULE as the next extraEnvs entry. The index is the count of
-# entries in the values file (each is a top-level "  - name:" under extraEnvs) —
-# read from the file, not the live release, so it is independent of release state.
-idx=$(grep -c '^  - name:' "$VALUES")
+# entries in the values file's extraEnvs block — read from the file, not the live
+# release, so it is independent of release state. The awk scopes the count to the
+# extraEnvs block (between "extraEnvs:" and the next top-level key), so a same-
+# indented "- name:" added to some other section can't silently shift the index.
+idx=$(awk '/^extraEnvs:/{f=1;next} f&&/^[^[:space:]#]/{f=0} f&&/^  - name:/{c++} END{print c+0}' "$VALUES")
 helm_apply --set-string "extraEnvs[${idx}].name=LOCKDOWN_SCHEDULE" \
            --set-string "extraEnvs[${idx}].value=${schedule}"
 start_pf
@@ -95,6 +97,14 @@ assert_ws=1
 if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
   echo "  OK   booted unlocked (pre-window); watching for the scheduled 'locked' broadcast"
   WS_URL="ws://localhost:${PORT}/ws" DURATION=400s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
+  # Wait for the probe to actually connect (OPEN) before the window opens, so a
+  # slow handshake can't miss the one-shot "locked" broadcast — same guard as
+  # shutdown-drain.sh. The window is still ~180s out, so 20s is ample.
+  ws_open=0
+  for _ in $(seq 1 20); do grep -q '^OPEN$' "$probe_out" && { ws_open=1; break; }; sleep 1; done
+  if [[ "$ws_open" != "1" ]]; then
+    echo "  FAIL WS probe never connected before the window opened"; fail=1; assert_ws=0
+  fi
 else
   echo "  NOTE rollout booted in-window; skipping the WS-transition sub-check (not a failure)"
   assert_ws=0

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -41,7 +41,7 @@ trap cleanup EXIT
 
 # (re)start the port-forward after a rollout swaps the pod out.
 start_pf() {
-  [ -n "$pf_pid" ] && kill "$pf_pid" 2>/dev/null || true
+  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
   kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
   pf_pid=$!
   for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Assert the scheduled-lockdown deploy-freeze end to end against the real server.
+#
+# LOCKDOWN_SCHEDULE is a server-global config, so it cannot be enabled in the
+# shared install without blocking every other deploy phase. This phase therefore
+# toggles it on the live release for its own duration and reverts before exiting:
+#
+#   1. helm-upgrade the release with a schedule whose window OPENS ~3 min in the
+#      future, so the pod boots UNLOCKED and then crosses into the lockdown window
+#      while we watch — the only way to observe a *scheduled* transition (the
+#      watcher notifies on state change, not at boot).
+#   2. While unlocked, hold a WebSocket client open (tools/wsprobe).
+#   3. When the window opens: GET /deploy-lock flips to `true` (evaluated live),
+#      POST /api/v1/tasks is rejected with 406 "lockdown is active", and within
+#      one poll interval the lockdown watcher broadcasts "locked" to the WS client.
+#   4. Revert the schedule (pod restart) and prove deploys are accepted again.
+#
+# The 406 + GET-true + revert-accepts checks are deterministic. The WS "locked"
+# broadcast is asserted only when we confirmed the pod booted before the window
+# (GET was false first): if a slow rollout boots in-window the transition already
+# happened un-observed, so that sub-check is skipped with a logged note rather
+# than flaking. Manual (Keycloak) lock/unlock WS notifications are a separate,
+# deterministic trigger covered by the heavy-tier Keycloak phase.
+set -euo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+PORT="${PORT:-18093}"
+# Helm coordinates for the in-place toggle (passed from the Taskfile).
+AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO is required}"
+AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+VALUES="${VALUES:-values/argo-watcher.yaml}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../../.." && pwd)"
+
+bin_dir="$(mktemp -d)"
+probe_out="$(mktemp)"
+pf_pid=""
+cleanup() { kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$probe_out"; }
+trap cleanup EXIT
+( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+
+# (re)start the port-forward after a rollout swaps the pod out.
+start_pf() {
+  [ -n "$pf_pid" ] && kill "$pf_pid" 2>/dev/null || true
+  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+  pf_pid=$!
+  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+}
+
+helm_apply() {  # extra --set args reconfigure the release in place
+  # --reset-values makes each apply deterministic from the values file + these
+  # --set args alone: without it helm carries a prior `--set extraEnvs[N]` forward,
+  # so the revert (values file only) would NOT drop the injected LOCKDOWN_SCHEDULE.
+  helm upgrade --install argo-watcher argo-watcher --repo "$AW_CHART_REPO" \
+    --version "$AW_CHART_VERSION" -n "$NS_AW" -f "$VALUES" --reset-values \
+    --set image.tag=race "$@" >/dev/null
+  kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
+}
+
+base="http://localhost:${PORT}/api/v1"
+task_json='{"app":"app1","author":"e2e","project":"lab","images":[{"image":"traefik/whoami","tag":"v1.10.2"}]}'
+# post_task -> sets CODE and BODY for a tokenless POST /api/v1/tasks.
+post_task() {
+  local out
+  out=$(curl -s -m 10 -w $'\n%{http_code}' -X POST -H 'Content-Type: application/json' \
+    -d "$task_json" "${base}/tasks")
+  CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
+}
+fail=0
+
+# --- 1. Enable a schedule whose window opens ~3 min out ------------------------
+# date arithmetic (GNU date) rolls days/weeks over cleanly, so the window is
+# valid whatever the wall-clock day. 12h end keeps it comfortably open for the
+# whole phase; the revert (not the end time) is what unlocks.
+#   -u  : compute in UTC, because the server evaluates the schedule against
+#         time.Now() in the pod's timezone — distroless has no zoneinfo, so that
+#         is UTC. A host in another zone would otherwise offset the window.
+#   LC_ALL=C : force the English 3-letter weekday (Sun..Sat) dayToWeekday expects;
+#         a localized host (e.g. "Pk"/"S ") would produce an unparseable schedule.
+start_day=$(LC_ALL=C date -u -d '+180 seconds' +%a); start_hm=$(date -u -d '+180 seconds' +%H:%M)
+end_day=$(LC_ALL=C date -u -d '+12 hours' +%a);      end_hm=$(date -u -d '+12 hours' +%H:%M)
+schedule="${start_day} ${start_hm} - ${end_day} ${end_hm}"
+echo "lockdown window: ${schedule} (opens ~180s from now)"
+
+# Append LOCKDOWN_SCHEDULE as the next extraEnvs entry. The index is the count of
+# entries in the values file (each is a top-level "  - name:" under extraEnvs) —
+# read from the file, not the live release, so it is independent of release state.
+idx=$(grep -c '^  - name:' "$VALUES")
+helm_apply --set-string "extraEnvs[${idx}].name=LOCKDOWN_SCHEDULE" \
+           --set-string "extraEnvs[${idx}].value=${schedule}"
+start_pf
+
+# --- 2. Confirm we booted pre-window, then hold a WS client open ---------------
+assert_ws=1
+if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
+  echo "  OK   booted unlocked (pre-window); watching for the scheduled 'locked' broadcast"
+  WS_URL="ws://localhost:${PORT}/ws" DURATION=400s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
+else
+  echo "  NOTE rollout booted in-window; skipping the WS-transition sub-check (not a failure)"
+  assert_ws=0
+fi
+
+# --- 3. Wait for the window to open, then assert the locked behaviour ----------
+locked=0
+for _ in $(seq 1 60); do   # up to ~300s: window opens at +180s, then evaluated live
+  if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then locked=1; break; fi
+  sleep 5
+done
+if [[ "$locked" == "1" ]]; then
+  echo "  OK   GET /deploy-lock -> true (window open)"
+else
+  echo "  FAIL GET /deploy-lock never reported locked"; fail=1
+fi
+
+post_task
+if [[ "$CODE" == "406" ]] && echo "$BODY" | jq -e '.status == "rejected" and .error == "lockdown is active, deployments are not accepted"' >/dev/null 2>&1; then
+  echo "  OK   POST /tasks -> 406 rejected (deploys frozen)"
+else
+  echo "  FAIL POST /tasks during lockdown: code=${CODE} body=${BODY} (want 406 rejected)"; fail=1
+fi
+
+if [[ "$assert_ws" == "1" ]]; then
+  ws_ok=0
+  for _ in $(seq 1 16); do   # up to ~80s: watcher polls once a minute
+    if grep -q '^MSG locked$' "$probe_out"; then ws_ok=1; break; fi
+    sleep 5
+  done
+  if [[ "$ws_ok" == "1" ]]; then
+    echo "  OK   WS client received the 'locked' broadcast on the schedule transition"
+  else
+    echo "  FAIL no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+  fi
+fi
+
+# --- 4. Revert the schedule and prove deploys are accepted again ---------------
+helm_apply   # values file only -> LOCKDOWN_SCHEDULE dropped -> unlocked
+start_pf
+if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
+  echo "  OK   GET /deploy-lock -> false after revert"
+else
+  echo "  FAIL GET /deploy-lock still true after revert"; fail=1
+fi
+post_task   # tokenless task is accepted (202) and skips write-back: no side effect
+if [[ "$CODE" == "202" ]]; then
+  echo "  OK   POST /tasks -> 202 accepted (deploys unfrozen)"
+else
+  echo "  FAIL POST /tasks after revert: code=${CODE} body=${BODY} (want 202)"; fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then echo "LOCKDOWN: PASS"; else echo "LOCKDOWN: FAIL"; exit 1; fi

--- a/test/e2e/scripts/shutdown-drain.sh
+++ b/test/e2e/scripts/shutdown-drain.sh
@@ -93,11 +93,12 @@ done
 for _ in $(seq 1 30); do kill -0 "$log_pid" 2>/dev/null || break; sleep 1; done
 kill "$log_pid" 2>/dev/null || true
 assert_log() {  # pattern human-label want(present|absent)
-  if grep -qF "$1" "$log_out"; then found=1; else found=0; fi
-  if { [[ "$3" == present && "$found" == 1 ]] || [[ "$3" == absent && "$found" == 0 ]]; }; then
-    echo "  OK   log ${3}: ${2}"
+  local pattern="$1" label="$2" want="$3" found
+  if grep -qF "$pattern" "$log_out"; then found=1; else found=0; fi
+  if { [[ "$want" == present && "$found" == 1 ]] || [[ "$want" == absent && "$found" == 0 ]]; }; then
+    echo "  OK   log ${want}: ${label}"
   else
-    echo "  FAIL log ${3} expected but not: ${2}"; fail=1
+    echo "  FAIL log ${want} expected but not: ${label}"; fail=1
   fi
 }
 assert_log "shutting down server..."                   "shutdown initiated"        present

--- a/test/e2e/scripts/shutdown-drain.sh
+++ b/test/e2e/scripts/shutdown-drain.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Assert argo-watcher shuts down gracefully and drains in-flight WebSocket
+# connections, guarding the hijack/shutdown-ordering races fixed upstream
+# (connWg not tracking the in-flight handshake; connWg.Wait racing new
+# handshakes). Runs against the -race build, so a regression in the shutdown
+# path surfaces as a logged DATA RACE or a WaitGroup panic.
+#
+#   1. Hold N WebSocket clients open (tools/wsprobe) against the live server.
+#   2. Follow the pod's logs, then delete the pod with a generous grace period so
+#      the container runs its full graceful shutdown (SIGTERM -> srv.Shutdown ->
+#      env.Shutdown drains the hijacked WS goroutines).
+#   3. Assert every WS client saw a graceful close: code 1001 (GoingAway) with
+#      reason "server shutdown" — the exact frame checkConnection sends on drain,
+#      NOT an abrupt socket drop.
+#   4. Assert the captured shutdown logs show the ordered graceful path
+#      ("shutting down server..." -> WS drain -> "server exited") with NO data
+#      race, NO panic, and NO drain-timeout warning.
+#   5. Assert the recreated pod comes back Ready and reaches real Argo.
+#
+# Scope note: in-flight *deploys* are deliberately not asserted here. A deploy's
+# write-back + Argo sync outlives the 30s HTTP drain budget by design and is
+# resumed by the poller, not the HTTP request — asserting it would test the
+# poller, not shutdown. This phase asserts the shutdown/drain contract only.
+set -euo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+PORT="${PORT:-18094}"
+WS_CLIENTS="${WS_CLIENTS:-3}"
+STS="${STS:-argo-watcher}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../../.." && pwd)"
+
+bin_dir="$(mktemp -d)"
+work="$(mktemp -d)"
+log_out="${work}/pod.log"
+pf_pid=""; log_pid=""
+cleanup() { kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$work"; }
+trap cleanup EXIT
+( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+
+pod="${STS}-0"
+old_uid=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.metadata.uid}')
+
+kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+pf_pid=$!
+for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+
+# --- 1. Hold WebSocket clients open through the shutdown -----------------------
+echo "opening ${WS_CLIENTS} WebSocket client(s)"
+probe_pids=()
+for i in $(seq 1 "$WS_CLIENTS"); do
+  WS_URL="ws://localhost:${PORT}/ws" DURATION=120s "${bin_dir}/wsprobe" >"${work}/probe${i}.out" 2>/dev/null &
+  probe_pids+=($!)
+done
+# Wait until every probe reports OPEN before triggering shutdown, so the
+# connections are provably registered in the server's set — a fixed sleep raced
+# the handshake on a loaded host and left the drain with nothing to observe.
+for i in $(seq 1 "$WS_CLIENTS"); do
+  opened=0
+  for _ in $(seq 1 20); do grep -q '^OPEN$' "${work}/probe${i}.out" && { opened=1; break; }; sleep 1; done
+  if [[ "$opened" != "1" ]]; then
+    echo "  FAIL client ${i} never established its WebSocket connection"; exit 1
+  fi
+done
+
+# --- 2. Capture logs, then trigger a graceful pod termination ------------------
+# Follow the pod's logs to a file BEFORE deleting: once the pod is gone its logs
+# go with it (a recreated StatefulSet pod is a new object, so `logs --previous`
+# would not have them). `logs -f` exits when the container stops.
+kubectl -n "$NS_AW" logs -f "$pod" >"$log_out" 2>/dev/null &
+log_pid=$!
+sleep 2
+echo "deleting pod ${pod} (grace 60s) to trigger graceful shutdown"
+# --grace-period=60 overrides the spec so the drain (srv.Shutdown 30s + WS drain
+# 10s) completes before SIGKILL; --wait=false returns so we can watch the clients.
+kubectl -n "$NS_AW" delete pod "$pod" --grace-period=60 --wait=false >/dev/null
+
+fail=0
+
+# --- 3. Every WS client must observe the graceful GoingAway close --------------
+for i in $(seq 1 "$WS_CLIENTS"); do
+  # wsprobe exits when its connection closes; bound the wait so a hung client fails.
+  for _ in $(seq 1 30); do kill -0 "${probe_pids[$((i-1))]}" 2>/dev/null || break; sleep 1; done
+  out="${work}/probe${i}.out"
+  if grep -q '^CLOSED code=1001 reason=server shutdown$' "$out"; then
+    echo "  OK   client ${i} drained gracefully (1001 server shutdown)"
+  else
+    echo "  FAIL client ${i} did not see a graceful close: $(tr '\n' ',' <"$out")"; fail=1
+  fi
+done
+
+# --- 4. The captured shutdown logs must show the clean ordered path ------------
+for _ in $(seq 1 30); do kill -0 "$log_pid" 2>/dev/null || break; sleep 1; done
+kill "$log_pid" 2>/dev/null || true
+assert_log() {  # pattern human-label want(present|absent)
+  if grep -qF "$1" "$log_out"; then found=1; else found=0; fi
+  if { [[ "$3" == present && "$found" == 1 ]] || [[ "$3" == absent && "$found" == 0 ]]; }; then
+    echo "  OK   log ${3}: ${2}"
+  else
+    echo "  FAIL log ${3} expected but not: ${2}"; fail=1
+  fi
+}
+assert_log "shutting down server..."                   "shutdown initiated"        present
+# This one line is Debug-level (env.go); it is asserted because the lab runs at
+# logLevel: debug (values/argo-watcher.yaml). If that is ever lowered to info this
+# check fails misleadingly — the drain itself would still be fine.
+assert_log "All WebSocket connections closed gracefully" "WS goroutines drained"   present
+assert_log "server exited"                             "run loop returned"         present
+assert_log "Shutdown timeout reached"                  "no WS drain timeout"       absent
+assert_log "DATA RACE"                                 "race detector clean"       absent
+assert_log "panic:"                                    "no panic during shutdown"  absent
+
+# --- 5. The recreated pod must come back Ready and reach Argo ------------------
+echo "waiting for ${pod} to be recreated and Ready"
+ready=0
+for _ in $(seq 1 60); do
+  uid=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+  rdy=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+  if [[ -n "$uid" && "$uid" != "$old_uid" && "$rdy" == "True" ]]; then ready=1; break; fi
+  sleep 3
+done
+if [[ "$ready" != "1" ]]; then
+  echo "  FAIL ${pod} did not come back Ready after shutdown"; fail=1
+else
+  kill "$pf_pid" 2>/dev/null || true
+  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+  pf_pid=$!
+  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "localhost:${PORT}/healthz")
+  unavail=$(curl -s -m 10 "localhost:${PORT}/metrics" | awk '/^argocd_unavailable /{print $2}')
+  if [[ "$code" == "200" && "$unavail" == "0" ]]; then
+    echo "  OK   recreated pod healthy and reaching Argo (healthz=200 argocd_unavailable=0)"
+  else
+    echo "  FAIL recreated pod not healthy: healthz=${code} argocd_unavailable=${unavail}"; fail=1
+  fi
+fi
+
+if [[ "$fail" -eq 0 ]]; then echo "SHUTDOWN-DRAIN: PASS"; else echo "SHUTDOWN-DRAIN: FAIL"; exit 1; fi

--- a/test/e2e/tools/wsprobe/main.go
+++ b/test/e2e/tools/wsprobe/main.go
@@ -1,0 +1,92 @@
+// Command wsprobe opens a single WebSocket connection to argo-watcher's /ws
+// endpoint and streams what happens to it, one event per line on stdout:
+//
+//	OPEN                            the connection was established (printed once, immediately)
+//	MSG <text>                      a text frame received (e.g. "heartbeat", "locked", "unlocked")
+//	CLOSED code=<n> reason=<text>   the server closed the connection
+//	DEADLINE                        DURATION elapsed with the connection still open
+//
+// A caller can wait for OPEN before acting (e.g. before triggering a shutdown),
+// so the connection is guaranteed established rather than raced by a fixed sleep.
+//
+// It exists so two e2e phases can assert WebSocket behaviour without a bespoke
+// client each:
+//   - the lockdown phase greps the stream for `MSG locked` to prove the scheduled
+//     lockdown watcher broadcast the transition;
+//   - the shutdown-drain phase asserts the final `CLOSED code=1001 reason=server
+//     shutdown` — proof the server drained the hijacked connection gracefully
+//     (websocket.StatusGoingAway) rather than the socket dying abruptly.
+//
+// The process exits 0 once the connection closes (so a caller can `wait` on it)
+// or once DURATION elapses. Output is flushed per line so a caller tailing the
+// file sees events as they arrive.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// env returns the value of environment variable k, or def when it is unset or empty.
+func env(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	wsURL := os.Getenv("WS_URL")
+	if wsURL == "" {
+		fmt.Fprintln(os.Stderr, "wsprobe: WS_URL is required")
+		os.Exit(2)
+	}
+	dur, err := time.ParseDuration(env("DURATION", "60s"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wsprobe: invalid DURATION: %v\n", err)
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wsprobe: dial failed: %v\n", err)
+		os.Exit(1)
+	}
+	// The lab never sends frames larger than a heartbeat/lock notification.
+	conn.SetReadLimit(4096)
+	// Signal the connection is established so a caller can wait on it.
+	fmt.Println("OPEN")
+
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			// DURATION elapsed with the connection still healthy: not a close.
+			if ctx.Err() != nil {
+				fmt.Println("DEADLINE")
+				conn.Close(websocket.StatusNormalClosure, "")
+				return
+			}
+			// The server closed the connection: surface the close code + reason
+			// so the drain phase can assert the graceful GoingAway/"server shutdown".
+			code := int(websocket.CloseStatus(err))
+			reason := ""
+			var ce websocket.CloseError
+			if errors.As(err, &ce) {
+				code = int(ce.Code)
+				reason = ce.Reason
+			}
+			fmt.Printf("CLOSED code=%s reason=%s\n", strconv.Itoa(code), reason)
+			return
+		}
+		fmt.Printf("MSG %s\n", string(data))
+	}
+}


### PR DESCRIPTION
Add two per-release lab phases and a shared WebSocket probe:

- lockdown: toggles LOCKDOWN_SCHEDULE on the live release with a window that opens ~3 min out (UTC-aligned to the pod clock), asserting in-window deploys are rejected (406), GET /deploy-lock reports true, and the watcher broadcasts "locked" on the transition, then reverts and proves deploys are accepted again.
- shutdown-drain: holds WebSocket clients open, deletes the pod with a generous grace period, and asserts every client sees a graceful 1001 "server shutdown" close and the logs show the ordered drain with no data race, panic, or drain timeout, guarding the hijack/shutdown-ordering fixes.
- tools/wsprobe: small Go WebSocket probe streaming OPEN/MSG/CLOSED events, used by both phases.

Verified by a full green task e2e run from a fresh cluster.