### PR TITLE
test(e2e): cover single-replica postgres state

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,7 +27,7 @@ the competitor writer. All pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → race → failure-diagnostics → shutdown-drain → down
+task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → race → state-postgres → failure-diagnostics → shutdown-drain → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed
@@ -51,6 +51,7 @@ task lockdown             # assert LOCKDOWN_SCHEDULE freezes deploys in-window (
 task notifications        # assert the generic webhook fires (start + result) with the correct payload
 task load                 # git-conflict soak: competitor + concurrent deploys, strict 0-failed
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
+task state-postgres       # flip the release to Postgres state: assert migration, deploy loop, task survives a pod restart, supersession under contention
 task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
 task shutdown-drain       # assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic
 task down                 # destroy the cluster
@@ -84,6 +85,9 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
 | `scripts/failure-diagnostics.sh` | table-driven failure-reason assertions, driven through the real client (add a case = one table entry) |
 | `scripts/race-supersede.sh` | same-app supersession assertion: real client, newer deploy wins, older is superseded |
+| `scripts/state-postgres.sh` | flip the release to `STATE_TYPE=postgres` and assert the Postgres-only path: schema migration Job, real deploy loop, task history surviving a pod restart (in-memory loses it), and supersession under contention (the hand-written `CancelInProgressTasks` SQL) |
+| `fixtures/postgres/` | in-cluster Postgres (Secret + Service + StatefulSet, one resource per file) the `state-postgres` phase points the release at; the chart bundles no database |
+| `values/argo-watcher-postgres.yaml` | overlay layered over `values/argo-watcher.yaml` that enables `postgres` (sets `STATE_TYPE=postgres`, wires `DB_*`, triggers the migration Job) |
 | `scripts/hook-fixture.sh` | add/remove a failing PreSync hook via the chart's `rawObject` |
 | `scripts/notifications.sh` | assert the generic webhook fires start + result with the templated payload and auth header |
 | `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when Keycloak is off |
@@ -136,6 +140,18 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
   revert-accepts checks are deterministic; the WS-transition sub-check is skipped
   (not failed) if a slow rollout boots in-window. Manual (Keycloak) lock/unlock
   WS notifications are a separate, deterministic trigger left to the heavy tier.
+- **`state-postgres` flips the shared release to Postgres mid-flow rather than
+  running a parallel stack.** The base lab is single-replica in-memory; every
+  functional phase before this one validates that backend. `state-postgres` then
+  helm-upgrades the SAME release with `values/argo-watcher-postgres.yaml` (the
+  chart bundles no database, so `fixtures/postgres.yaml` supplies an in-cluster
+  Postgres first) and asserts the Postgres-only properties — the migration Job,
+  the deploy loop, a task record surviving a pod restart, and supersession under
+  contention. It runs *before* `failure-diagnostics` so it deploys against
+  pristine apps; the two phases after it are backend-agnostic, so they simply run
+  on Postgres for free. Multi-replica is out of scope — the chart requires
+  postgres for `replicaCount > 1`, and shared-state / cross-replica handoff is
+  deliberately not exercised.
 - **`shutdown-drain` follows the pod's logs before deleting it.** A recreated
   StatefulSet pod is a new object, so `kubectl logs --previous` would not have the
   terminated instance's shutdown logs; the script streams `logs -f` to a file
@@ -150,7 +166,8 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 
 ## Topology note
 
-The base lab runs argo-watcher single-replica with in-memory state. The soak
-phase (see the project plan) flips `values/argo-watcher.yaml` to
-`replicaCount: 2` + Postgres to exercise shared state and cross-replica poller
-handoff.
+The base lab runs argo-watcher single-replica with in-memory state. The
+`state-postgres` phase (see Usage) flips the same release to Postgres, still
+single-replica, to exercise the Postgres-backed path. Multi-replica
+(`replicaCount: 2` + shared state / cross-replica poller handoff) is out of
+scope for this lab and remains future work.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -144,7 +144,7 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
   running a parallel stack.** The base lab is single-replica in-memory; every
   functional phase before this one validates that backend. `state-postgres` then
   helm-upgrades the SAME release with `values/argo-watcher-postgres.yaml` (the
-  chart bundles no database, so `fixtures/postgres.yaml` supplies an in-cluster
+  chart bundles no database, so `fixtures/postgres/` supplies an in-cluster
   Postgres first) and asserts the Postgres-only properties — the migration Job,
   the deploy loop, a task record surviving a pod restart, and supersession under
   contention. It runs *before* `failure-diagnostics` so it deploys against

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -83,6 +83,12 @@ tasks:
       - task: notifications
       - task: load
       - task: race
+      # state-postgres flips the release to STATE_TYPE=postgres and asserts the Postgres-only
+      # properties (schema migration, deploy loop, task-survives-restart, supersession under
+      # contention). Placed after the in-memory phases (which validate that backend) and BEFORE
+      # failure-diagnostics so it deploys against pristine apps. Everything after runs on
+      # Postgres — both remaining phases are backend-agnostic, so that is a free bonus.
+      - task: state-postgres
       # failure-diagnostics runs after the soak: it deliberately breaks apps (bad images, a
       # failing PreSync hook injected into the SHARED chart values) and pushes directly to the
       # gitops repo, so running it before load/race would perturb those pristine-state soak gates.
@@ -282,6 +288,13 @@ tasks:
         unavail=$(curl -s -m 10 localhost:18090/metrics | awk '/^argocd_unavailable /{print $2}')
         echo "healthz=$code argocd_unavailable=$unavail"
         test "$code" = "200" && test "$unavail" = "0"
+
+  state-postgres:
+    desc: "Flip the release to Postgres state and assert migration, deploy, task-survives-restart, supersession"
+    deps: [apply-apps]
+    cmds:
+      - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
+        DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/state-postgres.sh
 
   race:
     desc: "Same-app supersession race: a newer deploy must win over an older retrying one"

--- a/test/e2e/fixtures/postgres/secret.yaml
+++ b/test/e2e/fixtures/postgres/secret.yaml
@@ -1,0 +1,25 @@
+# In-cluster Postgres for the state-postgres phase (secret + service + statefulset,
+# one resource per file — applied together via `kubectl apply -f fixtures/postgres/`).
+#
+# The base lab runs argo-watcher on in-memory state; this stands up a dedicated
+# Postgres in the argo-watcher namespace so the state-postgres phase can flip the
+# release to STATE_TYPE=postgres and prove the Postgres-backed path end to end
+# (schema migration on boot, the deploy loop, and — the whole point of Postgres —
+# task history surviving a pod restart).
+#
+# The argo-watcher chart does NOT bundle a database: postgres.enabled only sets
+# STATE_TYPE=postgres and points DB_HOST/PORT/NAME/USER + a DB_PASSWORD secret at
+# an existing server (see values/argo-watcher-postgres.yaml). These manifests are
+# that server. Throwaway lab credentials — never a real secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-watcher-db
+  namespace: argo-watcher
+type: Opaque
+stringData:
+  # The chart envFrom's this whole Secret (no secretKey override), exposing
+  # DB_PASSWORD to both the server StatefulSet and the migration Job. The Postgres
+  # container reads the same key for POSTGRES_PASSWORD, so one value wires both
+  # sides.
+  DB_PASSWORD: e2e-db-password

--- a/test/e2e/fixtures/postgres/service.yaml
+++ b/test/e2e/fixtures/postgres/service.yaml
@@ -1,0 +1,14 @@
+# ClusterIP for the Postgres StatefulSet. The chart's postgres.host points here
+# (same namespace, so the short name resolves).
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-watcher-db
+  namespace: argo-watcher
+spec:
+  selector:
+    app: argo-watcher-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/test/e2e/fixtures/postgres/statefulset.yaml
+++ b/test/e2e/fixtures/postgres/statefulset.yaml
@@ -1,0 +1,68 @@
+# Single-replica Postgres backing argo-watcher's state during the state-postgres
+# phase. The persistence assertion deletes the argo-watcher pod, not this one, so
+# the DB (and the task history it holds) stays up across that restart.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argo-watcher-db
+  namespace: argo-watcher
+spec:
+  serviceName: argo-watcher-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: argo-watcher-db
+  template:
+    metadata:
+      labels:
+        app: argo-watcher-db
+    spec:
+      # The official image's initdb runs as uid 999 (postgres); fsGroup lets it
+      # own the mounted PVC.
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          # Pinned to match the Postgres the unit/integration tests run against
+          # in CI (.github/workflows/run-tests.yml), so the e2e schema path is
+          # exercised on the same major version.
+          image: postgres:18.4
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: argo_watcher
+            - name: POSTGRES_DB
+              value: argo_watcher
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: argo-watcher-db
+                  key: DB_PASSWORD
+            # Point PGDATA at a subdirectory so initdb owns an empty dir, not the
+            # volume's lost+found root.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "argo_watcher", "-d", "argo_watcher"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/test/e2e/fixtures/postgres/statefulset.yaml
+++ b/test/e2e/fixtures/postgres/statefulset.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         app: argo-watcher-db
     spec:
+      # Postgres needs no Kubernetes API access, so don't mount its token —
+      # a compromised container then has no service-account credential to abuse.
+      automountServiceAccountToken: false
       # The official image's initdb runs as uid 999 (postgres); fsGroup lets it
       # own the mounted PVC.
       securityContext:
@@ -53,11 +56,16 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
           resources:
+            # The database itself lives on the PVC; ephemeral-storage here just
+            # bounds the container filesystem (logs, temp) so it can't exhaust the
+            # node disk.
             requests:
               cpu: 50m
               memory: 128Mi
+              ephemeral-storage: 128Mi
             limits:
               memory: 256Mi
+              ephemeral-storage: 1Gi
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/test/e2e/scripts/race-supersede.sh
+++ b/test/e2e/scripts/race-supersede.sh
@@ -45,14 +45,19 @@ if [[ "$BASE_TAG" == "$OLD_TAG" || "$BASE_TAG" == "$NEW_TAG" || "$OLD_TAG" == "$
   exit 1
 fi
 
-# Build the client once so both deploys launch a prebuilt binary — a per-invocation
-# `go run` compile would blow the sub-second submission ordering the race needs.
-bin_dir="$(mktemp -d)"
+# Use a prebuilt client so both deploys launch a binary — a per-invocation `go run`
+# compile would blow the sub-second submission ordering the race needs. A caller
+# (e.g. state-postgres.sh) can pass CLIENT_BIN to reuse its already-built binary;
+# otherwise build our own into a temp dir we own and clean up.
+bin_dir=""
 base_out="$(mktemp)"; old_out="$(mktemp)"; new_out="$(mktemp)"; clone_dir="$(mktemp -d)"
-CLIENT_BIN="${bin_dir}/aw-client"
 comp_pid=""
-trap '[ -n "$comp_pid" ] && kill "$comp_pid" 2>/dev/null; rm -rf "$bin_dir" "$clone_dir" "$base_out" "$old_out" "$new_out"' EXIT
-( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) || { echo "race: FAIL — client build failed" >&2; exit 1; }
+trap '[[ -n "$comp_pid" ]] && kill "$comp_pid" 2>/dev/null; rm -rf "$bin_dir" "$clone_dir" "$base_out" "$old_out" "$new_out"' EXIT
+if [[ -z "${CLIENT_BIN:-}" ]]; then
+  bin_dir="$(mktemp -d)"
+  CLIENT_BIN="${bin_dir}/aw-client"
+  ( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) || { echo "race: FAIL — client build failed" >&2; exit 1; }
+fi
 
 # deploy <tag> <outfile>: run the client to deploy APP:tag, blocking to a terminal
 # status. Combined stdout+stderr goes to outfile; the client's exit code propagates.

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -4,7 +4,7 @@
 # The rest of the lab runs argo-watcher on in-memory state; every functional phase
 # before this one has already validated that backend. This phase flips the SAME
 # release to STATE_TYPE=postgres (against the in-cluster Postgres from
-# fixtures/postgres.yaml) and asserts the things only Postgres can demonstrate:
+# fixtures/postgres/) and asserts the things only Postgres can demonstrate:
 #
 #   1. the chart's pre-upgrade migration Job applies the schema and the server
 #      boots reporting state_type=postgres (GET /config),
@@ -156,14 +156,18 @@ echo "=== supersession under git contention on Postgres ==="
 # Gitea forward for the commit check. Runs on app1, independent of app4 above.
 # Wait for app1 to be Healthy first (as the `race` task does) so the baseline reset
 # deploys from a known-good state — matters when this phase is run standalone.
+h=""
 for _ in $(seq 1 40); do
-  [[ "$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null)" == "Healthy" ]] && break
+  h=$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+  [[ "$h" == "Healthy" ]] && break
   sleep 3
 done
+[[ "$h" == "Healthy" ]] || { echo "STATE-POSTGRES: FAIL — app1 never reached Healthy (last: ${h:-unknown})"; exit 1; }
 kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &
 for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${GITEA_PORT}" && break; sleep 1; done
 
 if ! DEPLOY_TOKEN="${DEPLOY_TOKEN}" BASE_URL="http://localhost:${PORT}" \
+   CLIENT_BIN="${CLIENT_BIN}" \
    GITEA_REPO_URL="http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${GITEA_PORT}/e2e/gitops.git" \
    "${here}/race-supersede.sh"; then
   echo "STATE-POSTGRES: FAIL — supersession under contention failed on Postgres"

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Prove the Postgres-backed state path end to end.
+#
+# The rest of the lab runs argo-watcher on in-memory state; every functional phase
+# before this one has already validated that backend. This phase flips the SAME
+# release to STATE_TYPE=postgres (against the in-cluster Postgres from
+# fixtures/postgres.yaml) and asserts the things only Postgres can demonstrate:
+#
+#   1. the chart's pre-upgrade migration Job applies the schema and the server
+#      boots reporting state_type=postgres (GET /config),
+#   2. a real authenticated deploy still drives the whole loop on Postgres —
+#      task -> SSH write-back to Gitea -> Argo sync -> deployed,
+#   3. THE payoff: the task record SURVIVES a server pod restart. On in-memory the
+#      same restart loses all history (the task would 404); on Postgres it is
+#      still there, 'deployed'. This is the whole reason the Postgres backend
+#      exists, and nothing else in the suite (or the unit tests) asserts it.
+#   4. supersession under real git contention works on Postgres — a newer deploy
+#      cancels an older retrying one via CancelInProgressTasks (hand-written SQL
+#      that DIFFERS from the in-memory Go path) and the superseded task never
+#      clobbers the winner's write-back. This guards git-op correctness on the
+#      Postgres backend specifically.
+#
+# Runs BEFORE failure-diagnostics so it deploys against pristine fixture apps
+# (that phase dirties app tags and only best-effort restores them). Everything
+# after it (failure-diagnostics, shutdown-drain) then runs on Postgres too — both
+# are backend-agnostic assertions, so that is a free bonus, not lost coverage.
+#
+# Required env: AW_CHART_REPO, AW_CHART_VERSION (to helm-upgrade the release).
+# Optional env: DEPLOY_TOKEN, IMAGE, APP, PORT, GITEA_PORT, GITEA_ADMIN, GITEA_PW.
+set -euo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO required (chart repo URL)}"
+AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION required (pinned chart version)}"
+IMAGE="${IMAGE:-traefik/whoami}"
+# Persistence deploy runs against app4 — untouched by the earlier deploy phases
+# (smoke/commit-format/race use app1/app3), so its newest task is unambiguously
+# the one we create here.
+APP="${APP:-app4}"
+PORT="${PORT:-18098}"
+GITEA_PORT="${GITEA_PORT:-13004}"
+GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
+GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../../.." && pwd)"
+
+bin_dir="$(mktemp -d)"
+CLIENT_BIN="${bin_dir}/aw-client"
+pf_pid=""
+trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
+
+base="http://localhost:${PORT}/api/v1"
+
+# forward: (re)establish a port-forward to the argo-watcher service and block until
+# /healthz answers. Called again after the restart, since deleting the pod kills
+# the previous forward.
+forward() {
+  [ -n "$pf_pid" ] && kill "$pf_pid" 2>/dev/null || true
+  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+  pf_pid=$!
+  for _ in $(seq 1 30); do
+    curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && return 0
+    sleep 1
+  done
+  echo "STATE-POSTGRES: FAIL — argo-watcher /healthz never came up on :${PORT}"
+  exit 1
+}
+
+echo "=== provisioning in-cluster Postgres ==="
+kubectl apply -f "${here}/../fixtures/postgres/"
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher-db --timeout=180s
+
+echo "=== flipping the release to STATE_TYPE=postgres (runs the migration Job) ==="
+# --wait blocks on the pre-upgrade migration hook AND the rolled StatefulSet; the
+# hook (argo-watcher --migrate) applies the schema before the server starts.
+helm upgrade --install argo-watcher argo-watcher --repo "$AW_CHART_REPO" \
+  --version "$AW_CHART_VERSION" -n "$NS_AW" \
+  -f "${here}/../values/argo-watcher.yaml" \
+  -f "${here}/../values/argo-watcher-postgres.yaml" \
+  --set image.tag=race --wait --timeout 5m
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
+
+# The completed hook Job lingers (hook-delete-policy: before-hook-creation), so
+# assert it succeeded explicitly. Absence is tolerated: a green helm upgrade above
+# already implies the hook ran to completion.
+if kubectl -n "$NS_AW" get job/argo-watcher-migration >/dev/null 2>&1; then
+  kubectl -n "$NS_AW" wait --for=condition=complete job/argo-watcher-migration --timeout=120s \
+    || { echo "STATE-POSTGRES: FAIL — migration Job did not complete"; exit 1; }
+  echo "  OK   migration Job completed"
+fi
+
+forward
+
+echo "=== asserting the server is actually on Postgres ==="
+st="$(curl -s -m 10 "${base}/config" | jq -r '.state_type')"
+if [ "$st" != "postgres" ]; then
+  echo "STATE-POSTGRES: FAIL — /config state_type=${st:-<none>}, want postgres"
+  exit 1
+fi
+echo "  OK   /config reports state_type=postgres"
+
+echo "=== deploying ${APP} on Postgres (real write-back loop) ==="
+( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) \
+  || { echo "STATE-POSTGRES: FAIL — client build failed"; exit 1; }
+
+# Wait for the app's baseline sync, then deploy a tag different from its current one
+# so the write-back actually commits (an unchanged tag is byte-compared and skipped).
+for _ in $(seq 1 40); do
+  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
+  [ "$s" = "Synced/Healthy" ] && break
+  sleep 5
+done
+[ "$s" = "Synced/Healthy" ] || { echo "STATE-POSTGRES: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
+
+cur=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
+if [[ "$cur" == *v1.10.2* ]]; then TAG="v1.10.1"; else TAG="v1.10.2"; fi
+
+if ! ARGO_WATCHER_URL="http://localhost:${PORT}" \
+   IMAGES="${IMAGE}" IMAGE_TAG="${TAG}" ARGO_APP="${APP}" \
+   COMMIT_AUTHOR="e2e-pg" PROJECT_NAME="lab" \
+   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
+   RETRY_INTERVAL="5s" TASK_TIMEOUT="180" \
+   "$CLIENT_BIN"; then
+  echo "STATE-POSTGRES: FAIL — deploy of ${APP}:${TAG} did not reach 'deployed'"
+  exit 1
+fi
+echo "  OK   ${APP}:${TAG} deployed on Postgres"
+
+# Capture the task we just created: the newest task for this app.
+id=$(curl -s -m 10 "${base}/tasks?from_timestamp=0&app=${APP}" | jq -r '.tasks | sort_by(.created) | last | .id')
+if [ -z "$id" ] || [ "$id" = "null" ]; then
+  echo "STATE-POSTGRES: FAIL — could not read the created task id from the task list"
+  exit 1
+fi
+echo "  task id=${id}"
+
+echo "=== restarting the server; the task must survive (Postgres persistence) ==="
+kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
+forward   # the previous forward died with the pod
+
+code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${base}/tasks/${id}")
+status_after=$(curl -s -m 10 "${base}/tasks/${id}" | jq -r '.status')
+if [ "$code" != "200" ] || [ "$status_after" != "deployed" ]; then
+  echo "STATE-POSTGRES: FAIL — task ${id} did not survive the restart (http=${code} status=${status_after:-<none>})"
+  echo "  (in-memory loses history here; Postgres must return 200 'deployed')"
+  exit 1
+fi
+echo "  OK   task ${id} still present as 'deployed' after the restart"
+
+echo "=== supersession under git contention on Postgres ==="
+# race-supersede.sh is self-contained (resets its app to a baseline, runs its own
+# competitor) and drives CancelInProgressTasks — the one deploy-flow query whose
+# SQL differs from the in-memory path. Give it the already-forwarded API plus a
+# Gitea forward for the commit check. Runs on app1, independent of app4 above.
+# Wait for app1 to be Healthy first (as the `race` task does) so the baseline reset
+# deploys from a known-good state — matters when this phase is run standalone.
+for _ in $(seq 1 40); do
+  [ "$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null)" = "Healthy" ] && break
+  sleep 3
+done
+kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &
+for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${GITEA_PORT}" && break; sleep 1; done
+
+if ! DEPLOY_TOKEN="${DEPLOY_TOKEN}" BASE_URL="http://localhost:${PORT}" \
+   GITEA_REPO_URL="http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${GITEA_PORT}/e2e/gitops.git" \
+   "${here}/race-supersede.sh"; then
+  echo "STATE-POSTGRES: FAIL — supersession under contention failed on Postgres"
+  exit 1
+fi
+
+echo "STATE-POSTGRES: PASS (migrated, deployed, survived restart, superseded under contention)"

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -56,7 +56,7 @@ base="http://localhost:${PORT}/api/v1"
 # /healthz answers. Called again after the restart, since deleting the pod kills
 # the previous forward.
 forward() {
-  [ -n "$pf_pid" ] && kill "$pf_pid" 2>/dev/null || true
+  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
   kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
   pf_pid=$!
   for _ in $(seq 1 30); do
@@ -94,7 +94,7 @@ forward
 
 echo "=== asserting the server is actually on Postgres ==="
 st="$(curl -s -m 10 "${base}/config" | jq -r '.state_type')"
-if [ "$st" != "postgres" ]; then
+if [[ "$st" != "postgres" ]]; then
   echo "STATE-POSTGRES: FAIL — /config state_type=${st:-<none>}, want postgres"
   exit 1
 fi
@@ -108,10 +108,10 @@ echo "=== deploying ${APP} on Postgres (real write-back loop) ==="
 # so the write-back actually commits (an unchanged tag is byte-compared and skipped).
 for _ in $(seq 1 40); do
   s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [ "$s" = "Synced/Healthy" ] && break
+  [[ "$s" == "Synced/Healthy" ]] && break
   sleep 5
 done
-[ "$s" = "Synced/Healthy" ] || { echo "STATE-POSTGRES: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
+[[ "$s" == "Synced/Healthy" ]] || { echo "STATE-POSTGRES: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
 
 cur=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
 if [[ "$cur" == *v1.10.2* ]]; then TAG="v1.10.1"; else TAG="v1.10.2"; fi
@@ -129,7 +129,7 @@ echo "  OK   ${APP}:${TAG} deployed on Postgres"
 
 # Capture the task we just created: the newest task for this app.
 id=$(curl -s -m 10 "${base}/tasks?from_timestamp=0&app=${APP}" | jq -r '.tasks | sort_by(.created) | last | .id')
-if [ -z "$id" ] || [ "$id" = "null" ]; then
+if [[ -z "$id" || "$id" == "null" ]]; then
   echo "STATE-POSTGRES: FAIL — could not read the created task id from the task list"
   exit 1
 fi
@@ -142,7 +142,7 @@ forward   # the previous forward died with the pod
 
 code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${base}/tasks/${id}")
 status_after=$(curl -s -m 10 "${base}/tasks/${id}" | jq -r '.status')
-if [ "$code" != "200" ] || [ "$status_after" != "deployed" ]; then
+if [[ "$code" != "200" || "$status_after" != "deployed" ]]; then
   echo "STATE-POSTGRES: FAIL — task ${id} did not survive the restart (http=${code} status=${status_after:-<none>})"
   echo "  (in-memory loses history here; Postgres must return 200 'deployed')"
   exit 1
@@ -157,7 +157,7 @@ echo "=== supersession under git contention on Postgres ==="
 # Wait for app1 to be Healthy first (as the `race` task does) so the baseline reset
 # deploys from a known-good state — matters when this phase is run standalone.
 for _ in $(seq 1 40); do
-  [ "$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null)" = "Healthy" ] && break
+  [[ "$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null)" == "Healthy" ]] && break
   sleep 3
 done
 kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &

--- a/test/e2e/values/argo-watcher-postgres.yaml
+++ b/test/e2e/values/argo-watcher-postgres.yaml
@@ -1,0 +1,22 @@
+# Postgres-state overlay for the state-postgres phase.
+#
+# Layered ON TOP of values/argo-watcher.yaml (`-f values/argo-watcher.yaml -f
+# values/argo-watcher-postgres.yaml`), so it inherits the full base wiring (argo
+# token, SSH write-back, webhooks, all the toggles) and changes only the state
+# backend.
+#
+# Enabling postgres does two things in the chart:
+#   * sets STATE_TYPE=postgres and wires DB_HOST/PORT/NAME/USER on the server,
+#   * runs the pre-upgrade migration Job (`argo-watcher --migrate`) that applies
+#     the schema before the server rolls.
+# DB_PASSWORD comes from the argo-watcher-db Secret (fixtures/postgres.yaml); with
+# no secretKey override the chart envFrom's the whole Secret, exposing DB_PASSWORD
+# to both the server and the migration Job. host is the in-cluster Service DNS
+# (same namespace, so the short name resolves).
+postgres:
+  enabled: true
+  host: argo-watcher-db
+  port: 5432
+  name: argo_watcher
+  user: argo_watcher
+  secretName: argo-watcher-db

--- a/test/e2e/values/argo-watcher-postgres.yaml
+++ b/test/e2e/values/argo-watcher-postgres.yaml
@@ -9,7 +9,7 @@
 #   * sets STATE_TYPE=postgres and wires DB_HOST/PORT/NAME/USER on the server,
 #   * runs the pre-upgrade migration Job (`argo-watcher --migrate`) that applies
 #     the schema before the server rolls.
-# DB_PASSWORD comes from the argo-watcher-db Secret (fixtures/postgres.yaml); with
+# DB_PASSWORD comes from the argo-watcher-db Secret (fixtures/postgres/); with
 # no secretKey override the chart envFrom's the whole Secret, exposing DB_PASSWORD
 # to both the server and the migration Job. host is the in-cluster Service DNS
 # (same namespace, so the short name resolves).

--- a/test/e2e/values/argo-watcher.yaml
+++ b/test/e2e/values/argo-watcher.yaml
@@ -25,8 +25,12 @@ updater:
   knownHostsKey: ssh_known_hosts
 
 # Base lab runs single-replica, in-memory state — enough to exercise the real
-# ArgoCD polling path. Phase B (soak) flips these to replicaCount: 2 + postgres
-# to exercise shared state and cross-replica poller handoff.
+# ArgoCD polling path. The `state-postgres` phase layers
+# values/argo-watcher-postgres.yaml on top to flip this SAME release to
+# single-replica Postgres and assert the Postgres-only properties (schema
+# migration + task history surviving a pod restart). Multi-replica is out of
+# scope: the chart requires postgres for replicaCount > 1, and shared-state /
+# cross-replica handoff is deliberately not exercised here.
 postgres:
   enabled: false
 replicaCount: 1


### PR DESCRIPTION
The e2e lab ran only in-memory state, so the deployed binary on STATE_TYPE=postgres — schema migration, the write-back loop, and task history surviving a restart — was never exercised end to end.

Add a state-postgres phase that stands up an in-cluster Postgres (the chart bundles none), flips the release to postgres via a values overlay, and asserts: the migration Job runs, GET /config reports state_type=postgres, a real deploy writes back, the task record survives a pod restart (in-memory would 404), and supersession holds under git contention (the hand-written CancelInProgressTasks SQL path).

Runs after race and before failure-diagnostics so it deploys against pristine apps; the backend-agnostic phases after it then run on postgres for free. Multi-replica and the git-conflict soak are out of scope. Also corrects the stale multi-replica comments in the values file and README.