### PR TITLE
chore: resolve SonarCloud code smells and CI hardening findings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           set -euo pipefail
           tmp="$(mktemp -d)"
-          curl -fsSL -o "$tmp/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          curl -fsSL -o "$tmp/kubectl" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar -xz -C "$tmp" --strip-components=1 linux-amd64/helm
+          curl --proto '=https' --tlsv1.2 -fsSL -o "$tmp/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          curl --proto '=https' --tlsv1.2 -fsSL -o "$tmp/kubectl" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl --proto '=https' --tlsv1.2 -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar -xz -C "$tmp" --strip-components=1 linux-amd64/helm
           sudo install -m 0755 "$tmp"/kind "$tmp"/kubectl "$tmp"/helm /usr/local/bin/
 
       - name: Run e2e lab

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: web
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run frontend tests with coverage
         working-directory: web

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,7 +59,7 @@ jobs:
         id: govulncheck
         continue-on-error: true
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           "$(go env GOPATH)/bin/govulncheck" ./...
 
       - name: Fail if any Go scanner failed

--- a/docs/scripts/build-swagger.sh
+++ b/docs/scripts/build-swagger.sh
@@ -14,7 +14,7 @@ DOCS_OUT="${REPO_ROOT}/docs/reference/swagger.json"
 
 if command -v swag >/dev/null 2>&1; then
   SWAG_BIN="swag"
-elif [ -x "$(go env GOPATH)/bin/swag" ]; then
+elif [[ -x "$(go env GOPATH)/bin/swag" ]]; then
   SWAG_BIN="$(go env GOPATH)/bin/swag"
 else
   echo "error: 'swag' binary not found on PATH or in \$(go env GOPATH)/bin" >&2

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/golang-migrate/migrate/v4"
+	// Registers the "postgres" database driver with golang-migrate.
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	// Registers the "file" migration source driver with golang-migrate.
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -230,30 +230,44 @@ func timeWithinSchedule(now time.Time, startDay, endDay time.Weekday, startHour,
 
 	// If it's the same day
 	if startDay == endDay {
-		isAfterStart := (currHour > startHour) || (currHour == startHour && currMin >= startMin)
-		isBeforeEnd := (currHour < endHour) || (currHour == endHour && currMin < endMin)
-
-		return (currDay == startDay) && isAfterStart && isBeforeEnd
+		return currDay == startDay &&
+			timeAtOrAfter(currHour, currMin, startHour, startMin) &&
+			timeBefore(currHour, currMin, endHour, endMin)
 	}
 
 	// For different days
-	weekdaysInOrder := endDay >= startDay
-	isInDayRange := (weekdaysInOrder && currDay >= startDay && currDay <= endDay) ||
-		(!weekdaysInOrder && (currDay >= startDay || currDay <= endDay))
-
-	if !isInDayRange {
+	if !dayInRange(currDay, startDay, endDay) {
 		return false
 	}
 
 	// Check times for start and end day
 	switch currDay {
 	case startDay:
-		return currHour > startHour || (currHour == startHour && currMin >= startMin)
+		return timeAtOrAfter(currHour, currMin, startHour, startMin)
 	case endDay:
-		return currHour < endHour || (currHour == endHour && currMin < endMin)
+		return timeBefore(currHour, currMin, endHour, endMin)
 	default:
 		return true
 	}
+}
+
+// timeAtOrAfter reports whether hour:min is at or after ref hour:min on the same day.
+func timeAtOrAfter(hour, min, refHour, refMin int) bool {
+	return hour > refHour || (hour == refHour && min >= refMin)
+}
+
+// timeBefore reports whether hour:min is strictly before ref hour:min on the same day.
+func timeBefore(hour, min, refHour, refMin int) bool {
+	return hour < refHour || (hour == refHour && min < refMin)
+}
+
+// dayInRange reports whether day falls within [start, end], wrapping to the next
+// week when end is before start (e.g. Fri→Mon).
+func dayInRange(day, start, end time.Weekday) bool {
+	if end >= start {
+		return day >= start && day <= end
+	}
+	return day >= start || day <= end
 }
 
 // dayToWeekday converts a three-letter abbreviation of a weekday (e.g., "Mon") to its corresponding time.Weekday enum value.

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -138,7 +138,7 @@ func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 // It takes a string parameter for the task ID, status, and reason.
 // The method iterates over the tasks in the in-memory state and updates the task with the matching ID.
 // Returns an error if the task ID is not found.
-func (state *InMemoryState) SetTaskStatus(id string, status string, reason string) error {
+func (state *InMemoryState) SetTaskStatus(id, status, reason string) error {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
+
+	// Registers the "postgres" SQL driver used by the database/sql-based tooling.
 	_ "github.com/lib/pq"
 	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
@@ -142,7 +144,7 @@ func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 // It takes the task ID, new status, and status reason as input parameters.
 // The updated field is set to the current UTC time.
 // Returns an error if the task ID is not found.
-func (state *PostgresState) SetTaskStatus(id string, status string, reason string) error {
+func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	uuidv4, err := uuid.Parse(id)
 	if err != nil {
 		return err

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,7 +41,7 @@ type TaskRepository interface {
 	AddTask(task models.Task) (*models.Task, error)
 	GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) ([]models.Task, int64)
 	GetTask(id string) (*models.Task, error)
-	SetTaskStatus(id string, status string, reason string) error
+	SetTaskStatus(id, status, reason string) error
 	// CancelInProgressTasks marks in-progress tasks for the given app as
 	// cancelled and returns how many were affected. A task is only cancelled when
 	// it shares at least one image name with the supplied images, so independent

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -374,7 +374,7 @@ func (repo *GitRepo) commitAndPush(ctx context.Context, fullPath, commitMsg stri
 // mergeParameters updates the `existing` parameters with values from `newContent`.
 // If a parameter from `newContent` already exists by name in `existing`, it is overwritten.
 // If it does not exist, it is appended.
-func mergeParameters(existing *ArgoOverrideFile, newContent *ArgoOverrideFile) {
+func mergeParameters(existing, newContent *ArgoOverrideFile) {
 	for _, newParam := range newContent.Helm.Parameters {
 		found := false
 		for idx, existingParam := range existing.Helm.Parameters {

--- a/web/src/features/tasks/components/AppCell.tsx
+++ b/web/src/features/tasks/components/AppCell.tsx
@@ -43,7 +43,10 @@ export const describeProject = (project: string): ProjectLinkInfo => {
   if (!isUrl) {
     return { isUrl: false, label: project };
   }
-  const stripped = project.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  let stripped = project.replace(/^https?:\/\//, '');
+  while (stripped.endsWith('/')) {
+    stripped = stripped.slice(0, -1);
+  }
   const parts = stripped.split('/').filter(Boolean);
   const host = parts[0] ?? stripped;
   const lastPath = parts.length > 1 ? parts[parts.length - 1] : '';

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -605,7 +605,10 @@ const ProjectReference = ({ project }: { project?: string | null }) => {
     return <Typography variant="body1">{project}</Typography>;
   }
 
-  const label = project.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  let label = project.replace(/^https?:\/\//, '');
+  while (label.endsWith('/')) {
+    label = label.slice(0, -1);
+  }
   return (
     <Link href={project} target="_blank" rel="noopener noreferrer">
       {label}

--- a/web/src/layout/components/AppTopBar.test.tsx
+++ b/web/src/layout/components/AppTopBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
@@ -78,9 +78,7 @@ describe('AppTopBar', () => {
     await screen.findByText('1.2.3');
 
     const user = userEvent.setup();
-    await act(async () => {
-      await user.click(screen.getByLabelText(/open configuration drawer/i));
-    });
+    await user.click(screen.getByLabelText(/open configuration drawer/i));
 
     await waitFor(() => {
       expect(screen.getByLabelText(/Workspace configuration drawer/i)).toBeInTheDocument();

--- a/web/src/layout/components/ConfigDrawer.test.tsx
+++ b/web/src/layout/components/ConfigDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HttpResponse } from '../../data/httpClient';
@@ -85,10 +85,8 @@ describe('ConfigDrawer', () => {
   it('toggles theme mode', async () => {
     renderDrawer();
     const user = userEvent.setup();
-    await act(async () => {
-      const toggleButton = await screen.findByRole('button', { name: /Switch to dark/i });
-      await user.click(toggleButton);
-    });
+    const toggleButton = await screen.findByRole('button', { name: /Switch to dark/i });
+    await user.click(toggleButton);
     expect(screen.getByTestId('theme-mode').textContent).toBe('dark');
   });
 
@@ -128,18 +126,14 @@ describe('ConfigDrawer', () => {
     await screen.findByRole('switch', { name: /toggle deploy lock/i });
 
     const user = userEvent.setup();
-    await act(async () => {
-      await user.click(screen.getByRole('switch', { name: /toggle deploy lock/i }));
-    });
+    await user.click(screen.getByRole('switch', { name: /toggle deploy lock/i }));
     expect(deployLockService.setLock).toHaveBeenCalled();
   });
 
   it('updates timezone preference when toggled', async () => {
     renderDrawer();
     const user = userEvent.setup();
-    await act(async () => {
-      await user.click(await screen.findByRole('button', { name: /Local/ }));
-    });
+    await user.click(await screen.findByRole('button', { name: /Local/ }));
 
     expect(globalThis.localStorage?.getItem('argo-watcher:timezone')).toBe('local');
   });
@@ -151,9 +145,7 @@ describe('ConfigDrawer', () => {
     });
     renderDrawer();
     const user = userEvent.setup();
-    await act(async () => {
-      await user.click(await screen.findByRole('switch', { name: /toggle deploy lock/i }));
-    });
+    await user.click(await screen.findByRole('switch', { name: /toggle deploy lock/i }));
 
     expect(deployLockService.releaseLock).toHaveBeenCalled();
     expect(notifyMock).toHaveBeenCalledWith('Deploy lock released.', { type: 'info' });

--- a/web/src/theme/ThemeModeProvider.test.tsx
+++ b/web/src/theme/ThemeModeProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { ThemeModeProvider, useThemeMode } from './ThemeModeProvider';
@@ -27,9 +27,7 @@ describe('ThemeModeProvider', () => {
     );
 
     expect(screen.getByTestId('mode').textContent).toBe('light');
-    await act(async () => {
-      await user.click(screen.getByRole('button', { name: /toggle/i }));
-    });
+    await user.click(screen.getByRole('button', { name: /toggle/i }));
     expect(screen.getByTestId('mode').textContent).toBe('dark');
   });
 });


### PR DESCRIPTION
  ## Summary
   
  Clears the actionable SonarCloud findings on `main` (33 open → 10 remaining,
  all of which are accepted false-positives to be dismissed in the UI). Every
  change is either behavior-preserving or a CI hardening tweak — no user-facing
  behavior changes.

  ## Changes
   
  **Go**
  - `refactor(server)` — split `timeWithinSchedule` into `timeAtOrAfter` /
    `timeBefore` / `dayInRange` helpers to drop below the cognitive-complexity
    threshold (S3776, CRITICAL). Verified 1:1 equivalent across all branches
    (same-day, startDay, endDay, default, week-wrap).
  - `style(go)` — group consecutive same-type params (S8209) and document the
    `golang-migrate` / `lib/pq` blank imports (S8184).

  **Frontend**
  - `refactor(web)` — replace the `/\/+$/` trailing-slash regex with an explicit
    `endsWith` loop in `AppCell.tsx` / `TaskShow.tsx` (S8786). Output is identical
    for empty, single, multiple, and all-slash inputs.
  - `test(web)` — drop redundant `act()` wrappers (and now-unused imports);
    `userEvent.setup()` already wraps interactions in `act()` (S8980 ×7).

  **CI / tooling**
  - `ci` — enforce HTTPS on the kind/kubectl/helm downloads
    (`--proto '=https' --tlsv1.2`, S6506), pin `govulncheck@v1.1.4` (S8545), and
    run `npm ci --ignore-scripts` (S6505). Only `@scarf/scarf` (telemetry) and
    macOS-only `fsevents` carry install scripts, so Linux CI is unaffected.
  - `style(docs)` — `[` → `[[` in `build-swagger.sh` (S7688).