### PR TITLE
feat: surface ArgoCD-unreachable state in the UI (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The Web UI now shows a prominent "ArgoCD unreachable" banner whenever Argo
+  Watcher cannot reach Argo CD (or its state backend), so operators can tell an
+  outage apart from "no recent deployments" without reading server logs or
+  scraping Prometheus. The banner appears and clears live via the existing
+  WebSocket. A read-only `GET /api/v1/argocd-status` endpoint exposes the same
+  cached reachability as a plain boolean for external polling.
+
+### Changed
+
+- Submitting a deployment (`POST /api/v1/tasks`) while Argo CD is unreachable now
+  fails fast with `503 {"status":"down"}` using the cached reachability state,
+  instead of blocking on the full Argo CD API retry budget until the client's own
+  HTTP timeout fired and masked the cause as an opaque `context deadline
+  exceeded`.
+
 ## [0.12.1] - 2026-07-20
 
 ### Changed

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -18,7 +18,7 @@ The server emits eight metrics today, all defined in [`internal/prometheus/metri
 |---|---|---|---|
 | `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. |
 | `processed_deployments` | counter | `app` | Total deployments processed since server startup, per application. |
-| `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. |
+| `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. The same cached state drives the Web UI's "ArgoCD unreachable" banner and is exposed as a plain boolean via `GET /api/v1/argocd-status` for external polling. |
 | `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |
 | `argocd_refresh_duration_seconds` | histogram | `app` | Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes. Recorded only when the status check requests a refresh. |
 | `gitops_writeback_duration_seconds` | histogram | `app` | Time the git write-back held the per-repo lock, covering the clone/commit/push cycle plus any retries and backoff. |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -33,6 +33,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - The `ARGO_APP` name does not match an application in Argo CD.
 - The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
 - The client timed out waiting for the deployment to complete.
+- Argo CD (or the state backend) is unreachable — the server now fails the submission fast with a `503` `{"status":"down"}` response instead of hanging until the client's own HTTP timeout, and the Web UI shows an "ArgoCD unreachable" banner until connectivity is restored.
 - A newer deployment of one of the same images was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). Only tasks sharing an image with the newer deployment are cancelled; independent per-image deployments of the same application do not cancel each other. This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
 
 **How to verify:**

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -59,9 +59,12 @@ func (argo *Argo) Init(state state.TaskRepository, api ArgoApiInterface, metrics
 	argo.api = api
 	argo.State = state
 	argo.metrics = metrics
-	// Assume ArgoCD is reachable until the first Check proves otherwise, so a
-	// deploy in the brief window before the initial liveness probe runs is not
-	// rejected and the banner does not flash "unreachable" on every startup.
+	// Assume ArgoCD is reachable until the first Check proves otherwise. Starting
+	// unavailable instead was considered and rejected: it would flash the
+	// "unreachable" banner and reject deploys on every healthy startup (crying
+	// wolf), for the sub-second until the first probe runs. This optimistic
+	// default only briefly mis-reports during a genuine startup-time outage,
+	// which the liveness probe corrects within ~one probe cycle.
 	argo.available = &atomic.Bool{}
 	argo.available.Store(true)
 }

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/shini4i/argo-watcher/internal/helpers"
@@ -44,6 +45,13 @@ type Argo struct {
 	metrics prometheus.MetricsInterface
 	api     ArgoApiInterface
 	State   state.TaskRepository
+	// available caches the most recent ArgoCD reachability observed by Check so
+	// it can be read synchronously (IsAvailable) off any request path. The
+	// background liveness probe keeps it fresh; AddTask gates on it and the
+	// frontend "ArgoCD unreachable" banner is driven by it (issue #498). It is a
+	// pointer so the value copies of Argo held by the updater and deployment
+	// monitor (which never read it) stay freely copyable; Init allocates it.
+	available *atomic.Bool
 }
 
 // Init initializes the Argo controller with its dependencies.
@@ -51,6 +59,11 @@ func (argo *Argo) Init(state state.TaskRepository, api ArgoApiInterface, metrics
 	argo.api = api
 	argo.State = state
 	argo.metrics = metrics
+	// Assume ArgoCD is reachable until the first Check proves otherwise, so a
+	// deploy in the brief window before the initial liveness probe runs is not
+	// rejected and the banner does not flash "unreachable" on every startup.
+	argo.available = &atomic.Bool{}
+	argo.available.Store(true)
 }
 
 // Check performs a health check on ArgoCD and the state backend.
@@ -59,22 +72,37 @@ func (argo *Argo) Check() (string, error) {
 	userLoggedIn, loginError := argo.api.GetUserInfo()
 
 	if !connectionActive {
-		argo.metrics.SetArgoUnavailable(true)
+		argo.setAvailable(false)
 		return "down", errors.New(models.StatusConnectionUnavailable)
 	}
 
 	if loginError != nil {
-		argo.metrics.SetArgoUnavailable(true)
+		argo.setAvailable(false)
 		return "down", errors.New(models.StatusArgoCDUnavailableMessage)
 	}
 
 	if userLoggedIn == nil || !userLoggedIn.LoggedIn {
-		argo.metrics.SetArgoUnavailable(true)
+		argo.setAvailable(false)
 		return "down", errors.New(models.StatusArgoCDFailedLogin)
 	}
 
-	argo.metrics.SetArgoUnavailable(false)
+	argo.setAvailable(true)
 	return "up", nil
+}
+
+// setAvailable records the latest ArgoCD reachability in one place, keeping the
+// synchronously-readable cache (IsAvailable) and the argocd_unavailable gauge in
+// lockstep. The gauge tracks unavailability, so it is set to the negation.
+func (argo *Argo) setAvailable(available bool) {
+	argo.available.Store(available)
+	argo.metrics.SetArgoUnavailable(!available)
+}
+
+// IsAvailable reports the most recently observed ArgoCD reachability without
+// performing a live probe. The background liveness probe (StartLivenessProbe)
+// keeps this current, so reads never block on a live ArgoCD call.
+func (argo *Argo) IsAvailable() bool {
+	return argo.available.Load()
 }
 
 // StartLivenessProbe periodically runs Check() so the argocd_unavailable metric
@@ -109,8 +137,14 @@ func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration
 
 // AddTask validates a new deployment task and adds it to the task repository.
 func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
-	if _, err := argo.Check(); err != nil {
-		return nil, err
+	// Gate on the cached reachability instead of a live Check(): a deploy
+	// attempted during an ArgoCD outage then fails fast with a clear error
+	// rather than blocking on the full API retry budget (ARGO_API_RETRIES ×
+	// ARGO_API_TIMEOUT) until the client's own HTTP timeout fires and masks the
+	// cause as a bare "context deadline exceeded" (issue #498). The liveness
+	// probe keeps this state fresh.
+	if !argo.IsAvailable() {
+		return nil, errors.New(models.StatusArgoCDUnavailableMessage)
 	}
 
 	if task.Images == nil || len(task.Images) == 0 {
@@ -199,10 +233,12 @@ func imageSignature(task models.Task) string {
 // is unavailable (e.g. a DNS/network outage): coupling the read to a live
 // ArgoCD `session/userinfo` call would otherwise make the whole list hang on the
 // API retry budget and then hide existing tasks behind an error. Write paths
-// (AddTask) keep the Check() gate because creating a deployment genuinely
-// requires ArgoCD to be up; that gate — not this read — is now the only place
-// the argocd_unavailable metric is refreshed. Note the /healthz endpoint probes
-// only the state backend (SimpleHealthCheck), not ArgoCD.
+// (AddTask) no longer run a live Check() either: they gate on the cached
+// reachability (IsAvailable) so a deploy fails fast during an outage. The
+// background liveness probe (StartLivenessProbe) is therefore the single place
+// the argocd_unavailable metric and the cached state are refreshed. Note the
+// /healthz endpoint probes only the state backend (SimpleHealthCheck), not
+// ArgoCD.
 func (argo *Argo) GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) models.TasksResponse {
 	tasks, total := argo.State.GetTasks(startTime, endTime, app, status, limit, offset)
 

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -118,6 +118,47 @@ func TestArgoCheck(t *testing.T) {
 	})
 }
 
+func TestArgoIsAvailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("defaults to available after Init", func(t *testing.T) {
+		argo := &Argo{}
+		argo.Init(mocks.NewMockTaskRepository(ctrl), newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+		// Optimistic default avoids a spurious "unreachable" banner before the
+		// first liveness probe runs.
+		assert.True(t, argo.IsAvailable())
+	})
+
+	t.Run("Check flips the cached state and mirrors the gauge", func(t *testing.T) {
+		api := newArgoApiMock(ctrl)
+		metrics := mocks.NewMockMetricsInterface(ctrl)
+		state := mocks.NewMockTaskRepository(ctrl)
+
+		// A failing Check must mark ArgoCD unavailable (gauge 1 / cache false),
+		// a passing one must restore it (gauge 0 / cache true).
+		gomock.InOrder(
+			state.EXPECT().Check().Return(true),
+			api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("boom")),
+			metrics.EXPECT().SetArgoUnavailable(true),
+			state.EXPECT().Check().Return(true),
+			api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil),
+			metrics.EXPECT().SetArgoUnavailable(false),
+		)
+
+		argo := &Argo{}
+		argo.Init(state, api, metrics)
+
+		_, err := argo.Check()
+		assert.Error(t, err)
+		assert.False(t, argo.IsAvailable())
+
+		_, err = argo.Check()
+		assert.NoError(t, err)
+		assert.True(t, argo.IsAvailable())
+	})
+}
+
 func TestArgoAddTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -128,14 +169,13 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls
-		state.EXPECT().Check().Return(true)
-		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("unexpected login error"))
-		metrics.EXPECT().SetArgoUnavailable(true)
-
 		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
+		// Simulate a cached outage: AddTask must reject fast, without a live
+		// probe (no Check/GetUserInfo calls) so the client is not held on the
+		// retry budget (issue #498).
+		argo.available.Store(false)
 		task := models.Task{} // empty task
 		newTask, err := argo.AddTask(task)
 
@@ -149,14 +189,6 @@ func TestArgoAddTask(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
-
-		// mock calls
-		state.EXPECT().Check().Return(true)
-		user := &models.Userinfo{
-			LoggedIn: true,
-		}
-		api.EXPECT().GetUserInfo().Return(user, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 
 		// argo manager
 		argo := &Argo{}
@@ -174,14 +206,6 @@ func TestArgoAddTask(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
-
-		// mock calls
-		state.EXPECT().Check().Return(true)
-		user := &models.Userinfo{
-			LoggedIn: true,
-		}
-		api.EXPECT().GetUserInfo().Return(user, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 
 		// argo manager
 		argo := &Argo{}
@@ -203,14 +227,6 @@ func TestArgoAddTask(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
-
-		// mock calls
-		state.EXPECT().Check().Return(true)
-		user := &models.Userinfo{
-			LoggedIn: true,
-		}
-		api.EXPECT().GetUserInfo().Return(user, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 
 		// mock calls to add task
 		stateError := fmt.Errorf("database error")
@@ -241,12 +257,6 @@ func TestArgoAddTask(t *testing.T) {
 		state := mocks.NewMockTaskRepository(ctrl)
 
 		// mock calls
-		state.EXPECT().Check().Return(true)
-		user := &models.Userinfo{
-			LoggedIn: true,
-		}
-		api.EXPECT().GetUserInfo().Return(user, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 		metrics.EXPECT().AddProcessedDeployment("test-app")
 
 		// tasks
@@ -293,9 +303,6 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		state.EXPECT().Check().Return(true)
-		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 		metrics.EXPECT().AddProcessedDeployment("test-app")
 
 		task := models.Task{App: "test-app", Images: []models.Image{{Tag: taskImageTag}}}
@@ -320,9 +327,6 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		state.EXPECT().Check().Return(true)
-		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 		metrics.EXPECT().AddProcessedDeployment("test-app")
 
 		// History ordered created DESC: current is v2, an earlier task (target) ran v1.
@@ -355,9 +359,6 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		state.EXPECT().Check().Return(true)
-		api.EXPECT().GetUserInfo().Return(&models.Userinfo{LoggedIn: true}, nil)
-		metrics.EXPECT().SetArgoUnavailable(false)
 		metrics.EXPECT().AddProcessedDeployment("test-app")
 
 		// Deploying a brand-new version (v3) with no earlier match: not a rollback.

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -59,6 +59,65 @@ func (env *Env) StartLockdownWatcher() {
 	}()
 }
 
+// WebSocket messages pushed when ArgoCD reachability changes. Clients treat
+// argoDownMessage as "show the unreachable banner" and argoUpMessage as "clear
+// it". Kept in sync with the frontend argocdStatus feature (issue #498).
+const (
+	argoUpMessage   = "argocd_up"
+	argoDownMessage = "argocd_down"
+)
+
+// argoWatchInterval is how often the ArgoCD-availability watcher samples the
+// cached reachability to detect a transition. The liveness probe refreshes that
+// state every argocd.ArgoLivenessProbeInterval; sampling it more frequently
+// bounds how quickly clients see the banner appear or clear after a transition,
+// while adding no live ArgoCD calls (each sample is a single atomic load).
+const argoWatchInterval = 5 * time.Second
+
+// StartArgoWatcher launches a background goroutine that notifies WebSocket
+// clients when ArgoCD reachability changes, so the frontend can show or hide the
+// "ArgoCD unreachable" banner (issue #498). The cached reachability is refreshed
+// by the liveness probe; this watcher only observes it and pushes transitions.
+// Clients connecting mid-outage learn the current state via the argocd-status
+// endpoint instead. The goroutine is tracked by connWg and stops when the
+// shutdown channel is closed.
+func (env *Env) StartArgoWatcher() {
+	env.connWg.Add(1)
+	go func() {
+		defer env.connWg.Done()
+		watchArgoTransitions(env.shutdownCh, argoWatchInterval, env.argo.IsAvailable, notifyWebSocketClients)
+	}()
+}
+
+// watchArgoTransitions samples isAvailable on the given interval and invokes
+// notify with argoUpMessage/argoDownMessage whenever reachability changes. The
+// initial state is recorded without notifying, so only genuine transitions
+// produce a message. It runs until stop is closed. Dependencies are parameters
+// so the transition logic can be unit-tested in isolation.
+func watchArgoTransitions(stop <-chan struct{}, interval time.Duration, isAvailable func() bool, notify func(string)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	last := isAvailable()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			current := isAvailable()
+			if current == last {
+				continue
+			}
+			last = current
+			if current {
+				notify(argoUpMessage)
+			} else {
+				notify(argoDownMessage)
+			}
+		}
+	}
+}
+
 const shutdownTimeout = 10 * time.Second // Maximum time to wait for WebSocket goroutines during shutdown
 
 // Shutdown gracefully shuts down the server and all WebSocket connections.

--- a/internal/server/handlers_argocd.go
+++ b/internal/server/handlers_argocd.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// argoStatus godoc
+// @Summary Report ArgoCD reachability
+// @Description Report whether argo-watcher can currently reach ArgoCD. Reflects
+// @Description the cached liveness-probe state and never performs a live probe,
+// @Description so it is cheap to poll. The frontend uses it to bootstrap the
+// @Description "ArgoCD unreachable" banner on connect; live changes then arrive
+// @Description over the WebSocket. Returns true when ArgoCD is reachable.
+// @Tags frontend
+// @Produce json
+// @Success 200 {boolean} boolean
+// @Router /api/v1/argocd-status [get]
+func (env *Env) argoStatus(c *gin.Context) {
+	c.JSON(http.StatusOK, env.argo.IsAvailable())
+}

--- a/internal/server/handlers_argocd_test.go
+++ b/internal/server/handlers_argocd_test.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/argocd"
+	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/mocks"
+)
+
+// TestArgoStatus verifies the read-only reachability endpoint reflects the
+// cached ArgoCD availability as a bare JSON boolean.
+func TestArgoStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	serve := func(argo *argocd.Argo) *httptest.ResponseRecorder {
+		env := &Env{argo: argo}
+		router := gin.New()
+		router.GET("/api/v1/argocd-status", env.argoStatus)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/argocd-status", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("reports available by default", func(t *testing.T) {
+		argo := &argocd.Argo{}
+		argo.Init(mocks.NewMockTaskRepository(ctrl), newArgoAPI(ctrl), newMetrics(ctrl))
+
+		w := serve(argo)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "true", w.Body.String())
+	})
+
+	t.Run("reports unavailable after a failed check", func(t *testing.T) {
+		repo := mocks.NewMockTaskRepository(ctrl)
+		repo.EXPECT().Check().Return(false)
+		argo := &argocd.Argo{}
+		argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+		_, err := argo.Check()
+		assert.Error(t, err)
+
+		w := serve(argo)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "false", w.Body.String())
+	})
+}
+
+// TestArgoStatusEndpointRegistration verifies the read-only reachability route
+// is registered unconditionally (unlike the Keycloak-gated deploy-lock writes),
+// so the frontend banner can always bootstrap its state.
+func TestArgoStatusEndpointRegistration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hasRoute := func(routes gin.RoutesInfo, method, path string) bool {
+		for _, r := range routes {
+			if r.Method == method && r.Path == path {
+				return true
+			}
+		}
+		return false
+	}
+
+	newRouter := func(t *testing.T, keycloakEnabled bool) *gin.Engine {
+		t.Helper()
+		serverConfig := &config.ServerConfig{
+			StaticFilePath: t.TempDir(),
+			Keycloak:       config.KeycloakConfig{Enabled: keycloakEnabled},
+		}
+		env := &Env{config: serverConfig}
+		var err error
+		env.lockdown, err = NewLockdown("")
+		require.NoError(t, err)
+		return env.CreateRouter()
+	}
+
+	const statusPath = "/api/v1/argocd-status"
+
+	for _, keycloakEnabled := range []bool{false, true} {
+		routes := newRouter(t, keycloakEnabled).Routes()
+		assert.True(t, hasRoute(routes, http.MethodGet, statusPath),
+			"GET argocd-status must be registered regardless of Keycloak (enabled=%v)", keycloakEnabled)
+	}
+}
+
+// TestStartArgoWatcher verifies the watcher goroutine is tracked by connWg and
+// exits when the shutdown channel closes, so graceful shutdown neither hangs nor
+// leaks it.
+func TestStartArgoWatcher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	argo := &argocd.Argo{}
+	argo.Init(mocks.NewMockTaskRepository(ctrl), newArgoAPI(ctrl), newMetrics(ctrl))
+
+	env := &Env{argo: argo, shutdownCh: make(chan struct{})}
+	env.StartArgoWatcher()
+
+	close(env.shutdownCh)
+
+	done := make(chan struct{})
+	go func() {
+		env.connWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// goroutine exited and released its connWg slot
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartArgoWatcher goroutine did not exit after shutdown")
+	}
+}
+
+// TestWatchArgoTransitions verifies the watcher pushes a message only when the
+// observed reachability actually changes, and that it stops on request.
+func TestWatchArgoTransitions(t *testing.T) {
+	recv := func(t *testing.T, msgs <-chan string) string {
+		t.Helper()
+		select {
+		case m := <-msgs:
+			return m
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for notification")
+			return ""
+		}
+	}
+
+	t.Run("notifies on reachability transitions", func(t *testing.T) {
+		var available atomic.Bool
+		available.Store(true)
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 4)
+		go watchArgoTransitions(stop, 5*time.Millisecond, available.Load, func(m string) { msgs <- m })
+		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its baseline
+
+		available.Store(false)
+		assert.Equal(t, argoDownMessage, recv(t, msgs))
+
+		available.Store(true)
+		assert.Equal(t, argoUpMessage, recv(t, msgs))
+	})
+
+	t.Run("does not notify without a transition", func(t *testing.T) {
+		var available atomic.Bool
+		available.Store(true)
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 1)
+		go watchArgoTransitions(stop, 5*time.Millisecond, available.Load, func(m string) { msgs <- m })
+
+		select {
+		case m := <-msgs:
+			t.Fatalf("unexpected notification: %q", m)
+		case <-time.After(50 * time.Millisecond):
+			// no transition occurred, so no notification is expected
+		}
+	})
+
+	t.Run("stops when stop channel is closed", func(t *testing.T) {
+		var available atomic.Bool
+		available.Store(true)
+		stop := make(chan struct{})
+		done := make(chan struct{})
+
+		go func() {
+			watchArgoTransitions(stop, 5*time.Millisecond, available.Load, func(string) {})
+			close(done)
+		}()
+
+		close(stop)
+
+		select {
+		case <-done:
+			// returned as expected
+		case <-time.After(time.Second):
+			t.Fatal("watchArgoTransitions did not return after stop was closed")
+		}
+	})
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -79,6 +79,10 @@ func (env *Env) CreateRouter() *gin.Engine {
 		v1.GET("/tasks/:id", env.getTaskStatus)
 		v1.GET("/version", env.getVersion)
 		v1.GET("/config", env.getConfig)
+		// Read-only ArgoCD reachability for the frontend "unreachable" banner
+		// (issue #498). Always registered: it exposes no privileged action and
+		// mirrors the cached liveness-probe state without a live probe.
+		v1.GET("/argocd-status", env.argoStatus)
 		// The state-changing deploy-lock endpoints are only registered when Keycloak
 		// is enabled: without an auth backend they cannot be protected, so exposing
 		// them would leave an unauthenticated deploy-freeze switch reachable by anyone

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,6 +131,10 @@ func (s *Server) Run() {
 	// otherwise learn about (scheduled state is evaluated lazily).
 	s.env.StartLockdownWatcher()
 
+	// Notify clients when ArgoCD reachability changes so the frontend can show
+	// or hide the "ArgoCD unreachable" banner (issue #498).
+	s.env.StartArgoWatcher()
+
 	// Start server in goroutine
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,7 +27,7 @@ the competitor writer. All pinned tool/chart versions are in `Taskfile.yml`.
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → race → state-postgres → failure-diagnostics → shutdown-drain → down
+task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → race → state-postgres → failure-diagnostics → argocd-unreachable → shutdown-drain → down
 ```
 
 `task e2e` walks the whole flow. It stops on the first failing step, so a failed
@@ -53,6 +53,7 @@ task load                 # git-conflict soak: competitor + concurrent deploys, 
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
 task state-postgres       # flip the release to Postgres state: assert migration, deploy loop, task survives a pod restart, supersession under contention
 task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
+task argocd-unreachable   # scale ArgoCD down: assert /argocd-status flips + the watcher broadcasts "argocd_down" + POST fast-fails 503, then recovers
 task shutdown-drain       # assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic
 task down                 # destroy the cluster
 ```
@@ -106,7 +107,8 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 | `fixtures/proxy-app.yaml` | `proxyapp`: reuses the shared chart with the image repository overridden to `mirror.gcr.io/traefik/whoami` |
 | `scripts/lockdown.sh` | assert scheduled lockdown: toggles `LOCKDOWN_SCHEDULE` on the release (window opening ~3 min out) and reverts, asserting in-window deploys are rejected (406), `GET /deploy-lock` reports `true`, and the watcher broadcasts `"locked"` on the transition |
 | `scripts/shutdown-drain.sh` | assert graceful shutdown: hold WebSocket clients open, delete the pod, and assert every client sees a `1001 "server shutdown"` close and the logs show the ordered drain with no data race / panic / drain timeout |
-| `tools/wsprobe/` | tiny Go WebSocket probe used by `lockdown` (grep for the `"locked"` broadcast) and `shutdown-drain` (assert the graceful GoingAway close), streaming `MSG`/`CLOSED` events one per line |
+| `scripts/argocd-unreachable.sh` | assert the ArgoCD-unreachable signal (#498): scale `argocd-server` to 0, assert `GET /argocd-status` flips to `false`, the watcher broadcasts `"argocd_down"`, and `POST /tasks` fast-fails `503 {"status":"down"}` (well under the retry budget); then scale back up and assert recovery (`true`, `"argocd_up"`, `202`) |
+| `tools/wsprobe/` | tiny Go WebSocket probe used by `lockdown` (grep for the `"locked"` broadcast), `shutdown-drain` (assert the graceful GoingAway close), and `argocd-unreachable` (grep for `"argocd_down"`/`"argocd_up"`), streaming `MSG`/`CLOSED` events one per line |
 
 ## Gotchas (why the scripts exist)
 

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
       # failing PreSync hook injected into the SHARED chart values) and pushes directly to the
       # gitops repo, so running it before load/race would perturb those pristine-state soak gates.
       - task: failure-diagnostics
+      # argocd-unreachable severs ArgoCD (scales argocd-server to 0) then restores it,
+      # so it must run after the phases that need a healthy ArgoCD. It is self-contained
+      # (its cleanup trap always scales ArgoCD back), and its tokenless deploys have no
+      # lasting side effect, so it sits safely between failure-diagnostics and shutdown-drain.
+      - task: argocd-unreachable
       # shutdown-drain runs LAST (before down): it deletes the argo-watcher pod to exercise
       # graceful shutdown, so nothing but `down` should depend on the server afterwards.
       - task: shutdown-drain
@@ -223,6 +228,11 @@ tasks:
     desc: "Assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic"
     cmds:
       - ./scripts/shutdown-drain.sh
+
+  argocd-unreachable:
+    desc: "Assert the ArgoCD-unreachable signal (#498): scale ArgoCD down, assert /argocd-status flips + WS argocd_down + POST fast-fails 503, then recover"
+    cmds:
+      - ./scripts/argocd-unreachable.sh
 
   notifications:
     desc: "Assert the generic webhook fires (start + result) with the correct payload against a real receiver"

--- a/test/e2e/scripts/argocd-unreachable.sh
+++ b/test/e2e/scripts/argocd-unreachable.sh
@@ -69,15 +69,20 @@ post_task() {
 }
 
 # status_is <true|false> -> succeeds when GET /argocd-status equals the argument.
-status_is() { curl -s -m 10 "${base}/argocd-status" | jq -e ". == $1" >/dev/null 2>&1; }
+status_is() {
+  local want="$1"
+  curl -s -m 10 "${base}/argocd-status" | jq -e ". == ${want}" >/dev/null 2>&1
+}
 # wait_status <true|false> <attempts> -> polls status_is on a 5s tick.
 wait_status() {
-  for _ in $(seq 1 "$2"); do status_is "$1" && return 0; sleep 5; done
+  local want="$1" attempts="$2"
+  for _ in $(seq 1 "$attempts"); do status_is "$want" && return 0; sleep 5; done
   return 1
 }
 # wait_ws <message> -> waits up to ~30s for wsprobe to capture `MSG <message>`.
 wait_ws() {
-  for _ in $(seq 1 6); do grep -q "^MSG $1\$" "$probe_out" && return 0; sleep 5; done
+  local message="$1"
+  for _ in $(seq 1 6); do grep -q "^MSG ${message}\$" "$probe_out" && return 0; sleep 5; done
   return 1
 }
 

--- a/test/e2e/scripts/argocd-unreachable.sh
+++ b/test/e2e/scripts/argocd-unreachable.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Assert the "ArgoCD unreachable" visibility feature end to end (issue #498)
+# against the real server, by inducing a genuine ArgoCD outage.
+#
+# The signal argo-watcher exposes for the frontend banner is the cached ArgoCD
+# reachability, refreshed by the 30s liveness probe. This phase drives it through
+# a full outage-and-recovery cycle and asserts every observable surface:
+#
+#   1. Baseline: GET /api/v1/argocd-status reports true (ArgoCD reachable).
+#   2. Hold a WebSocket client open (tools/wsprobe) BEFORE the outage so it can
+#      capture the transition broadcasts.
+#   3. Induce the outage by scaling argocd-server to 0 replicas.
+#   4. Within a few probe cycles: GET /api/v1/argocd-status flips to false, and
+#      the watcher broadcasts "argocd_down" to the WS client.
+#   5. POST /api/v1/tasks now fails fast with 503 {"status":"down"} off the cached
+#      state — it does NOT hang on the ArgoCD API retry budget (default
+#      ARGO_API_TIMEOUT=60 x ARGO_API_RETRIES=3 ~= 180s), which is the regression
+#      guard for the point-3 fast-fail; we assert the response returns well under
+#      that budget.
+#   6. Recover by scaling argocd-server back to 1: GET /api/v1/argocd-status
+#      returns to true, the watcher broadcasts "argocd_up", and POST /tasks is
+#      accepted again (202).
+#
+# Self-contained: the cleanup trap always restores argocd-server to 1 replica, so
+# a failed run never leaves ArgoCD down for the phases that follow (or for manual
+# debugging). Uses a tokenless POST (202, write-back skipped) so the recovery
+# check has no lasting side effect beyond a short-lived rollout monitor.
+set -euo pipefail
+
+NS_AW="${NS_AW:-argo-watcher}"
+NS_ARGOCD="${NS_ARGOCD:-argocd}"
+PORT="${PORT:-18094}"
+# Fast-fail budget guard: the cached path does zero network I/O, so a POST during
+# the outage returns in well under a second; anything under this bound proves we
+# did not fall back to a live ArgoCD check + retry budget.
+MAX_FASTFAIL_SECONDS="${MAX_FASTFAIL_SECONDS:-10}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/../../.." && pwd)"
+
+bin_dir="$(mktemp -d)"
+probe_out="$(mktemp)"
+pf_pid=""
+cleanup() {
+  kill $(jobs -p) 2>/dev/null || true
+  # Safety net: always bring ArgoCD back, even on an early failure exit.
+  kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=1 >/dev/null 2>&1 || true
+  rm -rf "$bin_dir" "$probe_out"
+}
+trap cleanup EXIT
+( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+
+start_pf() {
+  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
+  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
+  pf_pid=$!
+  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+}
+
+base="http://localhost:${PORT}/api/v1"
+task_json='{"app":"app1","author":"e2e","project":"lab","images":[{"image":"traefik/whoami","tag":"v1.10.2"}]}'
+# post_task -> sets CODE, BODY and TIME for a tokenless POST /api/v1/tasks.
+post_task() {
+  local out
+  out=$(curl -s -m 30 -w $'\n%{http_code}\n%{time_total}' -X POST -H 'Content-Type: application/json' \
+    -d "$task_json" "${base}/tasks")
+  TIME="${out##*$'\n'}"; out="${out%$'\n'*}"
+  CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
+}
+
+# status_is <true|false> -> succeeds when GET /argocd-status equals the argument.
+status_is() { curl -s -m 10 "${base}/argocd-status" | jq -e ". == $1" >/dev/null 2>&1; }
+# wait_status <true|false> <attempts> -> polls status_is on a 5s tick.
+wait_status() {
+  for _ in $(seq 1 "$2"); do status_is "$1" && return 0; sleep 5; done
+  return 1
+}
+# wait_ws <message> -> waits up to ~30s for wsprobe to capture `MSG <message>`.
+wait_ws() {
+  for _ in $(seq 1 6); do grep -q "^MSG $1\$" "$probe_out" && return 0; sleep 5; done
+  return 1
+}
+
+fail=0
+start_pf
+
+# --- 1. Baseline ---------------------------------------------------------------
+if status_is true; then
+  echo "  OK   GET /argocd-status -> true (ArgoCD reachable at baseline)"
+else
+  echo "  FAIL GET /argocd-status not true at baseline"; fail=1
+fi
+
+# --- 2. Hold a WS client open before the outage --------------------------------
+# DURATION comfortably exceeds the whole outage+recovery walk (each reachability
+# poll below is bounded to ~200s) so the probe never hits its own deadline before
+# we have observed both transitions.
+WS_URL="ws://localhost:${PORT}/ws" DURATION=900s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
+ws_open=0
+for _ in $(seq 1 20); do grep -q '^OPEN$' "$probe_out" && { ws_open=1; break; }; sleep 1; done
+if [[ "$ws_open" != "1" ]]; then
+  echo "  FAIL WS probe never connected before the outage"; fail=1
+fi
+
+# --- 3. Induce the outage ------------------------------------------------------
+echo "  ...  scaling argocd-server to 0 replicas to sever ArgoCD connectivity"
+kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=0 >/dev/null
+
+# --- 4. Reachability flips to false + argocd_down broadcast --------------------
+# Up to ~200s: the liveness probe runs every 30s and the watcher samples every 5s;
+# the wide margin absorbs a probe mid-cycle when the outage begins.
+if wait_status false 40; then
+  echo "  OK   GET /argocd-status -> false after the outage"
+else
+  echo "  FAIL GET /argocd-status never flipped to false during the outage"; fail=1
+fi
+if [[ "$ws_open" == "1" ]]; then
+  if wait_ws argocd_down; then
+    echo "  OK   WS client received the 'argocd_down' broadcast"
+  else
+    echo "  FAIL no 'argocd_down' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+  fi
+fi
+
+# --- 5. POST fails fast off the cached state -----------------------------------
+post_task
+if [[ "$CODE" == "503" ]] && echo "$BODY" | jq -e '.status == "down"' >/dev/null 2>&1; then
+  echo "  OK   POST /tasks -> 503 {\"status\":\"down\"} during the outage"
+else
+  echo "  FAIL POST /tasks during outage: code=${CODE} body=${BODY} (want 503 down)"; fail=1
+fi
+if awk -v t="$TIME" -v m="$MAX_FASTFAIL_SECONDS" 'BEGIN{exit !(t+0 < m+0)}'; then
+  echo "  OK   POST /tasks returned in ${TIME}s (< ${MAX_FASTFAIL_SECONDS}s: cached fast-fail, no retry budget)"
+else
+  echo "  FAIL POST /tasks took ${TIME}s (>= ${MAX_FASTFAIL_SECONDS}s: looks like a live ArgoCD check + retry)"; fail=1
+fi
+
+# --- 6. Recover ----------------------------------------------------------------
+echo "  ...  scaling argocd-server back to 1 replica"
+kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=1 >/dev/null
+kubectl -n "$NS_ARGOCD" rollout status deploy/argocd-server --timeout=180s >/dev/null
+
+if wait_status true 40; then
+  echo "  OK   GET /argocd-status -> true after recovery"
+else
+  echo "  FAIL GET /argocd-status never returned to true after recovery"; fail=1
+fi
+if [[ "$ws_open" == "1" ]]; then
+  if wait_ws argocd_up; then
+    echo "  OK   WS client received the 'argocd_up' broadcast"
+  else
+    echo "  FAIL no 'argocd_up' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+  fi
+fi
+post_task
+if [[ "$CODE" == "202" ]]; then
+  echo "  OK   POST /tasks -> 202 accepted (deploys resumed)"
+else
+  echo "  FAIL POST /tasks after recovery: code=${CODE} body=${BODY} (want 202)"; fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then echo "ARGOCD-UNREACHABLE: PASS"; else echo "ARGOCD-UNREACHABLE: FAIL"; exit 1; fi

--- a/web/src/data/webSocketUrl.test.ts
+++ b/web/src/data/webSocketUrl.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveWebSocketUrl } from './webSocketUrl';
+import * as sharedUtils from '../shared/utils';
+
+/**
+ * Covers the extracted, security-sensitive WebSocket URL resolution directly
+ * (rather than only through the deploy-lock service), so the same-host guard and
+ * protocol mapping keep dedicated coverage independent of any one feature.
+ */
+describe('resolveWebSocketUrl', () => {
+  const originalEnv = { ...import.meta.env };
+
+  const stubLocation = (protocol: string, host: string) =>
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue({
+      location: { protocol, host },
+    } as unknown as Window);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    import.meta.env.VITE_WS_BASE_URL = originalEnv.VITE_WS_BASE_URL;
+  });
+
+  it('accepts a same-host custom base URL', () => {
+    stubLocation('https:', 'custom.example');
+    import.meta.env.VITE_WS_BASE_URL = 'wss://custom.example';
+    expect(resolveWebSocketUrl()).toBe('wss://custom.example/ws');
+  });
+
+  it('rejects a cross-host custom base URL and falls back to the current location', () => {
+    stubLocation('https:', 'argo.example');
+    import.meta.env.VITE_WS_BASE_URL = 'wss://malicious.example';
+    expect(resolveWebSocketUrl()).toBe('wss://argo.example/ws');
+  });
+
+  it('falls back to the current location when the custom base URL is unparseable', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubLocation('https:', 'argo.example');
+    // "ws://" alone is not a valid URL and throws inside the URL constructor.
+    import.meta.env.VITE_WS_BASE_URL = 'ws://';
+    expect(resolveWebSocketUrl()).toBe('wss://argo.example/ws');
+    warnSpy.mockRestore();
+  });
+
+  it('derives wss from an https location when no override is set', () => {
+    stubLocation('https:', 'argo.example');
+    import.meta.env.VITE_WS_BASE_URL = '';
+    expect(resolveWebSocketUrl()).toBe('wss://argo.example/ws');
+  });
+
+  it('derives ws from an http location when no override is set', () => {
+    stubLocation('http:', 'argo.example:8080');
+    import.meta.env.VITE_WS_BASE_URL = '';
+    expect(resolveWebSocketUrl()).toBe('ws://argo.example:8080/ws');
+  });
+});

--- a/web/src/data/webSocketUrl.ts
+++ b/web/src/data/webSocketUrl.ts
@@ -1,0 +1,90 @@
+import { getBrowserWindow } from '../shared/utils';
+
+/**
+ * Shared resolution of the argo-watcher `/ws` WebSocket endpoint. Both the
+ * deploy-lock and ArgoCD-status features open a socket to the same endpoint, so
+ * the (security-sensitive) host validation lives here once rather than being
+ * copied per feature.
+ */
+
+const IS_DEV_BUILD = import.meta.env?.DEV ?? false;
+
+/** Logs an invalid websocket configuration, hiding the raw value outside dev builds. */
+const warnInvalidSocketConfig = (message: string, ...details: unknown[]) => {
+  if (IS_DEV_BUILD) {
+    console.warn(message, ...details);
+  } else {
+    console.warn('[websocket] Invalid websocket configuration; falling back to defaults.');
+  }
+};
+
+/** Normalizes custom websocket base URLs ensuring they match the current origin and use safe protocols. */
+const sanitizeCustomSocketBase = (rawBase: string, location?: Location | null): URL | null => {
+  const trimmed = rawBase.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    let candidate: URL;
+    if (trimmed.startsWith('http') || trimmed.startsWith('ws')) {
+      candidate = new URL(trimmed);
+    } else {
+      const relativePath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+      candidate = new URL(relativePath, location?.origin ?? 'http://localhost');
+    }
+
+    const isHttp = candidate.protocol === 'http:' || candidate.protocol === 'https:';
+    const isWs = candidate.protocol === 'ws:' || candidate.protocol === 'wss:';
+
+    if (!isHttp && !isWs) {
+      warnInvalidSocketConfig('[websocket] Ignoring custom websocket URL with unsupported protocol:', candidate.protocol);
+      return null;
+    }
+
+    if (location && candidate.host !== location.host) {
+      warnInvalidSocketConfig(
+        `[websocket] Ignoring custom websocket URL (${candidate.origin}) because it does not match the current host (${location.host}).`,
+      );
+      return null;
+    }
+
+    return candidate;
+  } catch (error) {
+    warnInvalidSocketConfig('[websocket] Invalid custom websocket URL, falling back to window.location.', error);
+    return null;
+  }
+};
+
+/** Ensures the socket URL ends with `/ws` and uses the websocket protocol scheme. */
+const toSocketUrl = (url: URL): string => {
+  const normalizedPath = url.pathname.endsWith('/ws')
+    ? url.pathname
+    : `${url.pathname.replace(/\/$/, '') || ''}/ws`;
+
+  let protocol: 'ws:' | 'wss:';
+  if (url.protocol === 'https:') {
+    protocol = 'wss:';
+  } else if (url.protocol === 'http:') {
+    protocol = 'ws:';
+  } else {
+    protocol = url.protocol as 'ws:' | 'wss:';
+  }
+  return `${protocol}//${url.host}${normalizedPath}`;
+};
+
+/** Determines the websocket endpoint based on env overrides or current location, validating custom hosts. */
+export const resolveWebSocketUrl = (): string => {
+  const location = getBrowserWindow()?.location ?? null;
+  const base = import.meta.env.VITE_WS_BASE_URL ?? '';
+  if (base) {
+    const sanitized = sanitizeCustomSocketBase(base, location);
+    if (sanitized) {
+      return toSocketUrl(sanitized);
+    }
+  }
+
+  const protocol = location?.protocol === 'https:' ? 'wss:' : 'ws:';
+  const host = location?.host ?? 'localhost';
+  return `${protocol}//${host}/ws`;
+};

--- a/web/src/features/argocdStatus/ArgocdStatusProvider.test.tsx
+++ b/web/src/features/argocdStatus/ArgocdStatusProvider.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ArgocdStatusProvider, useArgocdStatus } from './ArgocdStatusProvider';
+import { argocdStatusService } from './argocdStatusService';
+
+vi.mock('./argocdStatusService', () => ({
+  argocdStatusService: {
+    subscribe: vi.fn(),
+  },
+}));
+
+describe('ArgocdStatusProvider', () => {
+  it('subscribes to the status service and updates state', async () => {
+    const listeners: Array<(state: boolean) => void> = [];
+    vi.mocked(argocdStatusService.subscribe).mockImplementation(listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) {
+          listeners.splice(index, 1);
+        }
+      };
+    });
+
+    const { result, unmount } = renderHook(() => useArgocdStatus(), {
+      wrapper: ArgocdStatusProvider,
+    });
+
+    // Optimistic default before the first update arrives.
+    expect(result.current.available).toBe(true);
+
+    await act(async () => {
+      for (const callback of listeners) {
+        callback(false);
+      }
+    });
+    await waitFor(() => expect(result.current.available).toBe(false));
+
+    unmount();
+    expect(listeners).toHaveLength(0);
+  });
+
+  it('throws when hook is used outside provider', () => {
+    const wrapper = () => renderHook(() => useArgocdStatus());
+    expect(wrapper).toThrow('useArgocdStatus must be used within an ArgocdStatusProvider');
+  });
+});

--- a/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
+++ b/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { argocdStatusService } from './argocdStatusService';
+
+export interface ArgocdStatusContextValue {
+  /** True when argo-watcher can currently reach ArgoCD. */
+  available: boolean;
+}
+
+const ArgocdStatusContext = createContext<ArgocdStatusContextValue | undefined>(undefined);
+
+/** Provides ArgoCD reachability state backed by the shared WebSocket service. */
+export const ArgocdStatusProvider = ({ children }: { children: ReactNode }) => {
+  // Default to available so the banner never flashes before the initial fetch
+  // resolves; the service corrects this within one round-trip.
+  const [available, setAvailable] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = argocdStatusService.subscribe(status => {
+      setAvailable(status);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const value = useMemo<ArgocdStatusContextValue>(() => ({ available }), [available]);
+
+  return <ArgocdStatusContext.Provider value={value}>{children}</ArgocdStatusContext.Provider>;
+};
+
+/** Hook exposing ArgoCD reachability context. */
+export const useArgocdStatus = (): ArgocdStatusContextValue => {
+  const context = useContext(ArgocdStatusContext);
+  if (!context) {
+    throw new Error('useArgocdStatus must be used within an ArgocdStatusProvider');
+  }
+  return context;
+};

--- a/web/src/features/argocdStatus/ArgocdUnreachableBanner.test.tsx
+++ b/web/src/features/argocdStatus/ArgocdUnreachableBanner.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./useArgocdUnreachable', () => ({
+  useArgocdUnreachable: vi.fn(),
+}));
+
+import { useArgocdUnreachable } from './useArgocdUnreachable';
+import { ArgocdUnreachableBanner } from './ArgocdUnreachableBanner';
+
+describe('ArgocdUnreachableBanner', () => {
+  it('renders banner when ArgoCD is unreachable', () => {
+    (useArgocdUnreachable as unknown as vi.Mock).mockReturnValue(true);
+    render(<ArgocdUnreachableBanner />);
+    // <output> has an implicit role of "status"; aria-live escalates urgency.
+    const statusOutput = screen.getByRole('status');
+    expect(statusOutput.tagName).toBe('OUTPUT');
+    expect(statusOutput).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('renders nothing when ArgoCD is reachable', () => {
+    (useArgocdUnreachable as unknown as vi.Mock).mockReturnValue(false);
+    const { container } = render(<ArgocdUnreachableBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
+++ b/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
@@ -1,0 +1,38 @@
+import { Alert, Snackbar } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { useArgocdUnreachable } from './useArgocdUnreachable';
+
+// Anchored to the top so it does not overlap the bottom-anchored deploy-lock
+// banner when both are visible.
+const snackbarPosition: SxProps<Theme> = theme => ({
+  '&.MuiSnackbar-root': {
+    top: `calc(${theme.spacing(3)} + env(safe-area-inset-top))`,
+    zIndex: theme.zIndex.snackbar,
+  },
+});
+
+/** Displays an error banner at the top of the viewport when ArgoCD is unreachable. */
+export const ArgocdUnreachableBanner = () => {
+  const unreachable = useArgocdUnreachable();
+
+  if (!unreachable) {
+    return null;
+  }
+
+  return (
+    <Snackbar
+      open
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      autoHideDuration={null}
+      sx={snackbarPosition}
+    >
+      <Alert severity="error" variant="filled" sx={{ minWidth: 320, alignItems: 'center' }}>
+        <output aria-live="assertive" style={{ display: 'block', width: '100%' }}>
+          {/* The underlying signal also trips when the state backend is down, so
+              the wording names both causes rather than blaming ArgoCD alone. */}
+          argo-watcher cannot reach ArgoCD or its state backend — deployments are not being processed. Check argo-watcher, ArgoCD, and database connectivity.
+        </output>
+      </Alert>
+    </Snackbar>
+  );
+};

--- a/web/src/features/argocdStatus/argocdStatusService.test.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.test.ts
@@ -121,6 +121,47 @@ describe('ArgocdStatusService', () => {
     expect(listener).toHaveBeenLastCalledWith(false);
   });
 
+  it('does not let a slow REST bootstrap clobber a newer WebSocket transition', async () => {
+    // Bootstrap fetch is held pending while a WS transition lands, then resolves
+    // with the now-stale value; the WS state must win.
+    let resolveFetch: (r: Response) => void = () => {};
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise<Response>(resolve => { resolveFetch = resolve; }),
+    );
+    const service = new ArgocdStatusService();
+    const listener = vi.fn();
+    service.subscribe(listener); // fetchStatus is now in flight
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    MockWebSocket.instances[0].emit('argocd_down');
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    // The stale bootstrap now resolves "reachable" — it must be discarded.
+    resolveFetch(new Response(JSON.stringify(true), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('re-bootstraps on a fresh subscribe after full teardown', async () => {
+    mockFetch([{ body: true }, { body: false }]);
+    const service = new ArgocdStatusService();
+    const unsubscribe = service.subscribe(vi.fn());
+
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 1);
+    unsubscribe(); // last subscriber leaves -> teardown clears cached state
+
+    const listener = vi.fn();
+    service.subscribe(listener);
+    // currentStatus was reset, so a second bootstrap fetch must fire (not a replay).
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 2);
+    await vi.waitUntil(() => listener.mock.calls.some(c => c[0] === false));
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
   it('tears down websocket when the last subscriber unsubscribes', async () => {
     mockFetch([{ body: true }]);
     const service = new ArgocdStatusService();

--- a/web/src/features/argocdStatus/argocdStatusService.test.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ArgocdStatusListener } from './argocdStatusService';
+import { ArgocdStatusService } from './argocdStatusService';
+import * as sharedUtils from '../../shared/utils';
+
+class MockWebSocket {
+  public onopen: (() => void) | null = null;
+  public onmessage: ((event: { data: string }) => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public onerror: ((error: unknown) => void) | null = null;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  public open() {
+    this.onopen?.();
+  }
+
+  public close() {
+    this.onclose?.();
+  }
+
+  public emit(message: string) {
+    this.onmessage?.({ data: message });
+  }
+
+  static readonly instances: MockWebSocket[] = [];
+
+  static reset() {
+    MockWebSocket.instances.length = 0;
+  }
+}
+
+describe('ArgocdStatusService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    MockWebSocket.reset();
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  const mockFetch = (responses: Array<{ body: unknown; status?: number }>) => {
+    const sequence = [...responses];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      const next = sequence.shift() ?? { body: {}, status: 200 };
+      return new Response(JSON.stringify(next.body), {
+        status: next.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  };
+
+  it('fetches initial reachability and notifies subscribers', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenCalledWith(true);
+  });
+
+  it('fetches the argocd-status endpoint', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    service.subscribe(vi.fn());
+
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length > 0);
+    const fetchCalls = (globalThis.fetch as unknown as vi.Mock).mock.calls;
+    expect(fetchCalls[0][0]).toContain('/api/v1/argocd-status');
+  });
+
+  it('updates reachability on WebSocket messages', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    const listener: ArgocdStatusListener = vi.fn();
+
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const socket = MockWebSocket.instances[0];
+
+    socket.emit('argocd_down');
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    socket.emit('argocd_up');
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('ignores unrelated WebSocket messages', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    const listener = vi.fn();
+
+    service.subscribe(listener);
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    listener.mockClear();
+
+    // deploy-lock messages share the socket but must not move the argocd state.
+    MockWebSocket.instances[0].emit('locked');
+    MockWebSocket.instances[0].emit('unlocked');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('re-fetches reachability whenever the socket (re)connects', async () => {
+    // A transition missed during a socket drop must be reconciled on reconnect,
+    // otherwise the banner stays stale and hides a real outage.
+    mockFetch([{ body: true }, { body: false }]);
+    const service = new ArgocdStatusService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    listener.mockClear();
+
+    // Server now reports unreachable; the reconnect handshake must pick it up.
+    MockWebSocket.instances[0].open();
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('tears down websocket when the last subscriber unsubscribes', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    const listener = vi.fn();
+    const unsubscribe = service.subscribe(listener);
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const socketCloseSpy = vi.spyOn(MockWebSocket.instances[0], 'close');
+
+    unsubscribe();
+    await vi.waitUntil(() => socketCloseSpy.mock.calls.length > 0);
+    expect(socketCloseSpy).toHaveBeenCalled();
+  });
+
+  it('schedules reconnects when the socket closes with active listeners', async () => {
+    mockFetch([{ body: true }]);
+    const service = new ArgocdStatusService();
+    service.subscribe(vi.fn());
+    service.subscribe(vi.fn());
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+
+    const mockWindow = {
+      setTimeout: vi.fn((cb: () => void) => {
+        cb();
+        return 1 as unknown as number;
+      }),
+      clearTimeout: vi.fn(),
+    };
+    const windowSpy = vi
+      .spyOn(sharedUtils, 'getBrowserWindow')
+      .mockReturnValue(mockWindow as unknown as Window);
+
+    MockWebSocket.instances[0].onclose?.();
+
+    expect(mockWindow.setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
+    windowSpy.mockRestore();
+  });
+
+  it('logs errors when initial status fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const service = new ArgocdStatusService();
+    service.subscribe(() => {});
+
+    await vi.waitUntil(() => errorSpy.mock.calls.length > 0);
+    expect(errorSpy).toHaveBeenCalledWith('[argocd-status] Failed to fetch initial status', expect.any(Error));
+    errorSpy.mockRestore();
+  });
+
+  it('logs websocket errors and closes the socket', async () => {
+    mockFetch([{ body: true }]);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const service = new ArgocdStatusService();
+    service.subscribe(() => {});
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const socket = MockWebSocket.instances[0];
+    const closeSpy = vi.spyOn(socket, 'close');
+
+    const wsError = new Error('ws');
+    socket.onerror?.(wsError);
+
+    expect(errorSpy).toHaveBeenCalledWith('[argocd-status] WebSocket error', wsError);
+    expect(closeSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/web/src/features/argocdStatus/argocdStatusService.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.ts
@@ -1,0 +1,151 @@
+import { httpClient } from '../../data/httpClient';
+import { resolveWebSocketUrl } from '../../data/webSocketUrl';
+import { getBrowserWindow } from '../../shared/utils';
+
+/**
+ * Subscribed listener signature invoked whenever ArgoCD reachability changes.
+ * `available` is true when argo-watcher can reach ArgoCD.
+ */
+export type ArgocdStatusListener = (available: boolean) => void;
+
+const WS_RETRY_DELAY_MS = 5000;
+
+/**
+ * WebSocket messages the server pushes on reachability transitions. Kept in sync
+ * with the backend (internal/server/env.go).
+ */
+const ARGOCD_DOWN_MESSAGE = 'argocd_down';
+const ARGOCD_UP_MESSAGE = 'argocd_up';
+
+/**
+ * ArgocdStatusService mirrors the deploy-lock service for a different signal: it
+ * bootstraps ArgoCD reachability over REST and then tracks live changes pushed
+ * over the shared `/ws` WebSocket, so the frontend can surface an "ArgoCD
+ * unreachable" banner (issue #498). It is read-only — there are no imperative
+ * actions, unlike the deploy-lock service.
+ */
+export class ArgocdStatusService {
+  private currentStatus: boolean | null = null;
+  private readonly listeners = new Set<ArgocdStatusListener>();
+  private socket: WebSocket | null = null;
+  private reconnectHandle: number | null = null;
+
+  /**
+   * Retrieves the latest reachability from the backend and notifies subscribers.
+   */
+  public async fetchStatus(): Promise<boolean> {
+    const response = await httpClient<boolean>('/api/v1/argocd-status');
+    const available = Boolean(response.data);
+    this.updateStatus(available);
+    return available;
+  }
+
+  /**
+   * Subscribes to reachability changes, establishing a WebSocket connection when
+   * needed. Returns an unsubscribe function for convenient cleanup.
+   */
+  public subscribe(listener: ArgocdStatusListener): () => void {
+    this.listeners.add(listener);
+
+    if (this.currentStatus === null) {
+      this.fetchStatus().catch(error => {
+        console.error('[argocd-status] Failed to fetch initial status', error);
+      });
+    } else {
+      listener(this.currentStatus);
+    }
+
+    this.ensureSocket();
+
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size > 0) {
+        return;
+      }
+      this.teardownSocket();
+    };
+  }
+
+  /** Broadcasts the new reachability to all subscribers. */
+  private updateStatus(available: boolean) {
+    this.currentStatus = available;
+    for (const listener of this.listeners) {
+      listener(available);
+    }
+  }
+
+  /** Ensures a websocket connection exists whenever there are active listeners. */
+  private ensureSocket() {
+    if (this.socket || this.listeners.size === 0) {
+      return;
+    }
+
+    const url = resolveWebSocketUrl();
+    this.socket = new WebSocket(url);
+
+    // Re-bootstrap against the authoritative cached state on every (re)connect:
+    // the server only pushes on transitions, so a transition during a socket
+    // drop would otherwise leave the reconnected client with a stale banner —
+    // and a false-negative here hides a real outage (issue #498).
+    this.socket.onopen = () => {
+      this.fetchStatus().catch(error => {
+        console.error('[argocd-status] Failed to reconcile status on connect', error);
+      });
+    };
+
+    this.socket.onmessage = event => {
+      const payload = typeof event.data === 'string' ? event.data : '';
+      if (payload === ARGOCD_DOWN_MESSAGE) {
+        this.updateStatus(false);
+      } else if (payload === ARGOCD_UP_MESSAGE) {
+        this.updateStatus(true);
+      }
+    };
+
+    this.socket.onclose = () => {
+      this.socket = null;
+      if (this.listeners.size > 0) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.socket.onerror = error => {
+      console.error('[argocd-status] WebSocket error', error);
+      this.socket?.close();
+    };
+  }
+
+  /** Schedules a websocket reconnect attempt with basic backoff. */
+  private scheduleReconnect() {
+    if (this.reconnectHandle !== null) {
+      return;
+    }
+
+    const browserWindow = getBrowserWindow();
+    if (!browserWindow) {
+      return;
+    }
+
+    this.reconnectHandle = browserWindow.setTimeout(() => {
+      this.reconnectHandle = null;
+      this.ensureSocket();
+    }, WS_RETRY_DELAY_MS);
+  }
+
+  /** Closes any active websocket and cancels pending reconnect timers. */
+  private teardownSocket() {
+    if (this.reconnectHandle !== null) {
+      const browserWindow = getBrowserWindow();
+      browserWindow?.clearTimeout(this.reconnectHandle);
+      this.reconnectHandle = null;
+    }
+
+    this.socket?.close();
+    this.socket = null;
+  }
+}
+
+/**
+ * Shared singleton instance consumed by the React-admin UI.
+ */
+export const argocdStatusService = new ArgocdStatusService();

--- a/web/src/features/argocdStatus/argocdStatusService.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.ts
@@ -29,14 +29,32 @@ export class ArgocdStatusService {
   private readonly listeners = new Set<ArgocdStatusListener>();
   private socket: WebSocket | null = null;
   private reconnectHandle: number | null = null;
+  // Ordering guards so an out-of-order async result can never revert the banner
+  // to a stale value. Both matter because a (re)connect can have a bootstrap and
+  // an onopen fetch in flight at once, alongside live WS pushes:
+  //   fetchSeq     - only the most recently issued fetch may apply its result;
+  //                  older concurrent fetches are dropped.
+  //   wsGeneration - bumped on every WebSocket transition; a fetch is dropped if
+  //                  one landed while it was in flight, so a slow REST response
+  //                  cannot clobber a fresher live update.
+  private fetchSeq = 0;
+  private wsGeneration = 0;
 
   /**
    * Retrieves the latest reachability from the backend and notifies subscribers.
+   * The result is applied only if it is still the newest fetch AND no WebSocket
+   * transition landed while it was in flight; otherwise it is dropped so REST/WS
+   * ordering races cannot revert the banner to a stale value.
    */
   public async fetchStatus(): Promise<boolean> {
+    const seq = ++this.fetchSeq;
+    const wsGen = this.wsGeneration;
     const response = await httpClient<boolean>('/api/v1/argocd-status');
     const available = Boolean(response.data);
-    this.updateStatus(available);
+    if (seq !== this.fetchSeq || wsGen !== this.wsGeneration) {
+      return this.currentStatus ?? available;
+    }
+    this.setStatus(available);
     return available;
   }
 
@@ -67,7 +85,7 @@ export class ArgocdStatusService {
   }
 
   /** Broadcasts the new reachability to all subscribers. */
-  private updateStatus(available: boolean) {
+  private setStatus(available: boolean) {
     this.currentStatus = available;
     for (const listener of this.listeners) {
       listener(available);
@@ -96,9 +114,11 @@ export class ArgocdStatusService {
     this.socket.onmessage = event => {
       const payload = typeof event.data === 'string' ? event.data : '';
       if (payload === ARGOCD_DOWN_MESSAGE) {
-        this.updateStatus(false);
+        this.wsGeneration++;
+        this.setStatus(false);
       } else if (payload === ARGOCD_UP_MESSAGE) {
-        this.updateStatus(true);
+        this.wsGeneration++;
+        this.setStatus(true);
       }
     };
 
@@ -142,6 +162,10 @@ export class ArgocdStatusService {
 
     this.socket?.close();
     this.socket = null;
+    // Forget the cached reachability so a later re-subscribe bootstraps a fresh
+    // fetch instead of replaying a value that may have gone stale while nobody
+    // was listening.
+    this.currentStatus = null;
   }
 }
 

--- a/web/src/features/argocdStatus/useArgocdUnreachable.test.tsx
+++ b/web/src/features/argocdStatus/useArgocdUnreachable.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+vi.mock('./argocdStatusService', () => ({
+  argocdStatusService: {
+    subscribe: vi.fn(),
+  },
+}));
+
+import { ArgocdStatusProvider } from './ArgocdStatusProvider';
+import { useArgocdUnreachable } from './useArgocdUnreachable';
+
+let subscribeMock: vi.Mock;
+
+beforeAll(async () => {
+  const module = await import('./argocdStatusService');
+  subscribeMock = module.argocdStatusService.subscribe as vi.Mock;
+});
+
+describe('useArgocdUnreachable', () => {
+  it('reflects reachability updates from the service subscription', () => {
+    let listener: ((available: boolean) => void) | null = null;
+    subscribeMock.mockImplementation(cb => {
+      listener = cb;
+      return () => undefined;
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ArgocdStatusProvider>{children}</ArgocdStatusProvider>
+    );
+
+    const { result } = renderHook(() => useArgocdUnreachable(), { wrapper });
+    // Available by default -> not unreachable.
+    expect(result.current).toBe(false);
+
+    act(() => listener?.(false));
+    expect(result.current).toBe(true);
+
+    act(() => listener?.(true));
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/src/features/argocdStatus/useArgocdUnreachable.ts
+++ b/web/src/features/argocdStatus/useArgocdUnreachable.ts
@@ -1,0 +1,7 @@
+import { useArgocdStatus } from './ArgocdStatusProvider';
+
+/** Returns true when argo-watcher cannot currently reach ArgoCD. */
+export const useArgocdUnreachable = () => {
+  const { available } = useArgocdStatus();
+  return !available;
+};

--- a/web/src/features/deployLock/deployLockService.ts
+++ b/web/src/features/deployLock/deployLockService.ts
@@ -1,4 +1,5 @@
 import { httpClient, type HttpResponse } from '../../data/httpClient';
+import { resolveWebSocketUrl } from '../../data/webSocketUrl';
 import { getBrowserWindow } from '../../shared/utils';
 
 /**
@@ -7,86 +8,6 @@ import { getBrowserWindow } from '../../shared/utils';
 export type DeployLockListener = (locked: boolean) => void;
 
 const WS_RETRY_DELAY_MS = 5000;
-const IS_DEV_BUILD = import.meta.env?.DEV ?? false;
-
-const warnInvalidSocketConfig = (message: string, ...details: unknown[]) => {
-  if (IS_DEV_BUILD) {
-    console.warn(message, ...details);
-  } else {
-    console.warn('[deploy-lock] Invalid websocket configuration; falling back to defaults.');
-  }
-};
-
-/** Normalizes custom websocket base URLs ensuring they match the current origin and use safe protocols. */
-const sanitizeCustomSocketBase = (rawBase: string, location?: Location | null): URL | null => {
-  const trimmed = rawBase.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  try {
-    let candidate: URL;
-    if (trimmed.startsWith('http') || trimmed.startsWith('ws')) {
-      candidate = new URL(trimmed);
-    } else {
-      const relativePath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
-      candidate = new URL(relativePath, location?.origin ?? 'http://localhost');
-    }
-
-    const isHttp = candidate.protocol === 'http:' || candidate.protocol === 'https:';
-    const isWs = candidate.protocol === 'ws:' || candidate.protocol === 'wss:';
-
-    if (!isHttp && !isWs) {
-      warnInvalidSocketConfig('[deploy-lock] Ignoring custom websocket URL with unsupported protocol:', candidate.protocol);
-      return null;
-    }
-
-    if (location && candidate.host !== location.host) {
-      warnInvalidSocketConfig(
-        `[deploy-lock] Ignoring custom websocket URL (${candidate.origin}) because it does not match the current host (${location.host}).`,
-      );
-      return null;
-    }
-
-    return candidate;
-  } catch (error) {
-    warnInvalidSocketConfig('[deploy-lock] Invalid custom websocket URL, falling back to window.location.', error);
-    return null;
-  }
-};
-
-/** Ensures the socket URL ends with `/ws` and uses the websocket protocol scheme. */
-const toSocketUrl = (url: URL): string => {
-  const normalizedPath = url.pathname.endsWith('/ws')
-    ? url.pathname
-    : `${url.pathname.replace(/\/$/, '') || ''}/ws`;
-
-  let protocol: 'ws:' | 'wss:';
-  if (url.protocol === 'https:') {
-    protocol = 'wss:';
-  } else if (url.protocol === 'http:') {
-    protocol = 'ws:';
-  } else {
-    protocol = url.protocol as 'ws:' | 'wss:';
-  }
-  return `${protocol}//${url.host}${normalizedPath}`;
-};
-
-/** Determines the websocket endpoint based on env overrides or current location, validating custom hosts. */
-const resolveWebSocketUrl = () => {
-  const location = getBrowserWindow()?.location ?? null;
-  const base = import.meta.env.VITE_WS_BASE_URL ?? '';
-  if (base) {
-    const sanitized = sanitizeCustomSocketBase(base, location);
-    if (sanitized) {
-      return toSocketUrl(sanitized);
-    }
-  }
-
-  const protocol = location?.protocol === 'https:' ? 'wss:' : 'ws:';
-  const host = location?.host ?? 'localhost';
-  return `${protocol}//${host}/ws`;
-};
 
 /**
  * DeployLockService coordinates REST and WebSocket interactions for the deploy-lock feature,

--- a/web/src/shared/providers/AppProviders.tsx
+++ b/web/src/shared/providers/AppProviders.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 import { ThemeModeProvider } from '../../theme/ThemeModeProvider';
 import { DeployLockProvider } from '../../features/deployLock/DeployLockProvider';
 import { DeployLockBanner } from '../../features/deployLock/DeployLockBanner';
+import { ArgocdStatusProvider } from '../../features/argocdStatus/ArgocdStatusProvider';
+import { ArgocdUnreachableBanner } from '../../features/argocdStatus/ArgocdUnreachableBanner';
 import { TimezoneProvider } from './TimezoneProvider';
 
 interface AppProvidersProps {
@@ -15,10 +17,13 @@ interface AppProvidersProps {
 export const AppProviders = ({ children }: AppProvidersProps) => (
   <ThemeModeProvider>
     <TimezoneProvider>
-      <DeployLockProvider>
-        {children}
-        <DeployLockBanner />
-      </DeployLockProvider>
+      <ArgocdStatusProvider>
+        <DeployLockProvider>
+          {children}
+          <DeployLockBanner />
+          <ArgocdUnreachableBanner />
+        </DeployLockProvider>
+      </ArgocdStatusProvider>
     </TimezoneProvider>
   </ThemeModeProvider>
 );


### PR DESCRIPTION
When argo-watcher lost connectivity to ArgoCD there was no signal in the frontend: the task list looked identical to "no recent deployments" and a deploy submitted during the outage hung until the client's own HTTP timeout, masking the cause as an opaque "context deadline exceeded".

Backend:
- Cache the ArgoCD reachability observed by Check() in an atomic bool exposed via Argo.IsAvailable(), refreshed by the existing 30s liveness probe.
- Push argocd_up/argocd_down over the shared /ws socket on transitions via a watcher mirroring the lockdown WatchTransitions idiom, and add a read-only GET /api/v1/argocd-status for banner bootstrap.
- Gate AddTask on the cached state so a deploy during an outage fails fast with 503 {"status":"down"} instead of running the full API retry budget.

Frontend:
- Add an "ArgoCD unreachable" banner feature mirroring the deploy-lock pattern (REST bootstrap + WebSocket push, re-reconciled on every reconnect).
- Extract the shared, same-host-validated WebSocket URL resolution into data/webSocketUrl.ts so it is not duplicated per feature.

Also add a test/e2e argocd-unreachable phase that severs ArgoCD, asserts the status endpoint flips, the WS transitions fire, and the deploy fast-fails, then asserts recovery.

Closes #498