### PR TITLE
fix(server): stop logging every /ws request at debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{"available":bool,"reason":"argocd"|"database"|"both"}` (`reason` omitted when
   available) instead of a bare boolean. The WebSocket outage broadcast now carries
   the cause as `argocd_down:<reason>`; recovery is still `argocd_up`.
+- `LOG_LEVEL=debug` no longer logs a line for every request to the `/ws` WebSocket
+  endpoint, which previously drowned out the rest of the debug output. Requests
+  that fail to upgrade are still logged, together with the `Upgrade` and
+  `Connection` headers that actually arrived, so a reverse proxy stripping them
+  stays diagnosable — see the new troubleshooting entry for a Web UI that does not
+  update without a refresh.
 - `GET /api/v1/config` now exposes the authentication settings under an `oidc` key.
   The legacy `keycloak` key is still emitted with identical content for backward
   compatibility. Privileged requests (rollback, deploy-lock) may use the

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -98,6 +98,25 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 
 ---
 
+## Web UI does not update without a refresh
+
+**Symptom:** The Web UI loads, but task status and deploy-lock changes only appear after a manual page refresh.
+
+**Likely cause:** A reverse proxy or load balancer in front of the server is stripping the `Upgrade` and `Connection` headers, so the WebSocket handshake on `/ws` never happens and the server answers 400.
+
+**How to verify:**
+- Set `LOG_LEVEL=debug` and look for `non-upgrade request to /ws`. It logs the `upgrade` and `connection` header values that actually arrived — an empty `upgrade` means the proxy dropped it before the request reached Argo Watcher.
+
+**Fix:**
+1. Enable WebSocket support on the proxy. For nginx, forward the headers explicitly:
+   ```nginx
+   proxy_set_header Upgrade $http_upgrade;
+   proxy_set_header Connection "upgrade";
+   ```
+2. On an nginx Ingress, confirm the read/send timeouts are long enough to keep the connection open (`nginx.ingress.kubernetes.io/proxy-read-timeout`).
+
+---
+
 ## Lock will not release
 
 **Symptom:** An application is locked for deployment, but the lock cannot be removed.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -32,11 +32,6 @@ func (env *Env) CreateRouter() *gin.Engine {
 	// CORS middleware writes headers that interfere with WebSocket hijacking
 	router.Use(func(c *gin.Context) {
 		if c.Request.URL.Path == "/ws" {
-			slog.Debug("WebSocket request received",
-				"upgrade", c.Request.Header.Get("Upgrade"),
-				"connection", c.Request.Header.Get("Connection"),
-				"written", c.Writer.Written())
-
 			if strings.EqualFold(c.Request.Header.Get("Upgrade"), "websocket") {
 				env.handleWebSocketConnection(c)
 				c.Abort()
@@ -48,8 +43,16 @@ func (env *Env) CreateRouter() *gin.Engine {
 
 	router.Use(cors.New(env.corsConfig()))
 
-	// Keep the route registered for non-upgrade requests to /ws (will return 400)
+	// Keep the route registered for non-upgrade requests to /ws (will return 400).
+	// Reaching here means the interceptor above saw no "Upgrade: websocket"
+	// header, which usually means a proxy in front of argo-watcher stripped it.
+	// Log the headers we did receive so that is diagnosable. Requests that do
+	// upgrade are handled by the interceptor above and are deliberately not
+	// logged, since every browser tab hits /ws and reconnects.
 	router.GET("/ws", func(c *gin.Context) {
+		slog.Debug("non-upgrade request to /ws",
+			"upgrade", c.Request.Header.Get("Upgrade"),
+			"connection", c.Request.Header.Get("Connection"))
 		c.String(http.StatusBadRequest, "WebSocket upgrade required")
 	})
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -634,6 +636,57 @@ func TestStaticFileServing(t *testing.T) {
 	})
 }
 
+// logBuffer collects log output written from request-handling goroutines while
+// the test goroutine reads it, so both sides must hold the lock.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// String returns everything captured so far.
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *logBuffer) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
+}
+
+// captureDebugLogs redirects the global slog logger into a buffer at debug level
+// for the duration of the test and returns that buffer. It proves the capture is
+// live before handing the buffer back, so a test whose only assertion is
+// NotContains or Empty cannot pass because logging was silently broken.
+//
+// Not safe under t.Parallel: it swaps the process-global default logger.
+//
+// Call it after registering any cleanup that logs (env.Shutdown does): t.Cleanup
+// runs LIFO, so registering the capture last restores the real logger before
+// that shutdown logging runs, keeping it out of the buffer.
+func captureDebugLogs(t *testing.T) *logBuffer {
+	t.Helper()
+
+	logs := &logBuffer{}
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	slog.Debug("capture-live")
+	require.Contains(t, logs.String(), "capture-live", "debug log capture is not working")
+	logs.reset()
+
+	return logs
+}
+
 func TestWebSocketInterceptor(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -661,6 +714,53 @@ func TestWebSocketInterceptor(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "WebSocket upgrade required")
 	})
+
+	// The 400 is otherwise silent, and a proxy that strips or rewrites
+	// Upgrade/Connection is the usual cause; the log is what makes that
+	// diagnosable, so it must report the header values that actually arrived.
+	nonUpgradeCases := []struct {
+		name       string
+		upgrade    string
+		connection string
+		wantAttrs  []string
+	}{
+		{
+			name:       "header stripped entirely",
+			connection: "keep-alive",
+			wantAttrs:  []string{`"upgrade":""`, `"connection":"keep-alive"`},
+		},
+		{
+			name:       "upgrade rewritten to another protocol",
+			upgrade:    "h2c",
+			connection: "Upgrade",
+			wantAttrs:  []string{`"upgrade":"h2c"`, `"connection":"Upgrade"`},
+		},
+	}
+
+	for _, tc := range nonUpgradeCases {
+		t.Run("non-upgrade GET to /ws logs the received headers at debug: "+tc.name, func(t *testing.T) {
+			logs := captureDebugLogs(t)
+
+			req, _ := http.NewRequest(http.MethodGet, "/ws", nil)
+			if tc.upgrade != "" {
+				req.Header.Set("Upgrade", tc.upgrade)
+			}
+			req.Header.Set("Connection", tc.connection)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "WebSocket upgrade required")
+
+			assert.Contains(t, logs.String(), "non-upgrade request to /ws")
+			for _, attr := range tc.wantAttrs {
+				assert.Contains(t, logs.String(), attr)
+			}
+			// Debug specifically: at info this would be back to polluting the
+			// default log level, which is the problem the change exists to fix.
+			assert.Contains(t, logs.String(), `"level":"DEBUG"`)
+		})
+	}
 
 	t.Run("case-insensitive Upgrade header check", func(t *testing.T) {
 		// Test with different case variations - all should be intercepted by the WebSocket handler
@@ -728,6 +828,11 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 		connectionsMutex.Unlock()
 	})
 
+	// Capture debug output around the handshake: a successful upgrade must not
+	// log the non-upgrade diagnostic, otherwise every reconnecting browser tab
+	// floods debug output again.
+	logs := captureDebugLogs(t)
+
 	// Convert http:// to ws://
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
 
@@ -745,6 +850,11 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 
 	// Connection succeeded - the pre-hijack wrapper works
 	t.Log("WebSocket connection established successfully")
+
+	// Empty, not just "no diagnostic": the upgrade path must emit no per-request
+	// logging at all, so a differently-worded line added later is caught too. If
+	// a legitimate success-path log is ever added, make the exception here.
+	assert.Empty(t, logs.String(), "a successful /ws upgrade must not log per-request")
 }
 
 func TestWsResponseWriterHijackNilConn(t *testing.T) {


### PR DESCRIPTION
The WebSocket interceptor logged a line for every request to /ws, including successful upgrades. Since each browser tab connects and reconnects, this drowned out the rest of the debug output whenever LOG_LEVEL=debug was set to diagnose something else.

Genuine upgrade failures are already logged at error level, so the line's only unique signal was a request arriving without an Upgrade header - typically a reverse proxy stripping it, which otherwise produced a silent 400. Log that case alone, on the non-upgrade branch, together with the headers that actually arrived. The "written" field was dead instrumentation from the CORS ordering fix and is dropped.

Add a troubleshooting entry for the proxy misconfiguration this diagnoses.