### PR TITLE
feat(observability): add deployment_duration_seconds metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `deployment_duration_seconds` Prometheus histogram (label `app`) recording
+  the end-to-end wall-clock time of a successful deployment, from the start of
+  rollout monitoring until the app reached the deployed state. Surfaced as a
+  per-application percentile panel on the example Grafana dashboard.
 - Example Grafana dashboard (`monitoring/grafana/dashboards/argo-watcher.json`)
   visualizing every exposed Prometheus metric, with a per-application drill-down
   driven by an `Application` variable. A `monitoring` docker-compose profile runs

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -12,7 +12,7 @@ scrape_configs:
 
 ## Exposed metrics
 
-The server emits seven metrics today, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go).
+The server emits eight metrics today, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
@@ -23,6 +23,7 @@ The server emits seven metrics today, all defined in [`internal/prometheus/metri
 | `argocd_refresh_duration_seconds` | histogram | `app` | Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes. Recorded only when the status check requests a refresh. |
 | `gitops_writeback_duration_seconds` | histogram | `app` | Time the git write-back held the per-repo lock, covering the clone/commit/push cycle plus any retries and backoff. |
 | `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting to acquire the per-repository git write-back lock. High values mean tasks are queued behind concurrent write-backs to the same repo. |
+| `deployment_duration_seconds` | histogram | `app` | End-to-end wall-clock time of a successful deployment, from the start of rollout monitoring until the app reached the deployed state. Only successful deployments are observed (a failure's duration is dominated by the timeout). |
 
 In addition, the standard Go runtime metrics from the Prometheus client library are exposed (`go_*`, `process_*`).
 
@@ -102,8 +103,9 @@ A ready-made Grafana dashboard lives in the repository at
 It has an **Overview** row that illustrates every exposed metric in aggregate
 (availability, in-progress tasks, deployment counts, failing apps) and a
 **Per-Application Breakdown** row driven by an `Application` template variable, so
-you can select one app (or several) and see its deployment counts, failures, and
-the refresh / write-back / lock-wait latency percentiles.
+you can select one app (or several) and see its deployment counts, failures,
+end-to-end deployment duration, and the refresh / write-back / lock-wait latency
+percentiles.
 
 Import it into any Grafana by uploading the JSON (**Dashboards → New → Import**),
 or spin up a self-contained Prometheus + Grafana stack next to the dev server:

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -94,6 +94,12 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	// notify about the deployment start
 	sendNotification(task, updater.notifier)
 
+	// start bounds the deployment-duration metric: a monotonic in-process clock over the
+	// rollout work only. It is taken after the start notification so a slow synchronous
+	// notifier does not inflate the measured duration, and deliberately not derived from
+	// task.Created (whose stored unit differs across state backends).
+	start := time.Now()
+
 	// wait for application to get into deployed status or timeout
 	application, err := updater.waitForApplicationDeployment(task)
 
@@ -110,6 +116,13 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	default:
 		// process deployment result
 		updater.monitor.ProcessDeploymentResult(&task, application)
+	}
+
+	// Record how long a successful deployment took. Only the deployed state is timed:
+	// a failure/abort/supersession is not a completed deployment and its wall-clock is
+	// dominated by the timeout, so it would distort the histogram.
+	if task.Status == models.StatusDeployedMessage {
+		updater.monitor.ObserveDeploymentDuration(task.App, time.Since(start).Seconds())
 	}
 
 	// send webhook event about the deployment result

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -161,6 +161,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
+		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
@@ -214,6 +215,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
+		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
@@ -258,6 +260,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
+		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
@@ -1355,6 +1358,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(1)
 	metricsMock.EXPECT().AddInProgressTask()
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
+	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// Proceeds to a normal deployed result rather than stopping as superseded.
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -65,6 +65,11 @@ func (monitor *DeploymentMonitor) EndTracking() {
 	monitor.argo.metrics.RemoveInProgressTask()
 }
 
+// ObserveDeploymentDuration records the wall-clock duration of a successful deployment for the app.
+func (monitor *DeploymentMonitor) ObserveDeploymentDuration(app string, seconds float64) {
+	monitor.argo.metrics.ObserveDeploymentDuration(app, seconds)
+}
+
 // resolveRefresh reports whether this task's status check should request an ArgoCD refresh.
 // A per-task Refresh override wins over the instance-wide default; a nil override (field omitted
 // by the client) keeps the default, so old clients behave exactly as before (issue #334).

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -16,6 +16,7 @@ type MetricsInterface interface {
 	ObserveRefreshDuration(app string, seconds float64)
 	ObserveGitWritebackDuration(app string, seconds float64)
 	ObserveGitLockWaitDuration(app string, seconds float64)
+	ObserveDeploymentDuration(app string, seconds float64)
 }
 
 // Metrics contains all the prometheus collectors.
@@ -27,6 +28,7 @@ type Metrics struct {
 	RefreshDuration      *prometheus.HistogramVec
 	GitWritebackDuration *prometheus.HistogramVec
 	GitLockWaitDuration  *prometheus.HistogramVec
+	DeploymentDuration   *prometheus.HistogramVec
 }
 
 // NewMetrics creates and registers the metrics with the provided Registerer.
@@ -73,9 +75,19 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help:    "Time spent waiting to acquire the per-repository git write-back lock.",
 			Buckets: []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 180, 300},
 		}, []string{"app"}),
+		// DeploymentDuration times a successful deployment end to end: from the start of
+		// rollout monitoring until the application reaches the deployed state. Only successful
+		// deployments are observed — a failed deployment's wall-clock is dominated by the
+		// configured timeout and would distort the distribution. Buckets span seconds (a
+		// fire-and-forget commit) to minutes (a real rollout bounded by DEPLOYMENT_TIMEOUT).
+		DeploymentDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "deployment_duration_seconds",
+			Help:    "Wall-clock time a successful deployment took, from the start of monitoring until the app reached the deployed state.",
+			Buckets: []float64{1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+		}, []string{"app"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration)
+	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration)
 
 	return m
 }
@@ -129,4 +141,10 @@ func (m *Metrics) ObserveGitWritebackDuration(app string, seconds float64) {
 // the per-repository lock.
 func (m *Metrics) ObserveGitLockWaitDuration(app string, seconds float64) {
 	m.GitLockWaitDuration.WithLabelValues(app).Observe(seconds)
+}
+
+// ObserveDeploymentDuration records how long a successful deployment took for the given app,
+// measured from the start of rollout monitoring until the app reached the deployed state.
+func (m *Metrics) ObserveDeploymentDuration(app string, seconds float64) {
+	m.DeploymentDuration.WithLabelValues(app).Observe(seconds)
 }

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -133,6 +133,20 @@ func TestMetrics_ObserveGitLockWaitDuration(t *testing.T) {
 	assert.Equal(t, float64(12), sum)
 }
 
+func TestMetrics_ObserveDeploymentDuration(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+
+	// Act
+	m.ObserveDeploymentDuration("test-app", 42)
+
+	// Assert: exactly one observation of the passed value for the app.
+	count, sum := histogramSampleForApp(t, m.DeploymentDuration, "test-app")
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, float64(42), sum)
+}
+
 func TestMetrics_InProgressTasks(t *testing.T) {
 	// Arrange
 	reg := prometheus.NewRegistry()

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -103,6 +103,7 @@ func (m *mockMetrics) RemoveInProgressTask()                           {}
 func (m *mockMetrics) ObserveRefreshDuration(_ string, _ float64)      {}
 func (m *mockMetrics) ObserveGitWritebackDuration(_ string, _ float64) {}
 func (m *mockMetrics) ObserveGitLockWaitDuration(_ string, _ float64)  {}
+func (m *mockMetrics) ObserveDeploymentDuration(_ string, _ float64)   {}
 
 func TestGetVersion(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -674,6 +674,62 @@
       ],
       "title": "Git Lock Wait Duration — $app",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "End-to-end duration of successful deployments for the selected application(s): from the start of rollout monitoring until the app reached the deployed state (deployment_duration_seconds histogram quantiles). Failed/aborted deployments are not counted.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 38 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.3.8",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Deployment Duration — $app",
+      "type": "timeseries"
     }
   ]
 }

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -6,7 +6,8 @@
 #   - processed_deployments == 0 (no work was actually processed)
 #   - in_progress_tasks does not drain back to 0 (leaked/stuck task tracking)
 #   - any of the duration histograms recorded 0 observations, i.e. the
-#     refresh / git-writeback / lock-wait code path never ran (silent regression)
+#     refresh / git-writeback / lock-wait / deployment-duration code path never
+#     ran (silent regression)
 #   - a lost update: a fixture app's committed image tag != the last tag the
 #     driver deployed to it (per the driver summary JSON)
 #   - any failed task in the driver summary
@@ -51,6 +52,10 @@ au=$(echo "$metrics" | awk '/^argocd_unavailable /{print $NF}')
 rc=$(sum_metric argocd_refresh_duration_seconds_count)
 wc=$(sum_metric gitops_writeback_duration_seconds_count)
 lc=$(sum_metric gitops_lock_wait_duration_seconds_count)
+# Every successful deployment observes its end-to-end duration, so on a green soak
+# (all tasks deployed) this MUST be > 0; a zero means the deployment-duration timing
+# never ran.
+dc=$(sum_metric deployment_duration_seconds_count)
 # in_progress_tasks is decremented in a deferred EndTracking that runs AFTER the
 # task's terminal status is written, so the gauge can briefly lag the driver's exit.
 # Poll it down to 0 rather than gating on a single scrape (avoids a false FAIL on the
@@ -63,7 +68,7 @@ for _ in $(seq 1 15); do
 done
 kill $pf 2>/dev/null || true
 echo "  failed_deployment=${fd} processed_deployments=${pd} argocd_unavailable=${au:-?} in_progress_tasks=${ip:-?}"
-echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc}"
+echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc} deployment_count=${dc}"
 [[ "${fd:-0}" == "0" ]] || { echo "FAIL: failed_deployment=${fd}"; fail=1; }
 [[ "${au:-0}" == "0" ]] || { echo "FAIL: argocd_unavailable=${au}"; fail=1; }
 [[ "${pd:-0}" -gt 0 ]] || { echo "FAIL: processed_deployments=${pd} (expected > 0)"; fail=1; }
@@ -71,6 +76,7 @@ echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc}"
 [[ "${rc:-0}" -gt 0 ]] || { echo "FAIL: argocd_refresh_duration_seconds_count=${rc} (expected > 0)"; fail=1; }
 [[ "${wc:-0}" -gt 0 ]] || { echo "FAIL: gitops_writeback_duration_seconds_count=${wc} (expected > 0)"; fail=1; }
 [[ "${lc:-0}" -gt 0 ]] || { echo "FAIL: gitops_lock_wait_duration_seconds_count=${lc} (expected > 0)"; fail=1; }
+[[ "${dc:-0}" -gt 0 ]] || { echo "FAIL: deployment_duration_seconds_count=${dc} (expected > 0)"; fail=1; }
 
 echo "=== no lost updates ==="
 kubectl -n gitea port-forward svc/gitea-http 13001:3000 >/dev/null 2>&1 &


### PR DESCRIPTION
Record the end-to-end wall-clock time of a successful deployment as a per-application Prometheus histogram, from the start of rollout monitoring until the app reaches the deployed state. Timing is a monotonic in-process clock taken after the start notification, so notifier latency is excluded; it deliberately does not derive from the stored task timestamp, whose unit differs across state backends. Only successful deployments are observed — a failure's wall-clock is dominated by the timeout and would distort the distribution.

Surface it as a per-application p50/p95/p99 panel on the example Grafana dashboard, gate deployment_duration_seconds_count > 0 in the e2e soak, and document the metric in the observability guide.