### PR TITLE
feat(server): share the deploy lock across replicas via postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a lock change now see the banner within one poll interval (a few seconds) instead
   of instantly, which is the delay every other replica already had; the operator who
   made the change still sees their own result immediately.
+- The Web UI no longer replays a stale banner state after every listener has
+  detached and a new one subscribes. A reachability or deploy-lock request already
+  in flight at that moment repopulated the cache the detach had just cleared, so the
+  next subscriber was handed a value read before the gap instead of a fresh one —
+  which could show ArgoCD as reachable during a real outage. In production the
+  providers mount once, but React's development double-mount hit this on every
+  reload.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stale in-progress tasks aborted by the obsolete-task sweep now record a status
   reason ("did not complete within the staleness window"), distinguishing them
   from deployments aborted because Argo CD was unreachable.
+- The Web UI now re-reads the deploy lock state over REST every time its WebSocket
+  (re)connects, matching what the "unreachable" banner already did. The server only
+  pushes lock changes as transitions, so a lock set while a browser's socket was
+  down — or before its initial read failed — previously stayed invisible until a
+  manual page refresh, hiding an active deployment freeze. This matters more now
+  that the lock is shared, because the transition can come from another replica.
+- The lockdown watcher is now the only thing that broadcasts deploy-lock changes to
+  Web UI clients; the `POST`/`DELETE /api/v1/deploy-lock` handlers no longer push
+  directly. Two independent notifiers could leave the watcher's idea of the last
+  broadcast state stale, so a lock re-acquired through another replica within one
+  poll interval was never announced — leaving the serving replica's clients showing
+  unlocked while deployments were in fact frozen. Clients on the replica that serves
+  a lock change now see the banner within one poll interval (a few seconds) instead
+  of instantly, which is the delay every other replica already had; the operator who
+  made the change still sees their own result immediately.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per flush, and the new `gitops_batch_size` metric reports how many were coalesced.
 - `state_unavailable` metric: `1` when argo-watcher cannot reach its state backend
   (database), `0` otherwise. It tracks the state backend independently of ArgoCD.
+- The manual deploy lock is now shared across replicas when `STATE_TYPE=postgres`.
+  It is stored in a new `deploy_lock` table (migration `000006`), so a lock set
+  through any replica rejects deployments on all of them and survives a restart —
+  previously it lived in the process that served the request. With
+  `STATE_TYPE=in-memory` the lock stays process-local, which remains correct for
+  the single replica that backend supports.
 - Support for any OpenID Connect provider (e.g. Authentik) for Web UI login and
   privileged-group authorization, not just Keycloak. Configure it with
   `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, and `OIDC_PRIVILEGED_GROUPS`; the backend
@@ -27,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Releasing the deploy lock during a scheduled lockdown window now records a
+  15-minute override deadline in shared state instead of an in-process timer, so
+  the suppression ends at the same instant on every replica and survives a
+  restart. Setting the lock again clears a pending suppression.
+- If the deploy lock state cannot be read (database unreachable, or migrations not
+  applied), the server now rejects deployments as if a lock were active rather
+  than letting them through. The Web UI lockdown banner also reacts within a few
+  seconds instead of up to a minute.
+- The `POST` and `DELETE /api/v1/deploy-lock` endpoints now return `500` when the
+  lock state cannot be persisted, instead of reporting success.
 - The Web UI "unreachable" banner now names exactly which dependency is down —
   ArgoCD, the state backend (database), or both — instead of always hedging with
   "ArgoCD or its state backend". It is also anchored to the bottom of the page for

--- a/db/migrations/000006_deploy_lock.down.sql
+++ b/db/migrations/000006_deploy_lock.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS deploy_lock;

--- a/db/migrations/000006_deploy_lock.up.sql
+++ b/db/migrations/000006_deploy_lock.up.sql
@@ -1,0 +1,15 @@
+-- Shared deploy lock state, so a lockdown set through the API applies to every
+-- replica instead of only the one that served the request.
+-- The table holds exactly one row: the CHECK constraint on the primary key makes
+-- a second row impossible, which keeps reads free of "which row is current?".
+CREATE TABLE IF NOT EXISTS deploy_lock
+(
+    id             INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    manual_lock    BOOLEAN NOT NULL DEFAULT false,
+    -- Deadline of a temporary override of a scheduled lockdown; NULL when none
+    -- is active. A deadline rather than a flag so the override expires
+    -- consistently across replicas and restarts.
+    override_until TIMESTAMPTZ
+);
+
+INSERT INTO deploy_lock (id) VALUES (1) ON CONFLICT (id) DO NOTHING;

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -289,7 +289,7 @@ Releasing the lock while a scheduled lockdown window is open does not cancel the
 
 ### Behaviour With Multiple Replicas
 
-With `STATE_TYPE=postgres`, the manual lock and its temporary suppression are stored in the database, so a lock set through any replica rejects deployments on all of them, and it survives a restart. Enforcement is immediate: every deploy request resolves the lock state at that moment, so a lock set on one replica rejects the next deploy that reaches any other replica. Web UI clients connected to a replica that did not serve the lock request see the banner update within a few seconds, when that replica's watcher next samples the state.
+With `STATE_TYPE=postgres`, the manual lock and its temporary suppression are stored in the database, so a lock set through any replica rejects deployments on all of them, and it survives a restart. Enforcement is immediate: every deploy request resolves the lock state at that moment, so a lock set on one replica rejects the next deploy that reaches any other replica. Web UI clients see the banner update within a few seconds, when their replica's watcher next samples the state — including on the replica that served the lock request. The operator who set or released the lock sees their own change reflected right away.
 
 With `STATE_TYPE=in-memory` the lock lives in the process that served the request. That is correct for a single replica — the only supported configuration for in-memory state — but the lock is lost on restart.
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -250,7 +250,7 @@ scheduledLockdown:
 
 In this example, deployments are blocked between Wednesday 20:00 and Thursday 08:00, and between Friday 20:00 and Monday 08:00.
 
-The Web UI lockdown banner updates automatically (within about a minute) when a scheduled window begins or ends — no page refresh is needed.
+The Web UI lockdown banner updates automatically (within a few seconds) when a scheduled window begins or ends — no page refresh is needed.
 
 ### Manual Lockdown
 
@@ -272,7 +272,7 @@ curl -X DELETE https://argo-watcher.example.com/api/v1/deploy-lock
 ```
 
 !!! note
-    When OIDC authentication is enabled, a valid OIDC token (i.e., any authenticated user) is required to use the deploy lock API endpoints, sent via the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` header is still accepted).
+    When OIDC authentication is enabled, the deploy lock API endpoints require a token from a user in one of the `OIDC_PRIVILEGED_GROUPS`, sent via the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` header is still accepted).
 
 #### Via Web UI
 
@@ -282,6 +282,19 @@ Click the **Argo Watcher** logo in the Web UI and toggle the **Lockdown Mode** s
 
 !!! note
     When OIDC authentication is enabled, you must be authenticated to manage the deployment lock.
+
+#### Releasing a Lock During a Scheduled Window
+
+Releasing the lock while a scheduled lockdown window is open does not cancel the schedule: it suppresses it for 15 minutes, after which the window takes effect again (unless it has closed meanwhile). Setting the lock again clears a pending suppression.
+
+### Behaviour With Multiple Replicas
+
+With `STATE_TYPE=postgres`, the manual lock and its temporary suppression are stored in the database, so a lock set through any replica rejects deployments on all of them, and it survives a restart. Enforcement is immediate: every deploy request resolves the lock state at that moment, so a lock set on one replica rejects the next deploy that reaches any other replica. Web UI clients connected to a replica that did not serve the lock request see the banner update within a few seconds, when that replica's watcher next samples the state.
+
+With `STATE_TYPE=in-memory` the lock lives in the process that served the request. That is correct for a single replica — the only supported configuration for in-memory state — but the lock is lost on restart.
+
+!!! warning
+    If the database is unreachable, the lock state cannot be read and deployments are rejected as if a lock were active. Rejecting a deployment during an outage is recoverable; letting one through during a freeze is not.
 
 ## Migrating from Argo CD Image Updater
 

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -4,7 +4,7 @@ When `STATE_TYPE=postgres` is set, Argo Watcher persists task data in PostgreSQL
 
 ## Schema overview
 
-There is a single table, `tasks`, that stores every deployment task and its status. Indexes are tuned for the two access patterns the Web UI uses: listing recent tasks and looking up a task by ID.
+There are two tables. `tasks` stores every deployment task and its status; indexes are tuned for the two access patterns the Web UI uses: listing recent tasks and looking up a task by ID.
 
 | Column | Type | Notes |
 |---|---|---|
@@ -19,6 +19,14 @@ There is a single table, `tasks`, that stores every deployment task and its stat
 | `app` | `varchar(255) NOT NULL` | Argo CD application name. |
 | `author` | `varchar(255) NOT NULL` | Deployment author identifier. |
 | `project` | `varchar(255) NOT NULL` | Business project identifier. |
+
+`deploy_lock` holds the [manual deploy lock](../guides/gitops-updater.md#deployment-locking) so it applies to every replica and survives restarts. It is seeded by the migration and always holds exactly one row.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `int` | Primary key, pinned to `1` by a `CHECK` constraint so a second row cannot exist. |
+| `manual_lock` | `boolean NOT NULL DEFAULT false` | `true` while an operator-set lockdown is active. |
+| `override_until` | `timestamptz` | Deadline of a temporary override of a scheduled lockdown; `NULL` when none is active. |
 
 ## Migrations
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -60,14 +60,12 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 **Likely causes:**
 - The default `DEPLOYMENT_TIMEOUT` (900 seconds / 15 minutes) is too short for the workload.
 - Argo CD is not detecting the image update.
-- The lock is set on the application, blocking the deployment.
 - When relying on the built-in GitOps updater: the task was submitted without a valid deploy token or JWT, so the write-back was silently skipped and Argo CD never received the new tag. (If image tags are committed by other means — Argo CD Image Updater, your CI — this is expected and not the cause.)
 
 **How to verify:**
 - Check the Argo CD UI to confirm the application is syncing and the new image is being deployed.
 - Verify that the image tag annotation was correctly set: `kubectl describe app <ARGO_APP> -o yaml | grep -A5 argo-watcher`.
 - Confirm the CI job actually supplied `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`; with `LOG_LEVEL=debug` a skipped write-back logs "Skipping git repo update".
-- Check if the application is locked: `curl -H "Authorization: Bearer $BEARER_TOKEN" $ARGO_WATCHER_URL/api/v1/locks | jq '.[] | select(.app == "<ARGO_APP>")'`.
 
 **Fix:**
 1. Increase `DEPLOYMENT_TIMEOUT` to accommodate your typical rollout duration.
@@ -117,23 +115,45 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 
 ---
 
-## Lock will not release
+## All deployments rejected as locked, but nobody set a lock
 
-**Symptom:** An application is locked for deployment, but the lock cannot be removed.
+**Symptom:** Every deployment is rejected with `406` and `lockdown is active, deployments are not accepted`, while no manual lock was set and no scheduled window is open.
 
-**Likely causes:**
-- The lock was created with a future `until` timestamp and has not yet expired.
-- Insufficient permissions to remove the lock.
-- The API endpoint was called with incorrect parameters.
+**Likely causes:** With `STATE_TYPE=postgres` the lock state lives in the database. If it cannot be read, the server fails closed and treats the unknown state as locked. Two different problems produce that:
+
+- The database is unreachable.
+- The `deploy_lock` table does not exist because migration `000006` has not been applied — the database itself is perfectly healthy.
 
 **How to verify:**
-- Retrieve the lock details: `curl -H "Authorization: Bearer $BEARER_TOKEN" $ARGO_WATCHER_URL/api/v1/locks | jq '.[] | select(.app == "<ARGO_APP>")'`.
-- Check the `until` timestamp and `created_by` fields.
+- `GET /api/v1/deploy-lock` returns `true`.
+- The server log contains `failed to read deploy lock state, assuming locked`. The error on that line tells the two causes apart: a connection error for an outage, `relation "deploy_lock" does not exist` for a missing migration.
+- `/reachability` reports the `database` reason only for a genuine outage. A healthy `/reachability` alongside a permanent lock points at the migration.
+
+**Fix:** Restore database connectivity, or [apply the migrations](database.md#migrations). Lock resolution returns to normal on the next successful read; no manual intervention on the lock itself is needed.
+
+---
+
+## Lock will not release
+
+**Symptom:** Deployments stay blocked after releasing the deploy lock. The lock is server-global — there is no per-application lock.
+
+**Likely causes:**
+- A [scheduled lockdown](../guides/gitops-updater.md#scheduled-lockdown) window is open. Releasing the lock during a window only suppresses it for 15 minutes, after which it takes effect again.
+- The `DELETE` never reached the server: the state-changing endpoints are only registered when OIDC is enabled (otherwise `404`), and they require a token from a user in one of the `OIDC_PRIVILEGED_GROUPS` (otherwise `401`).
+- The lock state cannot be read at all — see [All deployments rejected as locked, but nobody set a lock](#all-deployments-rejected-as-locked-but-nobody-set-a-lock).
+
+**How to verify:**
+- Read the current state: `curl $ARGO_WATCHER_URL/api/v1/deploy-lock` (no authentication needed).
+- Check the response code of the release itself:
+  ```bash
+  curl -i -X DELETE -H "Oidc-Authorization: $OIDC_TOKEN" $ARGO_WATCHER_URL/api/v1/deploy-lock
+  ```
+  `404` means OIDC is disabled, `401` means the token was rejected or the user is not in a privileged group, and `500` means the lock state could not be persisted (the reason is in the server log).
+- Check whether `LOCKDOWN_SCHEDULE` covers the current time. The server evaluates schedules in its own timezone, which is UTC in the published container image unless `TZ` is set.
 
 **Fix:**
-1. Wait for the lock to expire naturally, or manually update the `until` timestamp to an earlier time.
-2. If you have API access, delete the lock: `curl -X DELETE -H "Authorization: Bearer $BEARER_TOKEN" $ARGO_WATCHER_URL/api/v1/locks/<lock_id>`.
-3. If using OIDC authentication, ensure your user has the required groups/permissions to manage locks.
+1. Re-issue the `DELETE` with a token belonging to a privileged group.
+2. If a scheduled window is the cause, either wait for it to close or remove the window from `LOCKDOWN_SCHEDULE` — a release cannot cancel a schedule, only suppress it for 15 minutes at a time.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,7 +19,7 @@ Authentication is only required to authorize the built-in [GitOps Updater](../gu
 
 A task submitted **without** a credential is still accepted (`202 Accepted`) and its rollout is monitored normally — argo-watcher simply does not perform the git write-back. This is the expected setup when the image tag is updated by other means (e.g. Argo CD Image Updater or your CI pipeline) and argo-watcher only tracks the resulting rollout. If you instead rely on the built-in updater to commit the tag and omit the credential, the write-back is skipped and the deployment times out waiting for an image change that never arrives. A token that is **present but invalid or expired** returns `401 Unauthorized`.
 
-The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [OIDC authentication](../guides/oidc.md) is enabled, and require a valid OIDC session (sent via the `Oidc-Authorization` header; the legacy `Keycloak-Authorization` header is still accepted); when OIDC is disabled these endpoints are not exposed (`404 Not Found`). The read-only `GET /api/v1/deploy-lock` is always available regardless of authentication.
+The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [OIDC authentication](../guides/oidc.md) is enabled, and require a session belonging to one of the `OIDC_PRIVILEGED_GROUPS` (sent via the `Oidc-Authorization` header; the legacy `Keycloak-Authorization` header is still accepted); when OIDC is disabled these endpoints are not exposed (`404 Not Found`). The read-only `GET /api/v1/deploy-lock` is always available regardless of authentication.
 
 ## Conventions
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,11 @@
           git
         ];
 
+        # The e2e lab and CI helpers are bash; shellcheck is the linter for them.
+        shellToolchain = with pkgs; [
+          shellcheck
+        ];
+
         # Security scanners, mirroring the CI security workflow so they can be
         # run locally. gosec is already part of goToolchain. nuclei is
         # intentionally absent — DAST runs only in CI against a live server.
@@ -116,7 +121,7 @@
       in
       {
         devShells.default = pkgs.mkShell {
-          packages = goToolchain ++ preCommitTools ++ securityTools ++ frontendToolchain ++ docsToolchain;
+          packages = goToolchain ++ preCommitTools ++ shellToolchain ++ securityTools ++ frontendToolchain ++ docsToolchain;
           shellHook = ''
             export GOPATH="$PWD/.go"
             export GOMODCACHE="$PWD/.gomod"

--- a/internal/lock/deploy_lock.go
+++ b/internal/lock/deploy_lock.go
@@ -1,0 +1,71 @@
+package lock
+
+import (
+	"sync"
+	"time"
+)
+
+// DeployLockState is the part of the deploy lock a replica cannot derive from
+// its own configuration and therefore has to share with its peers. Lockdown
+// schedules are deliberately absent: every replica reads the same
+// LOCKDOWN_SCHEDULE value and evaluates it locally.
+type DeployLockState struct {
+	// ManualLock is true while an operator-set lockdown is in effect. It
+	// outranks everything else.
+	ManualLock bool
+	// OverrideUntil is when a temporary override of a *scheduled* lockdown
+	// expires. A zero value means no override is active. Storing a deadline
+	// instead of a boolean plus a timer keeps the expiry meaningful across
+	// replicas and restarts.
+	OverrideUntil time.Time
+}
+
+// DeployLockStore persists the deploy lock state. The in-memory implementation
+// serves single-replica deployments; the Postgres one makes the lock effective
+// across every replica of an HA setup.
+type DeployLockStore interface {
+	// State returns the current deploy lock state.
+	State() (DeployLockState, error)
+	// Lock engages the manual lockdown and drops any pending override.
+	Lock() error
+	// Release clears the manual lockdown. A non-zero overrideUntil suppresses
+	// an active scheduled lockdown until that instant.
+	Release(overrideUntil time.Time) error
+}
+
+// InMemoryDeployLockStore keeps the deploy lock state in process memory. It is
+// correct only for a single replica: peers never observe its changes.
+type InMemoryDeployLockStore struct {
+	mu    sync.RWMutex
+	state DeployLockState
+}
+
+// NewInMemoryDeployLockStore creates a DeployLockStore backed by process memory.
+func NewInMemoryDeployLockStore() DeployLockStore {
+	return &InMemoryDeployLockStore{}
+}
+
+// State returns the current deploy lock state. The error is always nil; it
+// exists to satisfy the interface shared with the Postgres implementation.
+func (s *InMemoryDeployLockStore) State() (DeployLockState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state, nil
+}
+
+// Lock engages the manual lockdown and drops any pending override.
+func (s *InMemoryDeployLockStore) Lock() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = DeployLockState{ManualLock: true}
+	return nil
+}
+
+// Release clears the manual lockdown, recording overrideUntil as the deadline
+// of a temporary override of an active scheduled lockdown.
+func (s *InMemoryDeployLockStore) Release(overrideUntil time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = DeployLockState{OverrideUntil: overrideUntil}
+	return nil
+}

--- a/internal/lock/deploy_lock_postgres.go
+++ b/internal/lock/deploy_lock_postgres.go
@@ -1,0 +1,73 @@
+package lock
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// deployLockRowID is the primary key of the single row holding the deploy lock
+// state. The table is constrained to that one row (see the 000006 migration),
+// so every replica reads and writes the same record.
+const deployLockRowID = 1
+
+// PostgresDeployLockStore persists the deploy lock state in Postgres, making a
+// lock set on one replica effective on all of them.
+type PostgresDeployLockStore struct {
+	db *gorm.DB
+}
+
+// NewPostgresDeployLockStore creates a DeployLockStore backed by the deploy_lock
+// table of the given database.
+func NewPostgresDeployLockStore(db *gorm.DB) DeployLockStore {
+	return &PostgresDeployLockStore{db: db}
+}
+
+// State reads the shared deploy lock state. A missing row is reported as the
+// zero state (unlocked): the migration seeds the row, and Lock/Release recreate
+// it, so its absence means "never locked" rather than a failure.
+func (s *PostgresDeployLockStore) State() (DeployLockState, error) {
+	var (
+		manualLock    bool
+		overrideUntil sql.NullTime
+	)
+
+	row := s.db.Raw("SELECT manual_lock, override_until FROM deploy_lock WHERE id = ?", deployLockRowID).Row()
+	if err := row.Scan(&manualLock, &overrideUntil); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DeployLockState{}, nil
+		}
+		return DeployLockState{}, err
+	}
+
+	return DeployLockState{
+		ManualLock:    manualLock,
+		OverrideUntil: overrideUntil.Time,
+	}, nil
+}
+
+// Lock engages the manual lockdown and drops any pending override.
+func (s *PostgresDeployLockStore) Lock() error {
+	return s.write(true, time.Time{})
+}
+
+// Release clears the manual lockdown, recording overrideUntil as the deadline of
+// a temporary override of an active scheduled lockdown.
+func (s *PostgresDeployLockStore) Release(overrideUntil time.Time) error {
+	return s.write(false, overrideUntil)
+}
+
+// write upserts the single deploy lock row. The upsert (rather than a plain
+// UPDATE) keeps the store working even if the seeded row was removed.
+func (s *PostgresDeployLockStore) write(manualLock bool, overrideUntil time.Time) error {
+	until := sql.NullTime{Time: overrideUntil, Valid: !overrideUntil.IsZero()}
+
+	return s.db.Exec(`
+		INSERT INTO deploy_lock (id, manual_lock, override_until)
+		VALUES (?, ?, ?)
+		ON CONFLICT (id) DO UPDATE
+		SET manual_lock = EXCLUDED.manual_lock, override_until = EXCLUDED.override_until`,
+		deployLockRowID, manualLock, until).Error
+}

--- a/internal/lock/deploy_lock_postgres_test.go
+++ b/internal/lock/deploy_lock_postgres_test.go
@@ -1,0 +1,116 @@
+package lock
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newDeployLockTestDB connects to the migrated test database. Like the other
+// Postgres-backed tests in this repository it is skipped unless POSTGRES_DSN is
+// set, and it assumes migrations have already been applied (task ci-migrate).
+func newDeployLockTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode.")
+	}
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("POSTGRES_DSN environment variable not set. Skipping integration test.")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	return db
+}
+
+// reseedDeployLock restores the table to exactly what migration 000006 leaves
+// behind: one unlocked row. Tests both start and end here, so the contract runs
+// against the production table shape and no test leaves the shared database
+// locked for whatever runs next against the same DSN.
+func reseedDeployLock(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	require.NoError(t, db.Exec("DELETE FROM deploy_lock").Error)
+	require.NoError(t, db.Exec("INSERT INTO deploy_lock (id) VALUES (1)").Error)
+}
+
+func TestPostgresDeployLockStore(t *testing.T) {
+	runDeployLockStoreContract(t, func(t *testing.T) DeployLockStore {
+		t.Helper()
+
+		db := newDeployLockTestDB(t)
+		reseedDeployLock(t, db)
+		t.Cleanup(func() { reseedDeployLock(t, db) })
+
+		return NewPostgresDeployLockStore(db)
+	})
+}
+
+// TestPostgresDeployLockStore_MissingRowIsUnlocked covers the seeded row being
+// absent — a database someone truncated. It must read as "never locked" rather
+// than as an error, which would otherwise fail closed and freeze all deploys.
+func TestPostgresDeployLockStore_MissingRowIsUnlocked(t *testing.T) {
+	db := newDeployLockTestDB(t)
+	require.NoError(t, db.Exec("DELETE FROM deploy_lock").Error)
+	t.Cleanup(func() { reseedDeployLock(t, db) })
+
+	state, err := NewPostgresDeployLockStore(db).State()
+	require.NoError(t, err)
+	assert.False(t, state.ManualLock)
+	assert.True(t, state.OverrideUntil.IsZero())
+}
+
+// TestPostgresDeployLockStore_StateSurfacesReadErrors guards the foundation of
+// the fail-closed guarantee: Lockdown only rejects deploys during an outage
+// because State reports the failure. A read error must never be flattened into
+// the zero state the way a missing row legitimately is.
+func TestPostgresDeployLockStore_StateSurfacesReadErrors(t *testing.T) {
+	db := newDeployLockTestDB(t)
+
+	// A dedicated connection, closed underneath the store: no other test shares
+	// this handle, so nothing else is affected.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	_, err = NewPostgresDeployLockStore(db).State()
+	assert.Error(t, err, "an unreadable lock state must surface as an error, not as 'unlocked'")
+}
+
+// TestPostgresDeployLockStore_SharedAcrossInstances is the reason this store
+// exists: a lock engaged by one replica must be visible to another replica that
+// shares the database.
+func TestPostgresDeployLockStore_SharedAcrossInstances(t *testing.T) {
+	db := newDeployLockTestDB(t)
+	reseedDeployLock(t, db)
+	t.Cleanup(func() { reseedDeployLock(t, db) })
+
+	replicaA := NewPostgresDeployLockStore(db)
+	replicaB := NewPostgresDeployLockStore(newDeployLockTestDB(t))
+
+	require.NoError(t, replicaA.Lock())
+
+	state, err := replicaB.State()
+	require.NoError(t, err)
+	assert.True(t, state.ManualLock, "a lock set on one replica must be visible on the others")
+
+	until := time.Now().Add(15 * time.Minute)
+	require.NoError(t, replicaB.Release(until))
+
+	state, err = replicaA.State()
+	require.NoError(t, err)
+	assert.False(t, state.ManualLock)
+	assert.WithinDuration(t, until, state.OverrideUntil, time.Second)
+}

--- a/internal/lock/deploy_lock_test.go
+++ b/internal/lock/deploy_lock_test.go
@@ -1,0 +1,102 @@
+package lock
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runDeployLockStoreContract exercises the behaviour every DeployLockStore
+// implementation must provide, so the in-memory and Postgres stores cannot
+// drift apart.
+func runDeployLockStoreContract(t *testing.T, newStore func(t *testing.T) DeployLockStore) {
+	t.Helper()
+
+	t.Run("starts unlocked", func(t *testing.T) {
+		state, err := newStore(t).State()
+		require.NoError(t, err)
+		assert.False(t, state.ManualLock)
+		assert.True(t, state.OverrideUntil.IsZero())
+	})
+
+	t.Run("Lock sets the manual lock", func(t *testing.T) {
+		store := newStore(t)
+		require.NoError(t, store.Lock())
+
+		state, err := store.State()
+		require.NoError(t, err)
+		assert.True(t, state.ManualLock)
+	})
+
+	t.Run("Release clears the manual lock", func(t *testing.T) {
+		store := newStore(t)
+		require.NoError(t, store.Lock())
+		require.NoError(t, store.Release(time.Time{}))
+
+		state, err := store.State()
+		require.NoError(t, err)
+		assert.False(t, state.ManualLock)
+		assert.True(t, state.OverrideUntil.IsZero())
+	})
+
+	t.Run("Release stores the override deadline", func(t *testing.T) {
+		store := newStore(t)
+		until := time.Now().Add(15 * time.Minute)
+		require.NoError(t, store.Release(until))
+
+		state, err := store.State()
+		require.NoError(t, err)
+		assert.False(t, state.ManualLock)
+		// Postgres rounds to microsecond precision, so compare with a tolerance
+		// rather than requiring an exact round trip.
+		assert.WithinDuration(t, until, state.OverrideUntil, time.Second)
+	})
+
+	t.Run("Lock clears a pending override", func(t *testing.T) {
+		store := newStore(t)
+		require.NoError(t, store.Release(time.Now().Add(15*time.Minute)))
+		require.NoError(t, store.Lock())
+
+		state, err := store.State()
+		require.NoError(t, err)
+		assert.True(t, state.ManualLock)
+		assert.True(t, state.OverrideUntil.IsZero(), "setting the lock must drop the override")
+	})
+}
+
+func TestInMemoryDeployLockStore(t *testing.T) {
+	runDeployLockStoreContract(t, func(t *testing.T) DeployLockStore {
+		t.Helper()
+		return NewInMemoryDeployLockStore()
+	})
+}
+
+// TestInMemoryDeployLockStore_ConcurrentAccess is a race-detector target: the
+// store is read on every deploy request and written by API handlers.
+func TestInMemoryDeployLockStore_ConcurrentAccess(t *testing.T) {
+	store := NewInMemoryDeployLockStore()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// assert, not require: require calls t.FailNow, which is only
+			// valid on the goroutine running the test.
+			for j := 0; j < 100; j++ {
+				assert.NoError(t, store.Lock())
+				_, err := store.State()
+				assert.NoError(t, err)
+				assert.NoError(t, store.Release(time.Time{}))
+			}
+		}()
+	}
+	wg.Wait()
+
+	state, err := store.State()
+	require.NoError(t, err)
+	assert.False(t, state.ManualLock)
+}

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -37,19 +37,24 @@ type Env struct {
 // tick is well below the minute granularity of schedules. Each tick is one
 // indexed single-row read, or no I/O at all with the in-memory store.
 //
-// This bounds only how quickly the *banner* updates on replicas that did not
-// serve the request. Enforcement is not affected: every deploy request resolves
-// the lock state at that moment.
+// This bounds only how quickly the *banner* updates, including on the replica
+// that served the request. Enforcement is not affected: every deploy request
+// resolves the lock state at that moment.
 const lockdownPollInterval = 5 * time.Second
 
 // StartLockdownWatcher launches a background goroutine that notifies WebSocket
-// clients when the resolved lock state changes on its own: a scheduled window
-// opening or closing, a temporary override expiring, or — with a shared deploy
-// lock store — a lock another replica set or released. The direct notification
-// from the API handler only reaches clients connected to the replica that served
-// the request, so clients elsewhere learn about it here instead, at the cost of
-// one duplicate message on the serving replica. The goroutine is tracked by
-// connWg and stops when the shutdown channel is closed.
+// clients whenever the resolved lock state changes: an operator setting or
+// releasing the lock through any replica, a scheduled window opening or closing,
+// or a temporary override expiring.
+//
+// It is the *only* thing that pushes lock state to clients. The API handlers
+// deliberately stay silent, because the watcher compares each poll against the
+// state it last broadcast: a push from elsewhere would leave that baseline stale
+// and could swallow a later transition (see TestDeployLockNotifiedOnlyByWatcher).
+// The price is that clients on the replica serving a lock change learn about it
+// within one poll interval rather than instantly — the same delay every other
+// replica already had. The goroutine is tracked by connWg and stops when the
+// shutdown channel is closed.
 func (env *Env) StartLockdownWatcher() {
 	env.connWg.Add(1)
 	go func() {

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/prometheus"
 )
 
@@ -29,21 +30,27 @@ type Env struct {
 	connWg sync.WaitGroup
 }
 
-// lockdownPollInterval is how often the scheduled-lockdown watcher re-evaluates
-// the lock state to detect schedule boundary transitions. Schedules have
-// minute granularity, so a one-minute tick bounds the notification lag.
-const lockdownPollInterval = time.Minute
+// lockdownPollInterval is how often the lockdown watcher re-evaluates the lock
+// state to detect a transition it was not told about: a schedule boundary, an
+// override expiring, or — with a shared deploy lock store — a lock another
+// replica set or released. The last of those can happen at any instant, so the
+// tick is well below the minute granularity of schedules. Each tick is one
+// indexed single-row read, or no I/O at all with the in-memory store.
+//
+// This bounds only how quickly the *banner* updates on replicas that did not
+// serve the request. Enforcement is not affected: every deploy request resolves
+// the lock state at that moment.
+const lockdownPollInterval = 5 * time.Second
 
 // StartLockdownWatcher launches a background goroutine that notifies WebSocket
-// clients when a scheduled lockdown window automatically begins or ends. It is a
-// no-op when no schedules are configured, since manual set/release already
-// notify clients directly. The goroutine is tracked by connWg and stops when the
-// shutdown channel is closed.
+// clients when the resolved lock state changes on its own: a scheduled window
+// opening or closing, a temporary override expiring, or — with a shared deploy
+// lock store — a lock another replica set or released. The direct notification
+// from the API handler only reaches clients connected to the replica that served
+// the request, so clients elsewhere learn about it here instead, at the cost of
+// one duplicate message on the serving replica. The goroutine is tracked by
+// connWg and stops when the shutdown channel is closed.
 func (env *Env) StartLockdownWatcher() {
-	if len(env.lockdown.Schedules) == 0 {
-		return
-	}
-
 	env.connWg.Add(1)
 	go func() {
 		defer env.connWg.Done()
@@ -150,10 +157,11 @@ func (env *Env) Shutdown() {
 	}
 }
 
-// NewEnv wires up an Env from the server config: lockdown schedules and the
-// enabled auth strategies (deploy token, optional OIDC — registered under both
-// the canonical and legacy Keycloak headers — and optional JWT).
-func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater) (*Env, error) {
+// NewEnv wires up an Env from the server config: lockdown schedules backed by
+// the given deploy lock store and the enabled auth strategies (deploy token,
+// optional OIDC — registered under both the canonical and legacy Keycloak
+// headers — and optional JWT).
+func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater, deployLockStore lock.DeployLockStore) (*Env, error) {
 	var env *Env
 	var err error
 
@@ -165,7 +173,7 @@ func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prome
 		shutdownCh: make(chan struct{}),
 	}
 
-	if env.lockdown, err = NewLockdown(serverConfig.LockdownSchedule); err != nil {
+	if env.lockdown, err = NewLockdown(serverConfig.LockdownSchedule, deployLockStore); err != nil {
 		return nil, err
 	}
 

--- a/internal/server/handlers_argocd_test.go
+++ b/internal/server/handlers_argocd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/mocks"
 )
 
@@ -105,7 +106,7 @@ func TestArgoStatusEndpointRegistration(t *testing.T) {
 		}
 		env := &Env{config: serverConfig}
 		var err error
-		env.lockdown, err = NewLockdown("")
+		env.lockdown, err = NewLockdown("", lock.NewInMemoryDeployLockStore())
 		require.NoError(t, err)
 		return env.CreateRouter()
 	}

--- a/internal/server/handlers_lock.go
+++ b/internal/server/handlers_lock.go
@@ -9,6 +9,11 @@ import (
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
+// This handler deliberately does not push the new state to WebSocket clients.
+// StartLockdownWatcher is the single notifier — it compares each poll against the
+// state it last broadcast, and a push from here would leave that baseline stale
+// (see TestDeployLockNotifiedOnlyByWatcher).
+//
 // SetDeployLock godoc
 // @Summary Set deploy lock
 // @Description Set deploy lock. Only available when OIDC auth is enabled; requires a valid OIDC session.
@@ -33,8 +38,6 @@ func (env *Env) SetDeployLock(c *gin.Context) {
 	}
 
 	slog.Debug("deploy lock is set")
-
-	notifyWebSocketClients("locked")
 
 	c.JSON(http.StatusOK, "deploy lock is set")
 }
@@ -62,8 +65,6 @@ func (env *Env) ReleaseDeployLock(c *gin.Context) {
 	}
 
 	slog.Debug("deploy lock is released")
-
-	notifyWebSocketClients("unlocked")
 
 	c.JSON(http.StatusOK, "deploy lock is released")
 }

--- a/internal/server/handlers_lock.go
+++ b/internal/server/handlers_lock.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/shini4i/argo-watcher/internal/models"
 )
 
 // SetDeployLock godoc
@@ -13,13 +15,22 @@ import (
 // @Tags frontend
 // @Success 200 {string} string
 // @Failure 401 {object} models.TaskStatus
+// @Failure 500 {object} models.TaskStatus
 // @Router /api/v1/deploy-lock [post]
 func (env *Env) SetDeployLock(c *gin.Context) {
 	if !env.requireOIDCAuth(c) {
 		return
 	}
 
-	env.lockdown.SetLock()
+	if err := env.lockdown.SetLock(); err != nil {
+		// The caller must not believe deployments are frozen when they are not.
+		slog.Error("failed to set deploy lock", "error", err)
+		c.JSON(http.StatusInternalServerError, models.TaskStatus{
+			Status: "failed to set deploy lock",
+			Error:  "internal server error",
+		})
+		return
+	}
 
 	slog.Debug("deploy lock is set")
 
@@ -34,13 +45,21 @@ func (env *Env) SetDeployLock(c *gin.Context) {
 // @Tags frontend
 // @Success 200 {string} string
 // @Failure 401 {object} models.TaskStatus
+// @Failure 500 {object} models.TaskStatus
 // @Router /api/v1/deploy-lock [delete]
 func (env *Env) ReleaseDeployLock(c *gin.Context) {
 	if !env.requireOIDCAuth(c) {
 		return
 	}
 
-	env.lockdown.ReleaseLock()
+	if err := env.lockdown.ReleaseLock(); err != nil {
+		slog.Error("failed to release deploy lock", "error", err)
+		c.JSON(http.StatusInternalServerError, models.TaskStatus{
+			Status: "failed to release deploy lock",
+			Error:  "internal server error",
+		})
+		return
+	}
 
 	slog.Debug("deploy lock is released")
 

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
 )
 
 // Keycloak coordinates for the docker-compose `integration` profile. The realm,
@@ -100,7 +101,7 @@ func newKeycloakEnv(t *testing.T) *Env {
 	oidcService, err := auth.NewOIDCAuthService(cfg)
 	require.NoError(t, err)
 
-	lockdown, err := NewLockdown("")
+	lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
 	require.NoError(t, err)
 
 	// Register under both headers, mirroring production wiring (NewEnv).

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -5,15 +5,29 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/shini4i/argo-watcher/internal/lock"
 )
 
+// defaultOverrideDuration is how long releasing the lock suppresses an active
+// scheduled lockdown before it takes effect again.
+const defaultOverrideDuration = 15 * time.Minute
+
+// Lockdown resolves whether deployments are currently frozen, combining the
+// shared manual lock and override deadline held in the store with the schedules
+// each replica evaluates locally.
 type Lockdown struct {
-	mu           sync.RWMutex // protects ManualLock and OverrideMode
-	ManualLock   bool         // used to manually lock the system
-	OverrideMode bool         // used to temporarily disable scheduled lockdowns
-	Schedules    []LockdownSchedule
+	// store holds the manual lock and override deadline. With the Postgres
+	// implementation those are shared by every replica, so a lock set through
+	// one of them rejects deployments on all of them.
+	store lock.DeployLockStore
+	// Schedules are parsed from configuration, which is identical on every
+	// replica, and are therefore evaluated locally rather than stored.
+	Schedules []LockdownSchedule
+	// overrideDuration is the lifetime of the override created by ReleaseLock.
+	// It is a field so tests can shorten it.
+	overrideDuration time.Duration
 }
 
 type LockdownSchedule struct {
@@ -100,28 +114,52 @@ func (l *Lockdown) Parse(schedules string) error {
 	return nil
 }
 
-// IsLocked checks if the system is under lockdown. It returns true if either
-// a manual lock is active or if the current time falls within a scheduled lockdown
-// and no override mode is active. Otherwise, it returns false.
+// IsLocked reports whether the system is under lockdown: true when a manual
+// lock is active, or when the current time falls within a scheduled lockdown
+// that is not currently overridden.
+//
+// A failure to read the shared state is treated as locked. Rejecting a
+// deployment while the state is unknown is recoverable; letting one through
+// during a freeze because the database blinked is not.
 func (l *Lockdown) IsLocked() bool {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return l.isLockedInternal()
+	locked, err := l.resolve()
+	if err != nil {
+		slog.Error("failed to read deploy lock state, assuming locked", "error", err)
+	}
+
+	return locked
 }
 
-// isLockedInternal checks lock status without acquiring mutex.
-// Caller must hold at least a read lock.
-func (l *Lockdown) isLockedInternal() bool {
-	if l.ManualLock {
+// resolve reports the current lock state along with any store read error. On a
+// read error it returns the fail-closed answer (locked) *and* the error, so the
+// enforcement path can act on the safe default while the watcher can tell an
+// unknown state apart from a genuine transition.
+func (l *Lockdown) resolve() (bool, error) {
+	state, err := l.store.State()
+	if err != nil {
+		return true, err
+	}
+
+	return l.isLockedWith(state, time.Now()), nil
+}
+
+// isLockedWith resolves the lock state for a given store state and instant. It
+// is separate from IsLocked so the precedence rules can be tested without a
+// store or a clock.
+func (l *Lockdown) isLockedWith(state lock.DeployLockState, now time.Time) bool {
+	if state.ManualLock {
 		return true
 	}
 
-	if l.OverrideMode {
+	if now.Before(state.OverrideUntil) {
 		return false
 	}
 
-	now := time.Now()
+	return l.scheduleActive(now)
+}
 
+// scheduleActive reports whether now falls within any configured lockdown window.
+func (l *Lockdown) scheduleActive(now time.Time) bool {
 	for _, s := range l.Schedules {
 		if timeWithinSchedule(now, s.StartDay, s.EndDay, s.StartHour, s.StartMin, s.EndHour, s.EndMin) {
 			return true
@@ -134,65 +172,53 @@ func (l *Lockdown) isLockedInternal() bool {
 // SetLock immediately places the system into manual lockdown mode.
 // No matter what the scheduled lockdown settings are, once this method is invoked,
 // the system is considered to be under lockdown until manually released.
-func (l *Lockdown) SetLock() {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.ManualLock = true
+func (l *Lockdown) SetLock() error {
+	return l.store.Lock()
 }
 
-// ReleaseLock cancels the manual lockdown. If a scheduled lockdown is active,
-// it temporarily overrides it for the next 15 minutes. After that period,
-// if the scheduled lockdown is still in progress, the system re-locks.
-func (l *Lockdown) ReleaseLock() {
-	l.mu.Lock()
-	l.ManualLock = false
-	isLocked := l.isLockedInternal()
-	if isLocked {
-		l.OverrideMode = true
+// ReleaseLock cancels the manual lockdown. If a scheduled lockdown is active, it
+// is temporarily overridden for overrideDuration; once that deadline passes the
+// schedule takes effect again. The deadline is persisted with the lock state, so
+// the override ends at the same instant on every replica and survives a restart.
+// Clients learn about the expiry from the lockdown watcher, which polls the
+// resolved state.
+func (l *Lockdown) ReleaseLock() error {
+	var overrideUntil time.Time
+	if l.scheduleActive(time.Now()) {
+		overrideUntil = time.Now().Add(l.overrideDuration)
 	}
-	l.mu.Unlock()
 
-	if isLocked {
-		go l.expireOverride(15*time.Minute, notifyWebSocketClients)
-	}
-}
-
-// expireOverride waits for d, then clears the temporary override that ReleaseLock
-// enabled. It re-notifies clients with "locked" only when the system is genuinely
-// still locked once the override ends; if the scheduled window closed during the
-// wait, the system is now unlocked and no stale "locked" message is sent. The
-// duration and notifier are parameters so the guard can be unit-tested.
-func (l *Lockdown) expireOverride(d time.Duration, notify func(string)) {
-	time.Sleep(d)
-
-	l.mu.Lock()
-	l.OverrideMode = false
-	stillLocked := l.isLockedInternal()
-	l.mu.Unlock()
-
-	if stillLocked {
-		notify("locked")
-	}
+	return l.store.Release(overrideUntil)
 }
 
 // WatchTransitions polls the lock state on the given interval and invokes notify
 // with "locked" or "unlocked" whenever the computed state changes. Scheduled
-// lockdowns are evaluated lazily by IsLocked, so this is the only mechanism that
-// informs clients when a schedule window automatically begins or ends. The
-// initial state is recorded without notifying, so only genuine transitions
-// produce a notification. It runs until stop is closed.
+// lockdowns and shared locks set by other replicas are only observable by
+// polling, so this is the mechanism that informs clients about them. The initial
+// state is recorded without notifying, so only genuine transitions produce a
+// notification. It runs until stop is closed.
+//
+// A tick whose store read fails is skipped rather than reported: unlike the
+// enforcement path, which must fail closed, an unreadable state is not a
+// transition, and treating it as one would flap the banner on every transient
+// error. The failure is logged at debug level because a database outage is
+// already reported loudly by the reachability probe.
 func (l *Lockdown) WatchTransitions(stop <-chan struct{}, interval time.Duration, notify func(string)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	last := l.IsLocked()
+	last, _ := l.resolve()
 
 	for {
 		select {
 		case <-stop:
 			return
 		case <-ticker.C:
-			current := l.IsLocked()
+			current, err := l.resolve()
+			if err != nil {
+				slog.Debug("skipping lockdown transition check, lock state is unreadable", "error", err)
+				continue
+			}
 			if current == last {
 				continue
 			}
@@ -207,11 +233,14 @@ func (l *Lockdown) WatchTransitions(stop <-chan struct{}, interval time.Duration
 	}
 }
 
-// NewLockdown initializes a new Lockdown structure and parses the lockdown schedules
-// if provided. If the schedule parsing is successful, it returns the new Lockdown.
-// Otherwise, it returns an error.
-func NewLockdown(schedules string) (*Lockdown, error) {
-	lockdown := &Lockdown{}
+// NewLockdown initializes a new Lockdown structure backed by the given store and
+// parses the lockdown schedules if provided. If the schedule parsing is
+// successful, it returns the new Lockdown. Otherwise, it returns an error.
+func NewLockdown(schedules string, store lock.DeployLockStore) (*Lockdown, error) {
+	lockdown := &Lockdown{
+		store:            store,
+		overrideDuration: defaultOverrideDuration,
+	}
 	if schedules != "" {
 		if err := lockdown.Parse(schedules); err != nil {
 			return nil, err

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -1,12 +1,56 @@
 package server
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/lock"
 )
+
+// newTestLockdown builds a Lockdown backed by an in-memory store, mirroring how
+// a single-replica deployment is wired.
+func newTestLockdown(t *testing.T, schedules string) *Lockdown {
+	t.Helper()
+
+	l, err := NewLockdown(schedules, lock.NewInMemoryDeployLockStore())
+	require.NoError(t, err)
+	return l
+}
+
+// scheduleAround builds a one-off schedule window offset from now, so tests can
+// reproduce a scheduled lockdown that is still open or already closed. The wide
+// margins keep the window on the correct side of "now" across hour/day/week
+// boundaries.
+func scheduleAround(startOffset, endOffset time.Duration) LockdownSchedule {
+	now := time.Now()
+	start := now.Add(startOffset)
+	end := now.Add(endOffset)
+	return LockdownSchedule{
+		StartDay:  start.Weekday(),
+		StartHour: start.Hour(),
+		StartMin:  start.Minute(),
+		EndDay:    end.Weekday(),
+		EndHour:   end.Hour(),
+		EndMin:    end.Minute(),
+	}
+}
+
+// failingDeployLockStore is a DeployLockStore whose reads always fail, used to
+// verify that an unreadable lock state is treated as locked.
+type failingDeployLockStore struct{}
+
+func (failingDeployLockStore) State() (lock.DeployLockState, error) {
+	return lock.DeployLockState{}, errors.New("database is unreachable")
+}
+func (failingDeployLockStore) Lock() error { return errors.New("database is unreachable") }
+func (failingDeployLockStore) Release(_ time.Time) error {
+	return errors.New("database is unreachable")
+}
 
 func TestLockdown_Parse(t *testing.T) {
 	var testCases = []struct {
@@ -43,21 +87,21 @@ func TestLockdown_Parse(t *testing.T) {
 func TestLockdown_SetLock_ReleaseLock(t *testing.T) {
 	testCases := []struct {
 		name         string
-		action       func(l *Lockdown)
+		action       func(t *testing.T, l *Lockdown)
 		expectedLock bool
 	}{
 		{
 			name: "test setting the lock",
-			action: func(l *Lockdown) {
-				l.SetLock()
+			action: func(t *testing.T, l *Lockdown) {
+				require.NoError(t, l.SetLock())
 			},
 			expectedLock: true,
 		},
 		{
 			name: "test releasing the lock",
-			action: func(l *Lockdown) {
-				l.SetLock()
-				l.ReleaseLock()
+			action: func(t *testing.T, l *Lockdown) {
+				require.NoError(t, l.SetLock())
+				require.NoError(t, l.ReleaseLock())
 			},
 			expectedLock: false,
 		},
@@ -65,12 +109,65 @@ func TestLockdown_SetLock_ReleaseLock(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			l := &Lockdown{}
-			tt.action(l)
+			l := newTestLockdown(t, "")
+			tt.action(t, l)
 			isLocked := l.IsLocked()
 			assert.Equal(t, tt.expectedLock, isLocked)
 		})
 	}
+}
+
+// TestLockdown_ReleaseLockOverride covers the temporary override that releasing
+// the lock creates while a scheduled lockdown is active, and its expiry.
+func TestLockdown_ReleaseLockOverride(t *testing.T) {
+	t.Run("release overrides an active scheduled lockdown", func(t *testing.T) {
+		l := newTestLockdown(t, "")
+		l.Schedules = []LockdownSchedule{scheduleAround(-2*time.Minute, 2*time.Minute)}
+		require.True(t, l.IsLocked(), "the schedule should lock the system")
+
+		require.NoError(t, l.ReleaseLock())
+		assert.False(t, l.IsLocked(), "the release should suppress the scheduled lockdown")
+	})
+
+	t.Run("the schedule takes effect again once the override expires", func(t *testing.T) {
+		l := newTestLockdown(t, "")
+		l.Schedules = []LockdownSchedule{scheduleAround(-2*time.Minute, 2*time.Minute)}
+		l.overrideDuration = 10 * time.Millisecond
+
+		require.NoError(t, l.ReleaseLock())
+		require.False(t, l.IsLocked())
+
+		time.Sleep(20 * time.Millisecond)
+		assert.True(t, l.IsLocked(), "the scheduled lockdown should resume after the override deadline")
+	})
+
+	t.Run("no override is created without an active schedule", func(t *testing.T) {
+		l := newTestLockdown(t, "")
+		require.NoError(t, l.SetLock())
+		require.NoError(t, l.ReleaseLock())
+
+		state, err := l.store.State()
+		require.NoError(t, err)
+		assert.True(t, state.OverrideUntil.IsZero())
+	})
+
+	t.Run("setting the lock again drops the override", func(t *testing.T) {
+		l := newTestLockdown(t, "")
+		l.Schedules = []LockdownSchedule{scheduleAround(-2*time.Minute, 2*time.Minute)}
+
+		require.NoError(t, l.ReleaseLock())
+		require.False(t, l.IsLocked())
+
+		require.NoError(t, l.SetLock())
+		assert.True(t, l.IsLocked())
+	})
+}
+
+// TestLockdown_IsLockedFailsClosed verifies that an unreadable shared lock state
+// rejects deployments instead of silently letting them through during a freeze.
+func TestLockdown_IsLockedFailsClosed(t *testing.T) {
+	l := &Lockdown{store: failingDeployLockStore{}, overrideDuration: defaultOverrideDuration}
+	assert.True(t, l.IsLocked())
 }
 
 func TestTimeWithinSchedule(t *testing.T) {
@@ -268,7 +365,7 @@ func TestNewLockdown(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewLockdown(tt.schedules)
+			_, err := NewLockdown(tt.schedules, lock.NewInMemoryDeployLockStore())
 			if tt.hasError {
 				assert.Error(t, err)
 			} else {
@@ -280,7 +377,7 @@ func TestNewLockdown(t *testing.T) {
 
 // TestLockdown_ConcurrentAccess verifies that the lockdown struct is thread-safe.
 func TestLockdown_ConcurrentAccess(t *testing.T) {
-	l := &Lockdown{}
+	l := newTestLockdown(t, "")
 	var wg sync.WaitGroup
 
 	// Multiple goroutines setting and releasing locks
@@ -288,10 +385,12 @@ func TestLockdown_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// assert, not require: require calls t.FailNow, which is only
+			// valid on the goroutine running the test.
 			for j := 0; j < 100; j++ {
-				l.SetLock()
+				assert.NoError(t, l.SetLock())
 				_ = l.IsLocked()
-				l.ReleaseLock()
+				assert.NoError(t, l.ReleaseLock())
 				_ = l.IsLocked()
 			}
 		}()
@@ -320,40 +419,51 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 	}
 
 	t.Run("notifies on lock state transitions", func(t *testing.T) {
-		l := &Lockdown{}
+		l := newTestLockdown(t, "")
 		stop := make(chan struct{})
 		defer close(stop)
 
 		// Establish a locked baseline, then let the watcher record it before
 		// mutating state, so the transitions below are detected deterministically.
-		l.SetLock()
+		require.NoError(t, l.SetLock())
 
 		msgs := make(chan string, 4)
 		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
 		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its baseline
 
-		l.ReleaseLock()
+		require.NoError(t, l.ReleaseLock())
 		assert.Equal(t, "unlocked", recv(t, msgs))
 
-		l.SetLock()
+		require.NoError(t, l.SetLock())
 		assert.Equal(t, "locked", recv(t, msgs))
 	})
 
+	t.Run("notifies when another replica releases the lock", func(t *testing.T) {
+		// The watcher is how clients connected to a replica that did not serve
+		// the request learn about a lock change: it observes only the shared
+		// state, not the local call.
+		store := lock.NewInMemoryDeployLockStore()
+		l, err := NewLockdown("", store)
+		require.NoError(t, err)
+		require.NoError(t, store.Lock())
+
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 4)
+		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
+		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its locked baseline
+
+		require.NoError(t, store.Release(time.Time{}))
+
+		assert.Equal(t, "unlocked", recv(t, msgs))
+	})
+
 	t.Run("notifies on a schedule-derived transition", func(t *testing.T) {
-		// Build a schedule window spanning four minutes around now so IsLocked
-		// is true via the schedule (not ManualLock) at baseline. The wide margin
-		// keeps the window covering "now" across hour/day/week boundaries.
-		now := time.Now()
-		start := now.Add(-2 * time.Minute)
-		end := now.Add(2 * time.Minute)
-		l := &Lockdown{Schedules: []LockdownSchedule{{
-			StartDay:  start.Weekday(),
-			StartHour: start.Hour(),
-			StartMin:  start.Minute(),
-			EndDay:    end.Weekday(),
-			EndHour:   end.Hour(),
-			EndMin:    end.Minute(),
-		}}}
+		// A schedule window spanning four minutes around now locks the system
+		// without a manual lock, so the transition below is schedule-derived.
+		l := newTestLockdown(t, "")
+		l.Schedules = []LockdownSchedule{scheduleAround(-2*time.Minute, 2*time.Minute)}
 		assert.True(t, l.IsLocked(), "schedule should lock the system at baseline")
 
 		stop := make(chan struct{})
@@ -363,17 +473,14 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
 		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its locked baseline
 
-		// Enabling override mode makes isLockedInternal return false without
-		// touching ManualLock, simulating a scheduled window boundary.
-		l.mu.Lock()
-		l.OverrideMode = true
-		l.mu.Unlock()
+		// An override suppresses the scheduled window, simulating its boundary.
+		require.NoError(t, l.ReleaseLock())
 
 		assert.Equal(t, "unlocked", recv(t, msgs))
 	})
 
 	t.Run("does not notify without a transition", func(t *testing.T) {
-		l := &Lockdown{}
+		l := newTestLockdown(t, "")
 		stop := make(chan struct{})
 		defer close(stop)
 
@@ -388,8 +495,27 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 		}
 	})
 
+	t.Run("does not notify while the lock state is unreadable", func(t *testing.T) {
+		// Enforcement fails closed on a read error, but the watcher must not
+		// treat "unknown" as a transition — that would flap the banner between
+		// locked and unlocked on every transient database error.
+		l := &Lockdown{store: failingDeployLockStore{}, overrideDuration: defaultOverrideDuration}
+		stop := make(chan struct{})
+		defer close(stop)
+
+		msgs := make(chan string, 1)
+		go l.WatchTransitions(stop, 5*time.Millisecond, func(m string) { msgs <- m })
+
+		select {
+		case m := <-msgs:
+			t.Fatalf("unexpected notification while the store was failing: %q", m)
+		case <-time.After(50 * time.Millisecond):
+			// staying silent is the expected outcome
+		}
+	})
+
 	t.Run("stops when stop channel is closed", func(t *testing.T) {
-		l := &Lockdown{}
+		l := newTestLockdown(t, "")
 		stop := make(chan struct{})
 		done := make(chan struct{})
 
@@ -409,83 +535,61 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 	})
 }
 
-// TestLockdown_ExpireOverride verifies that once the override window ends, the
-// system re-notifies clients with "locked" only when it is genuinely still
-// locked, and stays silent when the lock has meanwhile been lifted.
-func TestLockdown_ExpireOverride(t *testing.T) {
-	// scheduleAround builds a one-off schedule window offset from now, so tests
-	// can reproduce a scheduled lockdown that is still open or already closed.
-	// The wide margins keep the window on the correct side of "now" across
-	// hour/day/week boundaries.
-	scheduleAround := func(startOffset, endOffset time.Duration) LockdownSchedule {
-		now := time.Now()
-		start := now.Add(startOffset)
-		end := now.Add(endOffset)
-		return LockdownSchedule{
-			StartDay:  start.Weekday(),
-			StartHour: start.Hour(),
-			StartMin:  start.Minute(),
-			EndDay:    end.Weekday(),
-			EndHour:   end.Hour(),
-			EndMin:    end.Minute(),
-		}
+// TestLockdown_IsLockedWith covers how the shared state and the local schedules
+// combine into the resolved lock state.
+func TestLockdown_IsLockedWith(t *testing.T) {
+	now := time.Now()
+	openWindow := scheduleAround(-2*time.Minute, 2*time.Minute)
+	closedWindow := scheduleAround(-4*time.Minute, -2*time.Minute)
+
+	testCases := []struct {
+		name      string
+		schedules []LockdownSchedule
+		state     lock.DeployLockState
+		expected  bool
+	}{
+		{
+			name:     "locked when the manual lock is set",
+			state:    lock.DeployLockState{ManualLock: true},
+			expected: true,
+		},
+		{
+			name:      "unlocked while an override is pending",
+			schedules: []LockdownSchedule{openWindow},
+			state:     lock.DeployLockState{OverrideUntil: now.Add(time.Minute)},
+			expected:  false,
+		},
+		{
+			name:      "the manual lock outranks a pending override",
+			schedules: []LockdownSchedule{openWindow},
+			state:     lock.DeployLockState{ManualLock: true, OverrideUntil: now.Add(time.Minute)},
+			expected:  true,
+		},
+		{
+			name:      "the schedule takes effect again once the override expired",
+			schedules: []LockdownSchedule{openWindow},
+			state:     lock.DeployLockState{OverrideUntil: now.Add(-time.Minute)},
+			expected:  true,
+		},
+		{
+			// The override deadline is not a promise to re-lock: if the window
+			// closed meanwhile, the system stays unlocked.
+			name:      "unlocked when the schedule window closed during the override",
+			schedules: []LockdownSchedule{closedWindow},
+			state:     lock.DeployLockState{OverrideUntil: now.Add(-time.Minute)},
+			expected:  false,
+		},
+		{
+			name:     "unlocked with no manual lock and no schedule",
+			expected: false,
+		},
 	}
 
-	t.Run("notifies locked when the scheduled window is still open", func(t *testing.T) {
-		// Mirrors the production path: ReleaseLock clears ManualLock, so the only
-		// way the system is still locked after the override expires is an active
-		// schedule window. Once OverrideMode clears, that window must re-notify.
-		l := &Lockdown{OverrideMode: true, Schedules: []LockdownSchedule{
-			scheduleAround(-2*time.Minute, 2*time.Minute),
-		}}
-
-		msgs := make(chan string, 1)
-		l.expireOverride(time.Millisecond, func(m string) { msgs <- m })
-
-		assert.False(t, l.OverrideMode, "override should be cleared")
-		select {
-		case m := <-msgs:
-			assert.Equal(t, "locked", m)
-		case <-time.After(time.Second):
-			t.Fatal("expected a 'locked' notification")
-		}
-	})
-
-	t.Run("stays silent when the scheduled window closed during the override", func(t *testing.T) {
-		// The exact bug scenario: the schedule window elapsed while the override
-		// was active, so once OverrideMode clears the system is unlocked and no
-		// stale "locked" message must be sent.
-		l := &Lockdown{OverrideMode: true, Schedules: []LockdownSchedule{
-			scheduleAround(-4*time.Minute, -2*time.Minute),
-		}}
-
-		msgs := make(chan string, 1)
-		l.expireOverride(time.Millisecond, func(m string) { msgs <- m })
-
-		assert.False(t, l.OverrideMode, "override should be cleared")
-		select {
-		case m := <-msgs:
-			t.Fatalf("unexpected notification: %q", m)
-		case <-time.After(50 * time.Millisecond):
-			// no notification is the expected outcome
-		}
-	})
-}
-
-// TestLockdown_IsLockedInternal tests the internal lock checking logic.
-func TestLockdown_IsLockedInternal(t *testing.T) {
-	t.Run("returns true when ManualLock is set", func(t *testing.T) {
-		l := &Lockdown{ManualLock: true}
-		assert.True(t, l.IsLocked())
-	})
-
-	t.Run("returns false when OverrideMode is set without ManualLock", func(t *testing.T) {
-		l := &Lockdown{OverrideMode: true}
-		assert.False(t, l.IsLocked())
-	})
-
-	t.Run("ManualLock takes precedence over OverrideMode", func(t *testing.T) {
-		l := &Lockdown{ManualLock: true, OverrideMode: true}
-		assert.True(t, l.IsLocked())
-	})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newTestLockdown(t, "")
+			l.Schedules = tt.schedules
+			assert.Equal(t, tt.expected, l.isLockedWith(tt.state, now))
+		})
+	}
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -856,6 +857,130 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	// logging at all, so a differently-worded line added later is caught too. If
 	// a legitimate success-path log is ever added, make the exception here.
 	assert.Empty(t, logs.String(), "a successful /ws upgrade must not log per-request")
+}
+
+// readCountingStore counts State() calls so a test can wait until the lock
+// watcher has read its baseline before changing the state under it.
+type readCountingStore struct {
+	lock.DeployLockStore
+	reads atomic.Int64
+}
+
+func (s *readCountingStore) State() (lock.DeployLockState, error) {
+	s.reads.Add(1)
+	return s.DeployLockStore.State()
+}
+
+// TestDeployLockNotifiedOnlyByWatcher pins the single-notifier invariant: the
+// lock watcher is the only thing that pushes lock state to clients, and the API
+// handlers do not push directly.
+//
+// This is not about the duplicate message it avoids. WatchTransitions compares
+// each tick against the state it last broadcast, and a handler-side push it does
+// not know about desynchronizes that baseline: if a release is served here and
+// another replica re-acquires the lock before the next tick, the tick sees no
+// change against the stale baseline and stays silent — leaving this replica's
+// clients showing unlocked while the lock is active. Keeping the watcher as the
+// sole notifier makes that impossible, at the cost of the banner on this replica
+// updating within one poll interval rather than instantly.
+// Both handlers are covered: the release path is the one the desync story above
+// turns on, so pinning only the lock path would leave it free to regress.
+func TestDeployLockNotifiedOnlyByWatcher(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		method      string
+		lockedFirst bool // state the watcher must see as its baseline
+		wantMsg     string
+	}{
+		{name: "set", method: http.MethodPost, lockedFirst: false, wantMsg: "locked"},
+		{name: "release", method: http.MethodDelete, lockedFirst: true, wantMsg: "unlocked"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connectionsMutex.Lock()
+			connections = nil
+			closedConns = make(map[*websocket.Conn]bool)
+			connectionsMutex.Unlock()
+
+			tmpDir := t.TempDir()
+			require.NoError(t, os.WriteFile(tmpDir+"/index.html", []byte("<html></html>"), 0644))
+
+			strategies := map[string]auth.AuthStrategy{oidcHeader: newAuthStrategy(t, true, nil)}
+			store := &readCountingStore{DeployLockStore: lock.NewInMemoryDeployLockStore()}
+			if tt.lockedFirst {
+				require.NoError(t, store.Lock())
+			}
+			lockdown, err := NewLockdown("", store)
+			require.NoError(t, err)
+
+			env := &Env{
+				lockdown:      lockdown,
+				strategies:    strategies,
+				authenticator: auth.NewAuthenticator(strategies),
+				// Without this, Shutdown has no channel to close, so it waits out the
+				// full shutdownTimeout and leaves the connection goroutine running.
+				shutdownCh: make(chan struct{}),
+				config: &config.ServerConfig{
+					StaticFilePath: tmpDir,
+					DevEnvironment: true, // allow the test origin through the WS origin check
+					OIDC:           config.OIDCConfig{Enabled: true},
+				},
+			}
+
+			server := httptest.NewServer(env.CreateRouter())
+			t.Cleanup(func() {
+				env.Shutdown()
+				server.Close()
+				connectionsMutex.Lock()
+				connections = nil
+				closedConns = make(map[*websocket.Conn]bool)
+				connectionsMutex.Unlock()
+			})
+
+			dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer dialCancel()
+			conn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http")+"/ws", nil)
+			require.NoError(t, err)
+			defer conn.Close(websocket.StatusNormalClosure, "test complete")
+
+			// Run the watcher far faster than production so the test does not wait 5s.
+			stop := make(chan struct{})
+			defer close(stop)
+			go lockdown.WatchTransitions(stop, 5*time.Millisecond, notifyWebSocketClients)
+
+			// The watcher captures its baseline on entry, and only a change against
+			// that baseline is broadcast. Wait for the baseline read before mutating,
+			// otherwise a request that wins the race makes the post-change value the
+			// baseline and nothing is ever pushed. Neither handler reads the state, so
+			// any read is the watcher's.
+			require.Eventually(t, func() bool { return store.reads.Load() > 0 },
+				5*time.Second, time.Millisecond, "lock watcher never read its baseline")
+
+			req, err := http.NewRequest(tt.method, server.URL+"/api/v1/deploy-lock", nil)
+			require.NoError(t, err)
+			req.Header.Set(oidcHeader, "Bearer valid-token")
+			resp, err := server.Client().Do(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer readCancel()
+			_, msg, err := conn.Read(readCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMsg, string(msg))
+
+			// Exactly one push: a second one would mean a notifier other than the
+			// watcher also fired, which is what desynchronizes the watcher's baseline.
+			quietCtx, quietCancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+			defer quietCancel()
+			_, extra, err := conn.Read(quietCtx)
+			assert.ErrorIs(t, err, context.DeadlineExceeded, "unexpected second push: %q", string(extra))
+		})
+	}
 }
 
 func TestWsResponseWriterHijackNilConn(t *testing.T) {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/prometheus"
@@ -135,7 +136,7 @@ func TestDeployLock(t *testing.T) {
 	router := gin.Default()
 	env := &Env{config: dummyConfig}
 
-	env.lockdown, err = NewLockdown(dummyConfig.LockdownSchedule)
+	env.lockdown, err = NewLockdown(dummyConfig.LockdownSchedule, lock.NewInMemoryDeployLockStore())
 	assert.NoError(t, err)
 
 	t.Run("SetDeployLock", func(t *testing.T) {
@@ -208,7 +209,7 @@ func TestDeployLockEndpointRegistration(t *testing.T) {
 		}
 		env := &Env{config: serverConfig}
 		var err error
-		env.lockdown, err = NewLockdown("")
+		env.lockdown, err = NewLockdown("", lock.NewInMemoryDeployLockStore())
 		require.NoError(t, err)
 		return env.CreateRouter()
 	}
@@ -291,7 +292,7 @@ func TestNewEnv(t *testing.T) {
 	metrics := &prometheus.Metrics{}
 	updater := &argocd.ArgoStatusUpdater{}
 
-	env, err := NewEnv(serverConfig, argo, metrics, updater)
+	env, err := NewEnv(serverConfig, argo, metrics, updater, lock.NewInMemoryDeployLockStore())
 
 	assert.NoError(t, err)
 	assert.Equal(t, env.config, serverConfig)
@@ -328,7 +329,7 @@ func TestNewEnvInvalidOIDCURL(t *testing.T) {
 		},
 	}
 
-	env, err := NewEnv(serverConfig, &argocd.Argo{}, &prometheus.Metrics{}, &argocd.ArgoStatusUpdater{})
+	env, err := NewEnv(serverConfig, &argocd.Argo{}, &prometheus.Metrics{}, &argocd.ArgoStatusUpdater{}, lock.NewInMemoryDeployLockStore())
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to initialize OIDC auth")
@@ -550,7 +551,7 @@ func TestStaticFileServing(t *testing.T) {
 		config: serverConfig,
 	}
 
-	env.lockdown, _ = NewLockdown("")
+	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 	router := env.CreateRouter()
 
@@ -702,7 +703,7 @@ func TestWebSocketInterceptor(t *testing.T) {
 	env := &Env{
 		config: serverConfig,
 	}
-	env.lockdown, _ = NewLockdown("")
+	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 	router := env.CreateRouter()
 
@@ -812,7 +813,7 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	}
 
 	env := &Env{config: serverConfig}
-	env.lockdown, _ = NewLockdown("")
+	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 	router := env.CreateRouter()
 
@@ -1427,9 +1428,10 @@ func TestEnvShutdown(t *testing.T) {
 	})
 }
 
-// TestStartLockdownWatcher verifies the watcher goroutine lifecycle: it is a
-// no-op without schedules, and when schedules exist it is tracked by connWg and
-// stops when the shutdown channel is closed.
+// TestStartLockdownWatcher verifies the watcher goroutine lifecycle: it runs
+// regardless of whether schedules are configured — with a shared deploy lock
+// store it is how clients learn about a lock another replica set — and it is
+// tracked by connWg so it stops when the shutdown channel is closed.
 func TestStartLockdownWatcher(t *testing.T) {
 	// waitTracked reports whether connWg reaches zero within the timeout.
 	waitTracked := func(env *Env, timeout time.Duration) bool {
@@ -1446,21 +1448,26 @@ func TestStartLockdownWatcher(t *testing.T) {
 		}
 	}
 
-	t.Run("no-op when no schedules are configured", func(t *testing.T) {
+	t.Run("runs even when no schedules are configured", func(t *testing.T) {
 		env := &Env{shutdownCh: make(chan struct{})}
-		env.lockdown = &Lockdown{}
+		env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 		env.StartLockdownWatcher()
 
-		// No goroutine should have been started, so connWg is already at zero.
-		assert.True(t, waitTracked(env, 100*time.Millisecond), "no watcher goroutine expected without schedules")
+		// Lock changes made on another replica are only observable by polling,
+		// so the watcher must run even without schedules.
+		assert.False(t, waitTracked(env, 100*time.Millisecond), "watcher should run without schedules")
+
+		close(env.shutdownCh)
+		assert.True(t, waitTracked(env, time.Second), "watcher should exit after shutdown channel is closed")
 	})
 
 	t.Run("tracks the watcher and stops on shutdown", func(t *testing.T) {
 		env := &Env{shutdownCh: make(chan struct{})}
-		env.lockdown = &Lockdown{Schedules: []LockdownSchedule{
+		env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
+		env.lockdown.Schedules = []LockdownSchedule{
 			{StartDay: time.Monday, StartHour: 0, StartMin: 0, EndDay: time.Monday, EndHour: 1, EndMin: 0},
-		}}
+		}
 
 		env.StartLockdownWatcher()
 
@@ -1487,7 +1494,7 @@ func TestStartRouter(t *testing.T) {
 	}
 
 	env := &Env{config: serverConfig}
-	env.lockdown, _ = NewLockdown("")
+	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 	router := env.CreateRouter()
 	srv := env.StartRouter(router)
@@ -1718,7 +1725,7 @@ func TestCreateRouterInitializesShutdownChannel(t *testing.T) {
 		config:     serverConfig,
 		shutdownCh: nil,
 	}
-	env.lockdown, _ = NewLockdown("")
+	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
 	// CreateRouter should initialize the shutdown channel
 	_ = env.CreateRouter()
@@ -1988,8 +1995,8 @@ func TestAddTaskEndpoint(t *testing.T) {
 	})
 
 	t.Run("rejects task when lockdown is active", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
-		lockdown.SetLock()
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
+		require.NoError(t, lockdown.SetLock())
 
 		env := &Env{
 			lockdown: lockdown,
@@ -2009,11 +2016,38 @@ func TestAddTaskEndpoint(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "lockdown is active")
 	})
 
+	t.Run("rejects task when a lock was set through the shared store", func(t *testing.T) {
+		// The reason the lock is shared: a lock engaged elsewhere — another
+		// replica, writing the same store — must reject deploys here, without
+		// this process ever being told. Locking the store directly, rather than
+		// via the Lockdown, is what a peer replica looks like from here.
+		store := lock.NewInMemoryDeployLockStore()
+		lockdown, err := NewLockdown("", store)
+		require.NoError(t, err)
+		require.NoError(t, store.Lock())
+
+		env := &Env{
+			lockdown: lockdown,
+		}
+
+		router := gin.New()
+		router.POST("/api/v1/tasks", env.addTask)
+
+		taskJSON := `{"app": "test-app", "author": "test-author", "project": "test-project", "images": [{"image": "test", "tag": "v1"}]}`
+		req, _ := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(taskJSON))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotAcceptable, w.Code)
+		assert.Contains(t, w.Body.String(), "lockdown is active")
+	})
+
 	t.Run("returns 401 with reason when token validation fails", func(t *testing.T) {
 		// A bad token is a client mistake, not a server failure — 401, not 500.
 		// The strategy's error must surface in the response body so the client
 		// can show the user something actionable (e.g. "deploy token is invalid").
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies["Authorization"] = newAuthStrategy(t, false, fmt.Errorf("deploy token is invalid"))
 
@@ -2038,7 +2072,7 @@ func TestAddTaskEndpoint(t *testing.T) {
 	})
 
 	t.Run("returns error when argo.AddTask fails", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := make(map[string]auth.AuthStrategy)
 
 		ctrl := gomock.NewController(t)
@@ -2078,7 +2112,7 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 		// Strategy returned (false, err) — auth attempted but failed.
 		// The 401 body should carry the strategy's reason so the client
 		// can distinguish "wrong token" from "expired token" etc.
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies[oidcHeader] = newAuthStrategy(t, false, fmt.Errorf("token expired"))
 
@@ -2107,7 +2141,7 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 		// No auth header at all — Authenticator returns (false, nil),
 		// distinct from invalid auth. The 401 body should hint that
 		// authentication is required, rather than implying a wrong token.
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies[oidcHeader] = newAuthStrategy(t, false, nil)
 
@@ -2133,7 +2167,7 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 	})
 
 	t.Run("sets lock when token is valid", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies[oidcHeader] = newAuthStrategy(t, true, nil)
 
@@ -2160,13 +2194,75 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 	})
 }
 
+// TestDeployLockStoreFailure verifies that a lock the server could not persist
+// is reported as a failure instead of a success: an operator who is told the
+// deploy lock is set must not be left with deployments still flowing. The store
+// error itself stays in the log.
+func TestDeployLockStoreFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// newEnv builds an authenticated Env whose deploy lock store always fails.
+	newEnv := func(t *testing.T) *Env {
+		t.Helper()
+
+		strategies := make(map[string]auth.AuthStrategy)
+		strategies[oidcHeader] = newAuthStrategy(t, true, nil)
+
+		return &Env{
+			lockdown:      &Lockdown{store: failingDeployLockStore{}, overrideDuration: defaultOverrideDuration},
+			strategies:    strategies,
+			authenticator: auth.NewAuthenticator(strategies),
+			config: &config.ServerConfig{
+				OIDC: config.OIDCConfig{Enabled: true},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		method   string
+		register func(*gin.Engine, *Env)
+		message  string
+	}{
+		{
+			name:     "set",
+			method:   http.MethodPost,
+			register: func(r *gin.Engine, env *Env) { r.POST("/api/v1/deploy-lock", env.SetDeployLock) },
+			message:  "failed to set deploy lock",
+		},
+		{
+			name:     "release",
+			method:   http.MethodDelete,
+			register: func(r *gin.Engine, env *Env) { r.DELETE("/api/v1/deploy-lock", env.ReleaseDeployLock) },
+			message:  "failed to release deploy lock",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newEnv(t)
+			router := gin.New()
+			tt.register(router, env)
+
+			req, _ := http.NewRequest(tt.method, "/api/v1/deploy-lock", nil)
+			req.Header.Set(oidcHeader, "Bearer valid-token")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			assert.Contains(t, w.Body.String(), tt.message)
+			assert.NotContains(t, w.Body.String(), "database is unreachable", "the store error must not reach the client")
+		})
+	}
+}
+
 // TestSetDeployLockAcceptsLegacyKeycloakHeader verifies backward compatibility:
 // a client still sending the deprecated Keycloak-Authorization header (instead of
 // the canonical Oidc-Authorization) is authenticated exactly as before.
 func TestSetDeployLockAcceptsLegacyKeycloakHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	lockdown, _ := NewLockdown("")
+	lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 	strategies := make(map[string]auth.AuthStrategy)
 	strategies[legacyKeycloakHeader] = newAuthStrategy(t, true, nil)
 
@@ -2199,7 +2295,7 @@ func TestRequireOIDCAuthHeaderPrecedence(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("invalid token on the legacy header surfaces the reason as 401", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		strategies := map[string]auth.AuthStrategy{
 			legacyKeycloakHeader: newAuthStrategy(t, false, fmt.Errorf("token expired")),
 		}
@@ -2222,7 +2318,7 @@ func TestRequireOIDCAuthHeaderPrecedence(t *testing.T) {
 	})
 
 	t.Run("a rejected canonical header does not fall through to the legacy header", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		legacy := mocks.NewMockAuthStrategy(gomock.NewController(t))
 		legacy.EXPECT().Validate(gomock.Any()).Times(0) // must never be consulted
 		strategies := map[string]auth.AuthStrategy{
@@ -2256,8 +2352,8 @@ func TestReleaseDeployLockWithKeycloak(t *testing.T) {
 	t.Run("returns 401 with reason when token is invalid", func(t *testing.T) {
 		// Strategy returned (false, err): auth attempted but failed.
 		// The 401 body should carry the strategy's reason.
-		lockdown, _ := NewLockdown("")
-		lockdown.SetLock()
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
+		require.NoError(t, lockdown.SetLock())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies[oidcHeader] = newAuthStrategy(t, false, fmt.Errorf("token expired"))
 
@@ -2283,8 +2379,8 @@ func TestReleaseDeployLockWithKeycloak(t *testing.T) {
 	})
 
 	t.Run("releases lock when token is valid", func(t *testing.T) {
-		lockdown, _ := NewLockdown("")
-		lockdown.SetLock()
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
+		require.NoError(t, lockdown.SetLock())
 		strategies := make(map[string]auth.AuthStrategy)
 		strategies[oidcHeader] = newAuthStrategy(t, true, nil)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,8 +133,9 @@ func (s *Server) Run() {
 
 	srv := s.env.StartRouter(s.router)
 
-	// Notify clients about scheduled lockdown transitions they wouldn't
-	// otherwise learn about (scheduled state is evaluated lazily).
+	// The only notifier of deploy-lock changes to Web UI clients — manual locks
+	// (including ones set through another replica), schedule boundaries and override
+	// expiry alike. Must always run; see StartLockdownWatcher.
 	s.env.StartLockdownWatcher()
 
 	// Notify clients when ArgoCD reachability changes so the frontend can show

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,9 +52,11 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	argo := &argocd.Argo{}
 	argo.Init(s, api, metrics)
 
-	// The distributed Postgres locker requires the Postgres state; otherwise fall
-	// back to an in-memory lock (single-instance only).
+	// The distributed Postgres locker and the shared deploy lock both require the
+	// Postgres state; otherwise fall back to in-memory equivalents, which are
+	// correct for a single replica only.
 	var locker lock.Locker
+	var deployLockStore lock.DeployLockStore
 	if serverConfig.StateType == "postgres" {
 		pgState, ok := s.(*state.PostgresState)
 		if !ok {
@@ -65,10 +67,12 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 			return nil, fmt.Errorf("could not get a valid DB connection from the postgres state")
 		}
 		locker = lock.NewPostgresLocker(db)
-		slog.Info("Using Postgres advisory locks for distributed locking.")
+		deployLockStore = lock.NewPostgresDeployLockStore(db)
+		slog.Info("Using Postgres advisory locks for distributed locking and a shared deploy lock.")
 	} else {
 		locker = lock.NewInMemoryLocker()
-		slog.Warn("Using in-memory lock. This is not suitable for HA setups.")
+		deployLockStore = lock.NewInMemoryDeployLockStore()
+		slog.Warn("Using in-memory lock and deploy lock. This is not suitable for HA setups.")
 	}
 
 	// Batch write-back settings are parsed independently of the full git config so
@@ -96,7 +100,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		return nil, fmt.Errorf("failed to initialize the argo updater: %w", err)
 	}
 
-	env, err := NewEnv(serverConfig, argo, metrics, statusUpdater)
+	env, err := NewEnv(serverConfig, argo, metrics, statusUpdater, deployLockStore)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -52,7 +52,7 @@ task notifications        # assert the generic webhook fires (start + result) wi
 task load                 # git-conflict soak: competitor + concurrent deploys, strict 0-failed
 task batch-writeback      # toggle GIT_BATCH_WRITEBACK on, re-run the contention soak: assert 0 lost updates + real coalescing (mean batch size > 1), then revert
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
-task state-postgres       # flip the release to Postgres state: assert migration, deploy loop, task survives a pod restart, supersession under contention
+task state-postgres       # flip the release to Postgres state: assert migration, deploy loop, task survives a pod restart, the shared deploy lock, supersession under contention
 task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks)
 task argocd-unreachable   # scale ArgoCD down: assert /reachability flips (reason "argocd") + the watcher broadcasts "argocd_down:argocd" + POST fast-fails 503, then recovers
 task shutdown-drain       # assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic
@@ -88,7 +88,7 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
 | `scripts/failure-diagnostics.sh` | table-driven failure-reason assertions, driven through the real client (add a case = one table entry) |
 | `scripts/race-supersede.sh` | same-app supersession assertion: real client, newer deploy wins, older is superseded |
-| `scripts/state-postgres.sh` | flip the release to `STATE_TYPE=postgres` and assert the Postgres-only path: schema migration Job, real deploy loop, task history surviving a pod restart (in-memory loses it), and supersession under contention (the hand-written `CancelInProgressTasks` SQL) |
+| `scripts/state-postgres.sh` | flip the release to `STATE_TYPE=postgres` and assert the Postgres-only path: schema migration Job, real deploy loop, task history surviving a pod restart (in-memory loses it), the shared deploy lock (a lock row written by another writer rejects deploys here), and supersession under contention (the hand-written `CancelInProgressTasks` SQL) |
 | `scripts/batch-writeback.sh` | toggle `GIT_BATCH_WRITEBACK=true` on the release, re-run the contention soak, and revert; reuses `collect.sh` (with `BATCH_MODE`) to gate on zero lost updates and real coalescing (`gitops_batch_size` mean > 1) |
 | `fixtures/postgres/` | in-cluster Postgres (Secret + Service + StatefulSet, one resource per file) the `state-postgres` phase points the release at; the chart bundles no database |
 | `values/argo-watcher-postgres.yaml` | overlay layered over `values/argo-watcher.yaml` that enables `postgres` (sets `STATE_TYPE=postgres`, wires `DB_*`, triggers the migration Job) |

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -143,8 +143,9 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
   to observe a *scheduled* `"locked"` broadcast (the watcher notifies on state
   change, not at boot, and polls at minute granularity). The 406 + `GET`-true +
   revert-accepts checks are deterministic; the WS-transition sub-check is skipped
-  (not failed) if a slow rollout boots in-window. Manual (Keycloak) lock/unlock
-  WS notifications are a separate, deterministic trigger left to the heavy tier.
+  (not failed) if a slow rollout boots in-window. A manual lock/unlock is not a
+  separate trigger — the API handlers do not push, so it reaches clients through
+  the same watcher poll; `state-postgres` asserts that over the WebSocket.
 - **`state-postgres` flips the shared release to Postgres mid-flow rather than
   running a parallel stack.** The base lab is single-replica in-memory; every
   functional phase before this one validates that backend. `state-postgres` then

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -19,8 +19,13 @@
 # broadcast is asserted only when we confirmed the pod booted before the window
 # (GET was false first): if a slow rollout boots in-window the transition already
 # happened un-observed, so that sub-check is skipped with a logged note rather
-# than flaking. Manual (Keycloak) lock/unlock WS notifications are a separate,
-# deterministic trigger covered by the heavy-tier Keycloak phase.
+# than flaking.
+#
+# A manual (Keycloak) lock/unlock is NOT a separate trigger: the API handlers do
+# not push, so it reaches clients through this same lockdown watcher and the same
+# one-poll-interval delay. state-postgres.sh asserts that path over the WS for a
+# lock written by another writer; TestDeployLockNotifiedOnlyByWatcher pins that the
+# handlers stay silent.
 set -euo pipefail
 
 NS_AW="${NS_AW:-argo-watcher}"

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -60,7 +60,10 @@ probe_pid=""
 # Set to 1 while the deploy-lock assertion holds the shared lock (see below).
 lock_set=0
 
-psql_db() { kubectl -n "$NS_AW" exec argo-watcher-db-0 -- psql -qtAX -U argo_watcher -d argo_watcher -c "$1"; }
+psql_db() {
+  local sql="$1"
+  kubectl -n "$NS_AW" exec argo-watcher-db-0 -- psql -qtAX -U argo_watcher -d argo_watcher -c "$sql"
+}
 
 cleanup() {
   # The deploy lock lives in the shared database, so a lock left set by an
@@ -68,6 +71,9 @@ cleanup() {
   if [[ "$lock_set" == 1 ]]; then
     psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null 2>&1 || true
   fi
+  # jobs -p prints one PID per line; splitting them into separate arguments is
+  # the point, and they are always bare digits.
+  # shellcheck disable=SC2046
   kill $(jobs -p) 2>/dev/null || true
   rm -rf "$bin_dir" "$probe_out"
 }

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -14,7 +14,12 @@
 #      same restart loses all history (the task would 404); on Postgres it is
 #      still there, 'deployed'. This is the whole reason the Postgres backend
 #      exists, and nothing else in the suite (or the unit tests) asserts it.
-#   4. supersession under real git contention works on Postgres — a newer deploy
+#   4. the deploy lock is SHARED and PERSISTENT: a lock row written by another
+#      writer (what a second replica's SetLock does) is honored by this server —
+#      GET reports it and deploys are rejected — it survives a pod restart, and
+#      clearing it unblocks deploys again. On in-memory state the lock never
+#      leaves the process that set it and dies with it.
+#   5. supersession under real git contention works on Postgres — a newer deploy
 #      cancels an older retrying one via CancelInProgressTasks (hand-written SQL
 #      that DIFFERS from the in-memory Go path) and the superseded task never
 #      clobbers the winner's write-back. This guards git-op correctness on the
@@ -48,7 +53,21 @@ root="$(cd "${here}/../../.." && pwd)"
 bin_dir="$(mktemp -d)"
 CLIENT_BIN="${bin_dir}/aw-client"
 pf_pid=""
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
+# Set to 1 while the deploy-lock assertion holds the shared lock (see below).
+lock_set=0
+
+psql_db() { kubectl -n "$NS_AW" exec argo-watcher-db-0 -- psql -qtAX -U argo_watcher -d argo_watcher -c "$1"; }
+
+cleanup() {
+  # The deploy lock lives in the shared database, so a lock left set by an
+  # aborted run would 406 every deploy in the phases that follow. Always drop it.
+  if [[ "$lock_set" == 1 ]]; then
+    psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null 2>&1 || true
+  fi
+  kill $(jobs -p) 2>/dev/null || true
+  rm -rf "$bin_dir"
+}
+trap cleanup EXIT
 
 base="http://localhost:${PORT}/api/v1"
 
@@ -149,6 +168,62 @@ if [[ "$code" != "200" || "$status_after" != "deployed" ]]; then
 fi
 echo "  OK   task ${id} still present as 'deployed' after the restart"
 
+echo "=== shared deploy lock: a lock written by another writer is honored ==="
+# The manual lock API needs OIDC (heavy tier), so write the shared row directly —
+# which is exactly what a second replica's SetLock does. This asserts the whole
+# read path on Postgres: the migration created deploy_lock, the server reads it
+# per request, and a lock nobody set on THIS process still rejects deployments.
+# The EXIT trap clears the lock, so an abort mid-assertion cannot freeze the
+# release for the phases that follow.
+psql_db "UPDATE deploy_lock SET manual_lock = true, override_until = NULL" >/dev/null
+lock_set=1
+
+if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then
+  echo "STATE-POSTGRES: FAIL — GET /deploy-lock did not report the shared lock"
+  exit 1
+fi
+
+code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "${base}/tasks" \
+  -H 'Content-Type: application/json' \
+  -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
+  -d "{\"app\":\"${APP}\",\"author\":\"e2e-pg\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.3\"}]}")
+if [[ "$code" != "406" ]]; then
+  echo "STATE-POSTGRES: FAIL — deploy during a shared lock returned ${code}, want 406"
+  exit 1
+fi
+echo "  OK   shared lock rejects deployments (406) on a replica that never set it"
+
+# The lock must also OUTLIVE the process that would have held it in memory: the
+# old implementation lost it on restart, which is the other half of why it moved
+# into the database. A fresh pod reads the row on its first request.
+echo "  restarting the server; the lock must still be in effect"
+kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
+forward
+
+if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then
+  echo "STATE-POSTGRES: FAIL — the shared lock did not survive the restart"
+  exit 1
+fi
+
+code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "${base}/tasks" \
+  -H 'Content-Type: application/json' \
+  -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
+  -d "{\"app\":\"${APP}\",\"author\":\"e2e-pg\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.3\"}]}")
+if [[ "$code" != "406" ]]; then
+  echo "STATE-POSTGRES: FAIL — deploy after the restart returned ${code}, want 406 (lock lost)"
+  exit 1
+fi
+echo "  OK   the lock survived the restart and still rejects deployments"
+
+psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null
+lock_set=0
+if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
+  echo "STATE-POSTGRES: FAIL — GET /deploy-lock still locked after the shared release"
+  exit 1
+fi
+echo "  OK   releasing the shared lock unblocks deployments again"
+
 echo "=== supersession under git contention on Postgres ==="
 # race-supersede.sh is self-contained (resets its app to a baseline, runs its own
 # competitor) and drives CancelInProgressTasks — the one deploy-flow query whose
@@ -174,4 +249,4 @@ if ! DEPLOY_TOKEN="${DEPLOY_TOKEN}" BASE_URL="http://localhost:${PORT}" \
   exit 1
 fi
 
-echo "STATE-POSTGRES: PASS (migrated, deployed, survived restart, superseded under contention)"
+echo "STATE-POSTGRES: PASS (migrated, deployed, survived restart, shared deploy lock, superseded under contention)"

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -16,8 +16,10 @@
 #      exists, and nothing else in the suite (or the unit tests) asserts it.
 #   4. the deploy lock is SHARED and PERSISTENT: a lock row written by another
 #      writer (what a second replica's SetLock does) is honored by this server —
-#      GET reports it and deploys are rejected — it survives a pod restart, and
-#      clearing it unblocks deploys again. On in-memory state the lock never
+#      GET reports it, deploys are rejected, and the lockdown watcher broadcasts it
+#      to a connected WebSocket client (the only path a browser has to a lock set
+#      elsewhere, since the API handlers do not push) — it survives a pod restart,
+#      and clearing it unblocks deploys again. On in-memory state the lock never
 #      leaves the process that set it and dies with it.
 #   5. supersession under real git contention works on Postgres — a newer deploy
 #      cancels an older retrying one via CancelInProgressTasks (hand-written SQL
@@ -52,7 +54,9 @@ root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
 CLIENT_BIN="${bin_dir}/aw-client"
+probe_out="$(mktemp)"
 pf_pid=""
+probe_pid=""
 # Set to 1 while the deploy-lock assertion holds the shared lock (see below).
 lock_set=0
 
@@ -65,11 +69,40 @@ cleanup() {
     psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null 2>&1 || true
   fi
   kill $(jobs -p) 2>/dev/null || true
-  rm -rf "$bin_dir"
+  rm -rf "$bin_dir" "$probe_out"
 }
 trap cleanup EXIT
 
 base="http://localhost:${PORT}/api/v1"
+
+# start_probe: hold a WebSocket client open and block until it has connected, so a
+# broadcast triggered afterwards cannot be missed by a slow handshake. A pod
+# restart kills the socket, so call this again after each forward. Any previous
+# probe is killed first: it would otherwise keep appending to the same file that
+# this one truncates, mixing the old capture into the new assertion.
+start_probe() {
+  [[ -n "$probe_pid" ]] && kill "$probe_pid" 2>/dev/null || true
+  : >"$probe_out"
+  WS_URL="ws://localhost:${PORT}/ws" DURATION=300s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
+  probe_pid=$!
+  for _ in $(seq 1 20); do
+    grep -q '^OPEN$' "$probe_out" && return 0
+    sleep 1
+  done
+  echo "STATE-POSTGRES: FAIL — WS probe never connected on :${PORT}"
+  exit 1
+}
+
+# wait_ws <message>: wait up to ~30s (6x the 5s lockdown poll interval) for the
+# lockdown watcher to broadcast <message> to the probe.
+wait_ws() {
+  local message="$1"
+  for _ in $(seq 1 6); do
+    grep -q "^MSG ${message}\$" "$probe_out" && return 0
+    sleep 5
+  done
+  return 1
+}
 
 # forward: (re)establish a port-forward to the argo-watcher service and block until
 # /healthz answers. Called again after the restart, since deleting the pod kills
@@ -122,6 +155,8 @@ echo "  OK   /config reports state_type=postgres"
 echo "=== deploying ${APP} on Postgres (real write-back loop) ==="
 ( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) \
   || { echo "STATE-POSTGRES: FAIL — client build failed"; exit 1; }
+( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe ) \
+  || { echo "STATE-POSTGRES: FAIL — wsprobe build failed"; exit 1; }
 
 # Wait for the app's baseline sync, then deploy a tag different from its current one
 # so the write-back actually commits (an unchanged tag is byte-compared and skipped).
@@ -175,11 +210,24 @@ echo "=== shared deploy lock: a lock written by another writer is honored ==="
 # per request, and a lock nobody set on THIS process still rejects deployments.
 # The EXIT trap clears the lock, so an abort mid-assertion cannot freeze the
 # release for the phases that follow.
+#
+# A WS client is held open across the write: since the API handlers do not push,
+# the lockdown watcher is the ONLY thing that tells a browser about a lock set
+# elsewhere. Nothing else in the lab observes that path — lockdown.sh covers the
+# schedule trigger, and that sub-check is skipped when the pod boots in-window.
+start_probe
 psql_db "UPDATE deploy_lock SET manual_lock = true, override_until = NULL" >/dev/null
 lock_set=1
 
 if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then
   echo "STATE-POSTGRES: FAIL — GET /deploy-lock did not report the shared lock"
+  exit 1
+fi
+
+if wait_ws locked; then
+  echo "  OK   the watcher broadcast 'locked' for a lock written by another writer"
+else
+  echo "STATE-POSTGRES: FAIL — no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
   exit 1
 fi
 
@@ -216,6 +264,9 @@ if [[ "$code" != "406" ]]; then
 fi
 echo "  OK   the lock survived the restart and still rejects deployments"
 
+# The restart above killed the previous socket along with its port-forward, so the
+# release needs a probe reconnected to the new pod.
+start_probe
 psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null
 lock_set=0
 if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
@@ -223,6 +274,13 @@ if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; t
   exit 1
 fi
 echo "  OK   releasing the shared lock unblocks deployments again"
+
+if wait_ws unlocked; then
+  echo "  OK   the watcher broadcast 'unlocked' for the shared release"
+else
+  echo "STATE-POSTGRES: FAIL — no 'unlocked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
+  exit 1
+fi
 
 echo "=== supersession under git contention on Postgres ==="
 # race-supersede.sh is self-contained (resets its app to a baseline, runs its own

--- a/web/src/features/argocdStatus/argocdStatusService.test.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.test.ts
@@ -197,6 +197,40 @@ describe('ArgocdStatusService', () => {
     expect(listener).toHaveBeenLastCalledWith({ available: false, reason: 'database' });
   });
 
+  it('discards a fetch that resolves after teardown', async () => {
+    // A fetch still in flight when the last subscriber leaves must not repopulate
+    // the cache teardown just cleared, or the next subscribe replays that value
+    // instead of bootstrapping — which can leave a stale "available" banner during
+    // a real outage (issue #498).
+    mockFetch([{ body: { available: true } }]);
+    const service = new ArgocdStatusService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 1);
+
+    let resolveFetch: (r: Response) => void = () => {};
+    let markStarted: () => void = () => {};
+    const started = new Promise<void>(resolve => { markStarted = resolve; });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise<Response>(resolve => { resolveFetch = resolve; markStarted(); }),
+    );
+    const pending = service.fetchStatus();
+    await started;
+
+    unsubscribe();
+    resolveFetch(new Response(JSON.stringify({ available: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    await pending; // the stale result has now been fully processed (or dropped)
+
+    mockFetch([{ body: { available: false, reason: 'database' } }]);
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith({ available: false, reason: 'database' });
+  });
+
   it('tears down websocket when the last subscriber unsubscribes', async () => {
     mockFetch([{ body: { available: true } }]);
     const service = new ArgocdStatusService();

--- a/web/src/features/argocdStatus/argocdStatusService.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.ts
@@ -210,7 +210,9 @@ export class ArgocdStatusService {
     this.socket = null;
     // Forget the cached reachability so a later re-subscribe bootstraps a fresh
     // fetch instead of replaying a value that may have gone stale while nobody
-    // was listening.
+    // was listening. Bumping fetchSeq invalidates any fetch issued before the
+    // teardown, which would otherwise repopulate the cache as it resolves.
+    this.fetchSeq++;
     this.currentStatus = null;
   }
 }

--- a/web/src/features/deployLock/deployLockService.test.ts
+++ b/web/src/features/deployLock/deployLockService.test.ts
@@ -4,12 +4,17 @@ import { DeployLockService, __testing } from './deployLockService';
 import * as sharedUtils from '../../shared/utils';
 
 class MockWebSocket {
+  public onopen: (() => void) | null = null;
   public onmessage: ((event: { data: string }) => void) | null = null;
   public onclose: (() => void) | null = null;
   public onerror: ((error: unknown) => void) | null = null;
 
   constructor(public url: string) {
     MockWebSocket.instances.push(this);
+  }
+
+  public open() {
+    this.onopen?.();
   }
 
   public close() {
@@ -48,6 +53,33 @@ describe('DeployLockService', () => {
     });
   };
 
+  const jsonResponse = (body: unknown) => new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  // Installs a fetch mock whose responses stay pending until resolved by hand, so
+  // a REST/WebSocket ordering race can be driven deterministically. Every call is
+  // recorded in order, so a test can resolve two concurrent fetches out of order.
+  const mockPendingFetch = () => {
+    const pending: Array<(r: Response) => void> = [];
+    let markStarted: () => void = () => {};
+    const started = new Promise<void>(resolve => { markStarted = resolve; });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise<Response>(resolve => {
+        pending.push(resolve);
+        markStarted();
+      }),
+    );
+    return {
+      started,
+      count: () => pending.length,
+      // Resolves the nth outstanding fetch (0 = the oldest).
+      resolveNth: (index: number, body: unknown) => pending[index](jsonResponse(body)),
+      resolveWith: (body: unknown) => pending[pending.length - 1](jsonResponse(body)),
+    };
+  };
+
   it('fetches initial status and notifies subscribers', async () => {
     mockFetch([{ body: false }]);
     const service = new DeployLockService();
@@ -72,6 +104,266 @@ describe('DeployLockService', () => {
     expect(listener).toHaveBeenLastCalledWith(true);
 
     socket.emit('unlocked');
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('re-fetches the lock state whenever the socket (re)connects', async () => {
+    // The server only pushes on transitions, and with the shared Postgres lock a
+    // transition can be driven by another replica. A lock set while this client's
+    // socket was down (or before its bootstrap fetch failed) would otherwise stay
+    // invisible, hiding an active freeze.
+    mockFetch([{ body: false }, { body: true }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    // Wait for the bootstrap fetch to land before clearing, so the assertion below
+    // can only be satisfied by the onopen refetch.
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    listener.mockClear();
+
+    MockWebSocket.instances[0].open();
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not let a slow REST fetch clobber a newer WebSocket transition', async () => {
+    // A reconcile fetch is held pending while a WS transition lands, then resolves
+    // with the now-stale value; the WS state must win.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+
+    MockWebSocket.instances[0].emit('locked');
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    resolveWith(false);
+    await pending;
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not let a slow REST fetch clobber a just-issued lock operation', async () => {
+    // A reconnect reconcile can be in flight when the operator hits lock; the
+    // explicit operation is newer than the fetch and must not be reverted.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+
+    mockFetch([{ body: 'ok' }]);
+    await service.setLock();
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    resolveWith(false);
+    await pending;
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('re-bootstraps on a fresh subscribe after full teardown', async () => {
+    mockFetch([{ body: false }, { body: true }]);
+    const service = new DeployLockService();
+    const unsubscribe = service.subscribe(vi.fn());
+
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 1);
+    unsubscribe(); // last subscriber leaves -> teardown clears cached state
+
+    const listener = vi.fn();
+    service.subscribe(listener);
+    // currentStatus was reset, so a second bootstrap fetch must fire (not a replay
+    // of a value that could have gone stale while nobody was listening).
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 2);
+    await vi.waitUntil(() => listener.mock.calls.some(call => call[0] === true));
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('drops an older concurrent fetch that resolves after a newer one', async () => {
+    // A (re)connect can have the bootstrap fetch and the onopen reconcile in flight
+    // at once. If the older one resolves last it carries the pre-change value, and
+    // applying it would revert the banner — hiding an active freeze.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    listener.mockClear();
+
+    const { started, count, resolveNth } = mockPendingFetch();
+    const older = service.fetchStatus();
+    await started;
+    const newer = service.fetchStatus();
+    await vi.waitUntil(() => count() === 2);
+
+    resolveNth(1, true);
+    await expect(newer).resolves.toBe(true);
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    // The older fetch must be dropped, and report the state that won rather than
+    // its own stale answer.
+    resolveNth(0, false);
+    await expect(older).resolves.toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a slow REST fetch clobber a newer WebSocket release', async () => {
+    // Mirror of the locking direction: a reconcile issued before the release
+    // resolves with manual_lock still true and would falsely re-freeze the UI.
+    mockFetch([{ body: true }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+
+    MockWebSocket.instances[0].emit('unlocked');
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    resolveWith(true);
+    await pending;
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not let a slow REST fetch clobber a just-issued release operation', async () => {
+    mockFetch([{ body: true }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+
+    mockFetch([{ body: 'ok' }]);
+    await service.releaseLock();
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    resolveWith(true);
+    await pending;
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reconciles on a reconnect after the socket dropped', async () => {
+    // The hole this closes: a lock set while the browser's socket was down. Only a
+    // replacement socket's onopen can surface it, so exercise the real reconnect.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+
+    const mockWindow = {
+      setTimeout: vi.fn((cb: () => void) => {
+        cb();
+        return 1 as unknown as number;
+      }),
+      clearTimeout: vi.fn(),
+    };
+    const windowSpy = vi.spyOn(sharedUtils, 'getBrowserWindow')
+      .mockReturnValue(mockWindow as unknown as Window);
+
+    MockWebSocket.instances[0].onclose?.();
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+
+    // The lock was set while the socket was down.
+    mockFetch([{ body: true }]);
+    listener.mockClear();
+    MockWebSocket.instances[1].open();
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith(true);
+    windowSpy.mockRestore();
+  });
+
+  it('ignores unrelated messages on the shared socket', async () => {
+    // /ws also carries ArgoCD reachability frames, which are far more frequent than
+    // lock frames. They must neither change the lock state nor invalidate an
+    // in-flight reconcile — that would disable the reconcile during outages.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    listener.mockClear();
+
+    const socket = MockWebSocket.instances[0];
+    socket.emit('argocd_down:argocd');
+    socket.emit('argocd_up');
+    socket.emit('nonsense');
+    expect(listener).not.toHaveBeenCalled();
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+    socket.emit('argocd_up');
+
+    resolveWith(true);
+    await pending;
+    expect(listener).toHaveBeenLastCalledWith(true);
+  });
+
+  it('keeps the last known state when a reconnect reconcile fails', async () => {
+    mockFetch([{ body: true }]);
+    const service = new DeployLockService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith(true);
+    listener.mockClear();
+
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    MockWebSocket.instances[0].open();
+
+    await vi.waitUntil(() => errorSpy.mock.calls.length > 0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[deploy-lock] Failed to reconcile status on connect', expect.any(Error),
+    );
+    // A failed reconcile must not clear the banner — that is the false negative the
+    // reconcile exists to prevent.
+    expect(listener).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('discards a fetch that resolves after teardown', async () => {
+    // A fetch still in flight when the last subscriber leaves must not repopulate
+    // the cache teardown just cleared, or the next subscribe replays that value
+    // instead of bootstrapping a fresh one.
+    mockFetch([{ body: false }]);
+    const service = new DeployLockService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => (globalThis.fetch as unknown as vi.Mock).mock.calls.length === 1);
+
+    const { resolveWith, started } = mockPendingFetch();
+    const pending = service.fetchStatus();
+    await started;
+
+    unsubscribe();
+    resolveWith(true);
+    await pending; // the stale result has now been fully processed (or dropped)
+
+    mockFetch([{ body: false }]);
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
     expect(listener).toHaveBeenLastCalledWith(false);
   });
 

--- a/web/src/features/deployLock/deployLockService.ts
+++ b/web/src/features/deployLock/deployLockService.ts
@@ -18,13 +18,32 @@ export class DeployLockService {
   private readonly listeners = new Set<DeployLockListener>();
   private socket: WebSocket | null = null;
   private reconnectHandle: number | null = null;
+  // Ordering guards so an out-of-order async result can never revert the banner
+  // to a stale value. Both matter because a (re)connect can have a bootstrap and
+  // an onopen fetch in flight at once, alongside live WS pushes and the operator's
+  // own lock/release calls:
+  //   fetchSeq        - only the most recently issued fetch may apply its result;
+  //                     older concurrent fetches are dropped.
+  //   stateGeneration - bumped on every authoritative update (WS push, lock,
+  //                     release); a fetch is dropped if one landed while it was
+  //                     in flight, so a slow REST response cannot clobber it.
+  private fetchSeq = 0;
+  private stateGeneration = 0;
 
   /**
-   * Retrieves the latest lock state from the backend and notifies subscribers of the result.
+   * Retrieves the latest lock state from the backend and notifies subscribers of
+   * the result. The result is applied only if it is still the newest fetch AND no
+   * authoritative update landed while it was in flight; otherwise it is dropped so
+   * REST/WebSocket ordering races cannot revert the banner to a stale value.
    */
   public async fetchStatus(): Promise<boolean> {
+    const seq = ++this.fetchSeq;
+    const generation = this.stateGeneration;
     const response = await httpClient<boolean>('/api/v1/deploy-lock');
     const locked = Boolean(response.data);
+    if (seq !== this.fetchSeq || generation !== this.stateGeneration) {
+      return this.currentStatus ?? locked;
+    }
     this.updateStatus(locked);
     return locked;
   }
@@ -34,7 +53,7 @@ export class DeployLockService {
    */
   public async setLock(): Promise<HttpResponse<unknown>> {
     const response = await httpClient('/api/v1/deploy-lock', { method: 'POST' });
-    this.updateStatus(true);
+    this.applyAuthoritative(true);
     return response;
   }
 
@@ -43,7 +62,7 @@ export class DeployLockService {
    */
   public async releaseLock(): Promise<HttpResponse<unknown>> {
     const response = await httpClient('/api/v1/deploy-lock', { method: 'DELETE' });
-    this.updateStatus(false);
+    this.applyAuthoritative(false);
     return response;
   }
 
@@ -73,6 +92,16 @@ export class DeployLockService {
     };
   }
 
+  /**
+   * Applies a state we know first-hand — a live WebSocket push or the operator's
+   * own lock/release — and invalidates any REST fetch still in flight, so a slower
+   * response carrying the pre-change value cannot overwrite it.
+   */
+  private applyAuthoritative(locked: boolean) {
+    this.stateGeneration++;
+    this.updateStatus(locked);
+  }
+
   /** Broadcasts the new lock status to all subscribers. */
   private updateStatus(locked: boolean) {
     this.currentStatus = locked;
@@ -90,12 +119,24 @@ export class DeployLockService {
     const url = resolveWebSocketUrl();
     this.socket = new WebSocket(url);
 
+    // Re-bootstrap against the authoritative state on every (re)connect: the
+    // server only pushes on transitions, and with the shared Postgres lock a
+    // transition can come from another replica. A change that happened while this
+    // socket was down — or before a failed bootstrap fetch — would otherwise leave
+    // the client showing a stale state, and a false-negative here hides an active
+    // deployment freeze.
+    this.socket.onopen = () => {
+      this.fetchStatus().catch(error => {
+        console.error('[deploy-lock] Failed to reconcile status on connect', error);
+      });
+    };
+
     this.socket.onmessage = event => {
       const payload = typeof event.data === 'string' ? event.data : '';
       if (payload === 'locked') {
-        this.updateStatus(true);
+        this.applyAuthoritative(true);
       } else if (payload === 'unlocked') {
-        this.updateStatus(false);
+        this.applyAuthoritative(false);
       }
     };
 
@@ -139,6 +180,12 @@ export class DeployLockService {
 
     this.socket?.close();
     this.socket = null;
+    // Forget the cached lock state so a later re-subscribe bootstraps a fresh
+    // fetch instead of replaying a value that may have gone stale while nobody
+    // was listening. Bumping fetchSeq invalidates any fetch issued before the
+    // teardown, which would otherwise repopulate the cache as it resolves.
+    this.fetchSeq++;
+    this.currentStatus = null;
   }
 }
 


### PR DESCRIPTION
The manual deploy lock lived in the process that served the request, so with more than one replica a lock set through one of them left the others happily accepting deployments, and the Web UI reported whichever answer the load balancer happened to pick.

Move the manual lock and the release override into a DeployLockStore with in-memory and Postgres implementations, selected by STATE_TYPE alongside the existing Locker. Schedules stay local: every replica parses the same LOCKDOWN_SCHEDULE. Enforcement resolves the state per request, so a lock takes effect on every replica immediately.

The 15-minute override of a scheduled window is now a persisted deadline instead of a goroutine timer, so it ends at the same instant everywhere and survives a restart. That also removes the stale "locked" broadcast the timer could emit after its window had closed.

An unreadable lock state fails closed on the enforcement path: rejecting a deployment during an outage is recoverable, letting one through during a freeze is not. The watcher instead skips ticks it cannot read, since an unknown state is not a transition and treating it as one would flap the banner. The watcher now also runs without schedules configured, at a 5s tick, because a lock set on another replica is only observable by polling.

STATE_TYPE=in-memory keeps process-local behaviour, which stays correct for the single replica that backend supports.

Refs #152