### PR TITLE
feat(state): fail fast and log when Postgres is unreachable at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of blocking on the full Argo CD API retry budget until the client's own
   HTTP timeout fired and masked the cause as an opaque `context deadline
   exceeded`.
+- The server and `--migrate` now bound the initial PostgreSQL connection with a
+  `connect_timeout` (new `DB_CONNECT_TIMEOUT` env var, default `10` seconds) and
+  log a `Connecting to PostgreSQL database...` line before dialing, so an
+  unreachable database fails fast with a diagnostic signal instead of blocking on
+  the OS TCP timeout with no logs. Deployments with high-latency links to Postgres
+  may need to raise `DB_CONNECT_TIMEOUT`; a non-positive value is rejected at
+  config-load time on both paths.
 
 ## [0.12.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `connect_timeout` (new `DB_CONNECT_TIMEOUT` env var, default `10` seconds) and
   log a `Connecting to PostgreSQL database...` line before dialing, so an
   unreachable database fails fast with a diagnostic signal instead of blocking on
-  the OS TCP timeout with no logs. Deployments with high-latency links to Postgres
-  may need to raise `DB_CONNECT_TIMEOUT`; a non-positive value is rejected at
-  config-load time on both paths.
+  the OS TCP timeout with no logs. The timeout is enforced even when `DB_DSN` is
+  supplied explicitly. Deployments with high-latency links to Postgres may need to
+  raise `DB_CONNECT_TIMEOUT`; a non-positive value is rejected at config-load time
+  on both paths.
+- The `--migrate` command now emits structured JSON logs honoring `LOG_LEVEL`,
+  consistent with the server, instead of the previous plain-text output.
 
 ## [0.12.1] - 2026-07-20
 

--- a/cmd/argo-watcher/main.go
+++ b/cmd/argo-watcher/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"flag"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/logging"
 	"github.com/shini4i/argo-watcher/internal/migrate"
 	"github.com/shini4i/argo-watcher/internal/server"
 )
@@ -16,22 +18,30 @@ import (
 // @description A small tool that will help to improve deployment visibility
 // @BasePath /
 func main() {
+	// Configure structured logging up front so both the --migrate and server
+	// paths emit consistent JSON, including early startup failures. NewServer
+	// re-applies this once the full config is loaded.
+	logging.Init(os.Getenv("LOG_LEVEL"))
+
 	migrateFlag := flag.Bool("migrate", false, "Run database migrations and exit.")
 	flag.Parse()
 
 	if *migrateFlag {
 		cfg, err := migrate.NewMigrationConfig()
 		if err != nil {
-			log.Fatalf("failed to load migration config: %v", err)
+			slog.Error("failed to load migration config", "error", err)
+			os.Exit(1)
 		}
 
 		migrator, err := migrate.NewMigrator(cfg)
 		if err != nil {
-			log.Fatalf("failed to create migrator: %v", err)
+			slog.Error("failed to create migrator", "error", err)
+			os.Exit(1)
 		}
 
 		if err := migrator.Run(); err != nil {
-			log.Fatalf("Migration failed: %v", err)
+			slog.Error("migration failed", "error", err)
+			os.Exit(1)
 		}
 
 		return
@@ -39,12 +49,14 @@ func main() {
 
 	serverConfig, err := config.NewServerConfig()
 	if err != nil {
-		log.Fatalf("failed to load server config: %v", err)
+		slog.Error("failed to load server config", "error", err)
+		os.Exit(1)
 	}
 
 	s, err := server.NewServer(serverConfig, prometheus.DefaultRegisterer)
 	if err != nil {
-		log.Fatalf("failed to create server: %v", err)
+		slog.Error("failed to create server", "error", err)
+		os.Exit(1)
 	}
 	s.Run()
 }

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -10,7 +10,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 **Likely causes:**
 - `ARGO_URL` or `ARGO_TOKEN` are incorrect or missing.
 - The server cannot reach the Argo CD API.
-- If using `STATE_TYPE=postgres`, the database is not accessible or migrations have not been applied.
+- If using `STATE_TYPE=postgres`, the database is not accessible or migrations have not been applied. The server (and `--migrate`) fail fast within `DB_CONNECT_TIMEOUT` seconds (default 10) instead of hanging on the OS TCP timeout; check the logs right after the `Connecting to PostgreSQL database...` line for the connection error.
 
 **How to verify:**
 - Check the server logs: `kubectl logs -f <pod-name>` or `docker logs <container-name>`.

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -59,6 +59,7 @@ These variables are required when `STATE_TYPE` is set to `postgres`.
 | `DB_PASSWORD` | Database password |             | Conditional   |
 | `DB_SSL_MODE` | PostgreSQL SSL mode | `disable` | No            |
 | `DB_TIMEZONE` | Database timezone | `UTC`       | No            |
+| `DB_CONNECT_TIMEOUT` | Max seconds to wait for the initial DB connection before failing (must be at least 1) | `10` | No |
 
 ## Git Integration Settings
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,7 @@ type DatabaseConfig struct {
 	// It is honored by both the pgx driver (server path) and libpq (migrations).
 	ConnectTimeout int    `env:"DB_CONNECT_TIMEOUT" envDefault:"10"`
 	TimeZone       string `env:"DB_TIMEZONE" envDefault:"UTC"`
-	DSN            string `env:"DB_DSN,expand" envDefault:"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} password=${DB_PASSWORD} dbname=${DB_NAME} sslmode=${DB_SSL_MODE} TimeZone=${DB_TIMEZONE} connect_timeout=${DB_CONNECT_TIMEOUT}"`
+	DSN            string `env:"DB_DSN,expand" envDefault:"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} password=${DB_PASSWORD} dbname=${DB_NAME} sslmode=${DB_SSL_MODE} TimeZone=${DB_TIMEZONE}"`
 }
 
 type WebhookConfig struct {
@@ -98,7 +98,32 @@ func NewServerConfig() (*ServerConfig, error) {
 		return nil, err
 	}
 
+	// Enforce the connect timeout even when DB_DSN is supplied explicitly (which
+	// bypasses the default template), so an unreachable Postgres always fails fast
+	// instead of blocking on the OS TCP timeout.
+	if config.StateType == "postgres" {
+		config.Db.DSN = ensureConnectTimeout(config.Db.DSN, config.Db.ConnectTimeout)
+	}
+
 	return &config, nil
+}
+
+// ensureConnectTimeout appends a connect_timeout parameter (in seconds) to a
+// PostgreSQL DSN when it does not already specify one. An operator-provided
+// connect_timeout is left untouched. Both the URI form (postgres://...) and the
+// keyword/value form (host=... port=...) are supported.
+func ensureConnectTimeout(dsn string, timeout int) string {
+	if strings.Contains(dsn, "connect_timeout=") {
+		return dsn
+	}
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		separator := "?"
+		if strings.Contains(dsn, "?") {
+			separator = "&"
+		}
+		return fmt.Sprintf("%s%sconnect_timeout=%d", dsn, separator, timeout)
+	}
+	return fmt.Sprintf("%s connect_timeout=%d", dsn, timeout)
 }
 
 // validateServerConfig checks the semantic rules that env parsing cannot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,9 +22,13 @@ type KeycloakConfig struct {
 }
 
 type DatabaseConfig struct {
-	SSLMode  string `env:"DB_SSL_MODE" envDefault:"disable"`
-	TimeZone string `env:"DB_TIMEZONE" envDefault:"UTC"`
-	DSN      string `env:"DB_DSN,expand" envDefault:"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} password=${DB_PASSWORD} dbname=${DB_NAME} sslmode=${DB_SSL_MODE} TimeZone=${DB_TIMEZONE}"`
+	SSLMode string `env:"DB_SSL_MODE" envDefault:"disable"`
+	// ConnectTimeout bounds the initial connection attempt (in seconds) so an
+	// unreachable Postgres fails fast instead of blocking on the OS TCP timeout.
+	// It is honored by both the pgx driver (server path) and libpq (migrations).
+	ConnectTimeout int    `env:"DB_CONNECT_TIMEOUT" envDefault:"10"`
+	TimeZone       string `env:"DB_TIMEZONE" envDefault:"UTC"`
+	DSN            string `env:"DB_DSN,expand" envDefault:"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} password=${DB_PASSWORD} dbname=${DB_NAME} sslmode=${DB_SSL_MODE} TimeZone=${DB_TIMEZONE} connect_timeout=${DB_CONNECT_TIMEOUT}"`
 }
 
 type WebhookConfig struct {
@@ -109,6 +113,11 @@ func validateServerConfig(config *ServerConfig) error {
 	}
 	if config.ArgoApiRetries < 1 || config.ArgoApiRetries > 10 {
 		problems = append(problems, fmt.Sprintf("  - ArgoApiRetries: must be between 1 and 10, got %d", config.ArgoApiRetries))
+	}
+	// A non-positive connect timeout means "wait indefinitely" for both pgx and
+	// libpq, silently defeating the fail-fast guard; only relevant for postgres.
+	if config.StateType == "postgres" && config.Db.ConnectTimeout < 1 {
+		problems = append(problems, fmt.Sprintf("  - ConnectTimeout: must be at least 1 second, got %d", config.Db.ConnectTimeout))
 	}
 
 	if len(problems) == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewServerConfig(t *testing.T) {
@@ -52,6 +53,58 @@ func TestNewServerConfig(t *testing.T) {
 		assert.Equal(t, "deploy-token", cfg.DeployToken)
 		assert.Equal(t, "jwt-secret", cfg.JWTSecret)
 	})
+}
+
+// TestNewServerConfig_DatabaseConnectTimeout verifies that the database DSN
+// carries a connect_timeout so an unreachable Postgres fails fast at startup
+// instead of blocking on the OS TCP timeout, and that DB_CONNECT_TIMEOUT
+// overrides the default.
+func TestNewServerConfig_DatabaseConnectTimeout(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 10, cfg.Db.ConnectTimeout)
+		assert.Contains(t, cfg.Db.DSN, "connect_timeout=10")
+	})
+
+	t.Run("Override", func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+		t.Setenv("DB_CONNECT_TIMEOUT", "3")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, cfg.Db.ConnectTimeout)
+		assert.Contains(t, cfg.Db.DSN, "connect_timeout=3")
+	})
+}
+
+// TestNewServerConfig_ConnectTimeoutValidation verifies that a non-positive
+// DB_CONNECT_TIMEOUT is rejected with a readable error, since 0 (and negatives on
+// libpq) mean "wait indefinitely" and would silently defeat the fail-fast guard.
+func TestNewServerConfig_ConnectTimeoutValidation(t *testing.T) {
+	for _, value := range []string{"0", "-1"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("ARGO_URL", "https://example.com")
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "postgres")
+			t.Setenv("DB_CONNECT_TIMEOUT", value)
+
+			cfg, err := NewServerConfig()
+
+			assert.Nil(t, cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ConnectTimeout")
+			assert.Contains(t, err.Error(), "must be at least 1 second")
+		})
+	}
 }
 
 func TestNewServerConfig_RequiredFieldsMissing(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,6 +89,49 @@ func TestNewServerConfig_DatabaseConnectTimeout(t *testing.T) {
 // TestNewServerConfig_ConnectTimeoutValidation verifies that a non-positive
 // DB_CONNECT_TIMEOUT is rejected with a readable error, since 0 (and negatives on
 // libpq) mean "wait indefinitely" and would silently defeat the fail-fast guard.
+// TestNewServerConfig_ConnectTimeoutInjectedIntoCustomDSN verifies that an
+// explicitly supplied DB_DSN (which bypasses the default template) still gets a
+// connect_timeout so the fail-fast guard cannot be silently defeated, while an
+// operator-provided connect_timeout is left untouched.
+func TestNewServerConfig_ConnectTimeoutInjectedIntoCustomDSN(t *testing.T) {
+	base := func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+	}
+
+	t.Run("Keyword/value DSN without connect_timeout", func(t *testing.T) {
+		base(t)
+		t.Setenv("DB_DSN", "host=db port=5432 user=u password=p dbname=aw sslmode=disable")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "host=db port=5432 user=u password=p dbname=aw sslmode=disable connect_timeout=10", cfg.Db.DSN)
+	})
+
+	t.Run("URI DSN without connect_timeout", func(t *testing.T) {
+		base(t)
+		t.Setenv("DB_DSN", "postgres://db:5432/aw?sslmode=disable")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "postgres://db:5432/aw?sslmode=disable&connect_timeout=10", cfg.Db.DSN)
+	})
+
+	t.Run("Operator connect_timeout is respected", func(t *testing.T) {
+		base(t)
+		t.Setenv("DB_CONNECT_TIMEOUT", "10")
+		t.Setenv("DB_DSN", "host=db user=u connect_timeout=30")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "host=db user=u connect_timeout=30", cfg.Db.DSN)
+	})
+}
+
 func TestNewServerConfig_ConnectTimeoutValidation(t *testing.T) {
 	for _, value := range []string{"0", "-1"} {
 		t.Run(value, func(t *testing.T) {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,44 @@
+// Package logging centralizes configuration of the global slog logger so every
+// entrypoint (the server and the --migrate CLI path) emits structured JSON logs
+// at a consistent, LOG_LEVEL-driven level.
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var levelVar = new(slog.LevelVar)
+
+// Init configures the global slog logger to emit JSON to stderr at the level
+// parsed from level. An unparseable level is logged as a warning and leaves the
+// logger at its default (info) level.
+func Init(level string) {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: levelVar})))
+	if lvl, err := parseLevel(level); err != nil {
+		slog.Warn("couldn't parse log level, using default", "error", err)
+	} else {
+		levelVar.Set(lvl)
+		slog.Debug("configured log level", "level", lvl)
+	}
+}
+
+// parseLevel maps a textual log level to its slog equivalent. It accepts the
+// level names previously handled by zerolog (including the trace/fatal/panic
+// aliases) so existing LOG_LEVEL values keep working; unknown values error.
+func parseLevel(level string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "trace", "debug":
+		return slog.LevelDebug, nil
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error", "fatal", "panic":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q", level)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,54 @@
+package logging
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	// A valid level is parsed and applied to the shared levelVar.
+	Init("debug")
+	assert.Equal(t, slog.LevelDebug, levelVar.Level())
+
+	Init("warn")
+	assert.Equal(t, slog.LevelWarn, levelVar.Level())
+
+	// An unparseable level is a no-op on the level: it logs a warning and
+	// leaves the previously configured level (warn) untouched.
+	Init("invalid-level")
+	assert.Equal(t, slog.LevelWarn, levelVar.Level())
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		input     string
+		want      slog.Level
+		expectErr bool
+	}{
+		{"trace", slog.LevelDebug, false},
+		{"debug", slog.LevelDebug, false},
+		{"info", slog.LevelInfo, false},
+		{"", slog.LevelInfo, false},
+		{"WARN", slog.LevelWarn, false},
+		{"warning", slog.LevelWarn, false},
+		{"error", slog.LevelError, false},
+		{"fatal", slog.LevelError, false},
+		{"panic", slog.LevelError, false},
+		{" Info ", slog.LevelInfo, false},
+		{"bogus", slog.LevelInfo, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseLevel(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -19,6 +19,7 @@ type dbConfig struct {
 	Port           string `env:"DB_PORT,required,notEmpty"`
 	Name           string `env:"DB_NAME,required,notEmpty"`
 	SSLMode        string `env:"DB_SSL_MODE" envDefault:"disable"`
+	ConnectTimeout int    `env:"DB_CONNECT_TIMEOUT" envDefault:"10"`
 	MigrationsPath string `env:"DB_MIGRATIONS_PATH" envDefault:"/app/db/migrations"`
 }
 
@@ -36,13 +37,22 @@ func NewMigrationConfig() (*MigrationConfig, error) {
 		return nil, helpers.PrettifyEnvError(err, "invalid argo-watcher migration configuration:")
 	}
 
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+	// A non-positive connect timeout means "wait indefinitely" for libpq, silently
+	// defeating the fail-fast guard against an unreachable database.
+	if dbCfg.ConnectTimeout < 1 {
+		return nil, fmt.Errorf("invalid argo-watcher migration configuration: DB_CONNECT_TIMEOUT must be at least 1 second, got %d", dbCfg.ConnectTimeout)
+	}
+
+	// connect_timeout bounds the initial connection so an unreachable database
+	// fails fast instead of blocking on the OS TCP timeout.
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&connect_timeout=%d",
 		url.QueryEscape(dbCfg.User),
 		url.QueryEscape(dbCfg.Password),
 		dbCfg.Host,
 		dbCfg.Port,
 		dbCfg.Name,
 		dbCfg.SSLMode,
+		dbCfg.ConnectTimeout,
 	)
 
 	return &MigrationConfig{DSN: dsn, MigrationsPath: dbCfg.MigrationsPath}, nil

--- a/internal/migrate/config_test.go
+++ b/internal/migrate/config_test.go
@@ -29,8 +29,26 @@ func TestNewMigrationConfig_Success(t *testing.T) {
 	require.NotNil(t, cfg)
 	assert.Equal(t, "/app/db/migrations", cfg.MigrationsPath)
 	// Verify the DSN is assembled correctly: DB_SSL_MODE flows into the sslmode
-	// segment and the password's special characters are URL-escaped.
-	assert.Equal(t, "postgres://testuser:testpassword%21%40%23@localhost:5432/testdb?sslmode=require", cfg.DSN)
+	// segment, the password's special characters are URL-escaped, and the default
+	// connect_timeout (10s) is appended so an unreachable database fails fast.
+	assert.Equal(t, "postgres://testuser:testpassword%21%40%23@localhost:5432/testdb?sslmode=require&connect_timeout=10", cfg.DSN)
+}
+
+// TestNewMigrationConfig_ConnectTimeoutOverride verifies DB_CONNECT_TIMEOUT flows
+// into the connect_timeout segment of the migration DSN.
+func TestNewMigrationConfig_ConnectTimeoutOverride(t *testing.T) {
+	t.Setenv("DB_HOST", "localhost")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("DB_USER", "testuser")
+	t.Setenv("DB_PASSWORD", "testpassword")
+	t.Setenv("DB_NAME", "testdb")
+	t.Setenv("DB_SSL_MODE", "require")
+	t.Setenv("DB_CONNECT_TIMEOUT", "3")
+
+	cfg, err := NewMigrationConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://testuser:testpassword@localhost:5432/testdb?sslmode=require&connect_timeout=3", cfg.DSN)
 }
 
 // TestNewMigrationConfig_CustomPath tests that a custom migration path from env vars is used.
@@ -49,6 +67,29 @@ func TestNewMigrationConfig_CustomPath(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, "/my/custom/path", cfg.MigrationsPath)
+}
+
+// TestNewMigrationConfig_ConnectTimeoutRejectsNonPositive verifies that a
+// non-positive DB_CONNECT_TIMEOUT is rejected, since 0 (and negatives on libpq)
+// mean "wait indefinitely" and would silently defeat the fail-fast guard.
+func TestNewMigrationConfig_ConnectTimeoutRejectsNonPositive(t *testing.T) {
+	for _, value := range []string{"0", "-1"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("DB_HOST", "localhost")
+			t.Setenv("DB_PORT", "5432")
+			t.Setenv("DB_USER", "testuser")
+			t.Setenv("DB_PASSWORD", "testpassword")
+			t.Setenv("DB_NAME", "testdb")
+			t.Setenv("DB_CONNECT_TIMEOUT", value)
+
+			cfg, err := NewMigrationConfig()
+
+			assert.Nil(t, cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "DB_CONNECT_TIMEOUT")
+			assert.Contains(t, err.Error(), "must be at least 1 second")
+		})
+	}
 }
 
 // TestNewMigrationConfig_ValidationError tests the failure case where a required

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -4,7 +4,7 @@ package migrate
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -25,7 +25,7 @@ type Migrator struct {
 func NewMigrator(cfg *MigrationConfig) (*Migrator, error) {
 	// migrate.New pings the database eagerly, so signal the attempt first; the
 	// DSN's connect_timeout bounds a stalled connection.
-	log.Println("Connecting to database for migrations...")
+	slog.Info("Connecting to database for migrations...")
 	m, err := migrate.New(fmt.Sprintf("file://%s", cfg.MigrationsPath), cfg.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("migration initialization failed: %w", err)
@@ -42,11 +42,11 @@ func NewMigratorWithDriver(driver migrator) *Migrator {
 
 // Run applies all available 'up' migrations and returns an error on failure.
 func (m *Migrator) Run() error {
-	log.Println("Applying database migrations...")
+	slog.Info("Applying database migrations...")
 	err := m.migrator.Up()
 	if err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("an error occurred while applying migrations: %w", err)
 	}
-	log.Println("Migrations applied successfully.")
+	slog.Info("Migrations applied successfully.")
 	return nil
 }

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -23,6 +23,9 @@ type Migrator struct {
 
 // NewMigrator initializes a new Migrator with a real migrate instance.
 func NewMigrator(cfg *MigrationConfig) (*Migrator, error) {
+	// migrate.New pings the database eagerly, so signal the attempt first; the
+	// DSN's connect_timeout bounds a stalled connection.
+	log.Println("Connecting to database for migrations...")
 	m, err := migrate.New(fmt.Sprintf("file://%s", cfg.MigrationsPath), cfg.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("migration initialization failed: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/config"
 	"github.com/shini4i/argo-watcher/internal/lock"
+	"github.com/shini4i/argo-watcher/internal/logging"
 	prom "github.com/shini4i/argo-watcher/internal/prometheus"
 	"github.com/shini4i/argo-watcher/internal/state"
 )
@@ -34,7 +34,7 @@ type Server struct {
 // NewServer creates a new server instance with the given configuration and prometheus registerer.
 func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*Server, error) {
 	// initialize logs
-	initLogs(serverConfig.LogLevel)
+	logging.Init(serverConfig.LogLevel)
 
 	// initialize metrics on the provided prometheus registry
 	metrics := prom.NewMetrics(reg)
@@ -178,39 +178,4 @@ func (s *Server) Run() {
 	s.env.Shutdown()
 
 	slog.Info("server exited")
-}
-
-// logLevelVar holds the active log level for the default logger so initLogs can
-// adjust it at runtime.
-var logLevelVar = new(slog.LevelVar)
-
-// initLogs configures the global slog logger to emit JSON to stderr at the
-// level parsed from logLevel. An unparseable level is logged as a warning and
-// leaves the logger at its default (info) level.
-func initLogs(logLevel string) {
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: logLevelVar})))
-	if lvl, err := parseLogLevel(logLevel); err != nil {
-		slog.Warn("couldn't parse log level, using default", "error", err)
-	} else {
-		logLevelVar.Set(lvl)
-		slog.Debug("configured log level", "level", lvl)
-	}
-}
-
-// parseLogLevel maps a textual log level to its slog equivalent. It accepts the
-// level names previously handled by zerolog (including the trace/fatal/panic
-// aliases) so existing LOG_LEVEL values keep working; unknown values error.
-func parseLogLevel(level string) (slog.Level, error) {
-	switch strings.ToLower(strings.TrimSpace(level)) {
-	case "trace", "debug":
-		return slog.LevelDebug, nil
-	case "", "info":
-		return slog.LevelInfo, nil
-	case "warn", "warning":
-		return slog.LevelWarn, nil
-	case "error", "fatal", "panic":
-		return slog.LevelError, nil
-	default:
-		return slog.LevelInfo, fmt.Errorf("unknown log level %q", level)
-	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"log/slog"
 	"net/url"
 	"testing"
 
@@ -74,50 +73,4 @@ func TestNewServer_PostgresConnectionFailure(t *testing.T) {
 	assert.Error(t, err)
 	// This is the corrected, more robust assertion.
 	assert.Contains(t, err.Error(), "failed to connect to")
-}
-
-func TestInitLogs(t *testing.T) {
-	// A valid level is parsed and applied to the shared logLevelVar.
-	initLogs("debug")
-	assert.Equal(t, slog.LevelDebug, logLevelVar.Level())
-
-	initLogs("warn")
-	assert.Equal(t, slog.LevelWarn, logLevelVar.Level())
-
-	// An unparseable level is a no-op on the level: it logs a warning and
-	// leaves the previously configured level (warn) untouched.
-	initLogs("invalid-level")
-	assert.Equal(t, slog.LevelWarn, logLevelVar.Level())
-}
-
-func TestParseLogLevel(t *testing.T) {
-	tests := []struct {
-		input     string
-		want      slog.Level
-		expectErr bool
-	}{
-		{"trace", slog.LevelDebug, false},
-		{"debug", slog.LevelDebug, false},
-		{"info", slog.LevelInfo, false},
-		{"", slog.LevelInfo, false},
-		{"WARN", slog.LevelWarn, false},
-		{"warning", slog.LevelWarn, false},
-		{"error", slog.LevelError, false},
-		{"fatal", slog.LevelError, false},
-		{"panic", slog.LevelError, false},
-		{" Info ", slog.LevelInfo, false},
-		{"bogus", slog.LevelInfo, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got, err := parseLogLevel(tt.input)
-			if tt.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -29,7 +29,11 @@ type PostgresState struct {
 var _ TaskRepository = (*PostgresState)(nil)
 
 // Connect establishes a connection to the PostgreSQL database using the provided server configuration.
+// It emits an INFO log before dialing (the first line at the default log level, so a stalled
+// connection is diagnosable) and relies on the DSN's connect_timeout to fail fast when Postgres is
+// unreachable rather than blocking on the OS TCP timeout.
 func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
+	slog.Info("Connecting to PostgreSQL database...")
 	// create ORM driver
 	if orm, err := gorm.Open(postgres.Open(serverConfig.Db.DSN)); err != nil {
 		return err


### PR DESCRIPTION
Add DB_CONNECT_TIMEOUT (integer seconds, default 10) and inject it as connect_timeout into both the server (pgx) and --migrate (libpq) DSNs, so an unreachable database fails fast instead of blocking on the OS TCP timeout. Emit a pre-connect log line on both paths so a stalled connection is diagnosable at the default log level. A non-positive timeout is rejected at config-load time on both paths.

Closes #497