### PR TITLE
docs: prune redundant and correct outdated code comments

### DIFF
--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -46,28 +46,24 @@ func NewArgoApi() *ArgoApi {
 
 func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 	slog.Debug("Initializing argo-watcher client...")
-	// set base url
 	api.baseUrl = serverConfig.ArgoUrl
 
-	// create cookie jar
 	jar, err := api.cookieJarFn(nil)
 	if err != nil {
 		return err
 	}
-	// prepare cookie token. This is an outbound request cookie sent to the
-	// ArgoCD API through the client's cookie jar, not a Set-Cookie response to a
-	// browser, so G124's Secure/HttpOnly/SameSite attributes do not apply — they
-	// are browser-storage directives the Go HTTP client ignores when sending.
+	// This is an outbound request cookie sent to the ArgoCD API through the
+	// client's cookie jar, not a Set-Cookie response to a browser, so G124's
+	// Secure/HttpOnly/SameSite attributes do not apply — the Go HTTP client
+	// ignores those browser-storage directives when sending.
 	cookie := &http.Cookie{ // #nosec G124
 		Name:  "argocd.token",
 		Value: serverConfig.ArgoToken,
 	}
-	// set cookies
 	jar.SetCookies(&api.baseUrl, []*http.Cookie{cookie})
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: serverConfig.SkipTlsVerify}, // #nosec G402
 	}
-	// create http client
 	api.client = &http.Client{
 		Transport: transport,
 		Jar:       jar,
@@ -76,7 +72,6 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 
 	slog.Debug("Timeout for ArgoCD API calls set", "timeout", api.client.Timeout)
 
-	// configure retry attempts for transient transport errors
 	api.maxRetries = serverConfig.ArgoApiRetries
 	slog.Debug("Max API retries set", "max_retries", api.maxRetries)
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -91,7 +91,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
 
-	// notify about the deployment start
+	// notify: deployment started
 	sendNotification(task, updater.notifier)
 
 	// start bounds the deployment-duration metric: a monotonic in-process clock over the
@@ -100,7 +100,6 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	// task.Created (whose stored unit differs across state backends).
 	start := time.Now()
 
-	// wait for application to get into deployed status or timeout
 	application, err := updater.waitForApplicationDeployment(task)
 
 	switch {
@@ -111,10 +110,8 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 		slog.Info("Deployment superseded by a newer deployment for the same app; stopping.", "id", task.Id)
 		task.Status = models.StatusCancelledMessage
 	case err != nil:
-		// handle application failure
 		updater.monitor.HandleArgoAPIFailure(&task, err)
 	default:
-		// process deployment result
 		updater.monitor.ProcessDeploymentResult(&task, application)
 	}
 
@@ -125,7 +122,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 		updater.monitor.ObserveDeploymentDuration(task.App, time.Since(start).Seconds())
 	}
 
-	// send webhook event about the deployment result
+	// notify: deployment finished
 	sendNotification(task, updater.notifier)
 }
 
@@ -145,7 +142,6 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 		return nil, err
 	}
 
-	// Save the initial application status
 	if err := updater.monitor.StoreInitialAppStatus(&task, app); err != nil {
 		return nil, err
 	}
@@ -163,7 +159,6 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 		return nil, err
 	}
 
-	// Wait for rollout completion
 	return updater.monitor.WaitRollout(task)
 }
 

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -157,7 +157,6 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 		}
 		application = app
 
-		// Early return for fire and forget mode
 		if app.IsFireAndForgetModeActive() {
 			slog.Debug("Fire and forget mode is active, skipping checks...", "id", task.Id)
 			return nil

--- a/internal/auth/keycloak.go
+++ b/internal/auth/keycloak.go
@@ -90,7 +90,6 @@ func (k *KeycloakAuthService) Validate(token string) (bool, error) {
 		}
 	}(resp.Body)
 
-	// Read and parse the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Error("keycloak: error reading userinfo response body", "error", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -52,7 +52,6 @@ func NewWatcher(baseUrl string, debugMode bool, timeout time.Duration) *Watcher 
 // addTask adds a given task to the watcher, using either JWT or a DeployToken for authorization.
 // It returns the task ID or an error.
 func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (string, error) {
-	// Marshal the task into JSON
 	requestBody, err := json.Marshal(task)
 	if err != nil {
 		return "", err
@@ -60,7 +59,6 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 
 	url := fmt.Sprintf("%s/api/v1/tasks", watcher.baseUrl)
 
-	// Create a new HTTP request with the JSON responseBody
 	request, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return "", err
@@ -68,7 +66,6 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 
 	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	// Set the deploy token header if provided
 	if authMethod != "" && token != "" {
 		switch authMethod {
 		case "JWT":
@@ -92,7 +89,6 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 		log.Printf("Adding task to argo-watcher. Equivalent cURL command: %s\n", curlCommand)
 	}
 
-	// Send the HTTP request
 	response, err := watcher.client.Do(request)
 	if err != nil {
 		return "", err
@@ -109,7 +105,6 @@ func (watcher *Watcher) addTask(task models.Task, authMethod, token string) (str
 		return "", err
 	}
 
-	// Check the HTTP status code for success
 	if response.StatusCode != http.StatusAccepted {
 		return "", serverErrorFromResponse(response.StatusCode, responseBody)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,10 +153,8 @@ func validateServerConfig(config *ServerConfig) error {
 		strings.Join(problems, "\n"))
 }
 
-// GetRetryAttempts calculates the number of retry attempts based on the Deployment timeout value in the server configuration.
-// It divides it by 15 to determine the number of 15-second intervals.
-// The calculated value is incremented by 1 to account for the initial attempt.
-// It returns the number of retry attempts as an unsigned integer.
+// GetRetryAttempts returns the number of 15-second poll attempts that fit in
+// DeploymentTimeout, plus one for the initial attempt.
 func (config *ServerConfig) GetRetryAttempts() uint {
 	return config.DeploymentTimeout/15 + 1
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -10,10 +10,8 @@ import (
 	"crypto/sha256"
 )
 
-// ImagesContains checks whether a given list of images contains a specific image.
-// It takes into account an optional registry proxy and checks both the image with
-// and without the proxy to ensure compatibility with mutating webhooks.
-// The function returns true if the image is found in the list, considering the proxy if specified; otherwise, it returns false.
+// ImagesContains reports whether images contains image. When a registry proxy is
+// set it matches the image both with and without the proxy prefix.
 func ImagesContains(images []string, image string, registryProxy string) bool {
 	if registryProxy != "" {
 		imageWithProxy := registryProxy + "/" + image
@@ -25,12 +23,10 @@ func ImagesContains(images []string, image string, registryProxy string) bool {
 	}
 }
 
-// CurlCommandFromRequest generates a cURL command string from an HTTP request,
-// including the request method, headers, request body, and URL.
-// The value of any header whose name matches redactHeaders (case-insensitively)
-// is replaced with "<redacted>" so secrets such as auth tokens are not written
-// to logs; the header name itself is kept for troubleshooting.
-// It handles any errors during the process and returns the formatted cURL command or an error if encountered.
+// CurlCommandFromRequest renders an HTTP request as an equivalent cURL command
+// (method, headers, body, URL). The value of any header whose name matches
+// redactHeaders (case-insensitively) is replaced with "<redacted>" so secrets
+// such as auth tokens are not written to logs; the header name is kept.
 func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (string, error) {
 	clonedRequest, err := httputil.DumpRequest(request, true)
 	if err != nil {
@@ -39,7 +35,6 @@ func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (str
 
 	cmd := "curl -X " + request.Method
 
-	// Iterate over request headers and add them to the cURL command
 	for key, values := range request.Header {
 		if headerMatches(key, redactHeaders) {
 			cmd += fmt.Sprintf(" -H '%s: <redacted>'", shellEscapeSingleQuote(key))
@@ -50,9 +45,8 @@ func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (str
 		}
 	}
 
-	// Add request body to cURL command
 	if len(clonedRequest) > 0 {
-		// Exclude the request line and headers when adding the body
+		// Skip past the request line and headers to the body.
 		headerEndIndex := strings.Index(string(clonedRequest), "\r\n\r\n")
 		if headerEndIndex != -1 && headerEndIndex+4 <= len(clonedRequest) {
 			body := string(clonedRequest[headerEndIndex+4:])
@@ -62,7 +56,6 @@ func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (str
 		}
 	}
 
-	// Add request URL to cURL command
 	cmd += " '" + shellEscapeSingleQuote(request.URL.String()) + "'"
 
 	return cmd, nil
@@ -88,12 +81,10 @@ func shellEscapeSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", `'\''`)
 }
 
-// GenerateHash generates a SHA256 hash from a given string.
-// It handles any errors during the process and returns the hash as []byte or an error if encountered.
+// GenerateHash returns the SHA-256 digest of s.
 func GenerateHash(s string) []byte {
 	hash := sha256.New()
-	// we intentionally ignore the error here because it will never return one
-	// if you know a way to make this return an error, please open an issue
+	// hash.Write is documented never to return an error.
 	hash.Write([]byte(s))
 	return hash.Sum(nil)
 }

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -110,35 +110,32 @@ type ApplicationSource struct {
 
 // GetRolloutStatus calculates application rollout status depending on the expected images and proxy configuration.
 func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUrl string, acceptSuspended bool) string {
-	// check if all the images rolled out
 	for _, image := range rolloutImages {
 		if !helpers.ImagesContains(app.Status.Summary.Images, image, registryProxyUrl) {
 			return ArgoRolloutAppNotAvailable
 		}
 	}
 
-	// if an application reached the degraded status, we can stop processing the task
+	// A degraded app is terminal and worth reporting, unless it is also OutOfSync
+	// (a sync is still pending and may recover).
 	if app.Status.Health.Status == "Degraded" && app.Status.Sync.Status != "OutOfSync" {
 		return ArgoRolloutAppDegraded
 	}
 
-	// verify app sync status
 	if app.Status.Sync.Status != "Synced" {
 		return ArgoRolloutAppNotSynced
 	}
 
-	// an optional check that helps when we are dealing with Rollout object that can be in a suspended state
-	// during the rollout process
+	// A Rollout object can sit in Suspended mid-rollout; treat that as success when
+	// the operator opted in via acceptSuspended.
 	if app.Status.Health.Status == "Suspended" && app.Status.Sync.Status == "Synced" && acceptSuspended {
 		return ArgoRolloutAppSuccess
 	}
 
-	// verify app health status
 	if app.Status.Health.Status != "Healthy" {
 		return ArgoRolloutAppNotHealthy
 	}
 
-	// all good
 	return ArgoRolloutAppSuccess
 }
 
@@ -152,9 +149,8 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 // are appended to both the "not available" and "not healthy"/"degraded" failures so on-call
 // users don't have to context-switch into the ArgoCD UI regardless of how the rollout failed.
 func (app *Application) GetRolloutMessage(status string, rolloutImages []string, tree *ApplicationTree) string {
-	// handle application sync failure
 	switch status {
-	// not all images were deployed to the application
+	// not all expected images were deployed
 	case ArgoRolloutAppNotAvailable:
 		// Image-mismatch is the bare minimum we always show, then append any diagnostics.
 		base := fmt.Sprintf(
@@ -167,9 +163,8 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 		)
 		// Base message has no resource listing, so fall back to Status.Resources when no tree.
 		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, true))
-	// application sync status wasn't valid
+	// sync status was not "Synced"
 	case ArgoRolloutAppNotSynced:
-		// display sync status and last sync message
 		return fmt.Sprintf(
 			"App status \"%s\"\n"+
 				"App message \"%s\"\n"+
@@ -179,7 +174,7 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 			app.Status.OperationState.Message,
 			strings.Join(app.ListSyncResultResources(), "\n\t"),
 		)
-	// application is not in a healthy status
+	// app is unhealthy or degraded
 	case ArgoRolloutAppNotHealthy, ArgoRolloutAppDegraded:
 		// display current health of the top-level resources, then append the same
 		// diagnostics as the "not available" path — a stalled rollout caused by a
@@ -198,7 +193,6 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, false))
 	}
 
-	// handle unexpected status
 	return fmt.Sprintf(
 		"received unexpected rollout status \"%s\"",
 		status,
@@ -221,10 +215,8 @@ func formatSyncResultResource(r ApplicationOperationResource) string {
 	return fmt.Sprintf("%s(%s) %s %s with message %s", r.Kind, r.Name, r.HookType, r.HookPhase, r.Message)
 }
 
-// ListSyncResultResources returns a list of strings representing the sync result resources of the application.
-// Each string in the list contains information about the resource's kind, name, hook type, hook phase, and message.
-// The information is formatted as "{kind}({name}) {hookType} {hookPhase} with message {message}".
-// The list is generated based on the Application's status and its operation state's sync result resources.
+// ListSyncResultResources returns one formatted line per sync-result resource
+// (see formatSyncResultResource for the format).
 func (app *Application) ListSyncResultResources() []string {
 	list := make([]string, len(app.Status.OperationState.SyncResult.Resources))
 	for index := range app.Status.OperationState.SyncResult.Resources {
@@ -243,11 +235,8 @@ func formatHealthResource(r ApplicationResource) string {
 	return line
 }
 
-// ListUnhealthyResources returns a list of strings representing the unhealthy resources of the application.
-// Each string in the list contains information about the resource's kind, name, and health status.
-// If available, the resource's health message is also included in the string.
-// The format of each string is "{kind}({name}) {status}" or "{kind}({name}) {status} with message {message}".
-// The list is generated based on the Application's status and its resources with non-empty health status.
+// ListUnhealthyResources returns one formatted line per resource with a non-empty
+// health status (see formatHealthResource for the format).
 func (app *Application) ListUnhealthyResources() []string {
 	var list []string
 
@@ -376,8 +365,7 @@ func (app *Application) buildFailureDiagnostics(tree *ApplicationTree, allowStat
 	return strings.Join(sections, "\n\n")
 }
 
-// IsManagedByWatcher checks if the application is managed by the watcher.
-// It checks if the application's metadata contains the "argo-watcher/managed" annotation with the value "true".
+// IsManagedByWatcher reports whether the app carries the "argo-watcher/managed=true" annotation.
 func (app *Application) IsManagedByWatcher() bool {
 	if app.Metadata.Annotations == nil {
 		return false

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -38,9 +38,7 @@ type Task struct {
 	SavedAppStatus   SavedAppStatus `json:"-"`
 }
 
-// ListImages returns a list of strings representing the images of the task.
-// Each string in the list is in the format "{image}:{tag}".
-// The list is generated based on the Task's Images field.
+// ListImages returns the task's images formatted as "{image}:{tag}".
 func (task *Task) ListImages() []string {
 	list := make([]string, len(task.Images))
 	for index := range task.Images {
@@ -49,13 +47,12 @@ func (task *Task) ListImages() []string {
 	return list
 }
 
-// IsAppNotFoundError check if app not found error.
+// IsAppNotFoundError reports whether err means ArgoCD does not have this app.
 func (task *Task) IsAppNotFoundError(err error) bool {
 	var appNotFoundError = fmt.Sprintf("applications.argoproj.io \"%s\" not found", task.App)
 
-	// starting from ArgoCD 2.6.7 we are affected by this issue: https://github.com/argoproj/argo-cd/issues/13000
-	// although it is closed as completed, it is not fixed, so it seems to be a mistake
-	// from now on we consider "permission denied" as app not found error as this is what argocd returns in such cases
+	// Since ArgoCD 2.6.7 a missing app can also surface as "permission denied"
+	// (argoproj/argo-cd#13000, closed but not actually fixed), so treat both as not-found.
 	return strings.Contains(err.Error(), appNotFoundError) || strings.Contains(err.Error(), "permission denied")
 }
 

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -14,22 +14,14 @@ import (
 
 // Env reference: https://www.alexedwards.net/blog/organising-database-access
 type Env struct {
-	// environment configurations
-	config *config.ServerConfig
-	// argo argo
-	argo *argocd.Argo
-	// argo updater
-	updater *argocd.ArgoStatusUpdater
-	// metrics
-	metrics *prometheus.Metrics
-	// deploy lock
-	lockdown *Lockdown
-	// enabled auth strategies
-	strategies map[string]auth.AuthStrategy
-	// authenticator orchestrates registered strategies
+	config        *config.ServerConfig
+	argo          *argocd.Argo
+	updater       *argocd.ArgoStatusUpdater
+	metrics       *prometheus.Metrics
+	lockdown      *Lockdown
+	strategies    map[string]auth.AuthStrategy
 	authenticator *auth.Authenticator
-	// shutdownCh signals graceful shutdown to all WebSocket goroutines.
-	// Using a channel instead of storing context.Context follows Go best practices.
+	// shutdownCh is closed to signal graceful shutdown to all WebSocket goroutines.
 	shutdownCh chan struct{}
 	// shutdownOnce ensures Shutdown() can be called multiple times safely.
 	shutdownOnce sync.Once
@@ -148,8 +140,8 @@ func (env *Env) Shutdown() {
 	}
 }
 
-// NewEnv initializes a new Env instance.
-// This function is used to set up the environment for the application's main operation, including setting configurations, initializing Argo service, and metrics.
+// NewEnv wires up an Env from the server config: lockdown schedules and the
+// enabled auth strategies (deploy token, optional Keycloak, optional JWT).
 func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater) (*Env, error) {
 	var env *Env
 	var err error

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -60,7 +60,7 @@ func (env *Env) addTask(c *gin.Context) {
 		return
 	}
 
-	// we need to handle cases when deploy lock is set either manually or by cron
+	// reject deploys while a lockdown (manual or scheduled) is active
 	if env.lockdown.IsLocked() {
 		slog.Warn("deploy lock is set, rejecting the task")
 		c.JSON(http.StatusNotAcceptable, models.TaskStatus{
@@ -95,10 +95,8 @@ func (env *Env) addTask(c *gin.Context) {
 		return
 	}
 
-	// start rollout monitor
 	go env.updater.WaitForRollout(*newTask)
 
-	// return information about created task
 	c.JSON(http.StatusAccepted, models.TaskStatus{
 		Id:     newTask.Id,
 		Status: models.StatusAccepted,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,31 +33,26 @@ type Server struct {
 
 // NewServer creates a new server instance with the given configuration and prometheus registerer.
 func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*Server, error) {
-	// initialize logs
 	logging.Init(serverConfig.LogLevel)
-
-	// initialize metrics on the provided prometheus registry
 	metrics := prom.NewMetrics(reg)
 
-	// create API client
 	api := argocd.NewArgoApi()
 	if err := api.Init(serverConfig); err != nil {
 		return nil, err
 	}
 
-	// create state management
 	s, err := state.NewState(serverConfig)
 	if err != nil {
 		return nil, err
 	}
-	// start cleanup go routine
+	// Background cleanup of obsolete tasks.
 	go s.ProcessObsoleteTasks(0)
 
-	// initialize argo client
 	argo := &argocd.Argo{}
 	argo.Init(s, api, metrics)
 
-	// Create the locker instance based on the state type
+	// The distributed Postgres locker requires the Postgres state; otherwise fall
+	// back to an in-memory lock (single-instance only).
 	var locker lock.Locker
 	if serverConfig.StateType == "postgres" {
 		pgState, ok := s.(*state.PostgresState)
@@ -75,7 +70,6 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		slog.Warn("Using in-memory lock. This is not suitable for HA setups.")
 	}
 
-	// initialize argo updater
 	updater := &argocd.ArgoStatusUpdater{}
 	err = updater.Init(*argo, argocd.ArgoStatusUpdaterConfig{
 		RetryAttempts:    serverConfig.GetRetryAttempts(),
@@ -92,13 +86,11 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		return nil, fmt.Errorf("failed to initialize the argo updater: %w", err)
 	}
 
-	// create environment
 	env, err := NewEnv(serverConfig, argo, metrics, updater)
 	if err != nil {
 		return nil, err
 	}
 
-	// create router
 	router := env.CreateRouter()
 
 	// Keep the argocd_unavailable metric fresh via a background probe. The task
@@ -135,7 +127,6 @@ func (s *Server) Run() {
 	// or hide the "ArgoCD unreachable" banner (issue #498).
 	s.env.StartArgoWatcher()
 
-	// Start server in goroutine
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("failed to start server", "error", err)

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -121,7 +121,6 @@ func (env *Env) handleWebSocketConnection(c *gin.Context) {
 	env.connWg.Add(1)
 	defer env.connWg.Done()
 
-	// Create wrapper with pre-hijacked connection
 	wrappedWriter := &wsResponseWriter{
 		ResponseWriter: c.Writer,
 		conn:           netConn,
@@ -175,11 +174,8 @@ func (env *Env) checkConnection(c *websocket.Conn) {
 	}
 }
 
-// notifyWebSocketClients is a function that sends a message to all active WebSocket clients.
-// It iterates over the global connections slice, which contains all active WebSocket connections,
-// and sends the provided message to each connection using the wsjson.Write function.
-// If an error occurs while sending the message to a connection (for example, if the connection has been closed),
-// it removes the connection from the connections slice to prevent further attempts to send messages to it.
+// notifyWebSocketClients sends message to every active WebSocket connection.
+// A connection that fails the write is closed and removed from the slice.
 func notifyWebSocketClients(message string) {
 	var wg sync.WaitGroup
 
@@ -211,11 +207,8 @@ func notifyWebSocketClients(message string) {
 	wg.Wait()
 }
 
-// removeWebSocketConnection is a helper function that removes a WebSocket connection
-// from the global connections slice. It is used to clean up connections that are no longer active.
-// The function takes a WebSocket connection as an argument and removes it from the connections slice.
-// It uses a mutex to prevent concurrent access to the connections slice, ensuring thread safety.
-// Note: Callers are responsible for closing the connection before calling this function.
+// removeWebSocketConnection removes conn from the global connections slice under
+// the mutex. Callers are responsible for closing the connection first.
 func removeWebSocketConnection(conn *websocket.Conn) {
 	connectionsMutex.Lock()
 	defer connectionsMutex.Unlock()

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -30,17 +30,14 @@ type InMemoryState struct {
 
 var _ TaskRepository = (*InMemoryState)(nil)
 
-// Connect is a placeholder method that does not establish any connection.
-// It logs a debug message indicating that the InMemoryState does not connect to anything and skips the connection process.
-// This method exists to fulfill the TaskRepository interface requirement and has no functional value.
+// Connect is a no-op that exists only to satisfy the TaskRepository interface.
 func (state *InMemoryState) Connect(serverConfig *config.ServerConfig) error {
 	slog.Debug("InMemoryState does not connect to anything. Skipping.")
 	return nil
 }
 
-// AddTask adds a new task to the in-memory repository.
-// It takes a models.Task parameter, updates timestamps and status, and appends the task to the list of tracked tasks.
-// The method returns the newly created task and a nil error because the in-memory implementation does not surface persistence failures.
+// AddTask assigns an id, timestamps, and in-progress status, then appends the
+// task. The error is always nil; in-memory storage has no persistence failure.
 func (state *InMemoryState) AddTask(task models.Task) (*models.Task, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -118,10 +115,7 @@ func (state *InMemoryState) GetTasks(startTime float64, endTime float64, app str
 	return paginate(tasks, limit, offset), int64(len(tasks))
 }
 
-// GetTask retrieves a task from the in-memory state based on the provided task ID.
-// It takes a string parameter for the task ID.
-// The method iterates over the tasks in the in-memory state and returns the task if a matching ID is found.
-// If no task with the given ID is found, it returns ErrTaskNotFound.
+// GetTask returns the task with the given id, or ErrTaskNotFound if none matches.
 func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
@@ -134,10 +128,8 @@ func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	return nil, ErrTaskNotFound
 }
 
-// SetTaskStatus updates the status and status reason of a task in the in-memory state based on the provided task ID.
-// It takes a string parameter for the task ID, status, and reason.
-// The method iterates over the tasks in the in-memory state and updates the task with the matching ID.
-// Returns an error if the task ID is not found.
+// SetTaskStatus updates the status and status reason of the task with the given
+// id, or returns an error if no task matches.
 func (state *InMemoryState) SetTaskStatus(id, status, reason string) error {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -176,16 +168,14 @@ func (state *InMemoryState) CancelInProgressTasks(app string, images []models.Im
 	return count, nil
 }
 
-// Check is a placeholder method that implements the Check() bool interface.
-// It always returns true and does not perform any actual state checking.
-// This method exists to fulfill the TaskRepository interface requirement and has no functional value.
+// Check always returns true; in-memory storage is always available.
 func (state *InMemoryState) Check() bool {
 	return true
 }
 
-// ProcessObsoleteTasks scans the in-memory tasks for obsolete tasks and updates their status.
-// It starts a process to watch for obsolete tasks by invoking the `processInMemoryObsoleteTasks` function.
-// The function uses the `retry` package to periodically retry the task processing with a fixed delay of 60 minutes.
+// ProcessObsoleteTasks runs processInMemoryObsoleteTasks every
+// ObsoleteTaskCheckInterval. retryTimes bounds the number of runs; 0 means run
+// forever (the production case). It is meant to run in its own goroutine.
 func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
 	slog.Debug("Starting watching for obsolete tasks...")
 	err := retry.Do(
@@ -204,13 +194,8 @@ func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
 	}
 }
 
-// processInMemoryObsoleteTasks processes a list of tasks and updates their status based on specific conditions.
-// It takes a slice of models.Task as input and returns a new slice of updated tasks.
-// The function iterates over the tasks and checks for specific status conditions.
-// If a task has a status of "app not found", it is skipped and excluded from the updated tasks.
-// If a task has a status of "in progress" and the updated timestamp plus 3600 seconds is less than the current Unix timestamp,
-// the task's status is updated to "aborted".
-// The function collects the updated tasks and returns them as a new slice.
+// processInMemoryObsoleteTasks returns tasks with "app not found" entries dropped
+// and "in progress" entries older than TaskStaleThresholdSeconds marked "aborted".
 func processInMemoryObsoleteTasks(tasks []models.Task) []models.Task {
 	var updatedTasks []models.Task
 	for _, task := range tasks {

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -36,7 +36,6 @@ var _ TaskRepository = (*PostgresState)(nil)
 // unreachable rather than blocking on the OS TCP timeout.
 func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 	slog.Info("Connecting to PostgreSQL database...")
-	// create ORM driver
 	if orm, err := gorm.Open(postgres.Open(serverConfig.Db.DSN)); err != nil {
 		return err
 	} else {
@@ -45,9 +44,7 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 	return nil
 }
 
-// AddTask inserts a new task into the PostgreSQL database with the provided details.
-// It takes a models.Task parameter and returns an error if the insertion fails.
-// The method executes an INSERT query to add a new record with the task details, including the current UTC time.
+// AddTask inserts a new in-progress task and returns it with the DB-generated id and creation time.
 func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 	ormTask := state_models.TaskModel{
 		Images:           datatypes.NewJSONSlice(task.Images),
@@ -64,7 +61,6 @@ func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 		return nil, fmt.Errorf("failed to create task in database")
 	}
 
-	// pass new values to the task object
 	task.Id = ormTask.Id.String()
 	task.Created = float64(ormTask.Created.UnixMilli())
 	task.Status = models.StatusInProgressMessage
@@ -116,12 +112,9 @@ func (state *PostgresState) GetTasks(startTime float64, endTime float64, app str
 	return tasks, total
 }
 
-// GetTask retrieves a task from the PostgreSQL database based on the provided task ID.
-// It returns ErrTaskNotFound when the id is malformed or no matching row exists,
-// and a wrapped error for any other retrieval failure so callers can distinguish
-// 404 from 500.
-// The method executes a SELECT query with the given task ID and scans the result into the task struct.
-// It handles converting the created and updated timestamps to float64 values and unmarshalling the images from the database.
+// GetTask retrieves a task by id. It returns ErrTaskNotFound when the id is
+// malformed or no matching row exists, and a wrapped error for any other
+// retrieval failure so callers can distinguish 404 from 500.
 func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 	// The id column is a uuid, so a malformed id can never match a row. Treat it
 	// as not-found instead of letting Postgres raise a syntax error, which would
@@ -140,10 +133,8 @@ func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 	return ormTask.ConvertToExternalTask(), nil
 }
 
-// SetTaskStatus updates the status, status_reason, and updated fields of a task in the PostgreSQL database.
-// It takes the task ID, new status, and status reason as input parameters.
-// The updated field is set to the current UTC time.
-// Returns an error if the task ID is not found.
+// SetTaskStatus updates a task's status and status_reason. It returns an error
+// if the id is malformed or no matching task exists.
 func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	uuidv4, err := uuid.Parse(id)
 	if err != nil {
@@ -201,9 +192,7 @@ func (state *PostgresState) CancelInProgressTasks(app string, images []models.Im
 	return result.RowsAffected, nil
 }
 
-// Check verifies the connection to the PostgreSQL database by executing a simple test query.
-// It returns true if the database connection is successful and the test query is executed without errors.
-// It returns false if there is an error in the database connection or the test query execution.
+// Check reports whether the database connection is alive by pinging it.
 func (state *PostgresState) Check() bool {
 	connection, err := state.orm.DB()
 	if err != nil {
@@ -219,10 +208,9 @@ func (state *PostgresState) Check() bool {
 	return true
 }
 
-// ProcessObsoleteTasks monitors and handles obsolete tasks in the PostgreSQL state.
-// It initiates a process to remove tasks with a status of 'app not found' and mark tasks older than 1 hour as 'aborted'.
-// The function utilizes retry logic to handle potential errors and retry the process if necessary.
-// The retry interval is set to 60 minutes, and the retry attempts are set to 0 (no limit).
+// ProcessObsoleteTasks runs doProcessPostgresObsoleteTasks every
+// ObsoleteTaskCheckInterval. retryTimes bounds the number of runs; 0 means run
+// forever (the production case). It is meant to run in its own goroutine.
 func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	slog.Debug("Starting watching for obsolete tasks...")
 	err := retry.Do(
@@ -243,10 +231,8 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	}
 }
 
-// processPostgresObsoleteTasks processes and handles obsolete tasks in the PostgreSQL database.
-// It removes tasks with a status of 'app not found' and marks tasks older than 1 hour as 'aborted'.
-// The function expects a valid *sql.DB connection to the PostgreSQL database.
-// It returns an error if any database operation encounters an error; otherwise, it returns nil.
+// doProcessPostgresObsoleteTasks deletes "app not found" tasks older than 1 hour
+// and marks "in progress" tasks older than 1 hour as "aborted".
 func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 	slog.Debug("Removing obsolete tasks...")
 

--- a/internal/updater/interfaces.go
+++ b/internal/updater/interfaces.go
@@ -78,15 +78,12 @@ func (GitClient) AddSSHKey(user, path, passphrase string) (*ssh.PublicKeys, erro
 // validateSSHKeyFile validates that the SSH key file exists, is readable,
 // is not empty, and contains a valid SSH private key format.
 func validateSSHKeyFile(path string) error {
-	// Check if path is provided
 	if path == "" {
 		return ErrSSHKeyNotProvided
 	}
 
-	// Normalize the path to prevent directory traversal attacks
 	path = filepath.Clean(path)
 
-	// Check if file exists
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -95,29 +92,24 @@ func validateSSHKeyFile(path string) error {
 		return fmt.Errorf("failed to stat SSH key file: %w", err)
 	}
 
-	// Check if path points to a file (not a directory)
 	if info.IsDir() {
 		return fmt.Errorf("SSH key path is a directory, not a file: %s", path)
 	}
 
-	// Check if file is not empty
 	if info.Size() == 0 {
 		return fmt.Errorf("%w: %s", ErrSSHKeyEmpty, path)
 	}
 
-	// Read and validate key format
 	keyData, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return fmt.Errorf("failed to read SSH key file: %w", err)
 	}
 
-	// Attempt to parse the private key to validate its format
 	_, err = cryptossh.ParsePrivateKey(keyData)
 	if err != nil {
-		// Check if it's a passphrase-protected key
+		// An encrypted key is valid; the passphrase is applied later at clone time.
 		var passphraseErr *cryptossh.PassphraseMissingError
 		if errors.As(err, &passphraseErr) {
-			// Key is valid but encrypted - this is OK, the passphrase will be used later
 			return nil
 		}
 		return fmt.Errorf("invalid SSH key format: %w", err)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -129,14 +129,7 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 			}
 		}
 
-		// Depth:1 makes this a shallow clone: only the branch tip commit is
-		// fetched, not the repository's full history. argo-watcher only ever reads
-		// the tip and commits one file on top of it, so history is dead weight. On a
-		// deep-history GitOps repo (100k+ commits) a full clone is minutes of work,
-		// and it runs while holding the distributed per-repo advisory lock — so it
-		// blocks every other replica's write-back to that repo. A shallow clone caps
-		// that to seconds. Tags:NoTags likewise skips fetching tag refs, which a
-		// large repo may have thousands of and which are never used here.
+		// Shallow, single-branch, no tags — see the Clone doc comment for why.
 		repo.localRepo, err = repo.GitHandler.PlainClone(ctx, repo.localRepoPath, false, &git.CloneOptions{
 			URL:           repo.RepoURL,
 			ReferenceName: plumbing.ReferenceName("refs/heads/" + repo.BranchName),
@@ -150,10 +143,8 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 
 	// If we get here, the cache is valid and has an 'origin' remote.
 	slog.Debug("Successfully opened cached repository", "path", repo.localRepoPath)
-	// Depth:1 keeps the cache shallow across warm fetches too: only the new tip
-	// is fetched, never the intervening history. Without it go-git would deepen
-	// the shallow clone toward full history on the first fetch, undoing the cold
-	// clone's win on a deep-history repo. Tags:NoTags mirrors the clone.
+	// Keep the fetch shallow too; otherwise go-git deepens the clone toward full
+	// history on the first fetch, undoing the shallow clone's win.
 	err = repo.localRepo.FetchContext(ctx, &git.FetchOptions{
 		RemoteName: "origin",
 		Auth:       repo.sshAuth,
@@ -267,7 +258,6 @@ func assertInsideRoot(root, path string) error {
 // merges the new parameter overrides into it. If no file exists, it returns the
 // new content directly.
 func (repo *GitRepo) mergeOverrideFileContent(fullPath string, overrideContent *ArgoOverrideFile) (*ArgoOverrideFile, error) {
-	// If the file doesn't exist, there's nothing to merge.
 	existingContent, err := os.ReadFile(fullPath) // #nosec G304 -- path already validated by assertInsideRoot in UpdateApp
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -276,13 +266,11 @@ func (repo *GitRepo) mergeOverrideFileContent(fullPath string, overrideContent *
 		return nil, fmt.Errorf("failed to read existing override file: %w", err)
 	}
 
-	// Unmarshal the YAML content into a struct.
 	existingOverrideFile := ArgoOverrideFile{}
 	if err := yaml.Unmarshal(existingContent, &existingOverrideFile); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal existing override file: %w", err)
 	}
 
-	// Merge the new parameters into the existing ones.
 	mergeParameters(&existingOverrideFile, overrideContent)
 
 	return &existingOverrideFile, nil
@@ -298,26 +286,21 @@ func (repo *GitRepo) commitAndPush(ctx context.Context, fullPath, commitMsg stri
 		return err
 	}
 
-	// Marshal the final merged content.
 	contentBytes, err := yaml.Marshal(overrideContent)
 	if err != nil {
 		return err
 	}
 
-	// Detect "nothing to commit" with a single-file byte compare instead of a
-	// full-worktree scan. Clone() hard-resets the worktree to origin HEAD before every
-	// attempt, and this override file is the only path argo-watcher ever writes, so the
-	// on-disk bytes equalling what we are about to write is equivalent to
-	// worktree.Status().IsClean() for our purposes — but O(1 file) instead of O(entire
-	// repo). On a large GitOps repo that whole-tree scan dominates the per-task cost, and
-	// it is paid serially for every concurrent task holding the per-repo lock in turn.
+	// Detect "nothing to commit" with a single-file byte compare instead of
+	// worktree.Status(). Clone() hard-resets to origin HEAD and this override file is
+	// the only path we write, so equal bytes mean a clean worktree — but O(1 file)
+	// instead of scanning the whole repo, which dominates the cost on a large repo.
 	// #nosec G304 -- path already validated by assertInsideRoot in UpdateApp
 	if existing, readErr := os.ReadFile(fullPath); readErr == nil && bytes.Equal(existing, contentBytes) {
 		slog.Debug("No changes detected. Skipping commit.")
 		return nil
 	}
 
-	// Write the final merged content to the override file.
 	if err := os.WriteFile(fullPath, contentBytes, 0600); err != nil {
 		return fmt.Errorf("failed to write override file: %w", err)
 	}
@@ -334,7 +317,6 @@ func (repo *GitRepo) commitAndPush(ctx context.Context, fullPath, commitMsg stri
 		return err
 	}
 
-	// Commit the changes with the configured author details.
 	commitOpts := &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  repo.gitConfig.SshCommitUser,

--- a/web/src/features/tasks/RecentTasksList.tsx
+++ b/web/src/features/tasks/RecentTasksList.tsx
@@ -11,7 +11,6 @@ const DEFAULT_PER_PAGE = 25;
 /**
  * Recent tasks list routed at `/` providing sortable columns, pagination, application filtering, and auto-refresh controls.
  */
-/** React-admin list page for the "recent" task feed. */
 export const RecentTasksList = () => {
   useEffect(() => {
     const previousTitle = document.title;

--- a/web/src/layout/AppLayout.tsx
+++ b/web/src/layout/AppLayout.tsx
@@ -3,10 +3,6 @@ import { Layout, type LayoutProps, type SidebarProps } from 'react-admin';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { AppTopBar } from './components/AppTopBar';
 
-/**
- * Custom application layout ensuring the branded AppBar sits flush with the viewport while
- * delegating the rest of the shell concerns to React-admin.
- */
 /** Removes the default react-admin top margin so our custom app bar sits flush. */
 const layoutSx: SxProps<Theme> = theme => ({
   '& .RaLayout-appFrame': {

--- a/web/src/shared/providers/AppProviders.tsx
+++ b/web/src/shared/providers/AppProviders.tsx
@@ -11,8 +11,8 @@ interface AppProvidersProps {
 }
 
 /**
- * Hosts global React providers required by the React-admin workspace.
- * Future phases will extend this with Keycloak, deploy-lock, and notification contexts.
+ * Hosts the global React providers (theme, timezone, ArgoCD-status, deploy-lock)
+ * that wrap the React-admin workspace.
  */
 export const AppProviders = ({ children }: AppProvidersProps) => (
   <ThemeModeProvider>

--- a/web/src/theme/index.ts
+++ b/web/src/theme/index.ts
@@ -2,9 +2,6 @@ import type { PaletteMode, ThemeOptions } from '@mui/material';
 import { createTheme, lighten } from '@mui/material/styles';
 import { tokens } from './tokens';
 
-/**
- * Reuses the legacy UI branding tokens so both frontends stay visually aligned.
- */
 /** Derives the design tokens (palette, typography, overrides) for the requested palette mode. */
 const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   palette: {


### PR DESCRIPTION
Housekeeping sweep over Go and frontend comments: remove comments that merely restate the code, tighten over-communicated docstrings, and fix a few that had drifted from the implementation. No behavior change.

Notable: collapse duplicated shallow-clone rationale in the git updater, trim the SQL-narration docstrings in the state package, fix helpers.GenerateHash (documented a nonexistent error return), and correct stale frontend comments (AppProviders "future phases", theme "both frontends"). Hard-won "why" comments — perf, security, race/shutdown ordering, issue references — were deliberately preserved.