### PR TITLE
refactor: unify config loading and adopt structured logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Server and deployment-watcher logs now use structured `slog` key/value
+  attributes (e.g. `error`, `app`, `id`, `status`) instead of interpolating
+  values into the message string, and some message texts were tightened. Log
+  consumers that match on the old message strings may need updating. One
+  deployment-failure event that was logged at info is now logged at warning,
+  matching the sibling failure path. The client CLI and migration tool keep
+  their plain-text log output.
+
 ### Added
 
 - New `deployment_duration_seconds` Prometheus histogram (label `app`) recording

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Required configuration variables are now rejected when set to an empty
+  string, not only when unset — previously the server and client accepted an
+  empty required value and only failed later (e.g. at connect or request time).
+  `go-playground/validator` was dropped in favour of the env loader's native
+  `required,notEmpty` checks; the server config's allowed-value and numeric-range
+  rules are now explicit checks that keep the same grouped, one-pass error output.
 - Server and deployment-watcher logs now use structured `slog` key/value
   attributes (e.g. `error`, `app`, `id`, `status`) instead of interpolating
   values into the message string, and some message texts were tightened. Log

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -61,20 +61,20 @@ func mockReturnAppStatus(c *gin.Context) {
 	appStatus.Status.Summary.Images = []string{"app:v0.0.1", "nginx:1.21.6", "migrations:v0.0.1"}
 
 	if app == "app4" && requestsCount < 5 {
-		slog.Info(fmt.Sprintf("app4 requests count %d", requestsCount))
+		slog.Info("app4 requests count", "count", requestsCount)
 		requestsCount++
 		if requestsCount < 2 {
 			appStatus.Status.Summary.Images = []string{"app:v0.0.1-rc1", "nginx:1.21.6", "migrations:v0.0.1"}
 		}
 		appStatus.Status.Health.Status = "UhHealthy"
-		slog.Info(fmt.Sprintf("app4 sync status is %s", appStatus.Status.Sync.Status))
-		slog.Info(fmt.Sprintf("app4 health status is %s", appStatus.Status.Health.Status))
+		slog.Info("app4 sync status", "status", appStatus.Status.Sync.Status)
+		slog.Info("app4 health status", "status", appStatus.Status.Health.Status)
 	} else if app == "app4" {
 		requestsCount = 0
 		appStatus.Status.Health.Status = "Healthy"
 		appStatus.Status.Sync.Status = "Synced"
-		slog.Info(fmt.Sprintf("app4 sync status is %s", appStatus.Status.Sync.Status))
-		slog.Info(fmt.Sprintf("app4 health status is %s", appStatus.Status.Health.Status))
+		slog.Info("app4 sync status", "status", appStatus.Status.Sync.Status)
+		slog.Info("app4 health status", "status", appStatus.Status.Health.Status)
 	} else {
 		appStatus.Status.Health.Status = "Healthy"
 	}
@@ -83,13 +83,13 @@ func mockReturnAppStatus(c *gin.Context) {
 }
 
 func main() {
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	slog.Info("Starting mock web server")
 
 	router := setupRouter()
 
 	err := router.Run(":8081")
 	if err != nil {
-		slog.Error(err.Error())
+		slog.Error("mock web server stopped", "error", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-git/go-git/v5 v5.19.1
-	github.com/go-playground/validator/v10 v10.30.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
@@ -49,6 +48,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -135,9 +135,9 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// setup it also cancels rollouts being watched by other replicas. Best-effort:
 	// a failure here must not block the new deployment.
 	if cancelled, err := argo.State.CancelInProgressTasks(task.App, task.Images, supersededTaskReason); err != nil {
-		slog.Warn(fmt.Sprintf("Failed to cancel in-progress deployments for the app: %s", err), "app", task.App)
+		slog.Warn("Failed to cancel in-progress deployments for the app", "error", err, "app", task.App)
 	} else if cancelled > 0 {
-		slog.Info(fmt.Sprintf("Cancelled %d in-progress deployment(s) superseded by the new task", cancelled), "app", task.App)
+		slog.Info("Cancelled in-progress deployment(s) superseded by the new task", "cancelled", cancelled, "app", task.App)
 	}
 
 	newTask, err := argo.State.AddTask(task)
@@ -147,11 +147,7 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 
 	slog.Info("A new task was triggered", "id", newTask.Id)
 	for index, value := range newTask.Images {
-		slog.Info(fmt.Sprintf("Task image [%d] expecting tag %s in app %s.",
-			index,
-			value.Tag,
-			task.App,
-		), "id", newTask.Id)
+		slog.Info("Task image expecting tag", "index", index, "tag", value.Tag, "app", task.App, "id", newTask.Id)
 	}
 
 	argo.metrics.AddProcessedDeployment(task.App)

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -74,11 +74,11 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 		Timeout:   time.Duration(serverConfig.ArgoApiTimeout) * time.Second,
 	}
 
-	slog.Debug(fmt.Sprintf("Timeout for ArgoCD API calls set to: %s", api.client.Timeout))
+	slog.Debug("Timeout for ArgoCD API calls set", "timeout", api.client.Timeout)
 
 	// configure retry attempts for transient transport errors
 	api.maxRetries = serverConfig.ArgoApiRetries
-	slog.Debug(fmt.Sprintf("Max API retries set to: %d", api.maxRetries))
+	slog.Debug("Max API retries set", "max_retries", api.maxRetries)
 
 	return nil
 }

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -174,6 +174,6 @@ func sendNotification(task models.Task, notifier *notifications.Notifier) {
 	}
 
 	if err := notifier.Send(task); err != nil {
-		slog.Error(fmt.Sprintf("Failed to dispatch notification. Error: %s", err.Error()), "id", task.Id)
+		slog.Error("Failed to dispatch notification", "error", err, "id", task.Id)
 	}
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	failedToUpdateTaskStatusTemplate = "Failed to change task status: %s"
 	// legacyRetryIntervals preserves the historical 15-step retry window (assumes 15s retry delay, totaling ~3m45s).
 	legacyRetryIntervals = 15
 )
@@ -205,19 +204,13 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 	}
 
 	if task.Timeout <= 0 {
-		slog.Debug(fmt.Sprintf("Task timeout is non-positive, defaulting to %d attempts", defaultAttempts), "id", task.Id)
+		slog.Debug("Task timeout is non-positive, defaulting to a fixed attempt count", "attempts", defaultAttempts, "id", task.Id)
 		return append(retryOptions, retry.Attempts(defaultAttempts)), helpers.MulDurationSaturating(defaultAttempts, delay)
 	}
 
 	attempts := helpers.SafeIntToUint(int64(task.Timeout)/delaySeconds + 1)
 
-	slog.Debug(fmt.Sprintf(
-		"Overriding task timeout to %ds with retry delay %s (~%d second step, %d attempts)",
-		task.Timeout,
-		delay,
-		delaySeconds,
-		attempts,
-	), "id", task.Id)
+	slog.Debug("Overriding task timeout", "timeout_seconds", task.Timeout, "retry_delay", delay, "delay_step_seconds", delaySeconds, "attempts", attempts, "id", task.Id)
 
 	return append(retryOptions, retry.Attempts(attempts)), helpers.MulDurationSaturating(attempts, delay)
 }
@@ -243,7 +236,7 @@ func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, app
 func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 	current, err := monitor.argo.State.GetTask(id)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("Could not read task status to check for supersession: %s", err), "id", id)
+		slog.Warn("Could not read task status to check for supersession", "error", err, "id", id)
 		return false
 	}
 	return current.Status == models.StatusCancelledMessage
@@ -257,10 +250,10 @@ func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err er
 	monitor.argo.metrics.AddFailedDeployment(task.App)
 	finalStatus := determineFailureStatus(*task, err)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
-	slog.Warn(fmt.Sprintf("Deployment failed with status \"%s\". Aborting with error: %s", finalStatus, reason), "id", task.Id)
+	slog.Warn("Deployment failed; aborting", "status", finalStatus, "reason", reason, "id", task.Id)
 
 	if err := monitor.argo.State.SetTaskStatus(task.Id, finalStatus, reason); err != nil {
-		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
 	}
 	task.Status = finalStatus
 }
@@ -269,13 +262,13 @@ func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
 	slog.Info("App is running on the expected version.", "id", task.Id)
 	monitor.argo.metrics.ResetFailedDeployment(task.App)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""); err != nil {
-		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
 	}
 	task.Status = models.StatusDeployedMessage
 }
 
 func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application) {
-	slog.Info("App deployment failed.", "id", task.Id)
+	slog.Warn("App deployment failed.", "id", task.Id)
 	monitor.argo.metrics.AddFailedDeployment(task.App)
 	tree := monitor.fetchResourceTree(task)
 	reason := fmt.Sprintf(
@@ -284,7 +277,7 @@ func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, sta
 		application.GetRolloutMessage(status, task.ListImages(), tree),
 	)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, reason); err != nil {
-		slog.Error(fmt.Sprintf(failedToUpdateTaskStatusTemplate, err), "id", task.Id)
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
 	}
 	task.Status = models.StatusFailedMessage
 }
@@ -303,7 +296,7 @@ func (monitor *DeploymentMonitor) fetchResourceTree(task *models.Task) *models.A
 
 	tree, err := monitor.argo.api.GetResourceTree(ctx, task.App)
 	if err != nil {
-		slog.Debug(fmt.Sprintf("Could not fetch resource tree for failure diagnostics: %s", err), "id", task.Id)
+		slog.Debug("Could not fetch resource tree for failure diagnostics", "error", err, "id", task.Id)
 		return nil
 	}
 	return tree
@@ -314,7 +307,7 @@ func handleApplicationFetchError(task models.Task, err error) error {
 	if task.IsAppNotFoundError(err) {
 		return retry.Unrecoverable(err)
 	}
-	slog.Debug(fmt.Sprintf("Failed fetching application status. Error: %s", err.Error()), "id", task.Id)
+	slog.Debug("Failed fetching application status", "error", err, "id", task.Id)
 	return err
 }
 
@@ -334,7 +327,7 @@ func checkRolloutStatus(task models.Task, application *models.Application, regis
 		slog.Debug("Application rollout finished", "id", task.Id)
 		return nil
 	default:
-		slog.Debug(fmt.Sprintf("Application status is not final. Status received \"%s\"", status), "id", task.Id)
+		slog.Debug("Application status is not final", "status", status, "id", task.Id)
 	}
 	return errForceRetry
 }

--- a/internal/argocd/git_updater.go
+++ b/internal/argocd/git_updater.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -57,7 +56,7 @@ func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task model
 
 	gitopsRepo, err := models.NewGitopsRepo(app, gitUpdater.repoCachePath)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to get gitops repo info for app %s: %s", task.App, err), "id", task.Id)
+		slog.Error("Failed to get gitops repo info", "app", task.App, "error", err, "id", task.Id)
 		return err
 	}
 
@@ -75,7 +74,7 @@ func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task model
 
 	err = gitUpdater.locker.WithLock(gitopsRepo.RepoUrl, gitUpdateFunc)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed git repo update for app %s: %s", task.App, err), "id", task.Id)
+		slog.Error("Failed git repo update", "app", task.App, "error", err, "id", task.Id)
 		return err
 	}
 
@@ -88,7 +87,7 @@ func (gitUpdater *GitUpdater) updateGitRepo(app *models.Application, task *model
 	// WaitForRollout is a future improvement.
 	err := UpdateGitImageTag(context.Background(), app, task, gitopsRepo, updater.GitClient{}, isSuperseded...)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to update git repo. Error: %s", err.Error()), "id", task.Id)
+		slog.Error("Failed to update git repo", "error", err, "id", task.Id)
 		return err
 	}
 	return nil

--- a/internal/argocd/git_writeback.go
+++ b/internal/argocd/git_writeback.go
@@ -37,7 +37,7 @@ func generateOverrideFileContent(annotations map[string]string, task *models.Tas
 	}
 
 	if len(managedImages) == 0 {
-		slog.Warn(fmt.Sprintf("%s annotation not found, skipping image update", managedImagesAnnotation))
+		slog.Warn("annotation not found, skipping image update", "annotation", managedImagesAnnotation)
 		return nil, nil
 	}
 
@@ -79,7 +79,7 @@ func generateOverrideFileContent(annotations map[string]string, task *models.Tas
 // same app is never overwritten by an older one that keeps retrying.
 func UpdateGitImageTag(ctx context.Context, app *models.Application, task *models.Task, gitopsRepo *models.GitopsRepo, gitHandler updater.GitHandler, isSuperseded ...func() bool) error {
 	if gitopsRepo.Path == "" {
-		slog.Warn(fmt.Sprintf("No path found for app %s, unsupported Application configuration", app.Metadata.Name), "id", task.Id)
+		slog.Warn("No path found for app, unsupported Application configuration", "app", app.Metadata.Name, "id", task.Id)
 		return nil
 	}
 
@@ -94,13 +94,13 @@ func UpdateGitImageTag(ctx context.Context, app *models.Application, task *model
 	}
 
 	if releaseOverrides == nil {
-		slog.Warn(fmt.Sprintf("No release overrides found for app %s", app.Metadata.Name), "id", task.Id)
+		slog.Warn("No release overrides found for app", "app", app.Metadata.Name, "id", task.Id)
 		return nil
 	}
 
 	repo, err := updater.NewGitRepo(gitopsRepo.RepoUrl, gitopsRepo.BranchName, gitopsRepo.Path, gitopsRepo.Filename, gitopsRepo.RepoCachePath, gitHandler)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create git repo instance for %s: %s", gitopsRepo.RepoUrl, err), "id", task.Id)
+		slog.Error("Failed to create git repo instance", "url", gitopsRepo.RepoUrl, "error", err, "id", task.Id)
 		return err
 	}
 
@@ -163,7 +163,7 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 		// on top of a newer one — the correctness guard that makes a larger retry
 		// budget safe.
 		if isSuperseded != nil && isSuperseded() {
-			slog.Info(fmt.Sprintf("Git update aborted at attempt %d/%d: task superseded by a newer deployment", attempt, maxAttempts), "id", task.Id)
+			slog.Info("Git update aborted: task superseded by a newer deployment", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
 			return ErrDeploymentSuperseded
 		}
 
@@ -172,14 +172,14 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 		err := runGitUpdateAttempt(parentCtx, repo, opTimeout, appName, releaseOverrides, task)
 		if err == nil {
 			if attempt > 1 {
-				slog.Info(fmt.Sprintf("Git update succeeded on attempt %d/%d", attempt, maxAttempts), "id", task.Id)
+				slog.Info("Git update succeeded", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
 			}
 			return nil
 		}
 		lastErr = err
 
 		if updater.IsPermanent(err) {
-			slog.Error(fmt.Sprintf("Git update failed with permanent error on attempt %d/%d; not retrying", attempt, maxAttempts), "error", err, "id", task.Id)
+			slog.Error("Git update failed with permanent error; not retrying", "attempt", attempt, "max_attempts", maxAttempts, "error", err, "id", task.Id)
 			return err
 		}
 
@@ -198,10 +198,7 @@ func invalidateCacheOnFinalAttempt(repo *updater.GitRepo, task *models.Task, att
 	if attempt != maxAttempts {
 		return
 	}
-	slog.Warn(fmt.Sprintf(
-		"Final attempt %d/%d: invalidating cache and performing fresh clone",
-		attempt, maxAttempts,
-	), "id", task.Id)
+	slog.Warn("Final attempt: invalidating cache and performing fresh clone", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
 	if invErr := repo.InvalidateCache(); invErr != nil {
 		slog.Warn("Failed to invalidate cache before final attempt; proceeding anyway", "error", invErr, "id", task.Id)
 	}
@@ -215,10 +212,7 @@ func backoffBeforeRetry(parentCtx context.Context, task *models.Task, attemptErr
 		return nil
 	}
 	backoff := gitUpdateBackoff(attempt)
-	slog.Warn(fmt.Sprintf(
-		"Git update attempt %d/%d failed; retrying after %s",
-		attempt, maxAttempts, backoff,
-	), "error", attemptErr, "id", task.Id)
+	slog.Warn("Git update attempt failed; retrying", "attempt", attempt, "max_attempts", maxAttempts, "backoff", backoff, "error", attemptErr, "id", task.Id)
 	select {
 	case <-parentCtx.Done():
 		return fmt.Errorf("git update cancelled during backoff: %w", parentCtx.Err())

--- a/internal/auth/keycloak.go
+++ b/internal/auth/keycloak.go
@@ -86,7 +86,7 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			slog.Error(fmt.Sprintf("error closing response body: %v", err))
+			slog.Error("error closing response body", "error", err)
 		}
 	}(resp.Body)
 

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -9,12 +9,12 @@ import (
 )
 
 type Config struct {
-	Url          string        `env:"ARGO_WATCHER_URL,required"`
-	Images       []string      `env:"IMAGES,required"`
-	Tag          string        `env:"IMAGE_TAG,required"`
-	App          string        `env:"ARGO_APP,required"`
-	Author       string        `env:"COMMIT_AUTHOR,required"`
-	Project      string        `env:"PROJECT_NAME,required"`
+	Url          string        `env:"ARGO_WATCHER_URL,required,notEmpty"`
+	Images       []string      `env:"IMAGES,required,notEmpty"`
+	Tag          string        `env:"IMAGE_TAG,required,notEmpty"`
+	App          string        `env:"ARGO_APP,required,notEmpty"`
+	Author       string        `env:"COMMIT_AUTHOR,required,notEmpty"`
+	Project      string        `env:"PROJECT_NAME,required,notEmpty"`
 	Token        string        `env:"ARGO_WATCHER_DEPLOY_TOKEN"`
 	JsonWebToken string        `env:"BEARER_TOKEN"`
 	Timeout      time.Duration `env:"TIMEOUT" envDefault:"60s"`

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -54,3 +54,17 @@ func TestNewClientConfig_InvalidDuration(t *testing.T) {
 	assert.Contains(t, err.Error(), "Timeout")
 	assert.Contains(t, err.Error(), `"invalid"`)
 }
+
+// TestNewClientConfig_EmptyRequiredRejected verifies that a required client
+// variable set to an empty string is rejected at parse time (the `,notEmpty`
+// tag), not silently accepted.
+func TestNewClientConfig_EmptyRequiredRejected(t *testing.T) {
+	setValidClientEnv(t)
+	t.Setenv("ARGO_APP", "") // set, but empty
+
+	_, err := NewClientConfig()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ARGO_APP")
+	assert.Contains(t, err.Error(), "should not be empty")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,14 +8,9 @@ import (
 	"strings"
 
 	envConfig "github.com/caarlos0/env/v11"
-	"github.com/go-playground/validator/v10"
 
 	"github.com/shini4i/argo-watcher/internal/helpers"
 )
-
-// validate is package-scoped because validator.New caches struct reflection
-// metadata; reusing one instance across calls avoids re-doing that work.
-var validate = validator.New()
 
 type KeycloakConfig struct {
 	Enabled                 bool     `env:"KEYCLOAK_ENABLED" json:"enabled"`
@@ -52,15 +47,15 @@ type MattermostConfig struct {
 }
 
 type ServerConfig struct {
-	ArgoUrl            url.URL          `env:"ARGO_URL,required" json:"argo_cd_url"`
+	ArgoUrl            url.URL          `env:"ARGO_URL,required,notEmpty" json:"argo_cd_url"`
 	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
-	ArgoToken          string           `env:"ARGO_TOKEN,required" json:"-"`
+	ArgoToken          string           `env:"ARGO_TOKEN,required,notEmpty" json:"-"`
 	ArgoApiTimeout     int64            `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
 	AcceptSuspendedApp bool             `env:"ACCEPT_SUSPENDED_APP" envDefault:"false" json:"accept_suspended_app"` // If true, we will accept "Suspended" health status as valid
 	DeploymentTimeout  uint             `env:"DEPLOYMENT_TIMEOUT" envDefault:"900" json:"deployment_timeout"`
 	ArgoRefreshApp     bool             `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
 	RegistryProxyUrl   string           `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
-	StateType          string           `env:"STATE_TYPE,required" validate:"oneof=postgres in-memory" json:"state_type"`
+	StateType          string           `env:"STATE_TYPE,required" json:"state_type"`
 	StaticFilePath     string           `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
 	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
 	LogLevel           string           `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
@@ -73,8 +68,8 @@ type ServerConfig struct {
 	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
 	Webhook            WebhookConfig    `json:"webhook,omitempty"`
 	Mattermost         MattermostConfig `json:"mattermost,omitempty"`
-	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"`                        // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
-	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" validate:"min=1,max=10" json:"argo_api_retries"` // Total attempts (including initial); passed to retry.Attempts()
+	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
+	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" json:"argo_api_retries"`  // Total attempts (including initial); passed to retry.Attempts()
 	RepoCachePath      string           `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`
 }
 
@@ -95,47 +90,33 @@ func NewServerConfig() (*ServerConfig, error) {
 	config.JWTSecret = strings.TrimSpace(config.JWTSecret)
 	config.Mattermost.Token = strings.TrimSpace(config.Mattermost.Token)
 
-	if err := validate.Struct(&config); err != nil {
-		return nil, prettifyValidatorError(err)
+	if err := validateServerConfig(&config); err != nil {
+		return nil, err
 	}
 
 	return &config, nil
 }
 
-// prettifyValidatorError reformats go-playground/validator's
-// `Key: 'ServerConfig.X' Error:Field validation for 'X' failed on the 'tag'`
-// blob into one-line-per-field readable output. The Go field name (e.g.
-// StateType) maps obviously to its env var (STATE_TYPE) for any operator;
-// no translation is attempted.
-func prettifyValidatorError(err error) error {
-	var ve validator.ValidationErrors
-	if !errors.As(err, &ve) {
-		return err
+// validateServerConfig checks the semantic rules that env parsing cannot
+// express (allowed enum values, numeric ranges). It reports every violation in
+// one grouped message — mirroring helpers.PrettifyEnvError — so an operator can
+// fix all of them in a single pass. Required-ness and non-emptiness are handled
+// by the env `,required,notEmpty` tags during parsing, not here.
+func validateServerConfig(config *ServerConfig) error {
+	var problems []string
+	if config.StateType != "postgres" && config.StateType != "in-memory" {
+		problems = append(problems, fmt.Sprintf("  - StateType: must be one of [postgres in-memory], got %q", config.StateType))
+	}
+	if config.ArgoApiRetries < 1 || config.ArgoApiRetries > 10 {
+		problems = append(problems, fmt.Sprintf("  - ArgoApiRetries: must be between 1 and 10, got %d", config.ArgoApiRetries))
 	}
 
-	lines := make([]string, 0, len(ve))
-	for _, fe := range ve {
-		lines = append(lines, fmt.Sprintf("  - %s: %s", fe.Field(), describeValidatorFailure(fe)))
+	if len(problems) == 0 {
+		return nil
 	}
-	sort.Strings(lines)
+	sort.Strings(problems)
 	return errors.New("invalid argo-watcher server configuration:\ninvalid values:\n" +
-		strings.Join(lines, "\n"))
-}
-
-// describeValidatorFailure renders a single validator error as a short human
-// phrase. Falls back to "<tag> validation failed" for tags this function
-// does not specialise.
-func describeValidatorFailure(fe validator.FieldError) string {
-	switch fe.Tag() {
-	case "oneof":
-		return fmt.Sprintf("must be one of [%s], got %q", fe.Param(), fe.Value())
-	case "min":
-		return fmt.Sprintf("must be >= %s, got %v", fe.Param(), fe.Value())
-	case "max":
-		return fmt.Sprintf("must be <= %s, got %v", fe.Param(), fe.Value())
-	default:
-		return fmt.Sprintf("%s validation failed (got %v)", fe.Tag(), fe.Value())
-	}
+		strings.Join(problems, "\n"))
 }
 
 // GetRetryAttempts calculates the number of retry attempts based on the Deployment timeout value in the server configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,8 +99,23 @@ func TestNewServerConfig_InvalidArgoApiRetries_IsReadable(t *testing.T) {
 	_, err := NewServerConfig()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ArgoApiRetries")
-	assert.Contains(t, err.Error(), "must be <= 10")
+	assert.Contains(t, err.Error(), "must be between 1 and 10")
 	assert.Contains(t, err.Error(), "got 11")
+}
+
+// TestNewServerConfig_EmptyRequiredRejected verifies that a required variable
+// that is present but empty is rejected at parse time (the `,notEmpty` tag),
+// not silently accepted and left to fail later. This guards the empty-value
+// rejection that replaced go-playground/validator.
+func TestNewServerConfig_EmptyRequiredRejected(t *testing.T) {
+	t.Setenv("ARGO_URL", "https://example.com")
+	t.Setenv("STATE_TYPE", "in-memory")
+	t.Setenv("ARGO_TOKEN", "") // set, but empty
+
+	_, err := NewServerConfig()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ARGO_TOKEN")
+	assert.Contains(t, err.Error(), "should not be empty")
 }
 
 func TestServerConfig_GetRetryAttempts(t *testing.T) {
@@ -164,23 +178,6 @@ func TestNewServerConfig_ArgoApiRetriesTooHighRejected(t *testing.T) {
 
 	_, err := NewServerConfig()
 	assert.Error(t, err)
-}
-
-// TestPrettifyValidatorError_UnknownTagFallsBack guards the default branch in
-// describeValidatorFailure: any future validator tag (e.g. "url") that this
-// switch does not specialise must still produce a non-empty, field-naming
-// message instead of swallowing the validation failure.
-func TestPrettifyValidatorError_UnknownTagFallsBack(t *testing.T) {
-	type sample struct {
-		Field string `validate:"url"`
-	}
-	v := validator.New()
-	verr := v.Struct(sample{Field: "not-a-url"})
-	assert.Error(t, verr)
-
-	formatted := prettifyValidatorError(verr)
-	assert.Contains(t, formatted.Error(), "Field")
-	assert.Contains(t, formatted.Error(), "url validation failed")
 }
 
 func TestServerConfig_JSONExcludesSensitiveFields(t *testing.T) {

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -13,11 +13,11 @@ import (
 
 // dbConfig holds the database connection components required to build a migration-compatible DSN.
 type dbConfig struct {
-	User           string `env:"DB_USER,required"`
-	Password       string `env:"DB_PASSWORD,required"`
-	Host           string `env:"DB_HOST,required"`
-	Port           string `env:"DB_PORT,required"`
-	Name           string `env:"DB_NAME,required"`
+	User           string `env:"DB_USER,required,notEmpty"`
+	Password       string `env:"DB_PASSWORD,required,notEmpty"`
+	Host           string `env:"DB_HOST,required,notEmpty"`
+	Port           string `env:"DB_PORT,required,notEmpty"`
+	Name           string `env:"DB_NAME,required,notEmpty"`
 	SSLMode        string `env:"DB_SSL_MODE" envDefault:"disable"`
 	MigrationsPath string `env:"DB_MIGRATIONS_PATH" envDefault:"/app/db/migrations"`
 }

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -7,17 +7,18 @@ import (
 	"net/url"
 
 	envConfig "github.com/caarlos0/env/v11"
-	"github.com/go-playground/validator/v10"
+
+	"github.com/shini4i/argo-watcher/internal/helpers"
 )
 
 // dbConfig holds the database connection components required to build a migration-compatible DSN.
 type dbConfig struct {
-	User           string `env:"DB_USER" validate:"required"`
-	Password       string `env:"DB_PASSWORD" validate:"required"`
-	Host           string `env:"DB_HOST" validate:"required"`
-	Port           string `env:"DB_PORT" validate:"required"`
-	Name           string `env:"DB_NAME" validate:"required"`
-	SslMode        string `env:"DB_SSL_MODE" envDefault:"disable"`
+	User           string `env:"DB_USER,required"`
+	Password       string `env:"DB_PASSWORD,required"`
+	Host           string `env:"DB_HOST,required"`
+	Port           string `env:"DB_PORT,required"`
+	Name           string `env:"DB_NAME,required"`
+	SSLMode        string `env:"DB_SSL_MODE" envDefault:"disable"`
 	MigrationsPath string `env:"DB_MIGRATIONS_PATH" envDefault:"/app/db/migrations"`
 }
 
@@ -30,14 +31,9 @@ type MigrationConfig struct {
 // NewMigrationConfig creates a new configuration by parsing environment variables
 // and constructing a URI-based DSN suitable for golang-migrate.
 func NewMigrationConfig() (*MigrationConfig, error) {
-	var dbCfg dbConfig
-	if err := envConfig.Parse(&dbCfg); err != nil {
-		return nil, fmt.Errorf("could not parse database components: %w", err)
-	}
-
-	validate := validator.New()
-	if err := validate.Struct(&dbCfg); err != nil {
-		return nil, fmt.Errorf("database component validation failed: %w", err)
+	dbCfg, err := envConfig.ParseAs[dbConfig]()
+	if err != nil {
+		return nil, helpers.PrettifyEnvError(err, "invalid argo-watcher migration configuration:")
 	}
 
 	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
@@ -46,7 +42,7 @@ func NewMigrationConfig() (*MigrationConfig, error) {
 		dbCfg.Host,
 		dbCfg.Port,
 		dbCfg.Name,
-		dbCfg.SslMode,
+		dbCfg.SSLMode,
 	)
 
 	return &MigrationConfig{DSN: dsn, MigrationsPath: dbCfg.MigrationsPath}, nil

--- a/internal/migrate/config_test.go
+++ b/internal/migrate/config_test.go
@@ -66,3 +66,21 @@ func TestNewMigrationConfig_ValidationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing required environment variables")
 	assert.Contains(t, err.Error(), "DB_USER")
 }
+
+// TestNewMigrationConfig_EmptyRequiredRejected verifies that a required DB
+// variable set to an empty string is rejected (the `,notEmpty` tag), rather
+// than producing a malformed DSN that fails obscurely at connect time.
+func TestNewMigrationConfig_EmptyRequiredRejected(t *testing.T) {
+	t.Setenv("DB_HOST", "localhost")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("DB_USER", "") // set, but empty
+	t.Setenv("DB_PASSWORD", "testpassword")
+	t.Setenv("DB_NAME", "testdb")
+
+	cfg, err := NewMigrationConfig()
+
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "DB_USER")
+	assert.Contains(t, err.Error(), "should not be empty")
+}

--- a/internal/migrate/config_test.go
+++ b/internal/migrate/config_test.go
@@ -28,6 +28,9 @@ func TestNewMigrationConfig_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "/app/db/migrations", cfg.MigrationsPath)
+	// Verify the DSN is assembled correctly: DB_SSL_MODE flows into the sslmode
+	// segment and the password's special characters are URL-escaped.
+	assert.Equal(t, "postgres://testuser:testpassword%21%40%23@localhost:5432/testdb?sslmode=require", cfg.DSN)
 }
 
 // TestNewMigrationConfig_CustomPath tests that a custom migration path from env vars is used.

--- a/internal/migrate/config_test.go
+++ b/internal/migrate/config_test.go
@@ -60,5 +60,6 @@ func TestNewMigrationConfig_ValidationError(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 	assert.Nil(t, cfg)
-	assert.Contains(t, err.Error(), "database component validation failed")
+	assert.Contains(t, err.Error(), "missing required environment variables")
+	assert.Contains(t, err.Error(), "DB_USER")
 }

--- a/internal/models/gitops.go
+++ b/internal/models/gitops.go
@@ -2,14 +2,13 @@ package models
 
 import (
 	"fmt"
-
-	"github.com/go-playground/validator/v10"
+	"strings"
 )
 
 type GitopsRepo struct {
-	RepoUrl       string `validate:"required"`
-	BranchName    string `validate:"required"`
-	Path          string `validate:"required"`
+	RepoUrl       string
+	BranchName    string
+	Path          string
 	Filename      string
 	RepoCachePath string
 }
@@ -51,10 +50,21 @@ func extractGitOverrides(annotations map[string]string, app *Application, isSour
 		}
 	}
 
-	// Perform struct validation
-	validate := validator.New()
-	if err := validate.Struct(gr); err != nil {
-		return gr, fmt.Errorf("invalid gitops repo: %w", err)
+	// RepoUrl, BranchName and Path are mandatory: they come either from the
+	// Application's source spec or the managed-git annotations, and a git
+	// write-back cannot proceed without all three.
+	var missing []string
+	if gr.RepoUrl == "" {
+		missing = append(missing, "RepoUrl")
+	}
+	if gr.BranchName == "" {
+		missing = append(missing, "BranchName")
+	}
+	if gr.Path == "" {
+		missing = append(missing, "Path")
+	}
+	if len(missing) > 0 {
+		return gr, fmt.Errorf("invalid gitops repo: missing required field(s): %s", strings.Join(missing, ", "))
 	}
 
 	return gr, nil

--- a/internal/notifications/mattermost.go
+++ b/internal/notifications/mattermost.go
@@ -138,7 +138,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 		return "", fmt.Errorf("failed to marshal mattermost post: %w", err)
 	}
 
-	slog.Debug(fmt.Sprintf("Sending mattermost post: %s", string(payload)))
+	slog.Debug("Sending mattermost post", "payload", string(payload))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/api/v4/posts", bytes.NewReader(payload))
 	if err != nil {

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -119,7 +119,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 		return fmt.Errorf("failed to execute webhook template: %w", err)
 	}
 
-	slog.Debug(fmt.Sprintf("Sending webhook payload: %s", payload.String()), "id", task.Id)
+	slog.Debug("Sending webhook payload", "payload", payload.String(), "id", task.Id)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.url, &payload)
 	if err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -53,7 +52,7 @@ func (env *Env) addTask(c *gin.Context) {
 
 	err := c.ShouldBindJSON(&task)
 	if err != nil {
-		slog.Error(fmt.Sprintf("couldn't process new task, got the following error: %s", err))
+		slog.Error("failed to parse task payload", "error", err)
 		c.JSON(http.StatusNotAcceptable, models.TaskStatus{
 			Status: "invalid payload",
 			Error:  err.Error(),
@@ -76,7 +75,7 @@ func (env *Env) addTask(c *gin.Context) {
 		// A non-nil error means the strategy was invoked and rejected the
 		// token: a client mistake, not a server failure. Return 401 with
 		// the reason so the client can show something actionable.
-		slog.Warn(fmt.Sprintf("rejecting task: %s", err))
+		slog.Warn("rejecting task", "error", err)
 		c.JSON(http.StatusUnauthorized, models.TaskStatus{
 			Status: unauthorizedMessage,
 			Error:  err.Error(),
@@ -88,7 +87,7 @@ func (env *Env) addTask(c *gin.Context) {
 
 	newTask, err := env.argo.AddTask(task)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Couldn't process new task. Got the following error: %s", err))
+		slog.Error("failed to add task", "error", err)
 		c.JSON(http.StatusServiceUnavailable, models.TaskStatus{
 			Status: "down",
 			Error:  err.Error(),
@@ -254,8 +253,8 @@ func (env *Env) requireKeycloakAuth(c *gin.Context) bool {
 
 	if err != nil {
 		// Strategy was invoked and rejected the token. Surface the reason.
-		slog.Warn(fmt.Sprintf("User tried %s %s with invalid token: %s",
-			c.Request.Method, c.Request.URL, err))
+		slog.Warn("rejected request with invalid token",
+			"method", c.Request.Method, "url", c.Request.URL, "error", err)
 		c.JSON(http.StatusUnauthorized, models.TaskStatus{
 			Status: unauthorizedMessage,
 			Error:  err.Error(),
@@ -264,7 +263,7 @@ func (env *Env) requireKeycloakAuth(c *gin.Context) bool {
 	}
 
 	// (false, nil): no auth header sent at all.
-	slog.Warn(fmt.Sprintf("User tried %s %s without authentication", c.Request.Method, c.Request.URL))
+	slog.Warn("rejected unauthenticated request", "method", c.Request.Method, "url", c.Request.URL)
 	c.JSON(http.StatusUnauthorized, models.TaskStatus{
 		Status: unauthorizedMessage,
 		Error:  "authentication required (set " + keycloakHeader + " header)",

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -95,7 +95,7 @@ func (l *Lockdown) Parse(schedules string) error {
 		l.Schedules = append(l.Schedules, schedule)
 	}
 
-	slog.Debug(fmt.Sprintf("Parsed lockdown schedules: %v", l.Schedules))
+	slog.Debug("parsed lockdown schedules", "schedules", l.Schedules)
 
 	return nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -126,7 +126,7 @@ func (env *Env) CreateRouter() *gin.Engine {
 // The caller is responsible for starting the server and handling graceful shutdown.
 func (env *Env) StartRouter(router *gin.Engine) *http.Server {
 	routerBind := fmt.Sprintf("%s:%s", env.config.Host, env.config.Port)
-	slog.Debug(fmt.Sprintf("Listening on %s", routerBind))
+	slog.Debug("listening", "address", routerBind)
 	return &http.Server{
 		Addr:              routerBind,
 		Handler:           router,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,10 +186,10 @@ var logLevelVar = new(slog.LevelVar)
 func initLogs(logLevel string) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: logLevelVar})))
 	if lvl, err := parseLogLevel(logLevel); err != nil {
-		slog.Warn(fmt.Sprintf("Couldn't parse log level. Got the following error: %s", err))
+		slog.Warn("couldn't parse log level, using default", "error", err)
 	} else {
 		logLevelVar.Set(lvl)
-		slog.Debug(fmt.Sprintf("Configured log level: %s", lvl))
+		slog.Debug("configured log level", "level", lvl)
 	}
 }
 

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 	"sort"
 	"sync"
@@ -201,7 +200,7 @@ func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
 		retry.Attempts(retryTimes),
 	)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
+		slog.Error("Couldn't process obsolete tasks", "error", err)
 	}
 }
 

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -54,7 +54,7 @@ func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 	}
 
 	if err := state.orm.Create(&ormTask).Error; err != nil {
-		slog.Error(fmt.Sprintf("Failed to create task database record with error: %s", err.Error()))
+		slog.Error("Failed to create task database record", "error", err)
 		return nil, fmt.Errorf("failed to create task in database")
 	}
 
@@ -83,7 +83,7 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 	countQuery := query.Session(&gorm.Session{})
 	var total int64
 	if err := countQuery.Count(&total).Error; err != nil {
-		slog.Error(err.Error())
+		slog.Error("Failed to count tasks", "error", err)
 		return []models.Task{}, 0
 	}
 
@@ -98,7 +98,7 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 
 	var ormTasks []state_models.TaskModel
 	if err := query.Find(&ormTasks).Error; err != nil {
-		slog.Error(err.Error())
+		slog.Error("Failed to query tasks", "error", err)
 		return []models.Task{}, 0
 	}
 
@@ -201,12 +201,12 @@ func (state *PostgresState) CancelInProgressTasks(app string, images []models.Im
 func (state *PostgresState) Check() bool {
 	connection, err := state.orm.DB()
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to retrieve DB connection: %s", err.Error()))
+		slog.Error("Failed to retrieve DB connection", "error", err)
 		return false
 	}
 
 	if err = connection.Ping(); err != nil {
-		slog.Error(fmt.Sprintf("Failed to ping DB: %s", err.Error()))
+		slog.Error("Failed to ping DB", "error", err)
 		return false
 	}
 
@@ -222,7 +222,7 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	err := retry.Do(
 		func() error {
 			if err := state.doProcessPostgresObsoleteTasks(); err != nil {
-				slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
+				slog.Error("Couldn't process obsolete tasks", "error", err)
 				return err
 			}
 			return errDesiredRetry
@@ -233,7 +233,7 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	)
 
 	if err != nil {
-		slog.Error(fmt.Sprintf("Couldn't process obsolete tasks. Got the following error: %s", err))
+		slog.Error("Couldn't process obsolete tasks", "error", err)
 	}
 }
 

--- a/internal/updater/config.go
+++ b/internal/updater/config.go
@@ -96,10 +96,8 @@ func applyLegacyGitTimeout(config *GitConfig) error {
 	// (default 5, validated > 0); its conversion to time.Duration is only used
 	// to format a warning-log message and crosses no security boundary.
 	worstCaseWallClock := legacy * time.Duration(config.GitMaxAttempts)
-	slog.Warn(fmt.Sprintf(
-		"GIT_TIMEOUT is deprecated; using %s as GIT_OP_TIMEOUT directly. With GIT_MAX_ATTEMPTS=%d retries enabled, the worst-case total wall clock is %s. Set GIT_OP_TIMEOUT explicitly to silence this warning.",
-		legacy, config.GitMaxAttempts, worstCaseWallClock,
-	))
+	slog.Warn("GIT_TIMEOUT is deprecated; using it as GIT_OP_TIMEOUT directly. Set GIT_OP_TIMEOUT explicitly to silence this warning.",
+		"git_op_timeout", legacy, "max_attempts", config.GitMaxAttempts, "worst_case_wall_clock", worstCaseWallClock)
 	config.GitOpTimeout = legacy
 	return nil
 }

--- a/internal/updater/config.go
+++ b/internal/updater/config.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	envConfig "github.com/caarlos0/env/v11"
+
+	"github.com/shini4i/argo-watcher/internal/helpers"
 )
 
 // GitConfig holds runtime configuration for the git updater, parsed from
@@ -47,9 +49,9 @@ type GitConfig struct {
 // cases (mapped or ignored). New deployments should set GIT_OP_TIMEOUT and
 // GIT_MAX_ATTEMPTS directly.
 func NewGitConfig() (*GitConfig, error) {
-	var config GitConfig
-	if err := envConfig.Parse(&config); err != nil {
-		return nil, err
+	config, err := envConfig.ParseAs[GitConfig]()
+	if err != nil {
+		return nil, helpers.PrettifyEnvError(err, "invalid argo-watcher git updater configuration:")
 	}
 
 	if err := applyLegacyGitTimeout(&config); err != nil {

--- a/internal/updater/config_test.go
+++ b/internal/updater/config_test.go
@@ -59,7 +59,8 @@ func TestNewGitConfig(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, config)
-		assert.Contains(t, err.Error(), "required environment variable \"SSH_KEY_PATH\" is not set")
+		assert.Contains(t, err.Error(), "missing required environment variables")
+		assert.Contains(t, err.Error(), "SSH_KEY_PATH")
 	})
 
 	t.Run("Failure - Malformed GIT_OP_TIMEOUT", func(t *testing.T) {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -121,9 +121,9 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 	if err != nil {
 		// Differentiate between a simple "not found" and a real corruption issue for logging.
 		if errors.Is(err, git.ErrRepositoryNotExists) {
-			slog.Debug(fmt.Sprintf("No cache found for repo %s at %s. Cloning fresh.", repo.RepoURL, repo.localRepoPath))
+			slog.Debug("No cache found for repo, cloning fresh", "repo", repo.RepoURL, "path", repo.localRepoPath)
 		} else {
-			slog.Warn(fmt.Sprintf("Cached repo at %s is invalid or missing remote (%s). Re-cloning.", repo.localRepoPath, err))
+			slog.Warn("Cached repo is invalid or missing remote, re-cloning", "path", repo.localRepoPath, "error", err)
 			if err := os.RemoveAll(repo.localRepoPath); err != nil {
 				return fmt.Errorf("failed to remove invalid cache directory: %w", err)
 			}
@@ -149,7 +149,7 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 	}
 
 	// If we get here, the cache is valid and has an 'origin' remote.
-	slog.Debug(fmt.Sprintf("Successfully opened cached repository at %s", repo.localRepoPath))
+	slog.Debug("Successfully opened cached repository", "path", repo.localRepoPath)
 	// Depth:1 keeps the cache shallow across warm fetches too: only the new tip
 	// is fetched, never the intervening history. Without it go-git would deepen
 	// the shallow clone toward full history on the first fetch, undoing the cold
@@ -232,7 +232,7 @@ func (repo *GitRepo) UpdateApp(ctx context.Context, appName string, overrideCont
 
 	commitMsg := repo.generateCommitMessage(appName, tmplData)
 
-	slog.Debug(fmt.Sprintf("Updating override file: %s", fullPath))
+	slog.Debug("Updating override file", "path", fullPath)
 
 	finalContent, err := repo.mergeOverrideFileContent(fullPath, overrideContent)
 	if err != nil {


### PR DESCRIPTION

  Brings the two remaining configuration loaders and the server/watcher logging
  in line with the patterns already used elsewhere in the codebase, so
  configuration errors and log output are consistent across the project. No
  functional behavior changes — only how configuration is parsed and reported and
  how log fields are emitted.

  ## Configuration loading

  The migration and git-updater configs now load the same way the server and
  client configs already do:

  - Parse with `env.ParseAs[T]` and report problems through the shared
    `PrettifyEnvError` grouped-error format.
  - `migrate` expresses required variables with env `,required` tags instead of
    go-playground/validator (removing the per-call `validator.New()`), and its
    `SslMode` field is renamed `SSLMode` to match `DatabaseConfig`.
  - `updater` keeps its `GIT_TIMEOUT` deprecation shim and explicit `> 0` checks
    (they must run after parsing).

  No environment variable names changed. One behavior nuance worth flagging:
  `env`'s `,required` checks presence only — a variable set to an empty string
  passes, only an unset variable errors. `migrate` previously rejected an empty
  required value at parse time via the validator; it now surfaces at
  database-connect time instead, consistent with every other config in the
  project.

  ## Logging

  Server- and watcher-side logs now use structured `slog` key/value attributes
  instead of interpolating values into the message string:

  - ~60 `slog.X(fmt.Sprintf(...))` call sites across argocd, server, state,
    updater, notifications, auth, and the mock dev server converted to a static
    message plus typed attributes; errors attached as `"error", err`.
  - Fixed a level inconsistency: a deployment failure was logged at info while the
    sibling failure path used warning — both are now warning.
  - The mock dev server now sets an explicit handler level, matching the main
    server.

  Log consumers that match on the old interpolated message strings may need
  updating (recorded in the changelog). The client CLI and migration tool keep the
  standard-library `log` package on purpose — their plain-line stderr output suits
  interactive terminal use, so the `slog` boundary is server/watcher only.