### PR TITLE
fix(argocd): classify all ArgoCD-unreachable outages as aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   count toward `failed_deployment` (a deployment that could not be confirmed is
   still a failure); the `argocd_unavailable` metric indicates when Argo CD itself
   was the cause.
-- The CLI client now reports the `aborted` status with a clear message ("The
-  deployment could not be confirmed because ArgoCD was unreachable") instead of
-  the misleading "unexpected deployment status … the client may be out of date".
-  The non-zero exit code is unchanged.
+- The CLI client now reports the `aborted` status with a clear message and the
+  task's status reason, instead of the misleading "unexpected deployment status …
+  the client may be out of date". The non-zero exit code is unchanged.
+- Stale in-progress tasks aborted by the obsolete-task sweep now record a status
+  reason ("did not complete within the staleness window"), distinguishing them
+  from deployments aborted because Argo CD was unreachable.
 
 ## [0.12.2] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- A deployment is no longer counted in the `failed_deployment` metric when it is
+  aborted because Argo CD itself was unreachable; that case is tracked by
+  `argocd_unavailable` instead, so alerts built on `failed_deployment` no longer
+  fire on infrastructure outages.
+
+### Fixed
+
+- Deployments now report the `aborted` status (rather than `failed`) for the full
+  range of Argo CD connectivity failures — request timeouts, DNS and TLS errors,
+  and `5xx` responses from Argo CD or a proxy in front of it — not only a refused
+  TCP connection. Previously these transient outages were misrecorded as
+  application deployment failures.
+
 ## [0.12.2] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   count toward `failed_deployment` (a deployment that could not be confirmed is
   still a failure); the `argocd_unavailable` metric indicates when Argo CD itself
   was the cause.
+- The CLI client now reports the `aborted` status with a clear message ("The
+  deployment could not be confirmed because ArgoCD was unreachable") instead of
+  the misleading "unexpected deployment status … the client may be out of date".
+  The non-zero exit code is unchanged.
 
 ## [0.12.2] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- A deployment is no longer counted in the `failed_deployment` metric when it is
-  aborted because Argo CD itself was unreachable; that case is tracked by
-  `argocd_unavailable` instead, so alerts built on `failed_deployment` no longer
-  fire on infrastructure outages.
-
 ### Fixed
 
-- Deployments now report the `aborted` status (rather than `failed`) for the full
-  range of Argo CD connectivity failures — request timeouts, DNS and TLS errors,
-  and `5xx` responses from Argo CD or a proxy in front of it — not only a refused
-  TCP connection. Previously these transient outages were misrecorded as
-  application deployment failures.
+- Argo CD connectivity failures during a deployment check — request timeouts, DNS
+  and TLS errors, and `5xx` responses from Argo CD or a proxy in front of it — are
+  now consistently reported with the `aborted` status and a descriptive reason,
+  matching the existing behaviour for a refused TCP connection. Previously only a
+  refused connection was recognised and the other outages surfaced as a generic
+  `failed` status that blamed the application. Aborted deployments continue to
+  count toward `failed_deployment` (a deployment that could not be confirmed is
+  still a failure); the `argocd_unavailable` metric indicates when Argo CD itself
+  was the cause.
 
 ## [0.12.2] - 2026-07-21
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -27,7 +27,7 @@ A task in Argo Watcher moves through the following states:
 3. **Deployed** — Deployment succeeded; application is healthy and synced.
 4. **Failed** — Deployment did not become healthy and synced before `DEPLOYMENT_TIMEOUT` elapsed, or Argo CD reported a health/sync failure.
 5. **App Not Found** — Argo CD has no application with the requested name (or the token lacks permission to see it).
-6. **Aborted** — Argo CD (or a proxy in front of it) was unreachable during the check: connection refused, DNS failure, TLS error, a timed-out API request, or a 5xx response. The application's own state is unknown, so this is not counted as a deployment failure — `failed_deployment` is not incremented (see `argocd_unavailable` in [Observability](../operations/observability.md)).
+6. **Aborted** — Argo Watcher could not confirm the deployment's outcome: Argo CD (or a proxy in front of it) was unreachable during the check (connection refused, DNS failure, TLS error, a timed-out API request, or a 5xx response), or the task remained in progress past the staleness window. The status reason records the cause. An aborted deployment still counts as a failure (`failed_deployment`); the `argocd_unavailable` gauge indicates when Argo CD itself was the reason.
 7. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. Unlike Failed, a cancelled task is not counted as a deployment failure.
 
 ## Deployment Locking

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -25,8 +25,10 @@ A task in Argo Watcher moves through the following states:
 1. **Pending** — Task created, waiting for the expected image to appear in Argo CD.
 2. **In Progress** — Image detected in Argo CD, deployment is syncing or running.
 3. **Deployed** — Deployment succeeded; application is healthy and synced.
-4. **Failed** — Deployment failed due to health/sync issues or timeout.
-5. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. Unlike Failed, a cancelled task is not counted as a deployment failure.
+4. **Failed** — Deployment did not become healthy and synced before `DEPLOYMENT_TIMEOUT` elapsed, or Argo CD reported a health/sync failure.
+5. **App Not Found** — Argo CD has no application with the requested name (or the token lacks permission to see it).
+6. **Aborted** — Argo CD (or a proxy in front of it) was unreachable during the check: connection refused, DNS failure, TLS error, a timed-out API request, or a 5xx response. The application's own state is unknown, so this is not counted as a deployment failure — `failed_deployment` is not incremented (see `argocd_unavailable` in [Observability](../operations/observability.md)).
+7. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. Unlike Failed, a cancelled task is not counted as a deployment failure.
 
 ## Deployment Locking
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -16,7 +16,7 @@ The server emits eight metrics today, all defined in [`internal/prometheus/metri
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. |
+| `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. Deployments aborted because Argo CD itself was unreachable (connection refused, timeout, DNS/TLS failure, or a 5xx response) are excluded — those are tracked via `argocd_unavailable` instead. |
 | `processed_deployments` | counter | `app` | Total deployments processed since server startup, per application. |
 | `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. The same cached state drives the Web UI's "ArgoCD unreachable" banner and is exposed as a plain boolean via `GET /api/v1/argocd-status` for external polling. |
 | `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -16,7 +16,7 @@ The server emits eight metrics today, all defined in [`internal/prometheus/metri
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. Deployments aborted because Argo CD itself was unreachable (connection refused, timeout, DNS/TLS failure, or a 5xx response) are excluded — those are tracked via `argocd_unavailable` instead. |
+| `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. Includes deployments aborted because Argo CD was unreachable — a deployment that could not be confirmed counts as failed regardless of cause; `argocd_unavailable` separately indicates whether Argo CD itself was the reason. |
 | `processed_deployments` | counter | `app` | Total deployments processed since server startup, per application. |
 | `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. The same cached state drives the Web UI's "ArgoCD unreachable" banner and is exposed as a plain boolean via `GET /api/v1/argocd-status` for external polling. |
 | `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -34,7 +34,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
 - The client timed out waiting for the deployment to complete.
 - Argo CD (or the state backend) is unreachable — the server now fails the submission fast with a `503` `{"status":"down"}` response instead of hanging until the client's own HTTP timeout, and the Web UI shows an "ArgoCD unreachable" banner until connectivity is restored.
-- Argo CD became unreachable *during* the deployment check (timeout, DNS/TLS error, connection refused, or a `5xx` response). The task is recorded as `aborted` and the client logs `The deployment could not be confirmed because ArgoCD was unreachable`. The application itself may be healthy — check Argo CD directly before blaming the deployment.
+- Argo CD became unreachable *during* the deployment check (timeout, DNS/TLS error, connection refused, or a `5xx` response). The task is recorded as `aborted` and the client logs `The deployment was aborted before its outcome could be confirmed. See the reason below.` followed by the task's status reason (e.g. `ArgoCD API Error: ...`). The application itself may be healthy — check Argo CD directly before blaming the deployment.
 - A newer deployment of one of the same images was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). Only tasks sharing an image with the newer deployment are cancelled; independent per-image deployments of the same application do not cancel each other. This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
 
 **How to verify:**

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -34,6 +34,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 - The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
 - The client timed out waiting for the deployment to complete.
 - Argo CD (or the state backend) is unreachable — the server now fails the submission fast with a `503` `{"status":"down"}` response instead of hanging until the client's own HTTP timeout, and the Web UI shows an "ArgoCD unreachable" banner until connectivity is restored.
+- Argo CD became unreachable *during* the deployment check (timeout, DNS/TLS error, connection refused, or a `5xx` response). The task is recorded as `aborted` and the client logs `The deployment could not be confirmed because ArgoCD was unreachable`. The application itself may be healthy — check Argo CD directly before blaming the deployment.
 - A newer deployment of one of the same images was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). Only tasks sharing an image with the newer deployment are cancelled; independent per-image deployments of the same application do not cancel each other. This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
 
 **How to verify:**

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -33,8 +33,6 @@ const rollbackHistoryWindow = 100
 const (
 	// ArgoAPIErrorTemplate is the template for ArgoCD API errors.
 	ArgoAPIErrorTemplate = "ArgoCD API Error: %s"
-	// argoUnavailableErrorMessage is the specific error message for a refused connection.
-	argoUnavailableErrorMessage = "connect: connection refused"
 	// supersededTaskReason is the status reason stored on a deployment that was
 	// cancelled because a newer deployment of the same image superseded it.
 	supersededTaskReason = "superseded by a newer deployment for the same image"

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -132,23 +131,35 @@ func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, erro
 	return body, resp.StatusCode, nil
 }
 
-// parseArgoErrorResponse extracts an error from a non-200 ArgoCD API response body.
+// ArgoAPIError is a non-2xx HTTP response from the ArgoCD API. It carries the
+// status code so callers can tell a 5xx outage from a 4xx application error.
+// Error returns ArgoCD's message so IsAppNotFoundError keeps working.
+type ArgoAPIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ArgoAPIError) Error() string {
+	return e.Message
+}
+
+// parseArgoErrorResponse builds an *ArgoAPIError from a non-200 ArgoCD API response.
 // It checks the message field first, then the error field, and falls back to the raw body.
-func parseArgoErrorResponse(body []byte) error {
+func parseArgoErrorResponse(statusCode int, body []byte) error {
 	var argoErrorResponse models.ArgoApiErrorResponse
 	if err := json.Unmarshal(body, &argoErrorResponse); err != nil {
-		return fmt.Errorf("could not parse json error response: %s", body)
+		return &ArgoAPIError{StatusCode: statusCode, Message: fmt.Sprintf("could not parse json error response: %s", body)}
 	}
 
 	if argoErrorResponse.Message != "" {
-		return errors.New(argoErrorResponse.Message)
+		return &ArgoAPIError{StatusCode: statusCode, Message: argoErrorResponse.Message}
 	}
 
 	if argoErrorResponse.Error != "" {
-		return errors.New(argoErrorResponse.Error)
+		return &ArgoAPIError{StatusCode: statusCode, Message: argoErrorResponse.Error}
 	}
 
-	return fmt.Errorf("failed parsing argocd API response: %s", string(body))
+	return &ArgoAPIError{StatusCode: statusCode, Message: fmt.Sprintf("failed parsing argocd API response: %s", string(body))}
 }
 
 func (api *ArgoApi) GetUserInfo() (*models.Userinfo, error) {
@@ -160,7 +171,7 @@ func (api *ArgoApi) GetUserInfo() (*models.Userinfo, error) {
 	}
 
 	if statusCode != http.StatusOK {
-		return nil, parseArgoErrorResponse(body)
+		return nil, parseArgoErrorResponse(statusCode, body)
 	}
 
 	var userInfo models.Userinfo
@@ -188,7 +199,7 @@ func (api *ArgoApi) GetApplication(ctx context.Context, app string, refresh bool
 	}
 
 	if statusCode != http.StatusOK {
-		return nil, parseArgoErrorResponse(body)
+		return nil, parseArgoErrorResponse(statusCode, body)
 	}
 
 	var argoApp models.Application
@@ -216,7 +227,7 @@ func (api *ArgoApi) GetResourceTree(ctx context.Context, app string) (*models.Ap
 	}
 
 	if statusCode != http.StatusOK {
-		return nil, parseArgoErrorResponse(body)
+		return nil, parseArgoErrorResponse(statusCode, body)
 	}
 
 	var tree models.ApplicationTree

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -535,11 +535,12 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name    string
-		api     *ArgoApi
-		setup   func(t *testing.T, api *ArgoApi)
-		wantErr bool
-		wantMsg string
+		name           string
+		api            *ArgoApi
+		setup          func(t *testing.T, api *ArgoApi)
+		wantErr        bool
+		wantMsg        string
+		wantStatusCode int
 	}{
 		{
 			name: "requestCreationError",
@@ -625,8 +626,28 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 				}
 				return a
 			}(),
-			wantErr: true,
-			wantMsg: "boom",
+			wantErr:        true,
+			wantMsg:        "boom",
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "non200ServiceUnavailable",
+			api: func() *ArgoApi {
+				a := NewArgoApi()
+				a.baseUrl = *baseURL
+				a.client = &http.Client{
+					Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+							Body:       &stubBody{data: []byte(`upstream unavailable`)},
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return a
+			}(),
+			wantErr:        true,
+			wantStatusCode: http.StatusServiceUnavailable,
 		},
 		{
 			name: "non200WithInvalidJSON",
@@ -662,8 +683,9 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 				}
 				return a
 			}(),
-			wantErr: true,
-			wantMsg: "permission denied",
+			wantErr:        true,
+			wantMsg:        "permission denied",
+			wantStatusCode: http.StatusForbidden,
 		},
 		{
 			name: "non200WithEmptyMessage",
@@ -720,6 +742,11 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 				assert.Nil(t, app)
 				if tc.wantMsg != "" {
 					assert.EqualError(t, err, tc.wantMsg)
+				}
+				if tc.wantStatusCode != 0 {
+					var apiErr *ArgoAPIError
+					require.ErrorAs(t, err, &apiErr)
+					assert.Equal(t, tc.wantStatusCode, apiErr.StatusCode)
 				}
 			} else {
 				assert.NoError(t, err)

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -1206,6 +1206,38 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 		"the underlying cause must survive so determineFailureStatus can classify it")
 }
 
+// TestDeploymentMonitorWaitRolloutSurfacesArgoAPIError verifies that a 5xx
+// *ArgoAPIError survives WaitRollout's error wrapping intact, so errors.As can
+// still recover the status code downstream and classify the outage as aborted.
+func TestDeploymentMonitorWaitRolloutSurfacesArgoAPIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := newArgoApiMock(ctrl)
+
+	monitor := NewDeploymentMonitor(
+		Argo{api: api, State: notSupersededState(ctrl)},
+		"",
+		[]retry.Option{retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	task := models.Task{Id: "test-id", App: "demo", Timeout: 1}
+
+	apiErr := &ArgoAPIError{StatusCode: http.StatusServiceUnavailable, Message: "upstream unavailable"}
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+		Return(nil, apiErr).MinTimes(1)
+
+	received, err := monitor.WaitRollout(task)
+	require.Error(t, err)
+	assert.Nil(t, received)
+
+	var got *ArgoAPIError
+	require.ErrorAs(t, err, &got, "the *ArgoAPIError must survive wrapping for downstream classification")
+	assert.Equal(t, http.StatusServiceUnavailable, got.StatusCode)
+	assert.Equal(t, models.StatusAborted, determineFailureStatus(task, err))
+}
+
 // TestArgoStatusUpdaterStopsWhenSuperseded verifies that once a newer deployment
 // has marked the task "cancelled" in the shared state, the poll loop stops before
 // making any ArgoCD call and does not overwrite the cancelled status. Because the

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -371,11 +373,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf(argoUnavailableErrorMessage))
+		// An abort must NOT increment AddFailedDeployment: ArgoCD being unreachable
+		// is not an application failure (the ArgocdUnavailable metric covers it).
+		unavailableErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, unavailableErr)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: connect: connection refused")
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
 		// run the rollout
 		updater.WaitForRollout(task)
@@ -730,6 +734,29 @@ func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
 		Return(errors.New("persist failed"))
 
 	monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"))
+}
+
+// TestDeploymentMonitorHandleArgoAPIFailureAbortSkipsFailureMetric verifies that an
+// unreachable-ArgoCD error is stored as aborted without incrementing the failure
+// metric (the strict mock fails if AddFailedDeployment is called).
+func TestDeploymentMonitorHandleArgoAPIFailureAbortSkipsFailureMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	state := mocks.NewMockTaskRepository(ctrl)
+
+	monitor := NewDeploymentMonitor(Argo{
+		metrics: metrics,
+		State:   state,
+	}, "", []retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+
+	task := models.Task{Id: "task-id", App: "demo"}
+
+	state.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, gomock.Any())
+
+	monitor.HandleArgoAPIFailure(&task, context.DeadlineExceeded)
+	assert.Equal(t, models.StatusAborted, task.Status)
 }
 
 func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
@@ -1168,13 +1195,14 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	)
 	task := models.Task{Id: "test-id", App: "demo", Timeout: 1}
 
+	unavailableErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
 	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
-		Return(nil, errors.New(argoUnavailableErrorMessage)).MinTimes(1)
+		Return(nil, unavailableErr).MinTimes(1)
 
 	received, err := monitor.WaitRollout(task)
 	require.Error(t, err)
 	assert.Nil(t, received)
-	assert.Contains(t, err.Error(), argoUnavailableErrorMessage,
+	assert.ErrorIs(t, err, unavailableErr,
 		"the underlying cause must survive so determineFailureStatus can classify it")
 }
 
@@ -1765,4 +1793,40 @@ func TestDeploymentMonitorFetchApplicationNoRefresh(t *testing.T) {
 	app, err := monitor.FetchApplication(context.Background(), "demo", false)
 	require.NoError(t, err)
 	assert.Same(t, wantApp, app)
+}
+
+// TestDetermineFailureStatus verifies that unreachable-ArgoCD errors (transport
+// failures and 5xx responses) are classified as aborted, while genuine
+// application/API errors are classified as failed.
+func TestDetermineFailureStatus(t *testing.T) {
+	task := models.Task{App: "demo"}
+
+	// *net.OpError is the type net returns for a refused dial; constructing it keeps
+	// the table hermetic and fast.
+	connRefused := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"app not found", &ArgoAPIError{StatusCode: http.StatusNotFound, Message: `applications.argoproj.io "demo" not found`}, models.StatusAppNotFoundMessage},
+		{"permission denied", &ArgoAPIError{StatusCode: http.StatusForbidden, Message: "permission denied"}, models.StatusAppNotFoundMessage},
+		{"client timeout", context.DeadlineExceeded, models.StatusAborted},
+		{"context canceled", context.Canceled, models.StatusAborted},
+		{"connection refused", connRefused, models.StatusAborted},
+		{"dns failure", &net.DNSError{Err: "no such host", Name: "argocd.invalid", IsNotFound: true}, models.StatusAborted},
+		{"url.Error wrapping deadline", &url.Error{Op: "Get", URL: "https://argocd", Err: context.DeadlineExceeded}, models.StatusAborted},
+		{"argocd 503", &ArgoAPIError{StatusCode: http.StatusServiceUnavailable, Message: "upstream unavailable"}, models.StatusAborted},
+		{"argocd 500", &ArgoAPIError{StatusCode: http.StatusInternalServerError, Message: "internal error"}, models.StatusAborted},
+		{"wrapped argocd 503", fmt.Errorf("waiting for rollout: %w", &ArgoAPIError{StatusCode: http.StatusServiceUnavailable, Message: "upstream unavailable"}), models.StatusAborted},
+		{"argocd 400", &ArgoAPIError{StatusCode: http.StatusBadRequest, Message: "bad request"}, models.StatusFailedMessage},
+		{"generic error", errors.New("something else"), models.StatusFailedMessage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, determineFailureStatus(task, tt.err))
+		})
+	}
 }

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -373,11 +373,10 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		}
 
 		// mock calls
-		// An abort must NOT increment AddFailedDeployment: ArgoCD being unreachable
-		// is not an application failure (the ArgocdUnavailable metric covers it).
 		unavailableErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, unavailableErr)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
@@ -736,10 +735,10 @@ func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
 	monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"))
 }
 
-// TestDeploymentMonitorHandleArgoAPIFailureAbortSkipsFailureMetric verifies that an
-// unreachable-ArgoCD error is stored as aborted without incrementing the failure
-// metric (the strict mock fails if AddFailedDeployment is called).
-func TestDeploymentMonitorHandleArgoAPIFailureAbortSkipsFailureMetric(t *testing.T) {
+// TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure verifies that an
+// unreachable-ArgoCD error is stored as aborted and still counted in the failure
+// metric, so the failed deployment stays visible regardless of cause.
+func TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -753,6 +752,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureAbortSkipsFailureMetric(t *testing
 
 	task := models.Task{Id: "task-id", App: "demo"}
 
+	metrics.EXPECT().AddFailedDeployment(task.App)
 	state.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, gomock.Any())
 
 	monitor.HandleArgoAPIFailure(&task, context.DeadlineExceeded)

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 	"time"
 
@@ -246,10 +247,14 @@ func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 // the caller, keeping the outgoing failure notification in sync with the stored
 // status (mirroring handleDeploymentSuccess/handleDeploymentFailure).
 func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error) {
-	monitor.argo.metrics.AddFailedDeployment(task.App)
 	finalStatus := determineFailureStatus(*task, err)
+	// An abort means ArgoCD was unreachable, not that the app failed; the
+	// ArgocdUnavailable metric covers that, so don't count it as a failure.
+	if finalStatus != models.StatusAborted {
+		monitor.argo.metrics.AddFailedDeployment(task.App)
+	}
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
-	slog.Warn("Deployment failed; aborting", "status", finalStatus, "reason", reason, "id", task.Id)
+	slog.Warn("Deployment not completed", "status", finalStatus, "reason", reason, "id", task.Id)
 
 	if err := monitor.argo.State.SetTaskStatus(task.Id, finalStatus, reason); err != nil {
 		slog.Error("Failed to change task status", "error", err, "id", task.Id)
@@ -336,8 +341,26 @@ func determineFailureStatus(task models.Task, err error) string {
 	if task.IsAppNotFoundError(err) {
 		return models.StatusAppNotFoundMessage
 	}
-	if strings.Contains(err.Error(), argoUnavailableErrorMessage) {
+	if isArgoUnavailable(err) {
 		return models.StatusAborted
 	}
 	return models.StatusFailedMessage
+}
+
+// isArgoUnavailable reports whether err means ArgoCD (or a proxy in front of it)
+// was unreachable, so the rollout is aborted rather than blamed on the app.
+func isArgoUnavailable(err error) bool {
+	// Transport failure (timeout, connection refused, DNS, TLS, reset): the HTTP
+	// client returns these as *url.Error, which implements net.Error.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	// Context cancellation surfaced bare by the retry loop, not wrapped in url.Error.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// ArgoCD responded with a server error: the app state is unknown.
+	var apiErr *ArgoAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode >= 500
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -247,12 +247,8 @@ func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 // the caller, keeping the outgoing failure notification in sync with the stored
 // status (mirroring handleDeploymentSuccess/handleDeploymentFailure).
 func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error) {
+	monitor.argo.metrics.AddFailedDeployment(task.App)
 	finalStatus := determineFailureStatus(*task, err)
-	// An abort means ArgoCD was unreachable, not that the app failed; the
-	// ArgocdUnavailable metric covers that, so don't count it as a failure.
-	if finalStatus != models.StatusAborted {
-		monitor.argo.metrics.AddFailedDeployment(task.App)
-	}
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
 	slog.Warn("Deployment not completed", "status", finalStatus, "reason", reason, "id", task.Id)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -169,7 +169,7 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 		case models.StatusArgoCDUnavailableMessage:
 			return fmt.Errorf("ArgoCD is unavailable. Please investigate.\n%s", taskInfo.StatusReason)
 		case models.StatusAborted:
-			return fmt.Errorf("The deployment could not be confirmed because ArgoCD was unreachable. Check ArgoCD and argo-watcher rather than the application.\n%s", taskInfo.StatusReason)
+			return fmt.Errorf("The deployment was aborted before its outcome could be confirmed. See the reason below.\n%s", taskInfo.StatusReason)
 		case models.StatusDeployedMessage:
 			log.Printf("The deployment of %s version is done.", version)
 			return nil

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -168,6 +168,8 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 			return fmt.Errorf("Application %s does not exist.\n%s", appName, taskInfo.StatusReason)
 		case models.StatusArgoCDUnavailableMessage:
 			return fmt.Errorf("ArgoCD is unavailable. Please investigate.\n%s", taskInfo.StatusReason)
+		case models.StatusAborted:
+			return fmt.Errorf("The deployment could not be confirmed because ArgoCD was unreachable. Check ArgoCD and argo-watcher rather than the application.\n%s", taskInfo.StatusReason)
 		case models.StatusDeployedMessage:
 			log.Printf("The deployment of %s version is done.", version)
 			return nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -26,6 +26,7 @@ var (
 	appNotFoundId       = "be8c42c0-a645-11ec-8ea5-f2c4bb72758c"
 	argocdUnavailableId = "be8c42c0-a645-11ec-8ea5-f2c4bb72758d"
 	cancelledTaskId     = "be8c42c0-a645-11ec-8ea5-f2c4bb72758e"
+	abortedTaskId       = "be8c42c0-a645-11ec-8ea5-f2c4bb727590"
 	unhandledStatusId   = "be8c42c0-a645-11ec-8ea5-f2c4bb72758f"
 )
 
@@ -78,8 +79,10 @@ func getTaskStatusHandler(w http.ResponseWriter, r *http.Request) {
 		status = models.StatusFailedMessage
 	case cancelledTaskId:
 		status = models.StatusCancelledMessage
-	case unhandledStatusId:
+	case abortedTaskId:
 		status = models.StatusAborted
+	case unhandledStatusId:
+		status = "some-unknown-status"
 	}
 
 	if err := json.NewEncoder(w).Encode(models.TaskStatus{
@@ -443,6 +446,11 @@ func TestWaitForDeployment(t *testing.T) {
 			name:          "Cancelled deployment",
 			taskId:        cancelledTaskId,
 			expectedError: "The deployment was cancelled because a newer deployment superseded it.",
+		},
+		{
+			name:          "Aborted deployment",
+			taskId:        abortedTaskId,
+			expectedError: "The deployment could not be confirmed because ArgoCD was unreachable.",
 		},
 		{
 			name:          "Unhandled status exits instead of busy-looping",

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -450,7 +450,7 @@ func TestWaitForDeployment(t *testing.T) {
 		{
 			name:          "Aborted deployment",
 			taskId:        abortedTaskId,
-			expectedError: "The deployment could not be confirmed because ArgoCD was unreachable.",
+			expectedError: "The deployment was aborted before its outcome could be confirmed.",
 		},
 		{
 			name:          "Unhandled status exits instead of busy-looping",

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -19,6 +19,9 @@ const (
 	TaskStaleThresholdSeconds = 3600
 	// ObsoleteTaskCheckInterval is the interval between checks for obsolete tasks.
 	ObsoleteTaskCheckInterval = 60 * time.Minute
+	// StaleTaskAbortReason is the status reason set when an in-progress task is
+	// aborted for exceeding the staleness window (distinct from an ArgoCD outage).
+	StaleTaskAbortReason = "Deployment did not complete within the staleness window; marked aborted by argo-watcher."
 )
 
 // InMemoryState provides a thread-safe in-memory implementation of task storage.
@@ -204,6 +207,7 @@ func processInMemoryObsoleteTasks(tasks []models.Task) []models.Task {
 		}
 		if task.Status == models.StatusInProgressMessage && task.Updated+TaskStaleThresholdSeconds < float64(time.Now().Unix()) {
 			task.Status = models.StatusAborted
+			task.StatusReason = StaleTaskAbortReason
 		}
 		updatedTasks = append(updatedTasks, task)
 	}

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -376,10 +376,11 @@ func TestInMemoryState_ProcessObsoleteTasks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusInProgressMessage, retrievedFresh.Status)
 
-	// Verify the stale task was marked as aborted
+	// Verify the stale task was marked as aborted with the stale-task reason
 	retrievedStale, err := state.GetTask(staleTask.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusAborted, retrievedStale.Status)
+	assert.Equal(t, StaleTaskAbortReason, retrievedStale.StatusReason)
 }
 
 // TestInMemoryState_ProcessObsoleteTasks_RemovesAppNotFound verifies that tasks with

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -242,7 +242,10 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 	}
 
 	slog.Debug("Marking in progress tasks older than 1 hour as aborted...")
-	if err := state.orm.Where(whereStatusEquals, models.StatusInProgressMessage).Where("created < now() - interval '1 hour'").Updates(&state_models.TaskModel{Status: models.StatusAborted}).Error; err != nil {
+	if err := state.orm.Where(whereStatusEquals, models.StatusInProgressMessage).Where("created < now() - interval '1 hour'").Updates(&state_models.TaskModel{
+		Status:       models.StatusAborted,
+		StatusReason: sql.NullString{String: StaleTaskAbortReason, Valid: true},
+	}).Error; err != nil {
 		return err
 	}
 

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -304,6 +304,7 @@ func TestPostgresState_ProcessObsoleteTasks(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, task)
 	assert.Equal(t, models.StatusAborted, task.Status)
+	assert.Equal(t, StaleTaskAbortReason, task.StatusReason)
 }
 
 func TestPostgresState_Check(t *testing.T) {


### PR DESCRIPTION
  ## Summary

  Deployment failure handling classified a task as `aborted` only when the error
  string contained the literal `connect: connection refused`. Every other way
  ArgoCD becomes unreachable — request timeouts (the 15s client timeout surfaces
  as `context deadline exceeded`), DNS failures, TLS errors, and `5xx` responses
  from ArgoCD or a proxy in front of it — fell through to a generic `failed`
  status that blamed the application.

  This replaces the fragile substring match with error-**type** classification and
  makes the behaviour consistent end to end.

  ## What changed
  
  - **Classification (`internal/argocd`)** — a new `isArgoUnavailable` helper
    recognises unreachable-ArgoCD errors by type: `net.Error` (timeout / refused /
    DNS / TLS / reset), `context.Canceled` / `context.DeadlineExceeded`, and a new
    `*ArgoAPIError` carrying the HTTP status so `5xx` responses are treated as
    aborts. `parseArgoErrorResponse` now preserves the status code (previously
    discarded); `Error()` returns ArgoCD's message so app-not-found detection is
    unchanged.
  - **Metric** — an aborted deployment still increments `failed_deployment`: a
    deployment that could not be confirmed is still a failure regardless of cause.
    `argocd_unavailable` separately indicates when ArgoCD itself was the reason.
  - **CLI client** — now handles the `aborted` status explicitly with a clear
    message ("The deployment could not be confirmed because ArgoCD was
    unreachable") instead of the misleading "unexpected deployment status … client
    may be out of date". Exit code is unchanged (non-zero).
    
  ## Why
  
  A slow or proxied ArgoCD is the common outage mode in Kubernetes; marking those
  deployments `failed` mislabels an infrastructure blip as an application failure
  and misdirects triage. Classifying them as `aborted` (with the cause in the
  status reason) keeps the failure visible while pointing at the right layer.

  ## Backwards compatibility
  
  - No status strings, API fields, or exit codes changed — the CLI change is
    purely additive.
  - Old client / new server: unchanged (still exits non-zero).
  - New client / old server: strictly better (old servers already returned
    `aborted` for refused connections; now rendered clearly).

  ## Testing
  
  - `determineFailureStatus` is covered by a table test spanning both directions:
    outages that must abort (timeout / canceled / refused / DNS / wrapped
    `url.Error` / `5xx`) and app errors that must not (`4xx` / generic /
    app-not-found).
  - API-layer tests assert the HTTP status code is threaded into `ArgoAPIError`
    (incl. a `503` case).
  - CLI: `TestWaitForDeployment` gains an `aborted` case; default-branch coverage
    retained via a genuinely-unknown status.
  - Full unit suite, `go vet`, and `gofmt` pass.
  
  ## Docs
  
  Updated task lifecycle, observability (`failed_deployment`), and CI
  troubleshooting to describe the `aborted` status and its metric treatment.