### PR TITLE
fix(web): bump postcss and dompurify for security advisories

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# react-router: RSC Mode CSRF Bypass (GHSA-qwww-vcr4-c8h2)
+# Not exploitable here: the advisory covers only the unstable RSC
+# APIs, which the Vite SPA does not use. No 7.x patch exists
+# (fixed in 8.3.0) and react-admin peer-requires
+# react-router ^6.28.1 || ^7.1.1, so v8 is out of range.
+# Revisit when react-admin supports react-router 8.
+GHSA-qwww-vcr4-c8h2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reason ("did not complete within the staleness window"), distinguishing them
   from deployments aborted because Argo CD was unreachable.
 
+### Security
+
+- Update frontend dependencies to clear the actionable Dependabot advisories: bump
+  `postcss` to 8.5.23 (path traversal via the `sourceMappingURL` previous-source-map
+  auto-loader; build-time only) and the `dompurify` pin to 3.4.12 (elements allowed
+  through `CUSTOM_ELEMENT_HANDLING` bypassed the `afterSanitizeElements` hook).
+  `react-router` deliberately stays on 7.18.1: the advisory affects only the
+  unstable RSC APIs, which the Web UI does not use, and the fix ships in 8.3.0 —
+  outside the range React Admin supports.
+
 ## [0.12.2] - 2026-07-21
 
 ### Added

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^29.1.1",
         "oxlint": "^1.73.0",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.23",
         "swagger-ui-dist": "^5.32.8",
         "typescript": "^7.0.2",
         "vite": "^8.1.4",
@@ -2754,9 +2754,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3718,9 +3718,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3966,9 +3966,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3986,7 +3986,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^29.1.1",
     "oxlint": "^1.73.0",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.23",
     "swagger-ui-dist": "^5.32.8",
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
@@ -43,7 +43,7 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "lodash": "^4.17.21",
     "ra-core": "5.15.0",
     "ra-ui-materialui": "5.15.1",


### PR DESCRIPTION
Bump postcss to ^8.5.23 (GHSA-r28c-9q8g-f849, path traversal via the sourceMappingURL previous-source-map auto-loader) and the dompurify override to ^3.4.12 (GHSA-c2j3-45gr-mqc4, elements allowed through CUSTOM_ELEMENT_HANDLING bypassed the afterSanitizeElements hook). postcss is a direct devDependency solely to pin vite's transitive copy; there is no postcss.config file.

react-router deliberately stays on 7.18.1 and its advisory (GHSA-qwww-vcr4-c8h2) is suppressed in a new .trivyignore, because:

- the flaw is scoped to the unstable RSC APIs, which this Vite SPA does not use - every import site goes through react-router-dom;
- there is no 7.x patch (first fixed in 8.3.0), and react-router-dom has no 8.x release at all;
- ra-core and ra-ui-materialui peer-require react-router ^6.28.1 || ^7.1.1, so v8 is out of range.

Without the ignore entry the security.yml Trivy gate fails, since its DB carries the advisory at HIGH. Revisit once react-admin supports react-router 8. npm audit will keep reporting this one high finding by design; it is not a regression.