### PR TITLE
refactor(e2e): replace lab harness glue with NodePorts, a shared lib and bats

### DIFF
--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -1,0 +1,75 @@
+name: E2E harness
+
+# Lints the e2e lab's bash and runs its offline test suites (test/e2e/scripts/lib.bats,
+# test/e2e/ports.bats). These need no cluster and finish in seconds, so unlike the
+# label-gated `E2E lab` workflow they run on every PR touching the lab — a regression
+# in lib.sh or in the kind-config <-> nodeports port coupling should not wait for a
+# per-release run to surface.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'test/e2e/**'
+      - '.github/workflows/e2e-harness.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'test/e2e/**'
+      - '.github/workflows/e2e-harness.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  harness:
+    name: lint + offline suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+
+      # bats is absent from the runner image; shellcheck is present but pinned here
+      # anyway, because the runner ships 0.9.0 while the flake devshell provides
+      # 0.11.0 — and findings differ between them, so an unpinned version would let
+      # CI and `nix develop` disagree. yq (4.53.3) and jq come from the image.
+      #
+      # bats-support/-assert are separate from bats core and lib.bats loads both, so
+      # they are installed into a BATS_LIB_PATH dir (the flake gets them from
+      # bats.withLibraries).
+      - name: Install bats and shellcheck
+        env:
+          BATS_VERSION: v1.12.0
+          BATS_SUPPORT_VERSION: v0.3.0
+          BATS_ASSERT_VERSION: v2.2.4
+          SHELLCHECK_VERSION: v0.11.0
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/bats-core/bats-core/archive/refs/tags/${BATS_VERSION}.tar.gz" \
+            | tar -xz -C "$tmp" --strip-components=1
+          sudo "$tmp/install.sh" /usr/local
+
+          sudo mkdir -p /usr/local/lib/bats/bats-support /usr/local/lib/bats/bats-assert
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/bats-core/bats-support/archive/refs/tags/${BATS_SUPPORT_VERSION}.tar.gz" \
+            | sudo tar -xz -C /usr/local/lib/bats/bats-support --strip-components=1
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/bats-core/bats-assert/archive/refs/tags/${BATS_ASSERT_VERSION}.tar.gz" \
+            | sudo tar -xz -C /usr/local/lib/bats/bats-assert --strip-components=1
+
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ -C "$tmp" --strip-components=1 "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          sudo install -m 0755 "$tmp/shellcheck" /usr/local/bin/
+
+      - name: Lint bash and run the offline suites
+        env:
+          BATS_LIB_PATH: /usr/local/lib/bats
+        run: task -d test/e2e lint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,9 @@ jobs:
     # Label path: run only when the `e2e` label is the one just added.
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'e2e'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # A measured full run is ~38m (13m boot + 25m phases) on a local machine; hosted
+    # runners are slower, so 45 left almost no headroom.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -66,6 +68,19 @@ jobs:
           curl --proto '=https' --tlsv1.2 -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar -xz -C "$tmp" --strip-components=1 linux-amd64/helm
           sudo install -m 0755 "$tmp"/kind "$tmp"/kubectl "$tmp"/helm /usr/local/bin/
 
+      # The phase suite runs under bats (test/e2e/phases.bats); the runner image
+      # does not ship it. phases.bats loads no bats libraries, so core is enough.
+      - name: Install bats
+        env:
+          BATS_VERSION: v1.12.0
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/bats-core/bats-core/archive/refs/tags/${BATS_VERSION}.tar.gz" \
+            | tar -xz -C "$tmp" --strip-components=1
+          sudo "$tmp/install.sh" /usr/local
+
       - name: Run e2e lab
         working-directory: test/e2e
         # Inputs bound to env (never interpolated into the script); defaults apply
@@ -75,6 +90,16 @@ jobs:
           SOAK_SECONDS: ${{ inputs.soak_seconds || '300' }}
           WORKERS: ${{ inputs.workers || '10' }}
         run: task e2e SOAK="${SOAK_SECONDS}s" SOAK_SECONDS="${SOAK_SECONDS}" WORKERS="${WORKERS}"
+
+      # bats writes one JUnit case per phase; keep it on both outcomes so a failed
+      # run says which phase broke without digging through the log.
+      - name: Upload phase report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-phase-report
+          path: test/e2e/reports/
+          if-no-files-found: warn
 
       - name: Diagnostics on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ site/
 
 # sandbox directory for experiments and scratch work
 sandbox/
+
+# per-phase JUnit reports written by the e2e lab's bats run
+test/e2e/reports/

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,15 @@
           git
         ];
 
-        # The e2e lab and CI helpers are bash; shellcheck is the linter for them.
+        # The e2e lab and CI helpers are bash: shellcheck lints them, bats runs them.
+        # bats-assert/-support are needed by test/e2e/scripts/lib.bats; yq-go by
+        # test/e2e/ports.bats, which reads the lab's kind/NodePort YAML.
+        # NOTE: this covers `task -d test/e2e lint` only. Running the lab itself also
+        # needs kind, kubectl, helm, jq and task, which this shell does NOT provide.
         shellToolchain = with pkgs; [
           shellcheck
+          yq-go
+          (bats.withLibraries (p: [ p.bats-support p.bats-assert ]))
         ];
 
         # Security scanners, mirroring the CI security workflow so they can be

--- a/test/e2e/.shellcheckrc
+++ b/test/e2e/.shellcheckrc
@@ -1,0 +1,6 @@
+# SC2329 ("function is never invoked") does not see the three indirect-invocation
+# patterns the lab is built on: EXIT-trap cleanups, predicates passed to retry(),
+# and the scenario/teardown functions failure-diagnostics.sh dispatches by name from
+# its SCENARIOS table. Every hit here is one of those.
+disable=SC2329
+source-path=SCRIPTDIR

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -17,21 +17,40 @@ Unlike the unit and integration suites, ArgoCD here is **not mocked**.
 
 ## Prerequisites
 
-`kind`, `kubectl`, `helm`, `go`, `git`, `jq`, `curl`, `task`, and **podman** as
-the kind provider (`KIND_EXPERIMENTAL_PROVIDER=podman`). The image-load step uses
-`podman exec` against the kind node, so a podman-backed cluster is required; a
-`docker` CLI that is a podman shim works, a real docker-provider cluster does
-not. `go` builds the client binary and runs the load driver, and `git` drives
-the competitor writer. All pinned tool/chart versions are in `Taskfile.yml`.
+`kind`, `kubectl`, `helm`, `go`, `git`, `jq`, `yq`, `curl`, `task`, `bats`, and
+**podman** as the kind provider (`KIND_EXPERIMENTAL_PROVIDER=podman`). The
+image-load step uses `podman exec` against the kind node, so a podman-backed
+cluster is required; a `docker` CLI that is a podman shim works, a real
+docker-provider cluster does not. `go` builds the client binary and runs the load
+driver, and `git` drives the competitor writer. Pinned tool/chart versions are in
+`Taskfile.yml`.
+
+`nix develop` provides the lint tooling (`shellcheck`, `bats`, `yq`) — enough for
+`task lint`. The cluster tools (`kind`, `kubectl`, `helm`, `jq`, `task`) are not in
+the dev shell and must be on `PATH` to run the lab itself.
+
+The lab creates and deletes a kind cluster, which writes to your **kubeconfig**.
+Point `KUBECONFIG` at a throwaway file first if your default one holds contexts you
+care about.
 
 ## Usage
 
 ```sh
-task e2e     # one-shot per-release run: up → api-surface → smoke → client-knobs → jwt-auth → fire-and-forget → commit-format → multi-image → accept-suspended → docker-proxy → lockdown → notifications → load → batch-writeback → race → state-postgres → failure-diagnostics → argocd-unreachable → shutdown-drain → down
+task e2e     # one-shot per-release run: boot the lab, run every phase, tear it down
 ```
 
-`task e2e` walks the whole flow. It stops on the first failing step, so a failed
-run leaves the cluster up for debugging; a fully green run tears it down.
+`task e2e` is `up` → `phases` → `down`. The phases run under **bats**
+(`phases.bats`, one test per phase, order documented there). Once a phase fails the
+remaining ones are skipped and `down` never runs, so the cluster is left up for
+debugging; a fully green run tears it down. A per-phase JUnit report lands in
+`reports/`.
+
+```sh
+task phases                    # re-run every phase against a lab that is already up
+bats --filter lockdown phases.bats          # one phase by name
+bats --filter-status failed phases.bats     # only what failed last run
+task lint                      # shellcheck + the offline bats suites (no cluster)
+```
 
 Individual steps (for iterating or debugging):
 
@@ -74,15 +93,29 @@ on a hosted `ubuntu-latest` runner, where kind uses the **docker** provider —
 `load-race-image.sh` takes its `kind load` fast path there and falls back to the
 podman `ctr import` locally, so the lab runs unchanged in both places.
 
-Reach any component with `kubectl port-forward` (there is no ingress), e.g.
-`kubectl -n argo-watcher port-forward svc/argo-watcher 8080:80`.
+## Reaching the lab
+
+Four services are published on fixed **localhost** ports (no ingress, no
+port-forward): argo-watcher `30080`, webhook-tester `30081`, Gitea `30300`, ArgoCD
+`30443`. `fixtures/nodeports/` assigns the node ports and `kind-config.yaml`
+maps them to the host; kind requires the two to use the same number, which
+`ports.bats` asserts. The URLs are exported by `scripts/lib.sh` (`AW_URL`,
+`GITEA_URL`, …), so a phase that restarts the server just waits for it to answer
+again instead of re-establishing a forward.
 
 ## Layout
 
 | Path | Purpose |
 |---|---|
 | `Dockerfile.server.race` | argo-watcher built with `-race` on a glibc distroless base |
-| `kind-config.yaml` | single-node cluster |
+| `kind-config.yaml` | single-node cluster + the host port mappings for the NodePorts below |
+| `fixtures/nodeports/` | fixed NodePort Services for the four components phases talk to from the host (one per file, matching `fixtures/postgres/`) |
+| `phases.bats` | the per-release phase suite: one test per phase, with the ordering constraints |
+| `ports.bats` | offline assertions on the kind-config ↔ nodeports port coupling |
+| `scripts/lib.sh` | shared phase helpers: endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`, `helm_apply_aw`, `ok`/`bad`/`phase_end` |
+| `scripts/lib.bats` | unit tests for lib.sh's pure text-processing helpers (no cluster needed) |
+| `scripts/soak.sh` | the git-conflict soak: competitor + concurrent deploys, then the `collect.sh` gates |
+| `scripts/verify.sh` | post-`up` gate: healthz 200 and `argocd_unavailable` 0 |
 | `values/` | pinned Helm values for argocd / argo-watcher / gitea / webhook-tester |
 | `scripts/load-race-image.sh` | load a local image into the kind node |
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
@@ -115,6 +148,10 @@ Reach any component with `kubectl port-forward` (there is no ingress), e.g.
 
 ## Gotchas (why the scripts exist)
 
+- **`/healthz` returns 503 while ArgoCD is unreachable**, so `wait_service` checks
+  only that a response arrives, never that it is 2xx. A `curl -f` there would hang
+  forever in `argocd-unreachable` (which severs ArgoCD on purpose) and can misfire in
+  `shutdown-drain` on a freshly-booted pod.
 - **`kind load docker-image` is broken with podman + containerd 2.x** — kind
   passes `--all-platforms` to `ctr import`, which fails on a single-arch image
   ("no unpack platforms defined"). `load-race-image.sh` imports via `ctr` with

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -13,6 +13,8 @@ silent: true
 vars:
   CLUSTER: aw-e2e
   RACE_IMAGE: ghcr.io/shini4i/argo-watcher:race
+  # bats writes the per-phase JUnit report here (gitignored).
+  REPORT_DIR: reports
   # Pinned chart versions for reproducibility.
   ARGOCD_CHART_VERSION: 9.1.3
   # argo-rollouts provides the Rollout CRD + controller for the accept-suspended phase.
@@ -60,6 +62,10 @@ tasks:
       - task: argo-rollouts
       - task: load-race-image
       - task: gitea
+      # NodePorts come before `seed`, which is the first step to reach a service
+      # (Gitea) from the host. A Service may exist before it has any endpoints, so
+      # publishing all four up front is safe and keeps them in one place.
+      - task: nodeports
       - task: seed
       - task: webhook-tester
       - task: argo-watcher
@@ -67,50 +73,35 @@ tasks:
       - task: verify
 
   e2e:
-    desc: "One-shot per-release run: boot the lab, run every phase in order, tear it down (see README Usage for the full step list)"
+    desc: "One-shot per-release run: boot the lab, run every phase in order, tear it down"
     cmds:
-      # Runs the whole flow. Stops on the first failing step, so a failed run
-      # leaves the cluster up for debugging; a fully green run tears it down.
       - task: up
-      - task: api-surface
-      - task: smoke
-      - task: client-knobs
-      - task: jwt-auth
-      - task: fire-and-forget
-      - task: commit-format
-      - task: multi-image
-      - task: accept-suspended
-      - task: docker-proxy
-      # lockdown toggles LOCKDOWN_SCHEDULE on the release and reverts before it
-      # returns (ending unlocked), so it must run BEFORE the soak but is otherwise
-      # self-contained; placed here after the light deploy phases.
-      - task: lockdown
-      - task: notifications
-      - task: load
-      # batch-writeback re-runs the contention soak with GIT_BATCH_WRITEBACK on and
-      # reverts before returning, so it must run AFTER the default-path soak (load)
-      # and is otherwise self-contained; placed here before race.
-      - task: batch-writeback
-      - task: race
-      # state-postgres flips the release to STATE_TYPE=postgres and asserts the Postgres-only
-      # properties (schema migration, deploy loop, task-survives-restart, supersession under
-      # contention). Placed after the in-memory phases (which validate that backend) and BEFORE
-      # failure-diagnostics so it deploys against pristine apps. Everything after runs on
-      # Postgres — both remaining phases are backend-agnostic, so that is a free bonus.
-      - task: state-postgres
-      # failure-diagnostics runs after the soak: it deliberately breaks apps (bad images, a
-      # failing PreSync hook injected into the SHARED chart values) and pushes directly to the
-      # gitops repo, so running it before load/race would perturb those pristine-state soak gates.
-      - task: failure-diagnostics
-      # argocd-unreachable severs ArgoCD (scales argocd-server to 0) then restores it,
-      # so it must run after the phases that need a healthy ArgoCD. It is self-contained
-      # (its cleanup trap always scales ArgoCD back), and its tokenless deploys have no
-      # lasting side effect, so it sits safely between failure-diagnostics and shutdown-drain.
-      - task: argocd-unreachable
-      # shutdown-drain runs LAST (before down): it deletes the argo-watcher pod to exercise
-      # graceful shutdown, so nothing but `down` should depend on the server afterwards.
-      - task: shutdown-drain
+      - task: phases
       - task: down
+
+  phases:
+    desc: "Run every phase in order against a lab that is already up (see phases.bats)"
+    cmds:
+      # The JUnit report gives CI a case per phase instead of one opaque exit code.
+      # Phase ORDER, and the skip-the-rest-after-a-failure behaviour, live in phases.bats.
+      - mkdir -p {{.REPORT_DIR}}
+      # Soak-only knobs are passed as SOAK_* / BATCH_* and applied by phases.bats to
+      # the soak phases alone. They must NOT be exported suite-wide: several phases
+      # read the same names (COMPETITOR_INTERVAL, WS_CLIENTS) and rely on their own
+      # tuned defaults, which a global value would silently override.
+      - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
+        DEPLOY_TOKEN={{.DEPLOY_TOKEN}} JWT_SECRET={{.JWT_SECRET}} WEBHOOK_UUID={{.WEBHOOK_UUID}}
+        SOAK_APPS={{.APPS}} SOAK_WORKERS={{.WORKERS}} SOAK_WS_CLIENTS={{.WS_CLIENTS}}
+        SOAK_DURATION={{.SOAK}} SOAK_SECONDS={{.SOAK_SECONDS}}
+        SOAK_COMPETITOR_INTERVAL={{.COMPETITOR_INTERVAL}}
+        BATCH_SOAK={{.BATCH_SOAK}} BATCH_SOAK_SECONDS={{.BATCH_SOAK_SECONDS}}
+        bats --timing --report-formatter junit --output {{.REPORT_DIR}} phases.bats
+
+  lint:
+    desc: "Lint the lab's bash (shellcheck) and run the offline bats suites (no cluster needed)"
+    cmds:
+      - shellcheck -x scripts/*.sh
+      - bats scripts/lib.bats ports.bats
 
   cluster:
     desc: "Create the kind cluster if it does not exist"
@@ -133,6 +124,18 @@ tasks:
     desc: "Load the race image into the kind node"
     cmds:
       - ./scripts/load-race-image.sh {{.RACE_IMAGE}} {{.CLUSTER}}
+
+  nodeports:
+    desc: "Publish argo-watcher / gitea / argocd / webhook-tester on the fixed NodePorts kind maps to localhost"
+    cmds:
+      # The namespaces are created up front so the Services can be applied in one
+      # shot, before the releases that will eventually back them exist. Each is
+      # idempotent, and the install tasks create them the same way.
+      - kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl create namespace gitea --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl create namespace argo-watcher --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl create namespace webhook-tester --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl apply -f fixtures/nodeports/
 
   argocd:
     desc: "Install ArgoCD"
@@ -182,8 +185,6 @@ tasks:
   api-surface:
     desc: "Assert the read-only HTTP surface (version/config/task-list/deploy-lock) to contract"
     cmds:
-      # Pure curl/jq, touches no state — runs right after `up`, before the deploy
-      # phases, as a fast contract check of the endpoints no other phase exercises.
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/api-surface.sh
 
   smoke:
@@ -229,8 +230,6 @@ tasks:
   lockdown:
     desc: "Assert LOCKDOWN_SCHEDULE freezes deploys in-window (406) and the watcher broadcasts 'locked'"
     cmds:
-      # Toggles LOCKDOWN_SCHEDULE on the live release for its own duration and
-      # reverts before returning; needs the chart coordinates to helm-upgrade.
       - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}} ./scripts/lockdown.sh
 
   shutdown-drain:
@@ -246,9 +245,6 @@ tasks:
   notifications:
     desc: "Assert the generic webhook fires (start + result) with the correct payload against a real receiver"
     cmds:
-      # Runs on a clean state (right after smoke, before load/race dirty things)
-      # and asserts on its own uniquely-tagged deploy, so later soak traffic to
-      # the shared receiver is irrelevant to the assertion.
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} WEBHOOK_UUID={{.WEBHOOK_UUID}} ./scripts/notifications.sh
 
   failure-diagnostics:
@@ -260,38 +256,16 @@ tasks:
     desc: "Git-conflict soak: competitor writer + concurrent deploys + collect/assert"
     deps: [apply-apps]
     cmds:
-      - |
-        set -uo pipefail
-        # Wait for all fixture apps to be Healthy so the driver never races a
-        # cold app (which would surface as a spurious "app not found").
-        for i in $(seq 1 {{.APPS}}); do
-          for _ in $(seq 1 40); do
-            [ "$(kubectl -n argocd get application app$i -o jsonpath='{.status.health.status}' 2>/dev/null)" = "Healthy" ] && break
-            sleep 3
-          done
-        done
-        kubectl -n argo-watcher port-forward svc/argo-watcher 8080:80 >/dev/null 2>&1 &
-        pf=$!; trap 'kill $pf 2>/dev/null || true' EXIT
-        for _ in $(seq 1 15); do curl -s -m3 -o /dev/null localhost:8080/healthz && break; sleep 1; done
-        SECONDS_TOTAL={{.SOAK_SECONDS}} INTERVAL={{.COMPETITOR_INTERVAL}} ./scripts/competitor.sh & comp=$!
-        summary=$(mktemp)
-        # Redirect (not pipe): go-task's POSIX shell has no PIPESTATUS. Driver
-        # JSON summary -> file; its logs stay on stderr in the task output.
-        APPS={{.APPS}} WORKERS={{.WORKERS}} WS_CLIENTS={{.WS_CLIENTS}} DURATION={{.SOAK}} \
-          DEPLOY_TOKEN={{.DEPLOY_TOKEN}} BASE_URL=http://localhost:8080 WS_URL=ws://localhost:8080/ws \
-          go run ./load >"$summary"; drv=$?
-        cat "$summary"
-        wait $comp 2>/dev/null || true
-        ./scripts/collect.sh "$summary"; col=$?
-        [ "$drv" -eq 0 ] && [ "$col" -eq 0 ]
+      # In a script, not inline: it needs real bash, and go-task's interpreter is not.
+      - APPS={{.APPS}} WORKERS={{.WORKERS}} WS_CLIENTS={{.WS_CLIENTS}}
+        SOAK={{.SOAK}} SOAK_SECONDS={{.SOAK_SECONDS}}
+        COMPETITOR_INTERVAL={{.COMPETITOR_INTERVAL}} DEPLOY_TOKEN={{.DEPLOY_TOKEN}}
+        ./scripts/soak.sh
 
   batch-writeback:
     desc: "Assert GIT_BATCH_WRITEBACK coalesces concurrent write-backs under contention with zero lost updates"
     deps: [apply-apps]
     cmds:
-      # Toggles GIT_BATCH_WRITEBACK on the live release, re-runs the contention
-      # soak, gates on zero lost updates + real coalescing, then reverts. Needs the
-      # chart coordinates to helm-upgrade in place.
       - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
         DEPLOY_TOKEN={{.DEPLOY_TOKEN}} APPS={{.APPS}} WORKERS={{.WORKERS}} WS_CLIENTS={{.WS_CLIENTS}}
         SOAK={{.BATCH_SOAK}} SOAK_SECONDS={{.BATCH_SOAK_SECONDS}} COMPETITOR_INTERVAL={{.COMPETITOR_INTERVAL}}
@@ -309,16 +283,7 @@ tasks:
   verify:
     desc: "Assert argo-watcher is up and reaching real Argo (argocd_unavailable == 0)"
     cmds:
-      - |
-        kubectl -n argo-watcher port-forward svc/argo-watcher 18090:80 >/dev/null 2>&1 &
-        pf=$!; trap 'kill $pf 2>/dev/null || true' EXIT
-        for _ in $(seq 1 15); do
-          curl -s -m 3 -o /dev/null localhost:18090/healthz && break; sleep 1
-        done
-        code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' localhost:18090/healthz)
-        unavail=$(curl -s -m 10 localhost:18090/metrics | awk '/^argocd_unavailable /{print $2}')
-        echo "healthz=$code argocd_unavailable=$unavail"
-        test "$code" = "200" && test "$unavail" = "0"
+      - ./scripts/verify.sh
 
   state-postgres:
     desc: "Flip the release to Postgres state and assert migration, deploy, task-survives-restart, supersession"
@@ -331,23 +296,7 @@ tasks:
     desc: "Same-app supersession race: a newer deploy must win over an older retrying one"
     deps: [apply-apps]
     cmds:
-      - |
-        set -uo pipefail
-        for _ in $(seq 1 40); do
-          [ "$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null)" = "Healthy" ] && break
-          sleep 3
-        done
-        kubectl -n argo-watcher port-forward svc/argo-watcher 8080:80 >/dev/null 2>&1 & awpf=$!
-        kubectl -n gitea port-forward svc/gitea-http 13000:3000 >/dev/null 2>&1 & gpf=$!
-        trap 'kill $awpf $gpf 2>/dev/null || true' EXIT
-        for _ in $(seq 1 15); do curl -s -m3 -o /dev/null localhost:8080/healthz && break; sleep 1; done
-        # race-supersede.sh is self-contained: it resets the app to a baseline tag,
-        # starts its own competitor writer (deliberately over-driven at INTERVAL=1
-        # to force the ordering window — the script's default), then runs the race.
-        ga=gitea_admin; gp=gitea_admin_pw1   # throwaway lab creds; kept out of a literal user:pass@ URL
-        DEPLOY_TOKEN={{.DEPLOY_TOKEN}} BASE_URL=http://localhost:8080 \
-          GITEA_REPO_URL="http://${ga}:${gp}@localhost:13000/e2e/gitops.git" \
-          ./scripts/race-supersede.sh
+      - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/race-supersede.sh
 
   down:
     desc: "Destroy the kind cluster"

--- a/test/e2e/fixtures/nodeports/argo-watcher.yaml
+++ b/test/e2e/fixtures/nodeports/argo-watcher.yaml
@@ -1,0 +1,31 @@
+# Fixed NodePort for the argo-watcher HTTP API + WebSocket, so phase scripts reach it
+# on a stable localhost URL that survives a pod restart (no port-forward).
+#
+# This is an ADDITIONAL Service alongside the chart's ClusterIP one, which the
+# in-cluster DNS names argo-watcher is configured with keep using.
+#
+# Why standalone rather than `service.type=NodePort` in the chart values: the
+# argo-watcher chart renders no `nodePort` field, so it could only get a RANDOM node
+# port — and kind needs a fixed one to map. A standalone Service also survives the
+# `helm upgrade --reset-values` the lockdown / batch-writeback / state-postgres phases
+# use to reconfigure the release in place.
+#
+# nodePort MUST equal the matching containerPort in kind-config.yaml (ports.bats
+# asserts this). The selector matches what the pinned chart renders; re-check it when
+# bumping AW_CHART_VERSION in Taskfile.yml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-watcher-nodeport
+  namespace: argo-watcher
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: argo-watcher
+    app.kubernetes.io/instance: argo-watcher
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30080
+      protocol: TCP

--- a/test/e2e/fixtures/nodeports/argocd.yaml
+++ b/test/e2e/fixtures/nodeports/argocd.yaml
@@ -1,0 +1,24 @@
+# Fixed NodePort for the ArgoCD API. Only the ARGO_TOKEN mint talks to it from the
+# host. See nodeports/argo-watcher.yaml for why these are standalone Services.
+#
+# argocd-server serves both HTTP and HTTPS off container port 8080 (it sniffs the
+# connection), so this mirrors the chart Service's 443 -> 8080 mapping and callers keep
+# using https:// with -k against the self-signed cert.
+#
+# nodePort MUST equal the matching containerPort in kind-config.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server-nodeport
+  namespace: argocd
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/instance: argocd
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8080
+      nodePort: 30443
+      protocol: TCP

--- a/test/e2e/fixtures/nodeports/gitea.yaml
+++ b/test/e2e/fixtures/nodeports/gitea.yaml
@@ -1,0 +1,25 @@
+# Fixed NodePort for Gitea HTTP: the seed script's admin API calls, and the git
+# clone/push the phases and the competitor writer do. See nodeports/argo-watcher.yaml
+# for why these are standalone Services.
+#
+# Gitea's SSH port is deliberately NOT exposed — argo-watcher writes back over SSH
+# from inside the cluster, so only in-cluster DNS needs to reach it.
+#
+# nodePort MUST equal the matching containerPort in kind-config.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitea-http-nodeport
+  namespace: gitea
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: gitea
+    app.kubernetes.io/instance: gitea
+  ports:
+    - name: http
+      port: 3000
+      # Named port: the gitea container declares http=3000.
+      targetPort: http
+      nodePort: 30300
+      protocol: TCP

--- a/test/e2e/fixtures/nodeports/webhook-tester.yaml
+++ b/test/e2e/fixtures/nodeports/webhook-tester.yaml
@@ -1,0 +1,22 @@
+# Fixed NodePort for the webhook receiver's capture API, which the notifications phase
+# reads back to assert what argo-watcher actually delivered. See
+# nodeports/argo-watcher.yaml for why these are standalone Services.
+#
+# nodePort MUST equal the matching containerPort in kind-config.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-tester-nodeport
+  namespace: webhook-tester
+spec:
+  type: NodePort
+  # The receiver runs under the generic `app` chart, hence name=app.
+  selector:
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: webhook-tester
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30081
+      protocol: TCP

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -1,7 +1,40 @@
 # Single-node kind cluster for the argo-watcher e2e lab.
-# Services are reached via `kubectl port-forward`, so no ingress / port mappings
-# are needed here.
+#
+# The lab's services are reached on FIXED host ports rather than through
+# `kubectl port-forward`: each hostPort below maps to the node port that
+# fixtures/nodeports/ publishes for one service. kind requires the node
+# `containerPort` and the Service's `nodePort` to be equal, so the two files must
+# agree — the numbers are duplicated there on purpose, with a pointer back here.
+#
+# Why not port-forward: a forward is a child process that dies with the pod it
+# targets, so every phase had to start one, poll it, and re-establish it after any
+# rollout or pod deletion (several phases delete the pod deliberately). A NodePort
+# URL stays valid across restarts and needs no process at all.
+#
+# listenAddress pins the mappings to loopback so a lab run never exposes ArgoCD or
+# Gitea (both with throwaway admin credentials) to the local network.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    extraPortMappings:
+      # argo-watcher HTTP API + WebSocket (svc port 80 -> container 8080)
+      - containerPort: 30080
+        hostPort: 30080
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # webhook-tester capture API (the notifications phase reads it back)
+      - containerPort: 30081
+        hostPort: 30081
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # Gitea HTTP (git push/clone + the admin API the seed script drives)
+      - containerPort: 30300
+        hostPort: 30300
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # ArgoCD API, TLS (only the ARGO_TOKEN mint talks to it)
+      - containerPort: 30443
+        hostPort: 30443
+        listenAddress: "127.0.0.1"
+        protocol: TCP

--- a/test/e2e/load/main.go
+++ b/test/e2e/load/main.go
@@ -73,8 +73,10 @@ func envInt(k string, def int) int {
 func loadConfig() config {
 	dur, _ := time.ParseDuration(env("DURATION", "5m"))
 	return config{
-		baseURL:    strings.TrimRight(env("BASE_URL", "http://localhost:8080"), "/"),
-		wsURL:      env("WS_URL", "ws://localhost:8080/ws"),
+		// Defaults are the lab's published NodePort (fixtures/nodeports/); the
+		// soak phases pass these explicitly from lib.sh.
+		baseURL:    strings.TrimRight(env("BASE_URL", "http://localhost:30080"), "/"),
+		wsURL:      env("WS_URL", "ws://localhost:30080/ws"),
 		token:      env("DEPLOY_TOKEN", "e2e-deploy-token"),
 		apps:       envInt("APPS", 5),
 		workers:    envInt("WORKERS", 10),

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# The per-release phase suite. Each phase is one test, run in the order below
+# against a lab that is already up (`task up`); `task e2e` wraps up → this → down.
+#
+# Once a phase fails, the rest are SKIPPED rather than run: a phase driven against an
+# already-broken lab only produces cascading noise, and `task e2e` then stops before
+# `down` so the cluster is left up for debugging. bats has no fail-fast flag (there is
+# no --abort in 1.12), so setup/teardown below carry the state in a marker file.
+#
+# The test IS the phase, not each assertion inside it: bats runs every test in its
+# own subshell, and a phase like lockdown is one sequential scenario (enable a
+# schedule, observe the transition, revert) whose steps cannot be split without
+# either breaking it or re-running minutes of setup per assertion. Per-phase tests
+# still give CI a JUnit case per phase and make `--filter` / `--filter-status failed`
+# work for reruns.
+#
+# ORDER IS LOAD-BEARING. Each comment below states what constrains a phase's
+# position; do not reorder without re-reading them.
+
+bats_require_minimum_version 1.5.0
+
+setup_file() {
+  export AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO is required (set by the Taskfile)}"
+  export AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION is required (set by the Taskfile)}"
+  export DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+  export JWT_SECRET="${JWT_SECRET:-e2e-jwt-secret}"
+  export WEBHOOK_UUID="${WEBHOOK_UUID:-11111111-1111-1111-1111-111111111111}"
+}
+
+# soak_env: the tuning knobs for the two contention soaks, named SOAK_*/BATCH_* by the
+# Taskfile so they cannot leak into phases that read the same variable under its plain
+# name. race-supersede.sh's COMPETITOR_INTERVAL and shutdown-drain.sh's WS_CLIENTS are
+# deliberately tuned per phase; a suite-wide export would silently override them.
+soak_env() {
+  echo "APPS=${SOAK_APPS:-5}"
+  echo "WORKERS=${SOAK_WORKERS:-10}"
+  echo "WS_CLIENTS=${SOAK_WS_CLIENTS:-10}"
+  echo "COMPETITOR_INTERVAL=${SOAK_COMPETITOR_INTERVAL:-2}"
+}
+
+setup() {
+  # BATS_FILE_TMPDIR is shared by every test in this file, so the marker survives
+  # between them (each test body runs in its own subshell).
+  [[ -f "${BATS_FILE_TMPDIR}/aborted" ]] && skip "an earlier phase failed"
+  cd "${BATS_TEST_DIRNAME}" || return 1
+}
+
+teardown() {
+  # BATS_TEST_COMPLETED is 1 only when the test body ran to the end.
+  [[ "${BATS_TEST_COMPLETED:-}" == 1 ]] || touch "${BATS_FILE_TMPDIR}/aborted"
+}
+
+# phase <script> [args...]: run a phase script; its exit status is the test result.
+#
+# Output goes to FD 3, which bats passes straight through, because a phase can run
+# for minutes (the soak is 5) and bats otherwise buffers a test's output until it
+# finishes — the run would look hung.
+phase() {
+  ./scripts/"$@" >&3 2>&3
+}
+
+@test "api-surface: read-only HTTP surface to contract" {
+  # Touches no state, so it runs first as a fast contract check.
+  phase api-surface.sh
+}
+
+@test "smoke: one authenticated deploy through the write-back loop" {
+  phase smoke-deploy.sh
+}
+
+@test "client-knobs: TASK_REFRESH override deploys, DEBUG log redacts the token" {
+  phase client-knobs.sh
+}
+
+@test "jwt-auth: the BEARER_TOKEN path drives an authenticated write-back" {
+  phase jwt-auth.sh
+}
+
+@test "fire-and-forget: a managed CronJob reports deployed without rolling out" {
+  phase fire-and-forget.sh
+}
+
+@test "commit-format: COMMIT_MESSAGE_FORMAT renders into the write-back commit" {
+  phase commit-format.sh
+}
+
+@test "multi-image: both images deploy and both tags are written back" {
+  phase multi-image.sh
+}
+
+@test "accept-suspended: a paused Rollout is accepted as deployed" {
+  phase accept-suspended.sh
+}
+
+@test "docker-proxy: a bare image name matches the proxy-prefixed running image" {
+  phase docker-proxy.sh
+}
+
+@test "lockdown: LOCKDOWN_SCHEDULE freezes deploys and broadcasts 'locked'" {
+  # Toggles a server-global freeze on the release and reverts before returning
+  # (ending unlocked), so it must precede the soak. Otherwise self-contained.
+  phase lockdown.sh
+}
+
+@test "notifications: the generic webhook fires start + result with the right payload" {
+  # Needs a clean state and asserts on its own uniquely-tagged deploy, so it runs
+  # before the soak dirties the shared receiver.
+  phase notifications.sh
+}
+
+@test "load: git-conflict soak with zero failed tasks and zero lost updates" {
+  env $(soak_env) SOAK="${SOAK_DURATION:-5m}" SOAK_SECONDS="${SOAK_SECONDS:-300}" \
+    ./scripts/soak.sh >&3 2>&3
+}
+
+@test "batch-writeback: GIT_BATCH_WRITEBACK coalesces under contention" {
+  # Re-runs the contention soak with batching on and reverts before returning, so it
+  # must follow the default-path soak above. Its soak is deliberately shorter: 10
+  # workers on one repo coalesce quickly, so a 2m window shows batching without
+  # doubling the run.
+  env $(soak_env) SOAK="${BATCH_SOAK:-2m}" SOAK_SECONDS="${BATCH_SOAK_SECONDS:-120}" \
+    ./scripts/batch-writeback.sh >&3 2>&3
+}
+
+@test "race: a newer deploy supersedes an older retrying one" {
+  phase race-supersede.sh
+}
+
+@test "state-postgres: migration, deploy loop, task survives restart, shared lock" {
+  # Flips the release to Postgres and asserts the Postgres-only properties. Placed
+  # after the in-memory phases (which validate that backend) and BEFORE
+  # failure-diagnostics so it deploys against pristine apps. Everything after runs on
+  # Postgres — both remaining phases are backend-agnostic, so that is a free bonus.
+  phase state-postgres.sh
+}
+
+@test "failure-diagnostics: failure reasons carry the real cause" {
+  # Deliberately breaks apps (bad images, a failing PreSync hook in the SHARED chart
+  # values) and pushes straight to the gitops repo, so running it before the soak
+  # would perturb those pristine-state gates.
+  phase failure-diagnostics.sh
+}
+
+@test "argocd-unreachable: /reachability flips, WS broadcasts, POST fast-fails 503" {
+  # Severs ArgoCD (scales argocd-server to 0) then restores it, so it must follow
+  # every phase that needs a healthy ArgoCD. Its cleanup trap always scales ArgoCD
+  # back and its tokenless deploys leave nothing behind.
+  phase argocd-unreachable.sh
+}
+
+@test "shutdown-drain: graceful shutdown drains in-flight WebSockets" {
+  # LAST: it deletes the argo-watcher pod, so nothing but `down` may depend on the
+  # server afterwards.
+  phase shutdown-drain.sh
+}

--- a/test/e2e/ports.bats
+++ b/test/e2e/ports.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# kind requires a node's extraPortMapping containerPort to EQUAL the nodePort it
+# forwards to, so kind-config.yaml and fixtures/nodeports/ duplicate every port
+# number. Nothing at runtime reports a mismatch — the phase just gets connection
+# refused and times out — so the coupling is asserted here instead.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  KIND_CONFIG="${BATS_TEST_DIRNAME}/kind-config.yaml"
+  NODEPORTS_DIR="${BATS_TEST_DIRNAME}/fixtures/nodeports"
+}
+
+mapped_ports() {
+  yq -oy '.nodes[0].extraPortMappings[].containerPort' "$KIND_CONFIG" | sort -n
+}
+
+service_nodeports() {
+  # -N suppresses the `---` separators yq emits between input files.
+  yq -N -oy 'select(.kind == "Service") | .spec.ports[].nodePort' \
+    "$NODEPORTS_DIR"/*.yaml | sort -n
+}
+
+@test "every Service nodePort is mapped into the kind node" {
+  run diff <(service_nodeports) <(mapped_ports)
+  assert_success
+}
+
+@test "each mapped hostPort equals its containerPort" {
+  # A mismatch here would publish the service on an unexpected localhost port, so
+  # every URL in lib.sh would point at nothing.
+  run yq -oy '[.nodes[0].extraPortMappings[] | select(.containerPort != .hostPort)] | length' "$KIND_CONFIG"
+  assert_output "0"
+}
+
+@test "mappings are bound to loopback only" {
+  # ArgoCD and Gitea run with throwaway admin credentials; a 0.0.0.0 binding would
+  # expose them to the local network for the lifetime of the lab.
+  run yq -oy '[.nodes[0].extraPortMappings[] | select(.listenAddress != "127.0.0.1")] | length' "$KIND_CONFIG"
+  assert_output "0"
+}
+
+@test "every nodePort is unique" {
+  total="$(service_nodeports | wc -l)"
+  unique="$(service_nodeports | sort -u | wc -l)"
+  assert_equal "$total" "$unique"
+}
+
+@test "lib.sh endpoint URLs use the published nodePorts" {
+  # shellcheck source=./scripts/lib.sh
+  . "${BATS_TEST_DIRNAME}/scripts/lib.sh"
+  for url in "$AW_URL" "$AW_WS_URL" "$WHT_URL" "$GITEA_URL" "$ARGOCD_URL" "$GITOPS_REPO_URL"; do
+    port="${url##*:}"; port="${port%%/*}"
+    run grep -rqE "nodePort: ${port}\$" "$NODEPORTS_DIR"
+    assert_success
+  done
+}

--- a/test/e2e/scripts/accept-suspended.sh
+++ b/test/e2e/scripts/accept-suspended.sh
@@ -14,50 +14,33 @@
 # Usage: DEPLOY_TOKEN=... accept-suspended.sh
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="suspendapp"
-IMAGE="${IMAGE:-traefik/whoami}"
 # A tag different from the chart's revision-1 tag (v1.10.1) so the write-back
 # triggers a second Rollout revision, which is what pauses at the canary step.
 TAG="${TAG:-v1.10.2}"
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18098}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
 # Apply the Rollout fixture and wait for revision 1 to roll out Healthy (the
 # initial revision skips the canary steps).
-kubectl apply -f "${here}/../fixtures/suspended-app.yaml"
-for _ in $(seq 1 60); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "ACCEPT-SUSPENDED: FAIL — ${APP} rev1 never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
-echo "suspendapp revision 1 status: ${s:-unknown}"
+kubectl apply -f "${E2E_DIR}/fixtures/suspended-app.yaml"
+require_app_synced "$APP" 60
+echo "suspendapp revision 1 status: ${APP_STATE}"
 
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> ${IMAGE}:${TAG} (write-back triggers a paused canary revision)"
 
 # With a token the write-back bumps image.tag, triggering revision 2 -> canary
 # pause -> Suspended. TASK_TIMEOUT covers write-back + sync + the rollout reaching
 # the pause; a regression (Suspended not accepted) fails once the timeout elapses.
-if ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client"; then
+if run_client "$APP" "$TAG" ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN"; then
   echo "ACCEPT-SUSPENDED: PASS (paused Rollout accepted as deployed)"
   exit 0
 fi

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -19,93 +19,79 @@
 #                                          must leave the lock unset (router.go).
 set -euo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-# Must match the ARGO_WATCHER_DEPLOY_TOKEN in the argo-watcher secret; asserted
-# ABSENT from GET /config to prove secrets stay redacted.
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18092}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
 
-trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
-
-base="http://localhost:${PORT}/api/v1"
-fail=0
-
-# req METHOD URL [curl-args...] -> sets CODE (HTTP status) and BODY (response body).
-req() {
-  local method="$1" url="$2"; shift 2
-  local out
-  out=$(curl -s -m 10 -w $'\n%{http_code}' -X "$method" "$@" "$url")
-  CODE="${out##*$'\n'}"
-  BODY="${out%$'\n'*}"
-}
+# DEPLOY_TOKEN (lib.sh) is asserted ABSENT from GET /config below, proving secrets
+# stay redacted.
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "=== version ==="
-req GET "${base}/version"
-if [[ "$CODE" == "200" ]] && echo "$BODY" | jq -e 'type == "string" and length > 0' >/dev/null 2>&1; then
-  echo "  OK   version=${BODY} (${CODE})"
+req GET "${AW_API}/version"
+if [[ "$CODE" == "200" ]] && jq -e 'type == "string" and length > 0' <<<"$BODY" >/dev/null 2>&1; then
+  ok "version=${BODY} (${CODE})"
 else
-  echo "  FAIL version: code=${CODE} body=${BODY}"; fail=1
+  bad "version: code=${CODE} body=${BODY}"
 fi
 
 echo "=== config ==="
-req GET "${base}/config"
+req GET "${AW_API}/config"
 if [[ "$CODE" != "200" ]]; then
-  echo "  FAIL config: code=${CODE}"; fail=1
-elif ! echo "$BODY" | jq -e '.oidc.enabled == false' >/dev/null 2>&1; then
-  echo "  FAIL config: oidc.enabled != false (lab runs without OIDC auth)"; fail=1
-elif ! echo "$BODY" | jq -e '.keycloak.enabled == false' >/dev/null 2>&1; then
+  bad "config: code=${CODE}"
+elif ! jq -e '.oidc.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
+  bad "config: oidc.enabled != false (lab runs without OIDC auth)"
+elif ! jq -e '.keycloak.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
   # The legacy keycloak mirror must keep matching the oidc block so pre-rename
   # consumers still work; a divergence here is a backward-compat regression.
-  echo "  FAIL config: legacy keycloak mirror missing or != oidc block"; fail=1
-elif echo "$BODY" | grep -qF "$DEPLOY_TOKEN"; then
+  bad "config: legacy keycloak mirror missing or != oidc block"
+elif grep -qF "$DEPLOY_TOKEN" <<<"$BODY"; then
   # A leaked secret here is the whole reason ServerConfig marks it json:"-".
-  echo "  FAIL config: deploy token leaked in /config response"; fail=1
+  bad "config: deploy token leaked in /config response"
 else
-  echo "  OK   config: oidc disabled (+ legacy keycloak mirror), deploy token redacted (${CODE})"
+  ok "config: oidc disabled (+ legacy keycloak mirror), deploy token redacted (${CODE})"
 fi
 
 echo "=== task-list filters ==="
-req GET "${base}/tasks?from_timestamp=0&status=bogus"
-if [[ "$CODE" == "400" ]] && echo "$BODY" | jq -e '.error' >/dev/null 2>&1; then
-  echo "  OK   invalid status -> 400"
+req GET "${AW_API}/tasks?from_timestamp=0&status=bogus"
+if [[ "$CODE" == "400" ]] && jq -e '.error' <<<"$BODY" >/dev/null 2>&1; then
+  ok "invalid status -> 400"
 else
-  echo "  FAIL invalid status: code=${CODE} body=${BODY} (want 400)"; fail=1
+  bad "invalid status: code=${CODE} body=${BODY} (want 400)"
 fi
-req GET "${base}/tasks?from_timestamp=0&status=deployed"
-if [[ "$CODE" == "200" ]] && echo "$BODY" | jq -e '.' >/dev/null 2>&1; then
-  echo "  OK   valid status filter -> 200"
+req GET "${AW_API}/tasks?from_timestamp=0&status=deployed"
+if [[ "$CODE" == "200" ]] && jq -e '.' <<<"$BODY" >/dev/null 2>&1; then
+  ok "valid status filter -> 200"
 else
-  echo "  FAIL valid status: code=${CODE} (want 200 + JSON)"; fail=1
+  bad "valid status: code=${CODE} (want 200 + JSON)"
 fi
 
 echo "=== task not found (404 vs 500) ==="
-req GET "${base}/tasks/00000000-0000-0000-0000-000000000000"
-if [[ "$CODE" == "404" ]] && echo "$BODY" | jq -e '.error == "task not found"' >/dev/null 2>&1; then
-  echo "  OK   unknown task -> 404 task not found"
+req GET "${AW_API}/tasks/00000000-0000-0000-0000-000000000000"
+if [[ "$CODE" == "404" ]] && jq -e '.error == "task not found"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "unknown task -> 404 task not found"
 else
-  echo "  FAIL unknown task: code=${CODE} body=${BODY} (want 404)"; fail=1
+  bad "unknown task: code=${CODE} body=${BODY} (want 404)"
 fi
 
 echo "=== deploy-lock endpoints ==="
-req GET "${base}/deploy-lock"
-if [[ "$CODE" == "200" ]] && echo "$BODY" | jq -e '. == false' >/dev/null 2>&1; then
-  echo "  OK   GET deploy-lock -> 200 (unlocked)"
+req GET "${AW_API}/deploy-lock"
+if [[ "$CODE" == "200" ]] && jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET deploy-lock -> 200 (unlocked)"
 else
-  echo "  FAIL GET deploy-lock: code=${CODE} body=${BODY} (want 200 false)"; fail=1
+  bad "GET deploy-lock: code=${CODE} body=${BODY} (want 200 false)"
 fi
 # Security property: with Keycloak disabled the state-changing POST/DELETE handlers
 # are NOT registered (router.go), so an unauthenticated caller cannot freeze
 # deploys. The unmatched route falls through to the SPA static handler (200 HTML),
 # NOT a 404 — so assert the guarantee behaviourally: after an unauthenticated POST
 # the lock is still not set.
-req POST "${base}/deploy-lock"
-req GET "${base}/deploy-lock"
-if echo "$BODY" | jq -e '. == false' >/dev/null 2>&1; then
-  echo "  OK   POST deploy-lock did not set the lock (still unlocked without Keycloak)"
+req POST "${AW_API}/deploy-lock"
+req GET "${AW_API}/deploy-lock"
+if jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
+  ok "POST deploy-lock did not set the lock (still unlocked without Keycloak)"
 else
-  echo "  FAIL POST deploy-lock set the lock without Keycloak (body=${BODY})"; fail=1
+  bad "POST deploy-lock set the lock without Keycloak (body=${BODY})"
 fi
 
-if [[ "$fail" -eq 0 ]]; then echo "API-SURFACE: PASS"; else echo "API-SURFACE: FAIL"; exit 1; fi
+phase_end API-SURFACE

--- a/test/e2e/scripts/argocd-unreachable.sh
+++ b/test/e2e/scripts/argocd-unreachable.sh
@@ -60,11 +60,15 @@ TASK="$(task_json app1 v1.10.2)"
 
 # status_is <true|false> -> succeeds when GET /reachability .available equals it.
 status_is() {
-  curl -s -m 10 "${AW_API}/reachability" | jq -e ".available == $1" >/dev/null 2>&1
+  local want="$1"
+  curl -s -m 10 "${AW_API}/reachability" | jq -e ".available == ${want}" >/dev/null 2>&1
+  return
 }
 # reason_is <reason> -> succeeds when GET /reachability .reason equals the arg.
 reason_is() {
-  curl -s -m 10 "${AW_API}/reachability" | jq -e ".reason == \"$1\"" >/dev/null 2>&1
+  local want="$1"
+  curl -s -m 10 "${AW_API}/reachability" | jq -e ".reason == \"${want}\"" >/dev/null 2>&1
+  return
 }
 
 wait_service || die "argo-watcher not reachable on ${AW_URL}"

--- a/test/e2e/scripts/argocd-unreachable.sh
+++ b/test/e2e/scripts/argocd-unreachable.sh
@@ -29,89 +29,62 @@
 # check has no lasting side effect beyond a short-lived rollout monitor.
 set -euo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-NS_ARGOCD="${NS_ARGOCD:-argocd}"
-PORT="${PORT:-18094}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 # Fast-fail budget guard: the cached path does zero network I/O, so a POST during
 # the outage returns in well under a second; anything under this bound proves we
 # did not fall back to a live ArgoCD check + retry budget.
 MAX_FASTFAIL_SECONDS="${MAX_FASTFAIL_SECONDS:-10}"
-
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
+# The POST during the outage must be allowed to run long enough to PROVE it is not
+# waiting out the ArgoCD retry budget, so this timeout sits above the guard.
+REQ_TIMEOUT=30
 
 bin_dir="$(mktemp -d)"
 probe_out="$(mktemp)"
-pf_pid=""
 cleanup() {
+  # jobs -p prints one PID per line; splitting them into separate arguments is the
+  # point, and they are always bare digits.
+  # shellcheck disable=SC2046
   kill $(jobs -p) 2>/dev/null || true
   # Safety net: always bring ArgoCD back, even on an early failure exit.
   kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=1 >/dev/null 2>&1 || true
   rm -rf "$bin_dir" "$probe_out"
 }
 trap cleanup EXIT
-( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+build_bin "$bin_dir" ./test/e2e/tools/wsprobe || die "wsprobe build failed"
+wsprobe="$BIN"
 
-start_pf() {
-  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
-  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-  pf_pid=$!
-  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
-}
-
-base="http://localhost:${PORT}/api/v1"
-task_json='{"app":"app1","author":"e2e","project":"lab","images":[{"image":"traefik/whoami","tag":"v1.10.2"}]}'
-# post_task -> sets CODE, BODY and TIME for a tokenless POST /api/v1/tasks.
-post_task() {
-  local out
-  out=$(curl -s -m 30 -w $'\n%{http_code}\n%{time_total}' -X POST -H 'Content-Type: application/json' \
-    -d "$task_json" "${base}/tasks")
-  TIME="${out##*$'\n'}"; out="${out%$'\n'*}"
-  CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
-}
+TASK="$(task_json app1 v1.10.2)"
 
 # status_is <true|false> -> succeeds when GET /reachability .available equals it.
 status_is() {
-  local want="$1"
-  curl -s -m 10 "${base}/reachability" | jq -e ".available == ${want}" >/dev/null 2>&1
+  curl -s -m 10 "${AW_API}/reachability" | jq -e ".available == $1" >/dev/null 2>&1
 }
 # reason_is <reason> -> succeeds when GET /reachability .reason equals the arg.
 reason_is() {
-  local want="$1"
-  curl -s -m 10 "${base}/reachability" | jq -e ".reason == \"${want}\"" >/dev/null 2>&1
-}
-# wait_status <true|false> <attempts> -> polls status_is on a 5s tick.
-wait_status() {
-  local want="$1" attempts="$2"
-  for _ in $(seq 1 "$attempts"); do status_is "$want" && return 0; sleep 5; done
-  return 1
-}
-# wait_ws <message> -> waits up to ~30s for wsprobe to capture `MSG <message>`.
-wait_ws() {
-  local message="$1"
-  for _ in $(seq 1 6); do grep -q "^MSG ${message}\$" "$probe_out" && return 0; sleep 5; done
-  return 1
+  curl -s -m 10 "${AW_API}/reachability" | jq -e ".reason == \"$1\"" >/dev/null 2>&1
 }
 
-fail=0
-start_pf
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
 
 # --- 1. Baseline ---------------------------------------------------------------
 if status_is true; then
-  echo "  OK   GET /reachability -> true (ArgoCD reachable at baseline)"
+  ok "GET /reachability -> true (ArgoCD reachable at baseline)"
 else
-  echo "  FAIL GET /reachability not true at baseline"; fail=1
+  bad "GET /reachability not true at baseline"
 fi
 
 # --- 2. Hold a WS client open before the outage --------------------------------
 # DURATION comfortably exceeds the whole outage+recovery walk (each reachability
 # poll below is bounded to ~200s) so the probe never hits its own deadline before
 # we have observed both transitions.
-WS_URL="ws://localhost:${PORT}/ws" DURATION=900s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
-ws_open=0
-for _ in $(seq 1 20); do grep -q '^OPEN$' "$probe_out" && { ws_open=1; break; }; sleep 1; done
-if [[ "$ws_open" != "1" ]]; then
-  echo "  FAIL WS probe never connected before the outage"; fail=1
+WS_URL="$AW_WS_URL" DURATION=900s "$wsprobe" >"$probe_out" 2>/dev/null &
+ws_open=1
+if ! wait_ws_open "$probe_out"; then
+  bad "WS probe never connected before the outage"
+  ws_open=0
 fi
 
 # --- 3. Induce the outage ------------------------------------------------------
@@ -121,37 +94,37 @@ kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=0 >/dev/null
 # --- 4. Reachability flips to false + argocd_down broadcast --------------------
 # Up to ~200s: the liveness probe runs every 30s and the watcher samples every 5s;
 # the wide margin absorbs a probe mid-cycle when the outage begins.
-if wait_status false 40; then
-  echo "  OK   GET /reachability -> false after the outage"
+if retry 40 5 status_is false; then
+  ok "GET /reachability -> false after the outage"
 else
-  echo "  FAIL GET /reachability never flipped to false during the outage"; fail=1
+  bad "GET /reachability never flipped to false during the outage"
 fi
 # The state backend stays up (only argocd-server was scaled down), so the cause
 # must be identified as "argocd" — not the combined "both" or a bare outage.
 if reason_is argocd; then
-  echo "  OK   GET /reachability -> reason \"argocd\" (ArgoCD-only outage)"
+  ok "GET /reachability -> reason \"argocd\" (ArgoCD-only outage)"
 else
-  echo "  FAIL GET /reachability reason not \"argocd\" during the outage"; fail=1
+  bad "GET /reachability reason not \"argocd\" during the outage"
 fi
 if [[ "$ws_open" == "1" ]]; then
-  if wait_ws argocd_down:argocd; then
-    echo "  OK   WS client received the 'argocd_down:argocd' broadcast"
+  if wait_ws "$probe_out" argocd_down:argocd; then
+    ok "WS client received the 'argocd_down:argocd' broadcast"
   else
-    echo "  FAIL no 'argocd_down:argocd' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+    bad "no 'argocd_down:argocd' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
   fi
 fi
 
 # --- 5. POST fails fast off the cached state -----------------------------------
-post_task
-if [[ "$CODE" == "503" ]] && echo "$BODY" | jq -e '.status == "down"' >/dev/null 2>&1; then
-  echo "  OK   POST /tasks -> 503 {\"status\":\"down\"} during the outage"
+post_task "$TASK"
+if [[ "$CODE" == "503" ]] && jq -e '.status == "down"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "POST /tasks -> 503 {\"status\":\"down\"} during the outage"
 else
-  echo "  FAIL POST /tasks during outage: code=${CODE} body=${BODY} (want 503 down)"; fail=1
+  bad "POST /tasks during outage: code=${CODE} body=${BODY} (want 503 down)"
 fi
 if awk -v t="$TIME" -v m="$MAX_FASTFAIL_SECONDS" 'BEGIN{exit !(t+0 < m+0)}'; then
-  echo "  OK   POST /tasks returned in ${TIME}s (< ${MAX_FASTFAIL_SECONDS}s: cached fast-fail, no retry budget)"
+  ok "POST /tasks returned in ${TIME}s (< ${MAX_FASTFAIL_SECONDS}s: cached fast-fail, no retry budget)"
 else
-  echo "  FAIL POST /tasks took ${TIME}s (>= ${MAX_FASTFAIL_SECONDS}s: looks like a live ArgoCD check + retry)"; fail=1
+  bad "POST /tasks took ${TIME}s (>= ${MAX_FASTFAIL_SECONDS}s: looks like a live ArgoCD check + retry)"
 fi
 
 # --- 6. Recover ----------------------------------------------------------------
@@ -159,23 +132,23 @@ echo "  ...  scaling argocd-server back to 1 replica"
 kubectl -n "$NS_ARGOCD" scale deploy/argocd-server --replicas=1 >/dev/null
 kubectl -n "$NS_ARGOCD" rollout status deploy/argocd-server --timeout=180s >/dev/null
 
-if wait_status true 40; then
-  echo "  OK   GET /reachability -> true after recovery"
+if retry 40 5 status_is true; then
+  ok "GET /reachability -> true after recovery"
 else
-  echo "  FAIL GET /reachability never returned to true after recovery"; fail=1
+  bad "GET /reachability never returned to true after recovery"
 fi
 if [[ "$ws_open" == "1" ]]; then
-  if wait_ws argocd_up; then
-    echo "  OK   WS client received the 'argocd_up' broadcast"
+  if wait_ws "$probe_out" argocd_up; then
+    ok "WS client received the 'argocd_up' broadcast"
   else
-    echo "  FAIL no 'argocd_up' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+    bad "no 'argocd_up' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
   fi
 fi
-post_task
+post_task "$TASK"
 if [[ "$CODE" == "202" ]]; then
-  echo "  OK   POST /tasks -> 202 accepted (deploys resumed)"
+  ok "POST /tasks -> 202 accepted (deploys resumed)"
 else
-  echo "  FAIL POST /tasks after recovery: code=${CODE} body=${BODY} (want 202)"; fail=1
+  bad "POST /tasks after recovery: code=${CODE} body=${BODY} (want 202)"
 fi
 
-if [[ "$fail" -eq 0 ]]; then echo "ARGOCD-UNREACHABLE: PASS"; else echo "ARGOCD-UNREACHABLE: FAIL"; exit 1; fi
+phase_end ARGOCD-UNREACHABLE

--- a/test/e2e/scripts/batch-writeback.sh
+++ b/test/e2e/scripts/batch-writeback.sh
@@ -21,15 +21,18 @@
 #
 # Required env: AW_CHART_REPO, AW_CHART_VERSION (to helm-upgrade the release).
 # Optional env: DEPLOY_TOKEN, APPS, WORKERS, WS_CLIENTS, SOAK, SOAK_SECONDS,
-#   COMPETITOR_INTERVAL, PORT, VALUES.
+#   COMPETITOR_INTERVAL.
 set -uo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-PORT="${PORT:-18094}"
-VALUES="${VALUES:-values/argo-watcher.yaml}"
-AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO required (chart repo URL)}"
-AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION required (pinned chart version)}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+# Required by helm_apply_aw; asserted up front rather than mid-soak.
+: "${AW_CHART_REPO:?AW_CHART_REPO is required}" "${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+# Not configurable: extra_envs_index must count entries in the SAME file
+# helm_apply_aw applies, or the appended --set would overwrite a real entry.
+VALUES="${E2E_DIR}/values/argo-watcher.yaml"
 APPS="${APPS:-5}"
 WORKERS="${WORKERS:-10}"
 WS_CLIENTS="${WS_CLIENTS:-10}"
@@ -37,60 +40,36 @@ SOAK="${SOAK:-2m}"
 SOAK_SECONDS="${SOAK_SECONDS:-120}"
 COMPETITOR_INTERVAL="${COMPETITOR_INTERVAL:-2}"
 
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-e2e_dir="$(cd "${here}/.." && pwd)"
-
-pf_pid=""
-cleanup() { kill $(jobs -p) 2>/dev/null || true; return; }
+cleanup() {
+  # jobs -p prints one PID per line; splitting them into separate arguments is the
+  # point, and they are always bare digits.
+  # shellcheck disable=SC2046
+  kill $(jobs -p) 2>/dev/null || true
+  return
+}
 trap cleanup EXIT
 
-# helm_apply reconfigures the live release from the values file + these --set args
-# alone. --reset-values makes each apply deterministic: without it a prior
-# `--set extraEnvs[N]` would carry forward, so the revert (values-file only) would
-# NOT drop the injected GIT_BATCH_WRITEBACK. Same mechanism as lockdown.sh.
-helm_apply() {
-  helm upgrade --install argo-watcher argo-watcher --repo "$AW_CHART_REPO" \
-    --version "$AW_CHART_VERSION" -n "$NS_AW" -f "${e2e_dir}/${VALUES}" --reset-values \
-    --set image.tag=race "$@" >/dev/null
-  kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
-  return
-}
-
-start_pf() {
-  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
-  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-  pf_pid=$!
-  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
-  return
-}
-
-# Append GIT_BATCH_WRITEBACK as the next extraEnvs entry. The index is the count of
-# entries in the values file's extraEnvs block (read from the file, not the live
-# release), scoped to the block so an unrelated same-indented "- name:" cannot shift
-# it — identical to lockdown.sh.
-idx=$(awk '/^extraEnvs:/{f=1;next} f&&/^[^[:space:]#]/{f=0} f&&/^  - name:/{c++} END{print c+0}' "${e2e_dir}/${VALUES}")
+# Append GIT_BATCH_WRITEBACK as the next free extraEnvs entry (see extra_envs_index
+# in lib.sh); helm_apply_aw handles the --reset-values determinism.
+idx=$(extra_envs_index "$VALUES")
 
 echo "=== enabling GIT_BATCH_WRITEBACK on the live release (extraEnvs[${idx}]) ==="
-helm_apply --set-string "extraEnvs[${idx}].name=GIT_BATCH_WRITEBACK" \
-           --set-string "extraEnvs[${idx}].value=true"
-start_pf
+helm_apply_aw --set-string "extraEnvs[${idx}].name=GIT_BATCH_WRITEBACK" \
+              --set-string "extraEnvs[${idx}].value=true"
+wait_service || die "argo-watcher never came back after enabling batch write-back"
 
 echo "=== waiting for the ${APPS} fixture apps to be Healthy ==="
 for i in $(seq 1 "$APPS"); do
-  for _ in $(seq 1 40); do
-    [[ "$(kubectl -n argocd get application "app$i" -o jsonpath='{.status.health.status}' 2>/dev/null)" == "Healthy" ]] && break
-    sleep 3
-  done
+  wait_app "app$i" Healthy 40 || die "app$i never became Healthy (last: ${APP_STATE:-unknown})"
 done
 
 echo "=== batch soak: ${WORKERS} workers x ${APPS} apps for ${SOAK}, competitor@${COMPETITOR_INTERVAL}s ==="
 summary="$(mktemp)"
-drv=1
 (
-  cd "$e2e_dir" || exit 1
+  cd "$E2E_DIR" || exit 1
   SECONDS_TOTAL="$SOAK_SECONDS" INTERVAL="$COMPETITOR_INTERVAL" ./scripts/competitor.sh & comp=$!
   APPS="$APPS" WORKERS="$WORKERS" WS_CLIENTS="$WS_CLIENTS" DURATION="$SOAK" \
-    DEPLOY_TOKEN="$DEPLOY_TOKEN" BASE_URL="http://localhost:${PORT}" WS_URL="ws://localhost:${PORT}/ws" \
+    DEPLOY_TOKEN="$DEPLOY_TOKEN" BASE_URL="$AW_URL" WS_URL="$AW_WS_URL" \
     go run ./load >"$summary"
   rc=$?
   wait $comp 2>/dev/null || true
@@ -106,8 +85,8 @@ BATCH_MODE=1 "${here}/collect.sh" "$summary"
 col=$?
 
 echo "=== reverting GIT_BATCH_WRITEBACK (restore the default serialized path) ==="
-helm_apply
-start_pf
+helm_apply_aw
+wait_service || die "argo-watcher never came back after reverting batch write-back"
 
 if [[ "$drv" -eq 0 && "$col" -eq 0 ]]; then
   echo "BATCH-WRITEBACK: PASS"

--- a/test/e2e/scripts/client-knobs.sh
+++ b/test/e2e/scripts/client-knobs.sh
@@ -12,71 +12,53 @@
 # Usage: client-knobs.sh [app] [tag]
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="${1:-app1}"
 # Any tag the fixture image actually has works — the assertions are the client's
 # exit code and its debug output, not a specific tag transition. v1.10.2 matches
 # the smoke tag so this phase is a no-op write-back if it runs after smoke.
 TAG="${2:-v1.10.2}"
-IMAGE="${IMAGE:-traefik/whoami}"
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18093}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
-for _ in $(seq 1 40); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "CLIENT-KNOBS: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
-
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+require_app_synced "$APP"
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> ${IMAGE}:${TAG} with TASK_REFRESH=false DEBUG=true"
 
 # Capture combined output AND exit code: the exit code is the TASK_REFRESH
 # assertion, the output is the DEBUG-redaction assertion.
 set +e
-out=$(ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   TASK_REFRESH="false" \
-   DEBUG="true" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client" 2>&1)
+out=$(run_client "$APP" "$TAG" \
+  ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" \
+  TASK_REFRESH="false" \
+  DEBUG="true")
 rc=$?
 set -e
 echo "$out"
 
-fail=0
 if [[ "$rc" -eq 0 ]]; then
-  echo "  OK   TASK_REFRESH=false deploy reached 'deployed' (exit 0)"
+  ok "TASK_REFRESH=false deploy reached 'deployed' (exit 0)"
 else
-  echo "  FAIL client exited ${rc} with TASK_REFRESH=false (did not reach 'deployed')"; fail=1
+  bad "client exited ${rc} with TASK_REFRESH=false (did not reach 'deployed')"
 fi
 
 # Go canonicalises the header key on Header.Set, so it appears as
 # "Argo_watcher_deploy_token" in the log — match case-insensitively.
 if grep -qiE "argo_watcher_deploy_token: <redacted>" <<<"$out"; then
-  echo "  OK   DEBUG cURL log redacts the deploy-token header"
+  ok "DEBUG cURL log redacts the deploy-token header"
 else
-  echo "  FAIL DEBUG cURL log did not show the redacted deploy-token header"; fail=1
+  bad "DEBUG cURL log did not show the redacted deploy-token header"
 fi
 if grep -qF "$DEPLOY_TOKEN" <<<"$out"; then
-  echo "  FAIL deploy token leaked verbatim into client output"; fail=1
+  bad "deploy token leaked verbatim into client output"
 else
-  echo "  OK   deploy token value never appears in client output"
+  ok "deploy token value never appears in client output"
 fi
 
-if [[ "$fail" -eq 0 ]]; then echo "CLIENT-KNOBS: PASS"; else echo "CLIENT-KNOBS: FAIL"; exit 1; fi
+phase_end CLIENT-KNOBS

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -64,6 +64,7 @@ ip=""
 drained() {
   ip=$(metric_raw in_progress_tasks)
   [[ "${ip:-1}" == "0" ]]
+  return
 }
 retry 15 1 drained
 

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -17,109 +17,96 @@
 # Usage: collect.sh <driver-summary.json>
 set -uo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 SUMMARY="${1:?usage: collect.sh <driver-summary.json>}"
-fail=0
 
 echo "=== race detector ==="
 races=0
-for p in $(kubectl -n argo-watcher get pods -o name); do
-  c=$(kubectl -n argo-watcher logs "$p" 2>/dev/null | grep -c 'DATA RACE')
+for p in $(kubectl -n "$NS_AW" get pods -o name); do
+  c=$(kubectl -n "$NS_AW" logs "$p" 2>/dev/null | grep -c 'DATA RACE')
   echo "  $p: $c"
   races=$((races + c))
 done
-[[ "$races" -eq 0 ]] || { echo "FAIL: $races DATA RACE line(s)"; fail=1; }
+[[ "$races" -eq 0 ]] || bad "$races DATA RACE line(s)"
 
 echo "=== metrics ==="
-kubectl -n argo-watcher port-forward svc/argo-watcher 18091:80 >/dev/null 2>&1 &
-pf=$!
-sleep 3
-metrics="$(curl -s -m 10 localhost:18091/metrics)"
-# Some metrics are per-app labeled (failed_deployment{app=..}, processed_..);
-# sum the value field ($NF) across all series of each. The `[ {]` guard anchors
-# on the exact metric name so e.g. `processed_deployments` never captures a
-# `processed_deployments_created` line, and a histogram's `_count` never pulls in
-# its `_bucket`/`_sum` siblings.
-sum_metric() {
-  local metric="$1"
-  echo "$metrics" | awk -v k="^${metric}[ {]" '$0 ~ k {s+=$NF} END{print s+0}'
-  return
-}
-fd=$(sum_metric failed_deployment)
-pd=$(sum_metric processed_deployments)
-au=$(echo "$metrics" | awk '/^argocd_unavailable /{print $NF}')
+metrics="$(curl -s -m 10 "${AW_URL}/metrics")"
+fd=$(metric_sum failed_deployment "$metrics")
+pd=$(metric_sum processed_deployments "$metrics")
 # Histogram observation counts. The soak drives many authenticated deploys, each of
 # which refreshes ArgoCD (ARGO_REFRESH_APP defaults true) and takes the per-repo
 # write-back lock — so all three counts MUST be > 0. A zero means the instrumented
 # code path never ran, i.e. that feature silently regressed even if no task failed.
-rc=$(sum_metric argocd_refresh_duration_seconds_count)
-wc=$(sum_metric gitops_writeback_duration_seconds_count)
-lc=$(sum_metric gitops_lock_wait_duration_seconds_count)
+rc=$(metric_sum argocd_refresh_duration_seconds_count "$metrics")
+wc=$(metric_sum gitops_writeback_duration_seconds_count "$metrics")
+lc=$(metric_sum gitops_lock_wait_duration_seconds_count "$metrics")
 # Every successful deployment observes its end-to-end duration, so on a green soak
 # (all tasks deployed) this MUST be > 0; a zero means the deployment-duration timing
 # never ran.
-dc=$(sum_metric deployment_duration_seconds_count)
+dc=$(metric_sum deployment_duration_seconds_count "$metrics")
 # Batch write-back (GIT_BATCH_WRITEBACK) routes through the coalescing batcher,
 # which records gitops_batch_size INSTEAD of the per-app writeback/lock-wait
 # histograms. Collected here so the BATCH_MODE gate below can assert on it.
-bc=$(sum_metric gitops_batch_size_count)
-bs=$(sum_metric gitops_batch_size_sum)
+bc=$(metric_sum gitops_batch_size_count "$metrics")
+bs=$(metric_sum gitops_batch_size_sum "$metrics")
+
+# These two gauges go through metric_raw, not metric_sum: an ABSENT metric must trip
+# their gates rather than read as 0 (see metric_raw in lib.sh).
+au=$(metric_raw argocd_unavailable "$metrics")
 # in_progress_tasks is decremented in a deferred EndTracking that runs AFTER the
 # task's terminal status is written, so the gauge can briefly lag the driver's exit.
 # Poll it down to 0 rather than gating on a single scrape (avoids a false FAIL on the
 # last task's decrement window); a stuck-non-zero value is a real drain/leak bug.
 ip=""
-for _ in $(seq 1 15); do
-  ip=$(curl -s -m 10 localhost:18091/metrics | awk '/^in_progress_tasks /{print $NF}')
-  [[ "${ip:-1}" == "0" ]] && break
-  sleep 1
-done
-kill $pf 2>/dev/null || true
+drained() {
+  ip=$(metric_raw in_progress_tasks)
+  [[ "${ip:-1}" == "0" ]]
+}
+retry 15 1 drained
+
 echo "  failed_deployment=${fd} processed_deployments=${pd} argocd_unavailable=${au:-?} in_progress_tasks=${ip:-?}"
 echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc} deployment_count=${dc}"
-[[ "${fd:-0}" == "0" ]] || { echo "FAIL: failed_deployment=${fd}"; fail=1; }
-[[ "${au:-0}" == "0" ]] || { echo "FAIL: argocd_unavailable=${au}"; fail=1; }
-[[ "${pd:-0}" -gt 0 ]] || { echo "FAIL: processed_deployments=${pd} (expected > 0)"; fail=1; }
-[[ "${ip:-1}" == "0" ]] || { echo "FAIL: in_progress_tasks=${ip} did not drain to 0"; fail=1; }
-[[ "${rc:-0}" -gt 0 ]] || { echo "FAIL: argocd_refresh_duration_seconds_count=${rc} (expected > 0)"; fail=1; }
-[[ "${dc:-0}" -gt 0 ]] || { echo "FAIL: deployment_duration_seconds_count=${dc} (expected > 0)"; fail=1; }
+[[ "${fd:-0}" == "0" ]]  || bad "failed_deployment=${fd}"
+[[ "${au:-0}" == "0" ]]  || bad "argocd_unavailable=${au}"
+[[ "${pd:-0}" -gt 0 ]]   || bad "processed_deployments=${pd} (expected > 0)"
+[[ "${ip:-1}" == "0" ]]  || bad "in_progress_tasks=${ip:-<absent>} did not drain to 0"
+[[ "${rc:-0}" -gt 0 ]]   || bad "argocd_refresh_duration_seconds_count=${rc} (expected > 0)"
+[[ "${dc:-0}" -gt 0 ]]   || bad "deployment_duration_seconds_count=${dc} (expected > 0)"
 if [[ -n "${BATCH_MODE:-}" ]]; then
   # Batch write-back records gitops_batch_size instead of the per-app
   # writeback/lock-wait histograms (those stay 0 by design in this mode).
   echo "  batch_size_count=${bc} batch_size_sum=${bs}"
-  [[ "${bc:-0}" -gt 0 ]] || { echo "FAIL: gitops_batch_size_count=${bc} (batch write-back path never ran)"; fail=1; }
+  [[ "${bc:-0}" -gt 0 ]] || bad "gitops_batch_size_count=${bc} (batch write-back path never ran)"
   # sum > count => at least one flush coalesced more than one app (mean batch
   # size > 1), proving batching actually collapsed concurrent write-backs under
   # contention rather than degenerating into one-app flushes.
-  awk "BEGIN{exit !(${bs:-0} > ${bc:-0})}" || { echo "FAIL: gitops_batch_size_sum=${bs} not > _count=${bc} (no coalescing observed)"; fail=1; }
+  awk "BEGIN{exit !(${bs:-0} > ${bc:-0})}" \
+    || bad "gitops_batch_size_sum=${bs} not > _count=${bc} (no coalescing observed)"
 else
-  [[ "${wc:-0}" -gt 0 ]] || { echo "FAIL: gitops_writeback_duration_seconds_count=${wc} (expected > 0)"; fail=1; }
-  [[ "${lc:-0}" -gt 0 ]] || { echo "FAIL: gitops_lock_wait_duration_seconds_count=${lc} (expected > 0)"; fail=1; }
+  [[ "${wc:-0}" -gt 0 ]] || bad "gitops_writeback_duration_seconds_count=${wc} (expected > 0)"
+  [[ "${lc:-0}" -gt 0 ]] || bad "gitops_lock_wait_duration_seconds_count=${lc} (expected > 0)"
 fi
 
 echo "=== no lost updates ==="
-kubectl -n gitea port-forward svc/gitea-http 13001:3000 >/dev/null 2>&1 &
-gpf=$!
-sleep 3
 work="$(mktemp -d)"
-# Credentials built from vars (not an inline user:pass@ URL) — matches
-# seed-gitea.sh and keeps a throwaway lab password out of a basic-auth URL literal.
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
-git clone -q "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:13001/e2e/gitops.git" "${work}/r" 2>/dev/null
-kill $gpf 2>/dev/null || true
+trap 'rm -rf "$work"' EXIT
+gitops_clone "${work}/r"
 for app in $(jq -r '.last_tag | keys[]' "$SUMMARY"); do
   want=$(jq -r ".last_tag[\"${app}\"]" "$SUMMARY")
-  got=$(awk '/value:/{print $2}' "${work}/r/chart/.argocd-source-${app}.yaml" 2>/dev/null | tr -d '"')
+  got=$(override_param "${work}/r/chart/.argocd-source-${app}.yaml" app.image.tag 2>/dev/null)
   if [[ "$got" == "$want" ]]; then
     echo "  ${app}: OK (${got})"
   else
-    echo "  ${app}: LOST UPDATE want=${want} got=${got:-<none>}"; fail=1
+    bad "${app}: LOST UPDATE want=${want} got=${got:-<none>}"
   fi
 done
 
 echo "=== task tallies ==="
 jq '{submitted,deployed,failed,other}' "$SUMMARY"
 tf=$(jq -r '.failed' "$SUMMARY")
-[[ "${tf}" == "0" ]] || { echo "FAIL: ${tf} failed task(s)"; fail=1; }
+[[ "${tf}" == "0" ]] || bad "${tf} failed task(s)"
 
-if [[ "$fail" -eq 0 ]]; then echo "COLLECT: PASS"; else echo "COLLECT: FAIL"; exit 1; fi
+phase_end COLLECT

--- a/test/e2e/scripts/commit-format.sh
+++ b/test/e2e/scripts/commit-format.sh
@@ -13,60 +13,39 @@
 # Usage: commit-format.sh
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="app3"
-IMAGE="${IMAGE:-traefik/whoami}"
 AUTHOR="commitfmt-tester"
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18096}"
-GITEA_PORT="${GITEA_PORT:-13002}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
 # Must match COMMIT_MESSAGE_FORMAT in values/argo-watcher.yaml, rendered for this
 # deploy (App=app3, Author=commitfmt-tester).
 WANT_MSG="e2e-commit-fmt app=${APP} by=${AUTHOR}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
 work="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$work"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir" "$work"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
-for _ in $(seq 1 40); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "COMMIT-FORMAT: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
+require_app_synced "$APP"
 
 # Deploy a tag differing from the current one so the write-back actually commits
 # (an unchanged tag is byte-compared and skipped).
-cur=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
-if [[ "$cur" == *v1.10.2* ]]; then TAG="v1.10.1"; else TAG="v1.10.2"; fi
+TAG="$(other_tag "$APP")"
 
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> ${IMAGE}:${TAG} (author=${AUTHOR}) to force a write-back commit"
-if ! ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="${AUTHOR}" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client"; then
+if ! run_client "$APP" "$TAG" \
+     COMMIT_AUTHOR="$AUTHOR" \
+     ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN"; then
   echo "COMMIT-FORMAT: FAIL (deploy did not reach 'deployed', no commit to inspect)"
   exit 1
 fi
 
 # Read the subject of the last commit touching this app's override file.
-kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${GITEA_PORT}" && break; sleep 1; done
-git clone -q "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${GITEA_PORT}/e2e/gitops.git" "${work}/r"
+gitops_clone "${work}/r"
 got=$(cd "${work}/r" && git log -1 --format=%s -- "chart/.argocd-source-${APP}.yaml")
 
 echo "  want: ${WANT_MSG}"

--- a/test/e2e/scripts/competitor.sh
+++ b/test/e2e/scripts/competitor.sh
@@ -8,24 +8,21 @@
 # renders, so it advances the branch HEAD without disturbing the deployed apps.
 set -uo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 SECONDS_TOTAL="${SECONDS_TOTAL:-300}"
 INTERVAL="${INTERVAL:-1}"
-ORG="${ORG:-e2e}"
-REPO="${REPO:-gitops}"
-HTTP_PORT="${HTTP_PORT:-13000}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
 
-kubectl -n gitea port-forward svc/gitea-http "${HTTP_PORT}:3000" >/dev/null 2>&1 &
-trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
-for _ in $(seq 1 20); do
-  curl -sf -m 2 "http://localhost:${HTTP_PORT}/api/healthz" >/dev/null 2>&1 && break; sleep 1
-done
+# Explicit -f predicate rather than wait_url: Gitea's healthz has no 503-by-design
+# case, so "answers at all" would let a 5xx during startup through.
+gitea_up() { curl -sf -m 3 -o /dev/null "${GITEA_URL}/api/healthz"; }
+retry 20 1 gitea_up || die "gitea not healthy on ${GITEA_URL}"
 
 work="$(mktemp -d)"
-url="http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${HTTP_PORT}/${ORG}/${REPO}.git"
-git clone -q "$url" "${work}/r" || { echo "competitor: clone failed" >&2; exit 1; }
-cd "${work}/r"
+gitops_clone "${work}/r"
+cd "${work}/r" || die "could not enter the clone"
 git config user.name competitor
 git config user.email competitor@e2e
 
@@ -36,7 +33,7 @@ while [[ "$(date +%s)" -lt "$end" ]]; do
   n=$((n + 1))
   echo "$n $(date +%s)" >> competitor.log
   git add competitor.log && git commit -q -m "competitor ${n}"
-  if git push -q "$url" HEAD:main 2>/dev/null; then
+  if git push -q "$GITOPS_REPO_URL" HEAD:main 2>/dev/null; then
     pushes=$((pushes + 1))
   else
     conflicts=$((conflicts + 1))   # argo-watcher pushed first; re-sync next loop

--- a/test/e2e/scripts/competitor.sh
+++ b/test/e2e/scripts/competitor.sh
@@ -17,7 +17,7 @@ INTERVAL="${INTERVAL:-1}"
 
 # Explicit -f predicate rather than wait_url: Gitea's healthz has no 503-by-design
 # case, so "answers at all" would let a 5xx during startup through.
-gitea_up() { curl -sf -m 3 -o /dev/null "${GITEA_URL}/api/healthz"; }
+gitea_up() { curl -sf -m 3 -o /dev/null "${GITEA_URL}/api/healthz"; return; }
 retry 20 1 gitea_up || die "gitea not healthy on ${GITEA_URL}"
 
 work="$(mktemp -d)"

--- a/test/e2e/scripts/docker-proxy.sh
+++ b/test/e2e/scripts/docker-proxy.sh
@@ -14,46 +14,31 @@
 # Usage: docker-proxy.sh
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="proxyapp"
-# The BARE image name the client requests; the app runs mirror.gcr.io/<this>.
-IMAGE="${IMAGE:-traefik/whoami}"
+# IMAGE (lib.sh) is the BARE image name the client requests; the app runs
+# mirror.gcr.io/<it>.
 # Must match the tag proxyapp runs (the shared chart's default).
 TAG="${TAG:-v1.10.1}"
-NS_AW="${NS_AW:-argo-watcher}"
-PORT="${PORT:-18099}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
 # Apply the proxy-prefixed fixture and wait for its initial sync (the proxied image
 # pulls through mirror.gcr.io and runs, so the app becomes Healthy).
-kubectl apply -f "${here}/../fixtures/proxy-app.yaml"
-for _ in $(seq 1 60); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "DOCKER-PROXY: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
-
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+kubectl apply -f "${E2E_DIR}/fixtures/proxy-app.yaml"
+require_app_synced "$APP" 60
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> bare ${IMAGE}:${TAG} (app runs mirror.gcr.io/${IMAGE})"
 
 # No deploy token: unvalidated, no write-back. TASK_TIMEOUT kept short so a
 # regression (proxy match not applied) fails fast instead of hanging.
-if ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="60" \
-   "${bin_dir}/aw-client"; then
+if run_client "$APP" "$TAG" TASK_TIMEOUT="60"; then
   echo "DOCKER-PROXY: PASS (bare image matched the proxy-prefixed running image)"
   exit 0
 fi

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -19,31 +19,25 @@
 # Usage: DEPLOY_TOKEN=... failure-diagnostics.sh
 set -uo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18095}"
-IMAGE="${IMAGE:-traefik/whoami}"
-GOOD_TAG="${GOOD_TAG:-v1.10.1}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+GOOD_TAG="${GOOD_TAG:-v1.10.1}"
 
 # Build the client once; every scenario runs the same binary (deterministic, no
 # per-invocation `go run` compile).
 bin_dir="$(mktemp -d)"
-CLIENT_BIN="${bin_dir}/aw-client"
-( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) || { echo "failure-diagnostics: FAIL — client build failed" >&2; exit 1; }
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
-# Register cleanup before starting the port-forward so an exit in the tiny window
-# between the two can never orphan it.
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
 
 # --- helpers ----------------------------------------------------------------
-# run_client <task-json> <use_token>: runs the client binary for the deploy
+# scenario_client <task-json> <use_token>: runs the client binary for the deploy
 # described by the JSON. Prints the client's combined stdout+stderr; returns the
 # client's exit code (0 = deployed, non-zero = failed/cancelled/etc.).
-run_client() {
+scenario_client() {
   local payload="$1" use_token="$2" token_env=()
   local app author project image tag timeout
   app=$(jq -r '.app' <<<"$payload")
@@ -62,20 +56,17 @@ run_client() {
     token_env=(ARGO_WATCHER_DEPLOY_TOKEN= BEARER_TOKEN=)
   fi
   # "${token_env[@]+...}" guards the empty-array expansion under `set -u` on bash < 4.4.
-  env ARGO_WATCHER_URL="http://localhost:${PORT}" \
-      IMAGES="$image" IMAGE_TAG="$tag" ARGO_APP="$app" \
-      COMMIT_AUTHOR="$author" PROJECT_NAME="$project" \
-      RETRY_INTERVAL="5s" TASK_TIMEOUT="$timeout" \
-      "${token_env[@]+"${token_env[@]}"}" \
-      "$CLIENT_BIN" 2>&1
-  return
+  run_client "$app" "$tag" \
+    IMAGES="$image" COMMIT_AUTHOR="$author" PROJECT_NAME="$project" \
+    TASK_TIMEOUT="$timeout" \
+    "${token_env[@]+"${token_env[@]}"}"
 }
 
 # restore_good_tag <app>: bump the app back to a pullable tag so the lab stays
 # reusable. Best-effort — a restore hiccup must not fail the suite.
 restore_good_tag() {
   local app="$1"
-  run_client "{\"app\":\"${app}\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":120,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${GOOD_TAG}\"}]}" 1 >/dev/null 2>&1 || true
+  scenario_client "{\"app\":\"${app}\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":120,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${GOOD_TAG}\"}]}" 1 >/dev/null 2>&1 || true
   return
 }
 
@@ -136,7 +127,6 @@ SCENARIOS=(
 )
 
 # --- runner -----------------------------------------------------------------
-overall=0
 for scenario in "${SCENARIOS[@]}"; do
   echo "=== ${scenario#scenario_} ==="
   spec="$($scenario)"
@@ -148,23 +138,21 @@ for scenario in "${SCENARIOS[@]}"; do
 
   [[ -n "$setup" ]] && { echo "  setup: $setup"; "$setup"; }
 
-  out=$(run_client "$task" "$token"); rc=$?
+  out=$(scenario_client "$task" "$token"); rc=$?
   echo "  client exit=${rc}"
   # shellcheck disable=SC2001  # per-line prefix needs a regex anchor; ${//} can't do it
   echo "  client output: $(sed 's/^/    | /' <<<"$out")"
 
-  ok=1
-  [[ "$rc" -ne 0 ]] || { echo "  FAIL: expected the client to exit non-zero, got ${rc}"; ok=0; }
+  [[ "$rc" -ne 0 ]] || bad "expected the client to exit non-zero, got ${rc}"
   for want in "${expects[@]}"; do
     if grep -qF -- "$want" <<<"$out"; then
-      echo "  OK: client output contains «${want}»"
+      ok "client output contains «${want}»"
     else
-      echo "  FAIL: client output missing «${want}»"; ok=0
+      bad "client output missing «${want}»"
     fi
   done
 
   [[ -n "$teardown" ]] && { echo "  teardown: $teardown"; "$teardown"; }
-  [[ "$ok" -eq 1 ]] || overall=1
 done
 
-if [[ "$overall" -eq 0 ]]; then echo "FAILURE-DIAGNOSTICS: PASS"; else echo "FAILURE-DIAGNOSTICS: FAIL"; exit 1; fi
+phase_end FAILURE-DIAGNOSTICS

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -60,6 +60,7 @@ scenario_client() {
     IMAGES="$image" COMMIT_AUTHOR="$author" PROJECT_NAME="$project" \
     TASK_TIMEOUT="$timeout" \
     "${token_env[@]+"${token_env[@]}"}"
+  return
 }
 
 # restore_good_tag <app>: bump the app back to a pullable tag so the lab stays

--- a/test/e2e/scripts/fire-and-forget.sh
+++ b/test/e2e/scripts/fire-and-forget.sh
@@ -16,61 +16,45 @@
 # Usage: DEPLOY_TOKEN=... fire-and-forget.sh
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="ffapp"
-IMAGE="${IMAGE:-traefik/whoami}"
 # A tag different from the chart's default (v1.10.1) so the write-back is a real
 # change; never actually runs (no pod until the far-future schedule).
 TAG="${TAG:-v1.10.2}"
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18095}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
 # Apply the managed CronJob fixture and wait for its initial sync. A CronJob app
 # becomes Synced/Healthy once the CronJob exists (no pod required).
-kubectl apply -f "${here}/../fixtures/fire-and-forget-app.yaml"
-for _ in $(seq 1 60); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "FIRE-AND-FORGET: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
-
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+kubectl apply -f "${E2E_DIR}/fixtures/fire-and-forget-app.yaml"
+require_app_synced "$APP" 60
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} (managed CronJob) -> ${IMAGE}:${TAG} in fire-and-forget mode"
 
 # With the token the write-back bumps the CronJob's image tag. TASK_TIMEOUT is kept
 # short so a regression (fire-and-forget NOT honoured) fails fast at "not available"
 # rather than hanging for the full default window.
-if ! ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="60" \
-   "${bin_dir}/aw-client"; then
+if ! run_client "$APP" "$TAG" \
+     ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" \
+     TASK_TIMEOUT="60"; then
   echo "FIRE-AND-FORGET: FAIL (client exited non-zero — the rollout wait was NOT skipped)"
   exit 1
 fi
 
 # Confirm the write-back actually reached the tracked workload: the live CronJob
 # must now run the deployed tag (ArgoCD synced argo-watcher's override).
-for _ in $(seq 1 20); do
-  img=$(kubectl -n "$APP" get cronjob ffapp-cron -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}' 2>/dev/null || true)
-  [[ "$img" == "${IMAGE}:${TAG}" ]] && break
-  sleep 3
-done
-if [[ "$img" == "${IMAGE}:${TAG}" ]]; then
+cronjob_on_tag() {
+  img=$(kubectl -n "$APP" get cronjob ffapp-cron \
+    -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+  [[ "$img" == "${IMAGE}:${TAG}" ]]
+}
+if retry 20 3 cronjob_on_tag; then
   echo "FIRE-AND-FORGET: PASS (write-back updated the CronJob to ${TAG}; deploy reported done without the image running)"
   exit 0
 fi

--- a/test/e2e/scripts/hook-fixture.sh
+++ b/test/e2e/scripts/hook-fixture.sh
@@ -8,16 +8,21 @@
 # Usage: hook-fixture.sh <add|remove> [app]
 set -euo pipefail
 
-ACTION="${1:?usage: hook-fixture.sh <add|remove> [app]}"
-ORG="${ORG:-e2e}"; REPO="${REPO:-gitops}"; PORT="${GITEA_PORT:-13030}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"; GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
 
-kubectl -n gitea port-forward svc/gitea-http "${PORT}:3000" >/dev/null 2>&1 &
-pf=$!; trap 'kill $pf 2>/dev/null || true; rm -rf "${work:-}"' EXIT
-for _ in $(seq 1 20); do curl -sf -m3 -u "${GITEA_ADMIN}:${GITEA_PW}" "http://localhost:${PORT}/api/v1/version" >/dev/null 2>&1 && break; sleep 1; done
+ACTION="${1:?usage: hook-fixture.sh <add|remove> [app]}"
 
 work="$(mktemp -d)"
-git -C "$work" clone -q "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${PORT}/${ORG}/${REPO}.git" r
+trap 'rm -rf "$work"' EXIT
+
+gitea_ready() {
+  curl -sf -m3 -u "${GITEA_ADMIN}:${GITEA_PW}" "${GITEA_API}/version" >/dev/null 2>&1
+}
+retry 20 1 gitea_ready || die "gitea API not reachable on ${GITEA_URL}"
+
+gitops_clone "${work}/r"
 
 values="$work/r/chart/values.yaml"
 case "$ACTION" in

--- a/test/e2e/scripts/jwt-auth.sh
+++ b/test/e2e/scripts/jwt-auth.sh
@@ -14,52 +14,35 @@
 # Usage: jwt-auth.sh [app]
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="${1:-app2}"
-IMAGE="${IMAGE:-traefik/whoami}"
-NS_AW="${NS_AW:-argo-watcher}"
 # MUST match JWT_SECRET in values/argo-watcher.yaml.
 JWT_SECRET="${JWT_SECRET:-e2e-jwt-secret}"
-PORT="${PORT:-18094}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
-for _ in $(seq 1 40); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "JWT-AUTH: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
+require_app_synced "$APP"
 
-# Pick a tag that differs from the currently deployed one so the deploy forces a
-# write-back regardless of what earlier phases left the app on. Both tags exist.
-cur=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
-if [[ "$cur" == *v1.10.2* ]]; then TAG="v1.10.1"; else TAG="v1.10.2"; fi
+# A tag differing from the currently deployed one, so the deploy forces a real
+# write-back regardless of what earlier phases left the app on.
+TAG="$(other_tag "$APP")"
 
 # Mint a short-lived HS256 JWT signed with JWT_SECRET via the in-repo Go minter
 # (signs with the same library the server validates with; no openssl dependency).
-jwt="$(cd "$root" && JWT_SECRET="$JWT_SECRET" go run ./test/e2e/tools/mintjwt)"
+jwt="$(cd "$E2E_ROOT" && JWT_SECRET="$JWT_SECRET" go run ./test/e2e/tools/mintjwt)"
 
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> ${IMAGE}:${TAG} via BEARER_TOKEN (JWT), no deploy token"
 
 # BEARER_TOKEN only, ARGO_WATCHER_DEPLOY_TOKEN unset: the deploy is authenticated
 # solely by the JWT, so a successful write-back proves the JWT strategy validated it.
-if ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   BEARER_TOKEN="${jwt}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client"; then
+if run_client "$APP" "$TAG" BEARER_TOKEN="$jwt"; then
   echo "JWT-AUTH: PASS (JWT-authenticated write-back reached 'deployed' on ${TAG})"
   exit 0
 fi

--- a/test/e2e/scripts/lib.bats
+++ b/test/e2e/scripts/lib.bats
@@ -248,6 +248,35 @@ PROM
   assert_equal "$attempts" "1"
 }
 
+# --- exit-status propagation --------------------------------------------------
+# Every helper ends with an explicit `return` (shelldre:S7682). A bare `return`
+# forwards the last command's status, but writing `return 0` — or reordering so
+# something else runs last — would silently swallow a failure. run_client's status IS
+# the assertion in six phases, so pin the contract rather than trusting it.
+
+@test "run_client propagates a non-zero client exit code" {
+  CLIENT_BIN="$(command -v false)"
+  run ! run_client app1 v1
+}
+
+@test "run_client propagates a zero client exit code" {
+  CLIENT_BIN="$(command -v true)"
+  run run_client app1 v1
+  assert_success
+}
+
+@test "wait_url propagates failure when nothing answers" {
+  run ! wait_url "http://127.0.0.1:1/nope" 1
+}
+
+@test "ok and note succeed; bad succeeds but counts the failure" {
+  E2E_FAILS=0
+  run ok "fine";  assert_success
+  run note "hmm"; assert_success
+  bad "broken"
+  assert_equal "$E2E_FAILS" "1"
+}
+
 # --- assertion accumulator ---------------------------------------------------
 
 @test "phase_end exits 0 when nothing failed" {

--- a/test/e2e/scripts/lib.bats
+++ b/test/e2e/scripts/lib.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+# Unit tests for the pure text-processing helpers in lib.sh — the awk/parameter
+# expansion logic whose failure mode is silent and wrong (a parse that returns
+# nothing reads as "assertion failed", a metric filter that over-matches inflates a
+# gate) rather than a loud error.
+#
+# Cluster-dependent helpers (wait_app, run_client, helm_apply_aw, ...) are not
+# covered here: they are only meaningful against the real lab, where the phases that
+# call them are the test.
+#
+#   task -d test/e2e lint     # or: bats test/e2e/scripts/lib.bats
+
+# `run !` and `run -N` need 1.5.0+.
+bats_require_minimum_version 1.5.0
+
+setup() {
+  # bats_load_library, not load: BATS_LIB_PATH is a colon-separated SEARCH path, so
+  # treating it as a single directory breaks as soon as it holds more than one entry.
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  # shellcheck source=./lib.sh
+  . "${BATS_TEST_DIRNAME}/lib.sh"
+}
+
+# --- override_param ----------------------------------------------------------
+
+override_fixture() {
+  cat >"${BATS_TEST_TMPDIR}/o.yaml" <<'YAML'
+helm:
+  parameters:
+    - name: app.image.tag
+      value: "v1.10.3"
+      forceString: true
+    - name: app.proxyTag
+      value: latest
+      forceString: true
+YAML
+}
+
+@test "override_param reads a quoted value" {
+  override_fixture
+  run override_param "${BATS_TEST_TMPDIR}/o.yaml" app.image.tag
+  assert_output "v1.10.3"
+}
+
+@test "override_param reads an unquoted value" {
+  override_fixture
+  run override_param "${BATS_TEST_TMPDIR}/o.yaml" app.proxyTag
+  assert_output "latest"
+}
+
+@test "override_param yields nothing for an absent parameter" {
+  override_fixture
+  run override_param "${BATS_TEST_TMPDIR}/o.yaml" app.nope
+  assert_output ""
+}
+
+@test "override_param treats dots as literal, not regex wildcards" {
+  # Unescaped, "app.image.tag" as a pattern also matches "appXimageYtag".
+  cat >"${BATS_TEST_TMPDIR}/dots.yaml" <<'YAML'
+helm:
+  parameters:
+    - name: appXimageYtag
+      value: "wrong"
+    - name: app.image.tag
+      value: "right"
+YAML
+  run override_param "${BATS_TEST_TMPDIR}/dots.yaml" app.image.tag
+  assert_output "right"
+}
+
+@test "override_param does not match a name by its prefix" {
+  # "app.image" must not be satisfied by the "app.image.tag" entry above it.
+  cat >"${BATS_TEST_TMPDIR}/prefix.yaml" <<'YAML'
+helm:
+  parameters:
+    - name: app.image.tag
+      value: "tag-entry"
+    - name: app.image
+      value: "image-entry"
+YAML
+  run override_param "${BATS_TEST_TMPDIR}/prefix.yaml" app.image
+  assert_output "image-entry"
+}
+
+# --- extra_envs_index --------------------------------------------------------
+
+@test "extra_envs_index counts the entries in the block" {
+  cat >"${BATS_TEST_TMPDIR}/v.yaml" <<'YAML'
+logLevel: debug
+
+extraEnvs:
+  - name: JWT_SECRET
+    value: "s"
+  - name: ARGO_URL_ALIAS
+    value: "u"
+
+postgres:
+  enabled: false
+YAML
+  run extra_envs_index "${BATS_TEST_TMPDIR}/v.yaml"
+  assert_output "2"
+}
+
+@test "extra_envs_index stops at the next top-level key" {
+  # A same-indented "- name:" in another section would otherwise shift the index and
+  # make a --set overwrite a real entry instead of appending.
+  cat >"${BATS_TEST_TMPDIR}/v.yaml" <<'YAML'
+extraEnvs:
+  - name: JWT_SECRET
+    value: "s"
+
+sidecars:
+  - name: not-an-env
+    image: busybox
+YAML
+  run extra_envs_index "${BATS_TEST_TMPDIR}/v.yaml"
+  assert_output "1"
+}
+
+@test "extra_envs_index yields 0 with no extraEnvs block" {
+  echo "logLevel: debug" >"${BATS_TEST_TMPDIR}/v.yaml"
+  run extra_envs_index "${BATS_TEST_TMPDIR}/v.yaml"
+  assert_output "0"
+}
+
+# --- metric_sum --------------------------------------------------------------
+
+metrics_fixture() {
+  cat <<'PROM'
+# HELP failed_deployment Failed deployments
+failed_deployment{app="app1"} 2
+failed_deployment{app="app2"} 3
+processed_deployments 7
+processed_deployments_created 1.7e+09
+argocd_unavailable 0
+gitops_writeback_duration_seconds_bucket{le="0.5"} 11
+gitops_writeback_duration_seconds_sum 4.2
+gitops_writeback_duration_seconds_count 9
+in_progress_tasks 0
+PROM
+}
+
+@test "metric_sum sums labelled series" {
+  run metric_sum failed_deployment "$(metrics_fixture)"
+  assert_output "5"
+}
+
+@test "metric_sum reads an unlabelled series" {
+  run metric_sum processed_deployments "$(metrics_fixture)"
+  assert_output "7"
+}
+
+@test "metric_sum preserves a zero value" {
+  run metric_sum argocd_unavailable "$(metrics_fixture)"
+  assert_output "0"
+}
+
+@test "metric_sum yields 0 for an absent metric" {
+  run metric_sum nonexistent_metric "$(metrics_fixture)"
+  assert_output "0"
+}
+
+@test "metric_sum does not capture the _created sibling" {
+  # A bare prefix match would fold processed_deployments_created (a unix timestamp)
+  # into processed_deployments.
+  run metric_sum processed_deployments "$(metrics_fixture)"
+  assert_output "7"
+}
+
+@test "metric_sum histogram _count excludes _bucket and _sum" {
+  run metric_sum gitops_writeback_duration_seconds_count "$(metrics_fixture)"
+  assert_output "9"
+}
+
+# --- metric_raw ---------------------------------------------------------------
+# The gauges gated on "must be 0" have to distinguish 0 from absent, which is the one
+# thing metric_sum cannot do: it reports a missing metric as 0, so an unregistered or
+# renamed gauge would satisfy the gate vacuously.
+
+@test "metric_raw reads a present gauge" {
+  run metric_raw argocd_unavailable "$(metrics_fixture)"
+  assert_output "0"
+}
+
+@test "metric_raw yields EMPTY for an absent gauge, unlike metric_sum" {
+  run metric_raw definitely_absent_gauge "$(metrics_fixture)"
+  assert_output ""
+  # The contrast is the whole point of having both helpers.
+  run metric_sum definitely_absent_gauge "$(metrics_fixture)"
+  assert_output "0"
+}
+
+@test "metric_raw does not match a longer metric name by prefix" {
+  # The trailing space in the pattern is what keeps in_progress_tasks from also
+  # matching an in_progress_tasks_total, and argocd_unavailable from a _created.
+  run metric_raw processed_deployments "$(metrics_fixture)"
+  assert_output "7"
+}
+
+# --- task_json ---------------------------------------------------------------
+
+@test "task_json builds a payload with defaults" {
+  json="$(task_json app1 v1.2.3)"
+  assert_equal "$(jq -r '.app' <<<"$json")" "app1"
+  assert_equal "$(jq -r '.author' <<<"$json")" "e2e"
+  assert_equal "$(jq -r '.project' <<<"$json")" "lab"
+  assert_equal "$(jq -r '.images[0].tag' <<<"$json")" "v1.2.3"
+  assert_equal "$(jq -r '.images[0].image' <<<"$json")" "traefik/whoami"
+}
+
+@test "task_json honours explicit author, project and image" {
+  json="$(task_json app9 v9 bob proj custom/img)"
+  assert_equal "$(jq -r '.author' <<<"$json")" "bob"
+  assert_equal "$(jq -r '.project' <<<"$json")" "proj"
+  assert_equal "$(jq -r '.images[0].image' <<<"$json")" "custom/img"
+}
+
+# --- retry -------------------------------------------------------------------
+# These counters are deliberately named `attempts` and `delay` — the same names
+# retry takes as parameters. A command retry runs executes in the same shell, so if
+# retry's locals were not underscore-prefixed, `never` below would increment retry's
+# own loop bound and the loop would never terminate.
+
+@test "retry succeeds on the third attempt" {
+  attempts=0
+  flaky() { attempts=$((attempts + 1)); [[ "$attempts" -ge 3 ]]; }
+  retry 5 0 flaky
+  assert_equal "$attempts" "3"
+}
+
+@test "retry returns 1 once exhausted, having run exactly <attempts> times" {
+  attempts=0
+  delay=0
+  never() { attempts=$((attempts + 1)); return 1; }
+  run ! retry 4 0 never
+  # `run` uses a subshell, so re-run in this shell to observe the counter.
+  attempts=0
+  retry 4 0 never || true
+  assert_equal "$attempts" "4"
+  assert_equal "$delay" "0"
+}
+
+@test "retry stops at the first success" {
+  attempts=0
+  always() { attempts=$((attempts + 1)); return 0; }
+  retry 3 0 always
+  assert_equal "$attempts" "1"
+}
+
+# --- assertion accumulator ---------------------------------------------------
+
+@test "phase_end exits 0 when nothing failed" {
+  run bash -c '. "'"${BATS_TEST_DIRNAME}"'/lib.sh"; ok fine; phase_end SAMPLE'
+  assert_success
+  assert_output --partial "SAMPLE: PASS"
+}
+
+@test "phase_end exits 1 after a bad() and counts every failure" {
+  run bash -c '. "'"${BATS_TEST_DIRNAME}"'/lib.sh"; bad one; bad two; phase_end SAMPLE'
+  assert_failure
+  assert_output --partial "SAMPLE: FAIL (2 failed assertion(s))"
+}

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -56,21 +56,29 @@ ok()   { echo "  OK   $*"; return; }
 bad()  { echo "  FAIL $*"; E2E_FAILS=$((E2E_FAILS + 1)); return; }
 note() { echo "  NOTE $*"; return; }
 
-# phase_end <PHASE-NAME>: print the verdict and exit 1 if any bad() fired.
+# phase_end <PHASE-NAME>: print the verdict, then exit 0 on a clean run or 1 if any
+# bad() fired. Never returns to the caller.
 phase_end() {
-  local name="$1"
+  local name="$1" code=0
   if [[ "$E2E_FAILS" -eq 0 ]]; then
     echo "${name}: PASS"
-    exit 0
+  else
+    echo "${name}: FAIL (${E2E_FAILS} failed assertion(s))"
+    code=1
   fi
-  echo "${name}: FAIL (${E2E_FAILS} failed assertion(s))"
-  exit 1
+  exit "$code"
+  # Unreachable, and deliberately so: SonarCloud's shelldre:S7682 wants every
+  # function to end in an explicit return, while shellcheck then flags it as
+  # unreachable. The two disagree; this keeps both quiet.
+  # shellcheck disable=SC2317
+  return
 }
 
 # die <message...>: abort the phase immediately. For preconditions a phase cannot
 # proceed without (a fixture never synced, a build failed) as opposed to a failed
 # assertion, which is bad() + phase_end.
-die() { echo "FAIL: $*" >&2; exit 1; }
+# shellcheck disable=SC2317  # the trailing return is unreachable; see phase_end
+die() { echo "FAIL: $*" >&2; exit 1; return; }
 
 # --- polling -----------------------------------------------------------------
 # retry <attempts> <delay-seconds> <cmd...>: run cmd until it succeeds. Returns 0

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Shared helpers for the argo-watcher e2e lab phase scripts.
+#
+# Source it, never run it:
+#   . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+#
+# Only helpers with more than one caller belong here; a phase's own domain
+# assertions stay in the phase script, where the rationale for them is.
+#
+# Deliberately does NOT set shell options: the phases disagree (some run `set -e`
+# and abort on the first problem, others `set -uo pipefail` and accumulate
+# failures), and sourcing a library must not change the caller's mode. Everything
+# below works under both.
+#
+# shellcheck disable=SC2034  # a library defines variables for the scripts sourcing it
+
+# --- paths -------------------------------------------------------------------
+E2E_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${E2E_SCRIPTS}/.." && pwd)"
+E2E_ROOT="$(cd "${E2E_DIR}/../.." && pwd)"
+
+NS_AW="${NS_AW:-argo-watcher}"
+NS_ARGOCD="${NS_ARGOCD:-argocd}"
+NS_GITEA="${NS_GITEA:-gitea}"
+
+# --- endpoints ---------------------------------------------------------------
+# Fixed host ports, published by fixtures/nodeports/ and mapped into the node by
+# kind-config.yaml. These survive a pod being replaced — which shutdown-drain,
+# lockdown, batch-writeback and state-postgres all do deliberately — so those phases
+# just wait for the service to answer again instead of re-forwarding.
+AW_URL="${AW_URL:-http://localhost:30080}"
+AW_API="${AW_URL}/api/v1"
+AW_WS_URL="${AW_WS_URL:-ws://localhost:30080/ws}"
+WHT_URL="${WHT_URL:-http://localhost:30081}"
+GITEA_URL="${GITEA_URL:-http://localhost:30300}"
+# Self-signed cert; callers pass -k.
+ARGOCD_URL="${ARGOCD_URL:-https://localhost:30443}"
+
+# Throwaway lab credentials, in vars rather than an inline user:pass@ URL literal.
+GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
+GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
+GITEA_ORG="${GITEA_ORG:-e2e}"
+GITEA_REPO="${GITEA_REPO:-gitops}"
+GITEA_API="${GITEA_URL}/api/v1"
+GITOPS_REPO_URL="${GITOPS_REPO_URL:-http://${GITEA_ADMIN}:${GITEA_PW}@localhost:30300/${GITEA_ORG}/${GITEA_REPO}.git}"
+
+# Only validated (authenticated) tasks trigger the updater push, so a phase asserting
+# a write-back must send this. Must match the secret mint-argo-token.sh writes.
+DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+IMAGE="${IMAGE:-traefik/whoami}"
+
+# --- assertions --------------------------------------------------------------
+E2E_FAILS=0
+
+ok()   { echo "  OK   $*"; }
+bad()  { echo "  FAIL $*"; E2E_FAILS=$((E2E_FAILS + 1)); }
+note() { echo "  NOTE $*"; }
+
+# phase_end <PHASE-NAME>: print the verdict and exit 1 if any bad() fired.
+phase_end() {
+  if [[ "$E2E_FAILS" -eq 0 ]]; then
+    echo "${1}: PASS"
+    exit 0
+  fi
+  echo "${1}: FAIL (${E2E_FAILS} failed assertion(s))"
+  exit 1
+}
+
+# die <message...>: abort the phase immediately. For preconditions a phase cannot
+# proceed without (a fixture never synced, a build failed) as opposed to a failed
+# assertion, which is bad() + phase_end.
+die() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- polling -----------------------------------------------------------------
+# retry <attempts> <delay-seconds> <cmd...>: run cmd until it succeeds. Returns 0
+# on the first success, 1 once every attempt has failed. cmd's own output is left
+# alone — redirect it at the call site if it is noisy.
+#
+# The locals are underscore-prefixed because cmd runs in THIS shell and may well
+# touch a variable of its own called `attempts` or `delay`. Without the prefix such
+# a name would resolve to retry's local: a cmd incrementing its own `attempts`
+# counter would grow this loop's bound on every pass and never terminate.
+retry() {
+  local _attempts="$1" _delay="$2" _i
+  shift 2
+  for ((_i = 1; _i <= _attempts; _i++)); do
+    "$@" && return 0
+    [[ "$_i" -lt "$_attempts" ]] && sleep "$_delay"
+  done
+  return 1
+}
+
+# wait_service [attempts]: block until argo-watcher answers on its HTTP port.
+#
+# Deliberately checks only that a response arrives, NOT that it is 2xx: /healthz
+# returns 503 while ArgoCD is unreachable (handlers.go healthz), which is a state
+# the argocd-unreachable phase induces on purpose and the shutdown-drain phase can
+# observe on a fresh pod. A `curl -f` here would hang in exactly those phases.
+wait_service() {
+  retry "${1:-30}" 2 curl -s -m 3 -o /dev/null "${AW_URL}/healthz"
+}
+
+# wait_url <url> [attempts]: block until <url> answers at all (see wait_service on
+# why the status code is not checked).
+wait_url() {
+  retry "${2:-15}" 2 curl -s -m 3 -o /dev/null "$1"
+}
+
+# wait_app <app> <want> [attempts]: poll an Argo Application until its
+# "<sync>/<health>" state equals <want> (e.g. "Synced/Healthy") — or, when <want>
+# has no slash, until its health alone equals it (e.g. "Healthy"). Leaves the last
+# observed state in APP_STATE so the caller can report what it actually saw.
+wait_app() {
+  local app="$1" want="$2" attempts="${3:-40}" path i
+  if [[ "$want" == */* ]]; then
+    path='{.status.sync.status}/{.status.health.status}'
+  else
+    path='{.status.health.status}'
+  fi
+  for ((i = 1; i <= attempts; i++)); do
+    APP_STATE=$(kubectl -n "$NS_ARGOCD" get application "$app" -o jsonpath="$path" 2>/dev/null || true)
+    [[ "$APP_STATE" == "$want" ]] && return 0
+    sleep 5
+  done
+  return 1
+}
+
+# require_app_synced <app> [attempts]: wait_app for Synced/Healthy, aborting with the
+# last observed state if it never gets there. Deploy phases open with this so they
+# deploy from a known-good baseline.
+require_app_synced() {
+  wait_app "$1" "Synced/Healthy" "${2:-40}" \
+    || die "${1} never reached Synced/Healthy (last: ${APP_STATE:-unknown})"
+}
+
+# wait_ws <file> <message> [attempts]: wait for a wsprobe capture file to contain
+# `MSG <message>`. The lockdown watcher polls every 5s, so the default ~30s window
+# covers a broadcast triggered just after the previous tick.
+wait_ws() {
+  retry "${3:-6}" 5 grep -q "^MSG ${2}\$" "$1"
+}
+
+# wait_ws_open <file> [attempts]: wait for a wsprobe to report its connection is
+# established. Every phase asserting a broadcast must do this BEFORE triggering it:
+# a one-shot broadcast is missed entirely if the handshake is still in flight, and
+# a fixed sleep raced it on a loaded host.
+wait_ws_open() {
+  retry "${2:-20}" 1 grep -q '^OPEN$' "$1"
+}
+
+# --- HTTP --------------------------------------------------------------------
+# req <method> <url> [curl-args...]: perform one request, setting CODE (HTTP
+# status), BODY (response body) and TIME (total seconds) for the caller to assert
+# on. The status and timing are appended on their own lines and split off from the
+# end, so a body containing newlines survives intact.
+req() {
+  local method="$1" url="$2" out
+  shift 2
+  out=$(curl -s -m "${REQ_TIMEOUT:-10}" -w $'\n%{http_code}\n%{time_total}' \
+    -X "$method" "$@" "$url")
+  TIME="${out##*$'\n'}"; out="${out%$'\n'*}"
+  CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
+}
+
+# task_json <app> <tag> [author] [project] [image]: a POST /tasks payload.
+task_json() {
+  printf '{"app":"%s","author":"%s","project":"%s","images":[{"image":"%s","tag":"%s"}]}' \
+    "$1" "${3:-e2e}" "${4:-lab}" "${5:-$IMAGE}" "$2"
+}
+
+# post_task <json> [curl-args...]: POST a deploy task, setting CODE/BODY/TIME.
+# Tokenless by default — an unauthenticated task is accepted (202) but skips
+# write-back, so it has no lasting side effect. Pass
+# -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" for a validated one.
+post_task() {
+  local json="$1"
+  shift
+  req POST "${AW_API}/tasks" -H 'Content-Type: application/json' -d "$json" "$@"
+}
+
+# metric_sum <metric> [metrics-text]: sum the value column across every series of
+# <metric>, scraping /metrics if no text is given. The `[ {]` guard anchors on the
+# exact metric name, so `processed_deployments` never captures
+# `processed_deployments_created` and a histogram's `_count` never pulls in its
+# `_bucket` / `_sum` siblings.
+metric_sum() {
+  local metric="$1" text="${2-}"
+  [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
+  awk -v k="^${metric}[ {]" '$0 ~ k {s+=$NF} END{print s+0}' <<<"$text"
+}
+
+# metric_raw <metric> [metrics-text]: the value of a single unlabelled series, or
+# EMPTY when the metric is absent from the scrape.
+#
+# Use this, not metric_sum, for any gauge whose gate is "must be 0": metric_sum
+# reports a missing metric as 0, so an unregistered or renamed gauge would satisfy
+# `== "0"` and the gate would pass vacuously — which is exactly the regression these
+# gauges exist to catch. An empty result fails the comparison instead.
+metric_raw() {
+  local metric="$1" text="${2-}"
+  [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
+  awk -v k="^${metric} " '$0 ~ k {print $NF}' <<<"$text"
+}
+
+# --- Go binaries -------------------------------------------------------------
+# build_bin <dir> <pkg>: build a Go binary from the repo root into <dir>, setting
+# BIN to its path. Phases run a prebuilt binary rather than `go run` so a
+# per-invocation compile never lands inside a timing-sensitive assertion (the
+# supersession race needs sub-second submission ordering). The caller owns <dir>
+# and its cleanup.
+#
+# Sets a variable instead of echoing the path so a build failure is visible to `||`
+# at the call site: inside $(...) it would only abort the subshell, and the phases
+# that run without `set -e` would carry on with an empty path.
+build_bin() {
+  local _dir="$1" _pkg="$2"
+  BIN="${_dir}/$(basename "$_pkg")"
+  ( cd "$E2E_ROOT" && go build -o "$BIN" "$_pkg" )
+}
+
+# build_client <dir>: build the real cmd/client binary, setting CLIENT_BIN for
+# run_client. The tool users actually run, so the deploy phases drive it rather
+# than a hand-rolled HTTP call.
+build_client() {
+  build_bin "$1" ./cmd/client || return 1
+  CLIENT_BIN="$BIN"
+}
+
+# run_client <app> <tag> [extra env KEY=VAL...]: run the real cmd/client binary for
+# one deploy, blocking until the task reaches a terminal status, with combined
+# stdout+stderr on stdout. The client's exit code IS the assertion: 0 = "deployed",
+# non-zero = anything else. CLIENT_BIN must point at a built binary (build_bin).
+#
+# Callers pass auth explicitly, because which strategy is under test differs by
+# phase: ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" (write-back enabled),
+# BEARER_TOKEN="$jwt" (the JWT path), or nothing (unvalidated, no write-back).
+# IMAGES / COMMIT_AUTHOR / PROJECT_NAME / RETRY_INTERVAL / TASK_TIMEOUT can be
+# overridden the same way, since env args later on the line win.
+run_client() {
+  local app="$1" tag="$2"
+  shift 2
+  env ARGO_WATCHER_URL="$AW_URL" \
+      IMAGES="$IMAGE" IMAGE_TAG="$tag" ARGO_APP="$app" \
+      COMMIT_AUTHOR="e2e" PROJECT_NAME="lab" \
+      RETRY_INTERVAL="5s" TASK_TIMEOUT="180" \
+      "$@" "$CLIENT_BIN" 2>&1
+}
+
+# --- gitops repo -------------------------------------------------------------
+# gitops_clone <dir>: clone the lab's shared gitops repo (every fixture app renders
+# from it, which is what makes their write-back pushes contend) into <dir>.
+gitops_clone() {
+  git clone -q "$GITOPS_REPO_URL" "$1" || die "gitops clone failed"
+}
+
+# override_param <file> <param>: read one helm parameter's value out of an
+# .argocd-source-*.yaml write-back override. The file is small controlled YAML
+# (helm.parameters: [{name, value, forceString}]); awk keeps this yq-free, since yq
+# is not installed on GitHub runners. After the <param> name line, take the value
+# on the next `value:` line, stripping quotes. Echoes nothing when the parameter is
+# absent — callers must tell that apart from a wrong value, or an unwritten
+# override reads as a wrong-tag failure.
+#
+# The name is compared as an exact string, not a regex: parameter names contain
+# dots (app.image.tag), and as a pattern those match any character — so
+# `appXimageYtag` would match. Escaping them is not an option either, because awk's
+# -v processes escape sequences and turns `\.` back into a plain dot.
+override_param() {
+  awk -v want="$2" '
+    # A name line, e.g. `    - name: app.image.tag`; the value is on a later line.
+    /(^|[[:space:]])name:[[:space:]]/ {
+      n = $NF; gsub(/"/, "", n)
+      if (n == want) { f = 1 }
+    }
+    f && /value:/ { v = $NF; gsub(/"/, "", v); print v; exit }
+  ' "$1"
+}
+
+# other_tag <app>: echo a pullable tag DIFFERENT from the one <app> currently runs,
+# so deploying it forces a real write-back. An unchanged tag is byte-compared and
+# skipped (#472), which would make a write-back assertion pass vacuously — and
+# earlier phases leave apps on varying tags, so this cannot be hardcoded.
+other_tag() {
+  local cur
+  cur=$(kubectl -n "$NS_ARGOCD" get application "$1" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
+  if [[ "$cur" == *v1.10.2* ]]; then echo "v1.10.1"; else echo "v1.10.2"; fi
+}
+
+# --- helm --------------------------------------------------------------------
+# extra_envs_index <values-file>: the index of the next free extraEnvs entry, so a
+# phase can append one with `--set extraEnvs[N]...`. Counted from the values FILE,
+# not the live release, so it does not depend on release state. The awk scopes the
+# count to the extraEnvs block (between "extraEnvs:" and the next top-level key),
+# so a same-indented "- name:" added to another section cannot silently shift it.
+extra_envs_index() {
+  awk '
+    /^extraEnvs:/ { f = 1; next }
+    f && /^[^[:space:]#]/ { f = 0 }
+    f && /^  - name:/ { c++ }
+    END { print c + 0 }
+  ' "$1"
+}
+
+# helm_apply_aw [extra --set args...]: reconfigure the LIVE argo-watcher release
+# from values/argo-watcher.yaml plus the given args, then wait for the rollout.
+# Used by the phases that toggle a server-global env var for their own duration and
+# revert before returning (a global cannot be set in the shared install without
+# affecting every other phase).
+#
+# --reset-values makes each apply deterministic from the values file + these args
+# alone: without it helm carries a prior `--set extraEnvs[N]` forward, so the
+# revert (values file only) would NOT drop the injected variable.
+#
+# Requires AW_CHART_REPO and AW_CHART_VERSION (passed from the Taskfile, which pins
+# the chart version).
+helm_apply_aw() {
+  helm upgrade --install argo-watcher argo-watcher \
+    --repo "${AW_CHART_REPO:?AW_CHART_REPO is required}" \
+    --version "${AW_CHART_VERSION:?AW_CHART_VERSION is required}" \
+    -n "$NS_AW" -f "${E2E_DIR}/values/argo-watcher.yaml" --reset-values \
+    --set image.tag=race "$@" >/dev/null
+  kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
+}

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -52,17 +52,18 @@ IMAGE="${IMAGE:-traefik/whoami}"
 # --- assertions --------------------------------------------------------------
 E2E_FAILS=0
 
-ok()   { echo "  OK   $*"; }
-bad()  { echo "  FAIL $*"; E2E_FAILS=$((E2E_FAILS + 1)); }
-note() { echo "  NOTE $*"; }
+ok()   { echo "  OK   $*"; return; }
+bad()  { echo "  FAIL $*"; E2E_FAILS=$((E2E_FAILS + 1)); return; }
+note() { echo "  NOTE $*"; return; }
 
 # phase_end <PHASE-NAME>: print the verdict and exit 1 if any bad() fired.
 phase_end() {
+  local name="$1"
   if [[ "$E2E_FAILS" -eq 0 ]]; then
-    echo "${1}: PASS"
+    echo "${name}: PASS"
     exit 0
   fi
-  echo "${1}: FAIL (${E2E_FAILS} failed assertion(s))"
+  echo "${name}: FAIL (${E2E_FAILS} failed assertion(s))"
   exit 1
 }
 
@@ -97,13 +98,17 @@ retry() {
 # the argocd-unreachable phase induces on purpose and the shutdown-drain phase can
 # observe on a fresh pod. A `curl -f` here would hang in exactly those phases.
 wait_service() {
-  retry "${1:-30}" 2 curl -s -m 3 -o /dev/null "${AW_URL}/healthz"
+  local attempts="${1:-30}"
+  retry "$attempts" 2 curl -s -m 3 -o /dev/null "${AW_URL}/healthz"
+  return
 }
 
 # wait_url <url> [attempts]: block until <url> answers at all (see wait_service on
 # why the status code is not checked).
 wait_url() {
-  retry "${2:-15}" 2 curl -s -m 3 -o /dev/null "$1"
+  local url="$1" attempts="${2:-15}"
+  retry "$attempts" 2 curl -s -m 3 -o /dev/null "$url"
+  return
 }
 
 # wait_app <app> <want> [attempts]: poll an Argo Application until its
@@ -129,15 +134,19 @@ wait_app() {
 # last observed state if it never gets there. Deploy phases open with this so they
 # deploy from a known-good baseline.
 require_app_synced() {
-  wait_app "$1" "Synced/Healthy" "${2:-40}" \
-    || die "${1} never reached Synced/Healthy (last: ${APP_STATE:-unknown})"
+  local app="$1" attempts="${2:-40}"
+  wait_app "$app" "Synced/Healthy" "$attempts" \
+    || die "${app} never reached Synced/Healthy (last: ${APP_STATE:-unknown})"
+  return
 }
 
 # wait_ws <file> <message> [attempts]: wait for a wsprobe capture file to contain
 # `MSG <message>`. The lockdown watcher polls every 5s, so the default ~30s window
 # covers a broadcast triggered just after the previous tick.
 wait_ws() {
-  retry "${3:-6}" 5 grep -q "^MSG ${2}\$" "$1"
+  local file="$1" message="$2" attempts="${3:-6}"
+  retry "$attempts" 5 grep -q "^MSG ${message}\$" "$file"
+  return
 }
 
 # wait_ws_open <file> [attempts]: wait for a wsprobe to report its connection is
@@ -145,7 +154,9 @@ wait_ws() {
 # a one-shot broadcast is missed entirely if the handshake is still in flight, and
 # a fixed sleep raced it on a loaded host.
 wait_ws_open() {
-  retry "${2:-20}" 1 grep -q '^OPEN$' "$1"
+  local file="$1" attempts="${2:-20}"
+  retry "$attempts" 1 grep -q '^OPEN$' "$file"
+  return
 }
 
 # --- HTTP --------------------------------------------------------------------
@@ -160,12 +171,15 @@ req() {
     -X "$method" "$@" "$url")
   TIME="${out##*$'\n'}"; out="${out%$'\n'*}"
   CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
+  return
 }
 
 # task_json <app> <tag> [author] [project] [image]: a POST /tasks payload.
 task_json() {
+  local app="$1" tag="$2" author="${3:-e2e}" project="${4:-lab}" image="${5:-$IMAGE}"
   printf '{"app":"%s","author":"%s","project":"%s","images":[{"image":"%s","tag":"%s"}]}' \
-    "$1" "${3:-e2e}" "${4:-lab}" "${5:-$IMAGE}" "$2"
+    "$app" "$author" "$project" "$image" "$tag"
+  return
 }
 
 # post_task <json> [curl-args...]: POST a deploy task, setting CODE/BODY/TIME.
@@ -176,6 +190,7 @@ post_task() {
   local json="$1"
   shift
   req POST "${AW_API}/tasks" -H 'Content-Type: application/json' -d "$json" "$@"
+  return
 }
 
 # metric_sum <metric> [metrics-text]: sum the value column across every series of
@@ -187,6 +202,7 @@ metric_sum() {
   local metric="$1" text="${2-}"
   [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
   awk -v k="^${metric}[ {]" '$0 ~ k {s+=$NF} END{print s+0}' <<<"$text"
+  return
 }
 
 # metric_raw <metric> [metrics-text]: the value of a single unlabelled series, or
@@ -200,6 +216,7 @@ metric_raw() {
   local metric="$1" text="${2-}"
   [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
   awk -v k="^${metric} " '$0 ~ k {print $NF}' <<<"$text"
+  return
 }
 
 # --- Go binaries -------------------------------------------------------------
@@ -216,14 +233,17 @@ build_bin() {
   local _dir="$1" _pkg="$2"
   BIN="${_dir}/$(basename "$_pkg")"
   ( cd "$E2E_ROOT" && go build -o "$BIN" "$_pkg" )
+  return
 }
 
 # build_client <dir>: build the real cmd/client binary, setting CLIENT_BIN for
 # run_client. The tool users actually run, so the deploy phases drive it rather
 # than a hand-rolled HTTP call.
 build_client() {
-  build_bin "$1" ./cmd/client || return 1
+  local dir="$1"
+  build_bin "$dir" ./cmd/client || return 1
   CLIENT_BIN="$BIN"
+  return
 }
 
 # run_client <app> <tag> [extra env KEY=VAL...]: run the real cmd/client binary for
@@ -244,13 +264,16 @@ run_client() {
       COMMIT_AUTHOR="e2e" PROJECT_NAME="lab" \
       RETRY_INTERVAL="5s" TASK_TIMEOUT="180" \
       "$@" "$CLIENT_BIN" 2>&1
+  return
 }
 
 # --- gitops repo -------------------------------------------------------------
 # gitops_clone <dir>: clone the lab's shared gitops repo (every fixture app renders
 # from it, which is what makes their write-back pushes contend) into <dir>.
 gitops_clone() {
-  git clone -q "$GITOPS_REPO_URL" "$1" || die "gitops clone failed"
+  local dir="$1"
+  git clone -q "$GITOPS_REPO_URL" "$dir" || die "gitops clone failed"
+  return
 }
 
 # override_param <file> <param>: read one helm parameter's value out of an
@@ -266,14 +289,16 @@ gitops_clone() {
 # `appXimageYtag` would match. Escaping them is not an option either, because awk's
 # -v processes escape sequences and turns `\.` back into a plain dot.
 override_param() {
-  awk -v want="$2" '
+  local file="$1" param="$2"
+  awk -v want="$param" '
     # A name line, e.g. `    - name: app.image.tag`; the value is on a later line.
     /(^|[[:space:]])name:[[:space:]]/ {
       n = $NF; gsub(/"/, "", n)
       if (n == want) { f = 1 }
     }
     f && /value:/ { v = $NF; gsub(/"/, "", v); print v; exit }
-  ' "$1"
+  ' "$file"
+  return
 }
 
 # other_tag <app>: echo a pullable tag DIFFERENT from the one <app> currently runs,
@@ -281,9 +306,10 @@ override_param() {
 # skipped (#472), which would make a write-back assertion pass vacuously — and
 # earlier phases leave apps on varying tags, so this cannot be hardcoded.
 other_tag() {
-  local cur
-  cur=$(kubectl -n "$NS_ARGOCD" get application "$1" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
+  local app="$1" cur
+  cur=$(kubectl -n "$NS_ARGOCD" get application "$app" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
   if [[ "$cur" == *v1.10.2* ]]; then echo "v1.10.1"; else echo "v1.10.2"; fi
+  return
 }
 
 # --- helm --------------------------------------------------------------------
@@ -293,12 +319,14 @@ other_tag() {
 # count to the extraEnvs block (between "extraEnvs:" and the next top-level key),
 # so a same-indented "- name:" added to another section cannot silently shift it.
 extra_envs_index() {
+  local file="$1"
   awk '
     /^extraEnvs:/ { f = 1; next }
     f && /^[^[:space:]#]/ { f = 0 }
     f && /^  - name:/ { c++ }
     END { print c + 0 }
-  ' "$1"
+  ' "$file"
+  return
 }
 
 # helm_apply_aw [extra --set args...]: reconfigure the LIVE argo-watcher release
@@ -320,4 +348,5 @@ helm_apply_aw() {
     -n "$NS_AW" -f "${E2E_DIR}/values/argo-watcher.yaml" --reset-values \
     --set image.tag=race "$@" >/dev/null
   kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
+  return
 }

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -28,50 +28,33 @@
 # handlers stay silent.
 set -euo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-PORT="${PORT:-18093}"
-# Helm coordinates for the in-place toggle (passed from the Taskfile).
-AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO is required}"
-AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
-VALUES="${VALUES:-values/argo-watcher.yaml}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+# Required by helm_apply_aw; asserted here so a missing value fails on line 1 rather
+# than part-way through the schedule arithmetic.
+: "${AW_CHART_REPO:?AW_CHART_REPO is required}" "${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+# Not configurable: extra_envs_index must count entries in the SAME file
+# helm_apply_aw applies, or the appended --set would overwrite a real entry.
+VALUES="${E2E_DIR}/values/argo-watcher.yaml"
 
 bin_dir="$(mktemp -d)"
 probe_out="$(mktemp)"
-pf_pid=""
-cleanup() { kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$probe_out"; }
+cleanup() {
+  # jobs -p prints one PID per line; splitting them into separate arguments is the
+  # point, and they are always bare digits.
+  # shellcheck disable=SC2046
+  kill $(jobs -p) 2>/dev/null || true
+  rm -rf "$bin_dir" "$probe_out"
+}
 trap cleanup EXIT
-( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+build_bin "$bin_dir" ./test/e2e/tools/wsprobe || die "wsprobe build failed"
+wsprobe="$BIN"
 
-# (re)start the port-forward after a rollout swaps the pod out.
-start_pf() {
-  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
-  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-  pf_pid=$!
-  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
-}
-
-helm_apply() {  # extra --set args reconfigure the release in place
-  # --reset-values makes each apply deterministic from the values file + these
-  # --set args alone: without it helm carries a prior `--set extraEnvs[N]` forward,
-  # so the revert (values file only) would NOT drop the injected LOCKDOWN_SCHEDULE.
-  helm upgrade --install argo-watcher argo-watcher --repo "$AW_CHART_REPO" \
-    --version "$AW_CHART_VERSION" -n "$NS_AW" -f "$VALUES" --reset-values \
-    --set image.tag=race "$@" >/dev/null
-  kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
-}
-
-base="http://localhost:${PORT}/api/v1"
-task_json='{"app":"app1","author":"e2e","project":"lab","images":[{"image":"traefik/whoami","tag":"v1.10.2"}]}'
-# post_task -> sets CODE and BODY for a tokenless POST /api/v1/tasks.
-post_task() {
-  local out
-  out=$(curl -s -m 10 -w $'\n%{http_code}' -X POST -H 'Content-Type: application/json' \
-    -d "$task_json" "${base}/tasks")
-  CODE="${out##*$'\n'}"; BODY="${out%$'\n'*}"
-}
-fail=0
+# A tokenless task: accepted (202) and skips write-back, so the checks below have no
+# lasting side effect.
+TASK="$(task_json app1 v1.10.2)"
 
 # --- 1. Enable a schedule whose window opens ~3 min out ------------------------
 # date arithmetic (GNU date) rolls days/weeks over cleanly, so the window is
@@ -87,79 +70,71 @@ end_day=$(LC_ALL=C date -u -d '+12 hours' +%a);      end_hm=$(date -u -d '+12 ho
 schedule="${start_day} ${start_hm} - ${end_day} ${end_hm}"
 echo "lockdown window: ${schedule} (opens ~180s from now)"
 
-# Append LOCKDOWN_SCHEDULE as the next extraEnvs entry. The index is the count of
-# entries in the values file's extraEnvs block — read from the file, not the live
-# release, so it is independent of release state. The awk scopes the count to the
-# extraEnvs block (between "extraEnvs:" and the next top-level key), so a same-
-# indented "- name:" added to some other section can't silently shift the index.
-idx=$(awk '/^extraEnvs:/{f=1;next} f&&/^[^[:space:]#]/{f=0} f&&/^  - name:/{c++} END{print c+0}' "$VALUES")
-helm_apply --set-string "extraEnvs[${idx}].name=LOCKDOWN_SCHEDULE" \
-           --set-string "extraEnvs[${idx}].value=${schedule}"
-start_pf
+# Append LOCKDOWN_SCHEDULE as the next free extraEnvs entry (see extra_envs_index
+# in lib.sh for why the index is counted from the values file).
+idx=$(extra_envs_index "$VALUES")
+helm_apply_aw --set-string "extraEnvs[${idx}].name=LOCKDOWN_SCHEDULE" \
+              --set-string "extraEnvs[${idx}].value=${schedule}"
+wait_service || die "argo-watcher never came back after enabling the schedule"
+
+# lock_is <true|false> -> succeeds when GET /deploy-lock equals it.
+lock_is() {
+  curl -s -m 10 "${AW_API}/deploy-lock" | jq -e ". == $1" >/dev/null 2>&1
+}
 
 # --- 2. Confirm we booted pre-window, then hold a WS client open ---------------
 assert_ws=1
-if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
-  echo "  OK   booted unlocked (pre-window); watching for the scheduled 'locked' broadcast"
-  WS_URL="ws://localhost:${PORT}/ws" DURATION=400s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
-  # Wait for the probe to actually connect (OPEN) before the window opens, so a
-  # slow handshake can't miss the one-shot "locked" broadcast — same guard as
-  # shutdown-drain.sh. The window is still ~180s out, so 20s is ample.
-  ws_open=0
-  for _ in $(seq 1 20); do grep -q '^OPEN$' "$probe_out" && { ws_open=1; break; }; sleep 1; done
-  if [[ "$ws_open" != "1" ]]; then
-    echo "  FAIL WS probe never connected before the window opened"; fail=1; assert_ws=0
+if lock_is false; then
+  ok "booted unlocked (pre-window); watching for the scheduled 'locked' broadcast"
+  WS_URL="$AW_WS_URL" DURATION=400s "$wsprobe" >"$probe_out" 2>/dev/null &
+  # The window is still ~180s out, so the default ~20s connect window is ample.
+  if ! wait_ws_open "$probe_out"; then
+    bad "WS probe never connected before the window opened"
+    assert_ws=0
   fi
 else
-  echo "  NOTE rollout booted in-window; skipping the WS-transition sub-check (not a failure)"
+  note "rollout booted in-window; skipping the WS-transition sub-check (not a failure)"
   assert_ws=0
 fi
 
 # --- 3. Wait for the window to open, then assert the locked behaviour ----------
-locked=0
-for _ in $(seq 1 60); do   # up to ~300s: window opens at +180s, then evaluated live
-  if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then locked=1; break; fi
-  sleep 5
-done
-if [[ "$locked" == "1" ]]; then
-  echo "  OK   GET /deploy-lock -> true (window open)"
+# Up to ~300s: the window opens at +180s and is then evaluated live per request.
+if retry 60 5 lock_is true; then
+  ok "GET /deploy-lock -> true (window open)"
 else
-  echo "  FAIL GET /deploy-lock never reported locked"; fail=1
+  bad "GET /deploy-lock never reported locked"
 fi
 
-post_task
-if [[ "$CODE" == "406" ]] && echo "$BODY" | jq -e '.status == "rejected" and .error == "lockdown is active, deployments are not accepted"' >/dev/null 2>&1; then
-  echo "  OK   POST /tasks -> 406 rejected (deploys frozen)"
+post_task "$TASK"
+if [[ "$CODE" == "406" ]] &&
+   jq -e '.status == "rejected" and .error == "lockdown is active, deployments are not accepted"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "POST /tasks -> 406 rejected (deploys frozen)"
 else
-  echo "  FAIL POST /tasks during lockdown: code=${CODE} body=${BODY} (want 406 rejected)"; fail=1
+  bad "POST /tasks during lockdown: code=${CODE} body=${BODY} (want 406 rejected)"
 fi
 
 if [[ "$assert_ws" == "1" ]]; then
-  ws_ok=0
-  for _ in $(seq 1 16); do   # up to ~80s: watcher polls once a minute
-    if grep -q '^MSG locked$' "$probe_out"; then ws_ok=1; break; fi
-    sleep 5
-  done
-  if [[ "$ws_ok" == "1" ]]; then
-    echo "  OK   WS client received the 'locked' broadcast on the schedule transition"
+  # Up to ~80s: the watcher polls once a minute.
+  if wait_ws "$probe_out" locked 16; then
+    ok "WS client received the 'locked' broadcast on the schedule transition"
   else
-    echo "  FAIL no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"; fail=1
+    bad "no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
   fi
 fi
 
 # --- 4. Revert the schedule and prove deploys are accepted again ---------------
-helm_apply   # values file only -> LOCKDOWN_SCHEDULE dropped -> unlocked
-start_pf
-if curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
-  echo "  OK   GET /deploy-lock -> false after revert"
+helm_apply_aw   # values file only -> LOCKDOWN_SCHEDULE dropped -> unlocked
+wait_service || die "argo-watcher never came back after reverting the schedule"
+if lock_is false; then
+  ok "GET /deploy-lock -> false after revert"
 else
-  echo "  FAIL GET /deploy-lock still true after revert"; fail=1
+  bad "GET /deploy-lock still true after revert"
 fi
-post_task   # tokenless task is accepted (202) and skips write-back: no side effect
+post_task "$TASK"
 if [[ "$CODE" == "202" ]]; then
-  echo "  OK   POST /tasks -> 202 accepted (deploys unfrozen)"
+  ok "POST /tasks -> 202 accepted (deploys unfrozen)"
 else
-  echo "  FAIL POST /tasks after revert: code=${CODE} body=${BODY} (want 202)"; fail=1
+  bad "POST /tasks after revert: code=${CODE} body=${BODY} (want 202)"
 fi
 
-if [[ "$fail" -eq 0 ]]; then echo "LOCKDOWN: PASS"; else echo "LOCKDOWN: FAIL"; exit 1; fi
+phase_end LOCKDOWN

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -79,7 +79,9 @@ wait_service || die "argo-watcher never came back after enabling the schedule"
 
 # lock_is <true|false> -> succeeds when GET /deploy-lock equals it.
 lock_is() {
-  curl -s -m 10 "${AW_API}/deploy-lock" | jq -e ". == $1" >/dev/null 2>&1
+  local want="$1"
+  curl -s -m 10 "${AW_API}/deploy-lock" | jq -e ". == ${want}" >/dev/null 2>&1
+  return
 }
 
 # --- 2. Confirm we booted pre-window, then hold a WS client open ---------------

--- a/test/e2e/scripts/mint-argo-token.sh
+++ b/test/e2e/scripts/mint-argo-token.sh
@@ -6,33 +6,24 @@
 # disposable and rebuilt per run, so session-token expiry (~24h) is a non-issue.
 set -euo pipefail
 
-NS_ARGOCD="${NS_ARGOCD:-argocd}"
-NS_AW="${NS_AW:-argo-watcher}"
-PORT="${PORT:-18080}"
-# Deploy token gating git write-back. Only validated (authenticated) tasks
-# trigger the updater push, so the driver must send this in the
-# ARGO_WATCHER_DEPLOY_TOKEN header. Fixed throwaway lab value.
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
 
 pw="$(kubectl -n "$NS_ARGOCD" get secret argocd-initial-admin-secret \
   -o jsonpath='{.data.password}' | base64 -d)"
 
-kubectl -n "$NS_ARGOCD" port-forward svc/argocd-server "${PORT}:443" >/dev/null 2>&1 &
-pf=$!
-trap 'kill $pf 2>/dev/null || true' EXIT
-
-# Retry the session call until the port-forward is accepting connections and
-# ArgoCD answers with a token.
+# Retry the session call until ArgoCD is accepting connections and answers with a
+# token. -k: the lab's argocd-server serves its own self-signed cert.
 token=""
-for _ in $(seq 1 30); do
-  token="$(curl -sk -m 5 "https://localhost:${PORT}/api/v1/session" \
+mint() {
+  token="$(curl -sk -m 5 "${ARGOCD_URL}/api/v1/session" \
     -H 'Content-Type: application/json' \
     -d "{\"username\":\"admin\",\"password\":\"${pw}\"}" \
     | jq -r '.token // empty' 2>/dev/null || true)"
-  [[ -n "$token" ]] && break
-  sleep 2
-done
-[[ -n "$token" ]] || { echo "failed to mint ARGO_TOKEN" >&2; exit 1; }
+  [[ -n "$token" ]]
+}
+retry 30 2 mint || die "failed to mint ARGO_TOKEN"
 
 kubectl create namespace "$NS_AW" --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n "$NS_AW" create secret generic argo-watcher-secret \

--- a/test/e2e/scripts/multi-image.sh
+++ b/test/e2e/scripts/multi-image.sh
@@ -13,74 +13,53 @@
 # Usage: multi-image.sh
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="multiapp"
 # Both images publish this tag; the client applies one IMAGE_TAG to every image.
 TAG="${TAG:-latest}"
 IMAGES_LIST="${IMAGES_LIST:-traefik/whoami,nginxinc/nginx-unprivileged}"
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18097}"
-GITEA_PORT="${GITEA_PORT:-13003}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
 work="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$work"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir" "$work"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
-# Apply the dedicated two-image fixture and wait for its initial sync.
-kubectl apply -f "${here}/../fixtures/multi-image-app.yaml"
-for _ in $(seq 1 60); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "MULTI-IMAGE: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
-
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+# Apply the dedicated two-image fixture and wait for its initial sync (60 attempts:
+# it pulls two images on first sync).
+kubectl apply -f "${E2E_DIR}/fixtures/multi-image-app.yaml"
+require_app_synced "$APP" 60
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> [${IMAGES_LIST}]:${TAG} (multi-image, authenticated)"
-if ! ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGES_LIST}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client"; then
+if ! run_client "$APP" "$TAG" \
+     IMAGES="$IMAGES_LIST" \
+     ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN"; then
   echo "MULTI-IMAGE: FAIL (deploy did not reach 'deployed' — not all images rolled out)"
   exit 1
 fi
 
 # Read the override file written back and assert BOTH image-tag params are present.
-kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${GITEA_PORT}" && break; sleep 1; done
-git clone -q "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${GITEA_PORT}/e2e/gitops.git" "${work}/r"
+gitops_clone "${work}/r"
 override="${work}/r/multi-image/.argocd-source-${APP}.yaml"
 
-fail=0
 if [[ ! -f "$override" ]]; then
-  echo "  FAIL override file not written: multi-image/.argocd-source-${APP}.yaml"; fail=1
+  bad "override file not written: multi-image/.argocd-source-${APP}.yaml"
 else
   # Assert both managed images were written back AND carry the deployed tag (not a
   # stale value) — a regression writing the wrong tag for one image would otherwise
   # slip through a names-only check.
-  v_main=$(yq -r '.helm.parameters[] | select(.name == "app.image.tag").value' "$override" 2>/dev/null || true)
-  v_proxy=$(yq -r '.helm.parameters[] | select(.name == "app.proxyTag").value' "$override" 2>/dev/null || true)
+  v_main=$(override_param "$override" app.image.tag)
+  v_proxy=$(override_param "$override" app.proxyTag)
   echo "  written params: app.image.tag=${v_main:-<none>} app.proxyTag=${v_proxy:-<none>}"
-  [[ "$v_main" == "$TAG" ]]  || { echo "  FAIL app.image.tag (primary image) not written back as ${TAG}"; fail=1; }
-  [[ "$v_proxy" == "$TAG" ]] || { echo "  FAIL app.proxyTag (second image) not written back as ${TAG}"; fail=1; }
+  [[ "$v_main" == "$TAG" ]]  || bad "app.image.tag (primary image) not written back as ${TAG}"
+  [[ "$v_proxy" == "$TAG" ]] || bad "app.proxyTag (second image) not written back as ${TAG}"
 fi
 
-if [[ "$fail" -eq 0 ]]; then
+if [[ "$E2E_FAILS" -eq 0 ]]; then
   echo "MULTI-IMAGE: PASS (both images deployed and both tags written back)"
   exit 0
 fi
-echo "MULTI-IMAGE: FAIL"
-exit 1
+phase_end MULTI-IMAGE

--- a/test/e2e/scripts/notifications.sh
+++ b/test/e2e/scripts/notifications.sh
@@ -13,58 +13,46 @@
 # Usage: DEPLOY_TOKEN=... WEBHOOK_UUID=... notifications.sh
 set -uo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-NS_WHT="${NS_WHT:-webhook-tester}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 # Must match the fixed UUID baked into WEBHOOK_URL (values/argo-watcher.yaml).
 WEBHOOK_UUID="${WEBHOOK_UUID:-11111111-1111-1111-1111-111111111111}"
 APP="${APP:-app1}"
-IMAGE="${IMAGE:-traefik/whoami}"
 # A pullable tag that differs from smoke's (v1.10.2) so this forces a real
 # rollout to "deployed" rather than a no-op.
 TAG="${TAG:-v1.10.1}"
 # Must match WEBHOOK_AUTHORIZATION_HEADER_* in values/argo-watcher.yaml.
 AUTH_HEADER="${AUTH_HEADER:-X-E2E-Token}"
 AUTH_VALUE="${AUTH_VALUE:-e2e-webhook-secret}"
-AW_PORT="${AW_PORT:-18096}"
-WHT_PORT="${WHT_PORT:-18097}"
 
-kubectl -n "$NS_AW"  port-forward svc/argo-watcher   "${AW_PORT}:80"  >/dev/null 2>&1 &
-kubectl -n "$NS_WHT" port-forward svc/webhook-tester "${WHT_PORT}:80" >/dev/null 2>&1 &
-trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
-# Wait for each port-forward to actually answer; fail loudly if it never does,
-# so a forwarding problem does not masquerade as a later "no task id" error.
-wait_ready() { # <name> <healthz-url>
-  local name="$1" url="$2"
-  for _ in $(seq 1 15); do curl -s -m3 -o /dev/null "$url" && return 0; sleep 1; done
-  echo "FAIL: port-forward to ${name} not ready"; exit 1
-}
-wait_ready argo-watcher   "localhost:${AW_PORT}/healthz"
-wait_ready webhook-tester "localhost:${WHT_PORT}/healthz"
+# Fail loudly if either service never answers, so an unreachable endpoint does not
+# masquerade as a later "no task id" error.
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
+wait_url "${WHT_URL}/healthz" || die "webhook-tester not reachable on ${WHT_URL}"
 
-wht="localhost:${WHT_PORT}/api/session/${WEBHOOK_UUID}"
+wht="${WHT_URL}/api/session/${WEBHOOK_UUID}"
 
 # Start from a clean session so we assert on this deploy alone. A no-op if the
 # session does not exist yet (the first webhook auto-creates it).
 curl -s -m10 -X DELETE "${wht}/requests" >/dev/null 2>&1 || true
 
 # Fire one authenticated deploy: validated -> real write-back -> "deployed".
-id=$(curl -s -m15 -X POST "localhost:${AW_PORT}/api/v1/tasks" \
-  -H 'Content-Type: application/json' -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
-  -d "{\"app\":\"${APP}\",\"author\":\"e2e\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\"}]}" \
-  | jq -r '.id')
+post_task "$(task_json "$APP" "$TAG")" -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}"
+id=$(jq -r '.id' <<<"$BODY")
 echo "task ${id}: deploying ${APP} -> ${IMAGE}:${TAG}"
-[[ -n "$id" && "$id" != "null" ]] || { echo "FAIL: no task id returned"; exit 1; }
+[[ -n "$id" && "$id" != "null" ]] || die "no task id returned (code=${CODE} body=${BODY})"
 
 # Wait for the terminal result so both webhooks (start + result) have fired.
 status=""
-for _ in $(seq 1 48); do
-  status=$(curl -s -m10 "localhost:${AW_PORT}/api/v1/tasks/${id}" | jq -r '.status // "?"')
-  case "$status" in deployed|failed|aborted) break ;; *) ;; esac # non-terminal: keep polling
-  sleep 5
-done
+terminal() {
+  status=$(curl -s -m10 "${AW_API}/tasks/${id}" | jq -r '.status // "?"')
+  case "$status" in deployed | failed | aborted) return 0 ;; *) return 1 ;; esac
+}
+retry 48 5 terminal
 echo "task status=${status}"
-[[ "$status" == "deployed" ]] || { echo "FAIL: expected terminal 'deployed', got '${status}'"; exit 1; }
+[[ "$status" == "deployed" ]] || die "expected terminal 'deployed', got '${status}'"
 
 # Pull captured requests for THIS task id. The capture-API shape below
 # (GET .../requests, body in .request_payload_base64, headers as [{name,value}])
@@ -73,7 +61,7 @@ echo "task status=${status}"
 # match is case-insensitive (Go canonicalizes header names on send/receive).
 # Retry briefly — the result webhook lands right around terminal status.
 events='[]'
-for _ in $(seq 1 15); do
+both_captured() {
   events=$(curl -s -m10 "${wht}/requests" | jq -c --arg id "$id" --arg hdr "$AUTH_HEADER" '
     [ .[]
       | . as $r
@@ -81,19 +69,19 @@ for _ in $(seq 1 15); do
       | select($b != null and $b.id == $id)
       | { status: $b.status, app: $b.app, tag: ($b.images[0].tag // ""),
           auth: ([ $r.headers[] | select((.name|ascii_downcase) == ($hdr|ascii_downcase)) | .value ] | first // "") } ]')
-  [[ "$(jq 'length' <<<"$events")" -ge 2 ]] && break
-  sleep 2
-done
+  [[ "$(jq 'length' <<<"$events")" -ge 2 ]]
+}
+retry 15 2 both_captured
 echo "captured events for task ${id}: ${events}"
 
 count=$(jq 'length' <<<"$events")
 [[ "$count" -ge 2 ]] \
-  || { echo "FAIL: expected >=2 webhook deliveries (start + result), got ${count}"; exit 1; }
+  || die "expected >=2 webhook deliveries (start + result), got ${count}"
 jq -e --arg a "$APP" 'any(.[]; .status == "in progress" and .app == $a)' <<<"$events" >/dev/null \
-  || { echo "FAIL: missing 'in progress' start event for app=${APP}"; exit 1; }
+  || die "missing 'in progress' start event for app=${APP}"
 jq -e --arg a "$APP" --arg t "$TAG" 'any(.[]; .status == "deployed" and .app == $a and .tag == $t)' <<<"$events" >/dev/null \
-  || { echo "FAIL: missing 'deployed' result event for app=${APP} tag=${TAG}"; exit 1; }
+  || die "missing 'deployed' result event for app=${APP} tag=${TAG}"
 jq -e --arg v "$AUTH_VALUE" 'all(.[]; .auth == $v)' <<<"$events" >/dev/null \
-  || { echo "FAIL: authorization header ${AUTH_HEADER} missing or wrong on a delivery"; exit 1; }
+  || die "authorization header ${AUTH_HEADER} missing or wrong on a delivery"
 
 echo "NOTIFICATIONS: PASS"

--- a/test/e2e/scripts/notifications.sh
+++ b/test/e2e/scripts/notifications.sh
@@ -70,6 +70,7 @@ both_captured() {
       | { status: $b.status, app: $b.app, tag: ($b.images[0].tag // ""),
           auth: ([ $r.headers[] | select((.name|ascii_downcase) == ($hdr|ascii_downcase)) | .value ] | first // "") } ]')
   [[ "$(jq 'length' <<<"$events")" -ge 2 ]]
+  return
 }
 retry 15 2 both_captured
 echo "captured events for task ${id}: ${events}"

--- a/test/e2e/scripts/race-supersede.sh
+++ b/test/e2e/scripts/race-supersede.sh
@@ -59,7 +59,9 @@ wait_service || die "argo-watcher not reachable on ${AW_URL}"
 # deploy <tag> <outfile>: run the client to deploy APP:tag, blocking to a terminal
 # status. Combined stdout+stderr goes to outfile; the client's exit code propagates.
 deploy() {
-  run_client "$APP" "$1" ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" >"$2"
+  local tag="$1" out="$2"
+  run_client "$APP" "$tag" ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" >"$out"
+  return
 }
 
 # 1) Baseline: pin the app to BASE_TAG (no competitor yet, so this is fast) so the

--- a/test/e2e/scripts/race-supersede.sh
+++ b/test/e2e/scripts/race-supersede.sh
@@ -19,30 +19,25 @@
 # and is never superseded. It then starts the competitor itself so contention is
 # active before the race fires.
 #
-# Required env: GITEA_REPO_URL (gitops repo clone URL, creds inline).
-# Optional env: BASE_URL, DEPLOY_TOKEN, APP, BASE_TAG, OLD_TAG, NEW_TAG, IMAGE,
-#               COMPETITOR_INTERVAL, COMPETITOR_SECONDS, COMPETITOR_HTTP_PORT.
+# Optional env: DEPLOY_TOKEN, APP, BASE_TAG, OLD_TAG, NEW_TAG, IMAGE,
+#               COMPETITOR_INTERVAL, COMPETITOR_SECONDS, CLIENT_BIN.
 set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
 
 APP="${APP:-app1}"
 BASE_TAG="${BASE_TAG:-v1.10.2}"
 OLD_TAG="${OLD_TAG:-v1.10.1}"
 NEW_TAG="${NEW_TAG:-v1.10.3}"
-IMAGE="${IMAGE:-traefik/whoami}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-BASE_URL="${BASE_URL:-http://localhost:8080}"
-GITEA_REPO_URL="${GITEA_REPO_URL:?GITEA_REPO_URL required (gitops repo clone URL)}"
 COMPETITOR_INTERVAL="${COMPETITOR_INTERVAL:-1}"
 COMPETITOR_SECONDS="${COMPETITOR_SECONDS:-90}"
-COMPETITOR_HTTP_PORT="${COMPETITOR_HTTP_PORT:-13010}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 # BASE_TAG, OLD_TAG, NEW_TAG must all differ: BASE ≠ OLD/NEW so both race deploys
 # force a real write-back; OLD ≠ NEW so NEW genuinely supersedes OLD.
 if [[ "$BASE_TAG" == "$OLD_TAG" || "$BASE_TAG" == "$NEW_TAG" || "$OLD_TAG" == "$NEW_TAG" ]]; then
-  echo "race: BASE_TAG/OLD_TAG/NEW_TAG must all differ (base=${BASE_TAG} old=${OLD_TAG} new=${NEW_TAG})" >&2
-  exit 1
+  die "BASE_TAG/OLD_TAG/NEW_TAG must all differ (base=${BASE_TAG} old=${OLD_TAG} new=${NEW_TAG})"
 fi
 
 # Use a prebuilt client so both deploys launch a binary — a per-invocation `go run`
@@ -55,21 +50,16 @@ comp_pid=""
 trap '[[ -n "$comp_pid" ]] && kill "$comp_pid" 2>/dev/null; rm -rf "$bin_dir" "$clone_dir" "$base_out" "$old_out" "$new_out"' EXIT
 if [[ -z "${CLIENT_BIN:-}" ]]; then
   bin_dir="$(mktemp -d)"
-  CLIENT_BIN="${bin_dir}/aw-client"
-  ( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) || { echo "race: FAIL — client build failed" >&2; exit 1; }
+  build_client "$bin_dir" || die "client build failed"
 fi
+
+wait_app "$APP" Healthy || die "${APP} never reached Healthy (last: ${APP_STATE:-unknown})"
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
 
 # deploy <tag> <outfile>: run the client to deploy APP:tag, blocking to a terminal
 # status. Combined stdout+stderr goes to outfile; the client's exit code propagates.
 deploy() {
-  local tag="$1" out="$2"
-  env ARGO_WATCHER_URL="$BASE_URL" \
-      IMAGES="$IMAGE" IMAGE_TAG="$tag" ARGO_APP="$APP" \
-      COMMIT_AUTHOR="e2e" PROJECT_NAME="lab" \
-      ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" \
-      RETRY_INTERVAL="5s" TASK_TIMEOUT="180" \
-      "$CLIENT_BIN" >"$out" 2>&1
-  return
+  run_client "$APP" "$1" ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" >"$2"
 }
 
 # 1) Baseline: pin the app to BASE_TAG (no competitor yet, so this is fast) so the
@@ -83,7 +73,7 @@ fi
 
 # 2) Start the competitor to force write-back contention, and give it a moment to
 #    clone and begin advancing origin/main before the race deploys run.
-HTTP_PORT="$COMPETITOR_HTTP_PORT" SECONDS_TOTAL="$COMPETITOR_SECONDS" INTERVAL="$COMPETITOR_INTERVAL" \
+SECONDS_TOTAL="$COMPETITOR_SECONDS" INTERVAL="$COMPETITOR_INTERVAL" \
   "${here}/competitor.sh" & comp_pid=$!
 sleep 5
 
@@ -99,30 +89,26 @@ echo "OLD ${OLD_TAG}: exit=${old_rc}"; sed 's/^/  | /' "$old_out"
 echo "NEW ${NEW_TAG}: exit=${new_rc}"; sed 's/^/  | /' "$new_out"
 
 # Read the tag currently committed in the app's override file.
-git clone -q "$GITEA_REPO_URL" "$clone_dir" || { echo "race: FAIL — gitops clone failed" >&2; exit 1; }
+gitops_clone "$clone_dir"
 override="${clone_dir}/chart/.argocd-source-${APP}.yaml"
-# The file is small controlled YAML (helm.parameters: [{name, value, forceString}]).
-# awk keeps this yq-free (yq is not on GitHub runners): after the app.image.tag
-# name line, take the value on the next `value:` line, stripping any quotes.
-committed=$(awk '/name:[[:space:]]*app\.image\.tag/{f=1} f&&/value:/{v=$NF; gsub(/"/,"",v); print v; exit}' "$override")
-# Distinguish a parse failure (key renamed / file missing / non-consecutive lines)
-# from a genuine supersede violation — an empty result would otherwise masquerade
-# as "committed tag <none> is not the newer tag" below.
+committed=$(override_param "$override" app.image.tag)
+# Distinguish a parse failure (key renamed / file missing) from a genuine supersede
+# violation — an empty result would otherwise masquerade as "committed tag <none> is
+# not the newer tag" below.
 if [[ -z "$committed" ]]; then
-  echo "race: FAIL — could not read app.image.tag from ${override} (parse failure, not a supersede result)" >&2
-  exit 1
+  die "could not read app.image.tag from ${override} (parse failure, not a supersede result)"
 fi
 echo "race: committed git tag=${committed}"
 
-rc=0
-[[ "$new_rc" -eq 0 ]] || { echo "race: FAIL — NEW ${NEW_TAG} client exited ${new_rc}, expected 0 (deployed)"; rc=1; }
-[[ "$old_rc" -ne 0 ]] || { echo "race: FAIL — OLD ${OLD_TAG} client exited 0, expected non-zero (superseded)"; rc=1; }
-if ! grep -qiE "supersed|cancel" "$old_out"; then
-  echo "race: FAIL — OLD client output did not report the deploy was superseded/cancelled"; rc=1
-fi
-[[ "$committed" == "$NEW_TAG" ]] || { echo "race: FAIL — committed tag ${committed:-<none>} is not the newer ${NEW_TAG} (superseded task may have clobbered the winner)"; rc=1; }
+[[ "$new_rc" -eq 0 ]] || bad "NEW ${NEW_TAG} client exited ${new_rc}, expected 0 (deployed)"
+[[ "$old_rc" -ne 0 ]] || bad "OLD ${OLD_TAG} client exited 0, expected non-zero (superseded)"
+grep -qiE "supersed|cancel" "$old_out" \
+  || bad "OLD client output did not report the deploy was superseded/cancelled"
+[[ "$committed" == "$NEW_TAG" ]] \
+  || bad "committed tag ${committed:-<none>} is not the newer ${NEW_TAG} (superseded task may have clobbered the winner)"
 
-if [[ "$rc" -eq 0 ]]; then
+if [[ "$E2E_FAILS" -eq 0 ]]; then
   echo "race OK: newer tag ${NEW_TAG} won; older ${OLD_TAG} was superseded and did not clobber it"
+  exit 0
 fi
-exit "$rc"
+phase_end RACE-SUPERSEDE

--- a/test/e2e/scripts/seed-gitea.sh
+++ b/test/e2e/scripts/seed-gitea.sh
@@ -9,50 +9,43 @@
 # SSH with the deploy key. Idempotent: safe to re-run.
 set -euo pipefail
 
-ORG="${ORG:-e2e}"
-REPO="${REPO:-gitops}"
-NS_AW="${NS_AW:-argo-watcher}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
-HTTP_PORT="${HTTP_PORT:-13000}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 # known_hosts entry label for Gitea SSH. Bracketed [host]:port form because
 # Gitea's rootless SSH binds 2222 (non-standard). Must match the host:port in
 # the write-back-repo annotation in fixtures/application.yaml.tmpl.
 SSH_HOST="[gitea-ssh.gitea.svc.cluster.local]:2222"
 
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-chart_src="${here}/../fixtures/chart"
-ffcron_src="${here}/../fixtures/fire-and-forget-chart"
-multiimage_src="${here}/../fixtures/multi-image"
-rollout_src="${here}/../fixtures/rollout-chart"
+chart_src="${E2E_DIR}/fixtures/chart"
+ffcron_src="${E2E_DIR}/fixtures/fire-and-forget-chart"
+multiimage_src="${E2E_DIR}/fixtures/multi-image"
+rollout_src="${E2E_DIR}/fixtures/rollout-chart"
 work="$(mktemp -d)"
-trap 'rm -rf "$work"; kill $(jobs -p) 2>/dev/null || true' EXIT
+trap 'rm -rf "$work"' EXIT
 
-# --- port-forward (HTTP API + git push) --------------------------------------
-kubectl -n gitea port-forward svc/gitea-http "${HTTP_PORT}:3000" >/dev/null 2>&1 &
-api="http://localhost:${HTTP_PORT}/api/v1"
-ready=false
-for _ in $(seq 1 30); do
-  curl -sf -m 3 -u "${GITEA_ADMIN}:${GITEA_PW}" "${api}/version" >/dev/null 2>&1 && { ready=true; break; }
-  sleep 1
-done
-[[ "$ready" == true ]] || { echo "gitea API never became ready" >&2; exit 1; }
+# --- wait for the Gitea API --------------------------------------------------
+gitea_ready() {
+  curl -sf -m 3 -u "${GITEA_ADMIN}:${GITEA_PW}" "${GITEA_API}/version" >/dev/null 2>&1
+}
+retry 30 1 gitea_ready || die "gitea API never became ready on ${GITEA_URL}"
 
 gapi() { curl -sf -m 10 -u "${GITEA_ADMIN}:${GITEA_PW}" -H 'Content-Type: application/json' "$@"; }
 
 # --- org + repo (ignore "already exists") ------------------------------------
-gapi -X POST "${api}/orgs" -d "{\"username\":\"${ORG}\"}" >/dev/null 2>&1 || true
-gapi -X POST "${api}/orgs/${ORG}/repos" \
-  -d "{\"name\":\"${REPO}\",\"private\":false,\"auto_init\":false}" >/dev/null 2>&1 || true
+gapi -X POST "${GITEA_API}/orgs" -d "{\"username\":\"${GITEA_ORG}\"}" >/dev/null 2>&1 || true
+gapi -X POST "${GITEA_API}/orgs/${GITEA_ORG}/repos" \
+  -d "{\"name\":\"${GITEA_REPO}\",\"private\":false,\"auto_init\":false}" >/dev/null 2>&1 || true
 
 # --- SSH keypair (RSA PEM: parsed by go-git without surprises) ---------------
 ssh-keygen -t rsa -b 4096 -m PEM -N '' -C 'argo-watcher-e2e' -f "${work}/id_rsa" >/dev/null
 
 # register public key as a WRITE deploy key (delete stale one first)
-for id in $(gapi "${api}/repos/${ORG}/${REPO}/keys" | jq -r '.[]|select(.title=="argo-watcher")|.id' 2>/dev/null); do
-  gapi -X DELETE "${api}/repos/${ORG}/${REPO}/keys/${id}" >/dev/null 2>&1 || true
+for id in $(gapi "${GITEA_API}/repos/${GITEA_ORG}/${GITEA_REPO}/keys" | jq -r '.[]|select(.title=="argo-watcher")|.id' 2>/dev/null); do
+  gapi -X DELETE "${GITEA_API}/repos/${GITEA_ORG}/${GITEA_REPO}/keys/${id}" >/dev/null 2>&1 || true
 done
-gapi -X POST "${api}/repos/${ORG}/${REPO}/keys" \
+gapi -X POST "${GITEA_API}/repos/${GITEA_ORG}/${GITEA_REPO}/keys" \
   -d "{\"title\":\"argo-watcher\",\"read_only\":false,\"key\":\"$(cat "${work}/id_rsa.pub")\"}" >/dev/null
 
 # --- push the fixture chart over HTTP ----------------------------------------
@@ -78,8 +71,7 @@ mkdir -p "${work}/rollout-chart"
 cp -r "${rollout_src}/." "${work}/rollout-chart/"
 git -C "$work" -c user.name=seed -c user.email=seed@e2e add chart fire-and-forget-chart multi-image rollout-chart
 git -C "$work" -c user.name=seed -c user.email=seed@e2e commit -qm 'seed fixture chart, fire-and-forget, multi-image, and rollout charts'
-git -C "$work" push -q --force \
-  "http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${HTTP_PORT}/${ORG}/${REPO}.git" main
+git -C "$work" push -q --force "$GITOPS_REPO_URL" main
 
 # --- k8s secret (private key) + known-hosts configmap ------------------------
 kubectl create namespace "$NS_AW" --dry-run=client -o yaml | kubectl apply -f -
@@ -88,13 +80,13 @@ kubectl -n "$NS_AW" create secret generic argo-watcher-ssh \
   --dry-run=client -o yaml | kubectl apply -f -
 
 # Read Gitea's SSH host public key straight from the pod (its built-in Go SSH
-# server does not answer ssh-keyscan cleanly through a port-forward). The key is
+# server does not answer ssh-keyscan cleanly from outside the cluster). The key is
 # per-server, so we prefix it with the in-cluster hostname argo-watcher uses.
-gitea_pod="$(kubectl -n gitea get pod -l app.kubernetes.io/name=gitea -o name | head -1)"
-hostkey="$(kubectl -n gitea exec "$gitea_pod" -- cat /data/ssh/gitea.rsa.pub)"
-[[ -n "$hostkey" ]] || { echo "failed to read gitea host key" >&2; exit 1; }
+gitea_pod="$(kubectl -n "$NS_GITEA" get pod -l app.kubernetes.io/name=gitea -o name | head -1)"
+hostkey="$(kubectl -n "$NS_GITEA" exec "$gitea_pod" -- cat /data/ssh/gitea.rsa.pub)"
+[[ -n "$hostkey" ]] || die "failed to read gitea host key"
 kubectl -n "$NS_AW" create configmap e2e-ssh-known-hosts \
   --from-literal=ssh_known_hosts="${SSH_HOST} ${hostkey}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-echo "seeded ${ORG}/${REPO}, deploy key + ssh secret + known-hosts ready"
+echo "seeded ${GITEA_ORG}/${GITEA_REPO}, deploy key + ssh secret + known-hosts ready"

--- a/test/e2e/scripts/shutdown-drain.sh
+++ b/test/e2e/scripts/shutdown-drain.sh
@@ -23,44 +23,46 @@
 # poller, not shutdown. This phase asserts the shutdown/drain contract only.
 set -euo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-PORT="${PORT:-18094}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 WS_CLIENTS="${WS_CLIENTS:-3}"
 STS="${STS:-argo-watcher}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
 work="$(mktemp -d)"
 log_out="${work}/pod.log"
-pf_pid=""; log_pid=""
-cleanup() { kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir" "$work"; }
+log_pid=""
+cleanup() {
+  # jobs -p prints one PID per line; splitting them into separate arguments is the
+  # point, and they are always bare digits.
+  # shellcheck disable=SC2046
+  kill $(jobs -p) 2>/dev/null || true
+  rm -rf "$bin_dir" "$work"
+}
 trap cleanup EXIT
-( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe )
+build_bin "$bin_dir" ./test/e2e/tools/wsprobe || die "wsprobe build failed"
+wsprobe="$BIN"
 
 pod="${STS}-0"
 old_uid=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.metadata.uid}')
 
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-pf_pid=$!
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
 
 # --- 1. Hold WebSocket clients open through the shutdown -----------------------
 echo "opening ${WS_CLIENTS} WebSocket client(s)"
 probe_pids=()
 for i in $(seq 1 "$WS_CLIENTS"); do
-  WS_URL="ws://localhost:${PORT}/ws" DURATION=120s "${bin_dir}/wsprobe" >"${work}/probe${i}.out" 2>/dev/null &
+  WS_URL="$AW_WS_URL" DURATION=120s "$wsprobe" >"${work}/probe${i}.out" 2>/dev/null &
   probe_pids+=($!)
 done
 # Wait until every probe reports OPEN before triggering shutdown, so the
 # connections are provably registered in the server's set — a fixed sleep raced
 # the handshake on a loaded host and left the drain with nothing to observe.
 for i in $(seq 1 "$WS_CLIENTS"); do
-  opened=0
-  for _ in $(seq 1 20); do grep -q '^OPEN$' "${work}/probe${i}.out" && { opened=1; break; }; sleep 1; done
-  if [[ "$opened" != "1" ]]; then
-    echo "  FAIL client ${i} never established its WebSocket connection"; exit 1
-  fi
+  wait_ws_open "${work}/probe${i}.out" \
+    || die "client ${i} never established its WebSocket connection"
 done
 
 # --- 2. Capture logs, then trigger a graceful pod termination ------------------
@@ -75,30 +77,29 @@ echo "deleting pod ${pod} (grace 60s) to trigger graceful shutdown"
 # 10s) completes before SIGKILL; --wait=false returns so we can watch the clients.
 kubectl -n "$NS_AW" delete pod "$pod" --grace-period=60 --wait=false >/dev/null
 
-fail=0
-
 # --- 3. Every WS client must observe the graceful GoingAway close --------------
+gone() { ! kill -0 "$1" 2>/dev/null; }
 for i in $(seq 1 "$WS_CLIENTS"); do
   # wsprobe exits when its connection closes; bound the wait so a hung client fails.
-  for _ in $(seq 1 30); do kill -0 "${probe_pids[$((i-1))]}" 2>/dev/null || break; sleep 1; done
+  retry 30 1 gone "${probe_pids[$((i - 1))]}" || true
   out="${work}/probe${i}.out"
   if grep -q '^CLOSED code=1001 reason=server shutdown$' "$out"; then
-    echo "  OK   client ${i} drained gracefully (1001 server shutdown)"
+    ok "client ${i} drained gracefully (1001 server shutdown)"
   else
-    echo "  FAIL client ${i} did not see a graceful close: $(tr '\n' ',' <"$out")"; fail=1
+    bad "client ${i} did not see a graceful close: $(tr '\n' ',' <"$out")"
   fi
 done
 
 # --- 4. The captured shutdown logs must show the clean ordered path ------------
-for _ in $(seq 1 30); do kill -0 "$log_pid" 2>/dev/null || break; sleep 1; done
+retry 30 1 gone "$log_pid" || true
 kill "$log_pid" 2>/dev/null || true
 assert_log() {  # pattern human-label want(present|absent)
   local pattern="$1" label="$2" want="$3" found
   if grep -qF "$pattern" "$log_out"; then found=1; else found=0; fi
   if { [[ "$want" == present && "$found" == 1 ]] || [[ "$want" == absent && "$found" == 0 ]]; }; then
-    echo "  OK   log ${want}: ${label}"
+    ok "log ${want}: ${label}"
   else
-    echo "  FAIL log ${want} expected but not: ${label}"; fail=1
+    bad "log ${want} expected but not: ${label}"
   fi
 }
 assert_log "shutting down server..."                   "shutdown initiated"        present
@@ -113,27 +114,25 @@ assert_log "panic:"                                    "no panic during shutdown
 
 # --- 5. The recreated pod must come back Ready and reach Argo ------------------
 echo "waiting for ${pod} to be recreated and Ready"
-ready=0
-for _ in $(seq 1 60); do
+recreated_ready() {
+  local uid rdy
   uid=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
   rdy=$(kubectl -n "$NS_AW" get pod "$pod" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
-  if [[ -n "$uid" && "$uid" != "$old_uid" && "$rdy" == "True" ]]; then ready=1; break; fi
-  sleep 3
-done
-if [[ "$ready" != "1" ]]; then
-  echo "  FAIL ${pod} did not come back Ready after shutdown"; fail=1
+  [[ -n "$uid" && "$uid" != "$old_uid" && "$rdy" == "True" ]]
+}
+if ! retry 60 3 recreated_ready; then
+  bad "${pod} did not come back Ready after shutdown"
 else
-  kill "$pf_pid" 2>/dev/null || true
-  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-  pf_pid=$!
-  for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
-  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "localhost:${PORT}/healthz")
-  unavail=$(curl -s -m 10 "localhost:${PORT}/metrics" | awk '/^argocd_unavailable /{print $2}')
+  # No port-forward to re-establish: the NodePort URL survived the pod swap.
+  wait_service || die "argo-watcher never answered after the pod came back"
+  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/healthz")
+  # metric_raw, not metric_sum: an ABSENT gauge must fail this gate, not read as 0.
+  unavail=$(metric_raw argocd_unavailable)
   if [[ "$code" == "200" && "$unavail" == "0" ]]; then
-    echo "  OK   recreated pod healthy and reaching Argo (healthz=200 argocd_unavailable=0)"
+    ok "recreated pod healthy and reaching Argo (healthz=200 argocd_unavailable=0)"
   else
-    echo "  FAIL recreated pod not healthy: healthz=${code} argocd_unavailable=${unavail}"; fail=1
+    bad "recreated pod not healthy: healthz=${code} argocd_unavailable=${unavail:-<absent>}"
   fi
 fi
 
-if [[ "$fail" -eq 0 ]]; then echo "SHUTDOWN-DRAIN: PASS"; else echo "SHUTDOWN-DRAIN: FAIL"; exit 1; fi
+phase_end SHUTDOWN-DRAIN

--- a/test/e2e/scripts/shutdown-drain.sh
+++ b/test/e2e/scripts/shutdown-drain.sh
@@ -78,7 +78,7 @@ echo "deleting pod ${pod} (grace 60s) to trigger graceful shutdown"
 kubectl -n "$NS_AW" delete pod "$pod" --grace-period=60 --wait=false >/dev/null
 
 # --- 3. Every WS client must observe the graceful GoingAway close --------------
-gone() { ! kill -0 "$1" 2>/dev/null; }
+gone() { local pid="$1"; ! kill -0 "$pid" 2>/dev/null; }
 for i in $(seq 1 "$WS_CLIENTS"); do
   # wsprobe exits when its connection closes; bound the wait so a hung client fails.
   retry 30 1 gone "${probe_pids[$((i - 1))]}" || true

--- a/test/e2e/scripts/smoke-deploy.sh
+++ b/test/e2e/scripts/smoke-deploy.sh
@@ -9,48 +9,31 @@
 # Usage: smoke-deploy.sh [app] [tag]
 set -euo pipefail
 
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 APP="${1:-app1}"
 TAG="${2:-v1.10.2}"
-IMAGE="${IMAGE:-traefik/whoami}"
-NS_AW="${NS_AW:-argo-watcher}"
-# Must match the ARGO_WATCHER_DEPLOY_TOKEN set in the argo-watcher secret;
-# unauthenticated tasks are accepted but skip write-back (Validated=false).
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
-PORT="${PORT:-18090}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 # Build the client once and run the binary (deterministic, no per-invocation
 # `go run` compile). Built into a temp dir cleaned up on exit.
 bin_dir="$(mktemp -d)"
-trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$bin_dir"' EXIT
-( cd "$root" && go build -o "${bin_dir}/aw-client" ./cmd/client )
+trap 'rm -rf "$bin_dir"' EXIT
+build_client "$bin_dir" || die "client build failed"
 
 # Wait for the app's initial sync so we deploy from a known-good baseline.
-for _ in $(seq 1 40); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-
-kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && break; sleep 1; done
+require_app_synced "$APP"
+wait_service || die "argo-watcher never answered on ${AW_URL}"
 
 echo "deploying ${APP} -> ${IMAGE}:${TAG} via the client binary"
 
-# The client submits the task, then polls to a terminal status on its own. A
-# short RETRY_INTERVAL keeps the smoke test snappy; TASK_TIMEOUT bounds it
-# server-side so a stuck sync fails instead of hanging.
-if ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" \
-   IMAGE_TAG="${TAG}" \
-   ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e" \
-   PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" \
-   TASK_TIMEOUT="180" \
-   "${bin_dir}/aw-client"; then
+# The client submits the task, then polls to a terminal status on its own. The
+# short RETRY_INTERVAL and bounded TASK_TIMEOUT (run_client defaults) keep the
+# smoke test snappy and make a stuck sync fail instead of hang. The deploy token
+# enables write-back — an unauthenticated task is accepted but skips it
+# (Validated=false).
+if run_client "$APP" "$TAG" ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN"; then
   echo "OK: client reported the deployment as done"
   exit 0
 fi

--- a/test/e2e/scripts/soak.sh
+++ b/test/e2e/scripts/soak.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Git-conflict soak: a competitor writer plus concurrent deploys against the shared
+# gitops repo, then the collect.sh gates. This is the phase that reproduces the
+# real-world pain — many apps' write-backs contending on one repo — so its gates are
+# strict (0 failed tasks, 0 lost updates).
+#
+# Usage: [APPS=..] [WORKERS=..] [WS_CLIENTS=..] [SOAK=..] [SOAK_SECONDS=..] soak.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+APPS="${APPS:-5}"
+WORKERS="${WORKERS:-10}"
+WS_CLIENTS="${WS_CLIENTS:-10}"
+SOAK="${SOAK:-5m}"
+SOAK_SECONDS="${SOAK_SECONDS:-300}"
+COMPETITOR_INTERVAL="${COMPETITOR_INTERVAL:-2}"
+
+# Wait for all fixture apps to be Healthy so the driver never races a cold app,
+# which would surface as a spurious "app not found".
+for i in $(seq 1 "$APPS"); do
+  wait_app "app$i" Healthy 40 || die "app$i never became Healthy (last: ${APP_STATE:-unknown})"
+done
+wait_service || die "argo-watcher not reachable on ${AW_URL}"
+
+summary="$(mktemp)"
+comp=""
+# The competitor keeps pushing to the shared gitops repo for up to SOAK_SECONDS, so an
+# early exit (a failed wait, a driver crash, Ctrl-C) must not leave it running.
+trap 'rm -f "$summary"; [[ -n "$comp" ]] && kill "$comp" 2>/dev/null || true' EXIT
+SECONDS_TOTAL="$SOAK_SECONDS" INTERVAL="$COMPETITOR_INTERVAL" "${here}/competitor.sh" & comp=$!
+
+echo "=== soak: ${WORKERS} workers x ${APPS} apps for ${SOAK}, competitor@${COMPETITOR_INTERVAL}s ==="
+(
+  cd "$E2E_DIR" || exit 1
+  APPS="$APPS" WORKERS="$WORKERS" WS_CLIENTS="$WS_CLIENTS" DURATION="$SOAK" \
+    DEPLOY_TOKEN="$DEPLOY_TOKEN" BASE_URL="$AW_URL" WS_URL="$AW_WS_URL" \
+    go run ./load >"$summary"
+)
+drv=$?
+cat "$summary"
+wait $comp 2>/dev/null || true
+
+"${here}/collect.sh" "$summary"
+col=$?
+
+[[ "$drv" -eq 0 && "$col" -eq 0 ]] || die "soak failed (driver=${drv} collect=${col})"
+echo "SOAK: PASS"

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -33,29 +33,22 @@
 # are backend-agnostic assertions, so that is a free bonus, not lost coverage.
 #
 # Required env: AW_CHART_REPO, AW_CHART_VERSION (to helm-upgrade the release).
-# Optional env: DEPLOY_TOKEN, IMAGE, APP, PORT, GITEA_PORT, GITEA_ADMIN, GITEA_PW.
+# Optional env: DEPLOY_TOKEN, IMAGE, APP.
 set -euo pipefail
 
-NS_AW="${NS_AW:-argo-watcher}"
-DEPLOY_TOKEN="${DEPLOY_TOKEN:-e2e-deploy-token}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
 AW_CHART_REPO="${AW_CHART_REPO:?AW_CHART_REPO required (chart repo URL)}"
 AW_CHART_VERSION="${AW_CHART_VERSION:?AW_CHART_VERSION required (pinned chart version)}"
-IMAGE="${IMAGE:-traefik/whoami}"
 # Persistence deploy runs against app4 — untouched by the earlier deploy phases
 # (smoke/commit-format/race use app1/app3), so its newest task is unambiguously
 # the one we create here.
 APP="${APP:-app4}"
-PORT="${PORT:-18098}"
-GITEA_PORT="${GITEA_PORT:-13004}"
-GITEA_ADMIN="${GITEA_ADMIN:-gitea_admin}"
-GITEA_PW="${GITEA_PW:-gitea_admin_pw1}"
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(cd "${here}/../../.." && pwd)"
 
 bin_dir="$(mktemp -d)"
-CLIENT_BIN="${bin_dir}/aw-client"
 probe_out="$(mktemp)"
-pf_pid=""
 probe_pid=""
 # Set to 1 while the deploy-lock assertion holds the shared lock (see below).
 lock_set=0
@@ -79,63 +72,31 @@ cleanup() {
 }
 trap cleanup EXIT
 
-base="http://localhost:${PORT}/api/v1"
-
 # start_probe: hold a WebSocket client open and block until it has connected, so a
 # broadcast triggered afterwards cannot be missed by a slow handshake. A pod
-# restart kills the socket, so call this again after each forward. Any previous
+# restart kills the socket, so call this again after each restart. Any previous
 # probe is killed first: it would otherwise keep appending to the same file that
 # this one truncates, mixing the old capture into the new assertion.
 start_probe() {
   [[ -n "$probe_pid" ]] && kill "$probe_pid" 2>/dev/null || true
   : >"$probe_out"
-  WS_URL="ws://localhost:${PORT}/ws" DURATION=300s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
+  WS_URL="$AW_WS_URL" DURATION=300s "${bin_dir}/wsprobe" >"$probe_out" 2>/dev/null &
   probe_pid=$!
-  for _ in $(seq 1 20); do
-    grep -q '^OPEN$' "$probe_out" && return 0
-    sleep 1
-  done
-  echo "STATE-POSTGRES: FAIL — WS probe never connected on :${PORT}"
-  exit 1
-}
-
-# wait_ws <message>: wait up to ~30s (6x the 5s lockdown poll interval) for the
-# lockdown watcher to broadcast <message> to the probe.
-wait_ws() {
-  local message="$1"
-  for _ in $(seq 1 6); do
-    grep -q "^MSG ${message}\$" "$probe_out" && return 0
-    sleep 5
-  done
-  return 1
-}
-
-# forward: (re)establish a port-forward to the argo-watcher service and block until
-# /healthz answers. Called again after the restart, since deleting the pod kills
-# the previous forward.
-forward() {
-  [[ -n "$pf_pid" ]] && kill "$pf_pid" 2>/dev/null || true
-  kubectl -n "$NS_AW" port-forward svc/argo-watcher "${PORT}:80" >/dev/null 2>&1 &
-  pf_pid=$!
-  for _ in $(seq 1 30); do
-    curl -s -m 3 -o /dev/null "localhost:${PORT}/healthz" && return 0
-    sleep 1
-  done
-  echo "STATE-POSTGRES: FAIL — argo-watcher /healthz never came up on :${PORT}"
-  exit 1
+  wait_ws_open "$probe_out" || die "WS probe never connected on ${AW_WS_URL}"
 }
 
 echo "=== provisioning in-cluster Postgres ==="
-kubectl apply -f "${here}/../fixtures/postgres/"
+kubectl apply -f "${E2E_DIR}/fixtures/postgres/"
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher-db --timeout=180s
 
 echo "=== flipping the release to STATE_TYPE=postgres (runs the migration Job) ==="
-# --wait blocks on the pre-upgrade migration hook AND the rolled StatefulSet; the
-# hook (argo-watcher --migrate) applies the schema before the server starts.
+# Not helm_apply_aw: this apply layers a SECOND values file (the postgres overlay)
+# and needs --wait to block on the pre-upgrade migration hook, which
+# helm_apply_aw's single-file + --reset-values shape does not cover.
 helm upgrade --install argo-watcher argo-watcher --repo "$AW_CHART_REPO" \
   --version "$AW_CHART_VERSION" -n "$NS_AW" \
-  -f "${here}/../values/argo-watcher.yaml" \
-  -f "${here}/../values/argo-watcher-postgres.yaml" \
+  -f "${E2E_DIR}/values/argo-watcher.yaml" \
+  -f "${E2E_DIR}/values/argo-watcher-postgres.yaml" \
   --set image.tag=race --wait --timeout 5m
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
 
@@ -144,70 +105,50 @@ kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
 # already implies the hook ran to completion.
 if kubectl -n "$NS_AW" get job/argo-watcher-migration >/dev/null 2>&1; then
   kubectl -n "$NS_AW" wait --for=condition=complete job/argo-watcher-migration --timeout=120s \
-    || { echo "STATE-POSTGRES: FAIL — migration Job did not complete"; exit 1; }
-  echo "  OK   migration Job completed"
+    || die "migration Job did not complete"
+  ok "migration Job completed"
 fi
 
-forward
+wait_service || die "argo-watcher /healthz never came up on ${AW_URL}"
 
 echo "=== asserting the server is actually on Postgres ==="
-st="$(curl -s -m 10 "${base}/config" | jq -r '.state_type')"
-if [[ "$st" != "postgres" ]]; then
-  echo "STATE-POSTGRES: FAIL — /config state_type=${st:-<none>}, want postgres"
-  exit 1
-fi
-echo "  OK   /config reports state_type=postgres"
+st="$(curl -s -m 10 "${AW_API}/config" | jq -r '.state_type')"
+[[ "$st" == "postgres" ]] || die "/config state_type=${st:-<none>}, want postgres"
+ok "/config reports state_type=postgres"
 
 echo "=== deploying ${APP} on Postgres (real write-back loop) ==="
-( cd "$root" && go build -o "$CLIENT_BIN" ./cmd/client ) \
-  || { echo "STATE-POSTGRES: FAIL — client build failed"; exit 1; }
-( cd "$root" && go build -o "${bin_dir}/wsprobe" ./test/e2e/tools/wsprobe ) \
-  || { echo "STATE-POSTGRES: FAIL — wsprobe build failed"; exit 1; }
+build_client "$bin_dir" || die "client build failed"
+build_bin "$bin_dir" ./test/e2e/tools/wsprobe || die "wsprobe build failed"
 
 # Wait for the app's baseline sync, then deploy a tag different from its current one
 # so the write-back actually commits (an unchanged tag is byte-compared and skipped).
-for _ in $(seq 1 40); do
-  s=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.sync.status}/{.status.health.status}' 2>/dev/null || true)
-  [[ "$s" == "Synced/Healthy" ]] && break
-  sleep 5
-done
-[[ "$s" == "Synced/Healthy" ]] || { echo "STATE-POSTGRES: FAIL — ${APP} never reached Synced/Healthy (last: ${s:-unknown})"; exit 1; }
+require_app_synced "$APP"
+TAG="$(other_tag "$APP")"
 
-cur=$(kubectl -n argocd get application "$APP" -o jsonpath='{.status.summary.images}' 2>/dev/null || true)
-if [[ "$cur" == *v1.10.2* ]]; then TAG="v1.10.1"; else TAG="v1.10.2"; fi
-
-if ! ARGO_WATCHER_URL="http://localhost:${PORT}" \
-   IMAGES="${IMAGE}" IMAGE_TAG="${TAG}" ARGO_APP="${APP}" \
-   COMMIT_AUTHOR="e2e-pg" PROJECT_NAME="lab" \
-   ARGO_WATCHER_DEPLOY_TOKEN="${DEPLOY_TOKEN}" \
-   RETRY_INTERVAL="5s" TASK_TIMEOUT="180" \
-   "$CLIENT_BIN"; then
-  echo "STATE-POSTGRES: FAIL — deploy of ${APP}:${TAG} did not reach 'deployed'"
-  exit 1
-fi
-echo "  OK   ${APP}:${TAG} deployed on Postgres"
+run_client "$APP" "$TAG" \
+  COMMIT_AUTHOR="e2e-pg" \
+  ARGO_WATCHER_DEPLOY_TOKEN="$DEPLOY_TOKEN" \
+  || die "deploy of ${APP}:${TAG} did not reach 'deployed'"
+ok "${APP}:${TAG} deployed on Postgres"
 
 # Capture the task we just created: the newest task for this app.
-id=$(curl -s -m 10 "${base}/tasks?from_timestamp=0&app=${APP}" | jq -r '.tasks | sort_by(.created) | last | .id')
-if [[ -z "$id" || "$id" == "null" ]]; then
-  echo "STATE-POSTGRES: FAIL — could not read the created task id from the task list"
-  exit 1
-fi
+id=$(curl -s -m 10 "${AW_API}/tasks?from_timestamp=0&app=${APP}" | jq -r '.tasks | sort_by(.created) | last | .id')
+[[ -n "$id" && "$id" != "null" ]] || die "could not read the created task id from the task list"
 echo "  task id=${id}"
 
 echo "=== restarting the server; the task must survive (Postgres persistence) ==="
 kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
-forward   # the previous forward died with the pod
+# No forward to re-establish: the NodePort URL is unaffected by the pod swap.
+wait_service || die "argo-watcher /healthz never came back after the restart"
 
-code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${base}/tasks/${id}")
-status_after=$(curl -s -m 10 "${base}/tasks/${id}" | jq -r '.status')
-if [[ "$code" != "200" || "$status_after" != "deployed" ]]; then
-  echo "STATE-POSTGRES: FAIL — task ${id} did not survive the restart (http=${code} status=${status_after:-<none>})"
+req GET "${AW_API}/tasks/${id}"
+status_after=$(jq -r '.status' <<<"$BODY")
+if [[ "$CODE" != "200" || "$status_after" != "deployed" ]]; then
   echo "  (in-memory loses history here; Postgres must return 200 'deployed')"
-  exit 1
+  die "task ${id} did not survive the restart (http=${CODE} status=${status_after:-<none>})"
 fi
-echo "  OK   task ${id} still present as 'deployed' after the restart"
+ok "task ${id} still present as 'deployed' after the restart"
 
 echo "=== shared deploy lock: a lock written by another writer is honored ==="
 # The manual lock API needs OIDC (heavy tier), so write the shared row directly —
@@ -225,27 +166,16 @@ start_probe
 psql_db "UPDATE deploy_lock SET manual_lock = true, override_until = NULL" >/dev/null
 lock_set=1
 
-if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then
-  echo "STATE-POSTGRES: FAIL — GET /deploy-lock did not report the shared lock"
-  exit 1
-fi
+curl -s -m 10 "${AW_API}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1 \
+  || die "GET /deploy-lock did not report the shared lock"
 
-if wait_ws locked; then
-  echo "  OK   the watcher broadcast 'locked' for a lock written by another writer"
-else
-  echo "STATE-POSTGRES: FAIL — no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
-  exit 1
-fi
+wait_ws "$probe_out" locked \
+  || die "no 'locked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
+ok "the watcher broadcast 'locked' for a lock written by another writer"
 
-code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "${base}/tasks" \
-  -H 'Content-Type: application/json' \
-  -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
-  -d "{\"app\":\"${APP}\",\"author\":\"e2e-pg\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.3\"}]}")
-if [[ "$code" != "406" ]]; then
-  echo "STATE-POSTGRES: FAIL — deploy during a shared lock returned ${code}, want 406"
-  exit 1
-fi
-echo "  OK   shared lock rejects deployments (406) on a replica that never set it"
+post_task "$(task_json "$APP" v1.10.3 e2e-pg)" -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}"
+[[ "$CODE" == "406" ]] || die "deploy during a shared lock returned ${CODE}, want 406"
+ok "shared lock rejects deployments (406) on a replica that never set it"
 
 # The lock must also OUTLIVE the process that would have held it in memory: the
 # old implementation lost it on restart, which is the other half of why it moved
@@ -253,64 +183,34 @@ echo "  OK   shared lock rejects deployments (406) on a replica that never set i
 echo "  restarting the server; the lock must still be in effect"
 kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
-forward
+wait_service || die "argo-watcher /healthz never came back after the second restart"
 
-if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1; then
-  echo "STATE-POSTGRES: FAIL — the shared lock did not survive the restart"
-  exit 1
-fi
+curl -s -m 10 "${AW_API}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1 \
+  || die "the shared lock did not survive the restart"
 
-code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "${base}/tasks" \
-  -H 'Content-Type: application/json' \
-  -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}" \
-  -d "{\"app\":\"${APP}\",\"author\":\"e2e-pg\",\"project\":\"lab\",\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v1.10.3\"}]}")
-if [[ "$code" != "406" ]]; then
-  echo "STATE-POSTGRES: FAIL — deploy after the restart returned ${code}, want 406 (lock lost)"
-  exit 1
-fi
-echo "  OK   the lock survived the restart and still rejects deployments"
+post_task "$(task_json "$APP" v1.10.3 e2e-pg)" -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}"
+[[ "$CODE" == "406" ]] || die "deploy after the restart returned ${CODE}, want 406 (lock lost)"
+ok "the lock survived the restart and still rejects deployments"
 
-# The restart above killed the previous socket along with its port-forward, so the
-# release needs a probe reconnected to the new pod.
+# The restart above killed the previous socket, so the release needs a probe
+# reconnected to the new pod.
 start_probe
 psql_db "UPDATE deploy_lock SET manual_lock = false" >/dev/null
 lock_set=0
-if ! curl -s -m 10 "${base}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1; then
-  echo "STATE-POSTGRES: FAIL — GET /deploy-lock still locked after the shared release"
-  exit 1
-fi
-echo "  OK   releasing the shared lock unblocks deployments again"
+curl -s -m 10 "${AW_API}/deploy-lock" | jq -e '. == false' >/dev/null 2>&1 \
+  || die "GET /deploy-lock still locked after the shared release"
+ok "releasing the shared lock unblocks deployments again"
 
-if wait_ws unlocked; then
-  echo "  OK   the watcher broadcast 'unlocked' for the shared release"
-else
-  echo "STATE-POSTGRES: FAIL — no 'unlocked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
-  exit 1
-fi
+wait_ws "$probe_out" unlocked \
+  || die "no 'unlocked' WS broadcast (captured: $(tr '\n' ',' <"$probe_out"))"
+ok "the watcher broadcast 'unlocked' for the shared release"
 
 echo "=== supersession under git contention on Postgres ==="
-# race-supersede.sh is self-contained (resets its app to a baseline, runs its own
-# competitor) and drives CancelInProgressTasks — the one deploy-flow query whose
-# SQL differs from the in-memory path. Give it the already-forwarded API plus a
-# Gitea forward for the commit check. Runs on app1, independent of app4 above.
-# Wait for app1 to be Healthy first (as the `race` task does) so the baseline reset
-# deploys from a known-good state — matters when this phase is run standalone.
-h=""
-for _ in $(seq 1 40); do
-  h=$(kubectl -n argocd get application app1 -o jsonpath='{.status.health.status}' 2>/dev/null || true)
-  [[ "$h" == "Healthy" ]] && break
-  sleep 3
-done
-[[ "$h" == "Healthy" ]] || { echo "STATE-POSTGRES: FAIL — app1 never reached Healthy (last: ${h:-unknown})"; exit 1; }
-kubectl -n gitea port-forward svc/gitea-http "${GITEA_PORT}:3000" >/dev/null 2>&1 &
-for _ in $(seq 1 15); do curl -s -m 3 -o /dev/null "localhost:${GITEA_PORT}" && break; sleep 1; done
-
-if ! DEPLOY_TOKEN="${DEPLOY_TOKEN}" BASE_URL="http://localhost:${PORT}" \
-   CLIENT_BIN="${CLIENT_BIN}" \
-   GITEA_REPO_URL="http://${GITEA_ADMIN}:${GITEA_PW}@localhost:${GITEA_PORT}/e2e/gitops.git" \
-   "${here}/race-supersede.sh"; then
-  echo "STATE-POSTGRES: FAIL — supersession under contention failed on Postgres"
-  exit 1
-fi
+# race-supersede.sh drives CancelInProgressTasks — the one deploy-flow query whose
+# SQL differs from the in-memory path. It is self-contained (waits for its app,
+# resets it to a baseline, runs its own competitor) and runs on app1, independent of
+# app4 above; reuses the client binary built here.
+CLIENT_BIN="$CLIENT_BIN" DEPLOY_TOKEN="$DEPLOY_TOKEN" "${here}/race-supersede.sh" \
+  || die "supersession under contention failed on Postgres"
 
 echo "STATE-POSTGRES: PASS (migrated, deployed, survived restart, shared deploy lock, superseded under contention)"

--- a/test/e2e/scripts/verify.sh
+++ b/test/e2e/scripts/verify.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Assert the freshly-installed argo-watcher is up and actually talking to the real
+# ArgoCD: /healthz is 200 (it returns 503 when ArgoCD is unreachable) and the
+# argocd_unavailable gauge is 0. Run right after `task up` as the gate that the lab
+# is wired correctly before any phase drives a deploy.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+wait_service || die "argo-watcher never answered on ${AW_URL}"
+# The webhook-tester NodePort is otherwise first used by the notifications phase, ~20
+# minutes in; prove its selector resolves here instead of failing late.
+wait_url "${WHT_URL}/healthz" || die "webhook-tester not reachable on ${WHT_URL} (check the nodeports selector)"
+
+code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/healthz")
+# metric_raw, not metric_sum: an ABSENT gauge must fail this gate, not read as 0.
+unavail=$(metric_raw argocd_unavailable)
+echo "healthz=${code} argocd_unavailable=${unavail:-<absent>}"
+
+[[ "$code" == "200" ]]  || die "healthz=${code}, want 200"
+[[ "$unavail" == "0" ]] || die "argocd_unavailable=${unavail:-<absent>}, want 0 (not reaching ArgoCD)"
+echo "VERIFY: PASS"


### PR DESCRIPTION
## Summary

The e2e lab was built up phase by phase, and every phase had grown its own copy of
the same harness code. This replaces that with three standard pieces and leaves the
domain assertions — which are the lab's actual value — untouched.

| | before | after |
|---|---|---|
| `kubectl port-forward` invocations | 39 across 22 files | 0 |
| `for _ in $(seq …)` poll loops | 56 | 0 |
| hand-rolled OK/FAIL accumulators | 7 | 0 |
| hand-assigned non-colliding ports | 7 | 4 fixed, asserted by a test |
| tests runnable without a cluster | 0 | 29 |

## What changed

**Transport.** `fixtures/nodeports/` publishes four fixed NodePorts that
`kind-config.yaml` maps to loopback, so a URL survives a pod being replaced — which
`shutdown-drain`, `lockdown`, `batch-writeback` and `state-postgres` all do on
purpose. Standalone Services rather than chart `service.type`: neither the
argo-watcher nor the generic `app` chart renders a `nodePort` field, so they can only
get a random one, and standalone Services also survive the
`helm upgrade --reset-values` three phases depend on.

**Shared helpers.** `scripts/lib.sh` holds only what more than one phase needs
(endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`/`metric_raw`,
`helm_apply_aw`, the assertion accumulator). Inline shell in `Taskfile.yml` moved to
`soak.sh` and `verify.sh`, since go-task's interpreter is not bash.

**bats.** Phases run as one test each (`phases.bats`), giving a JUnit case per phase
and `--filter` / `--filter-status failed` reruns. bats has no fail-fast flag, so a
marker file skips the remaining phases after a failure, keeping the previous "stop
and leave the cluster up for debugging" behaviour. `lib.bats` and `ports.bats` cover
the text-processing helpers and the kind-config ↔ nodeports port coupling offline,
and now run on every PR touching the lab instead of only in the per-release job.

## Notes

Extracting the helpers surfaced two latent bugs, both now covered by tests: `retry`'s
locals shadowed a caller's `attempts`, so its own loop bound grew on every pass and
never terminated; and awk's `-v` unescapes `\.`, so `override_param` matched its
parameter name as a wildcard. `metric_raw` exists alongside `metric_sum` because a
"must be 0" gauge gate has to tell 0 apart from absent — `metric_sum` reports a
missing metric as 0, which made two `argocd_unavailable` gates pass vacuously.

`multi-image.sh` read the write-back override with `yq` while `race-supersede.sh`
avoided it citing "yq is not on GitHub runners"; both now use the same helper.

Considered and rejected: chainsaw/kuttl (the phases assert HTTP, WebSocket frames,
Prometheus counters and git contents, not resource state — they would host the same
bash inside YAML), k6 (cannot express "app N's committed tag equals the last tag
deployed"), and e2e-framework/Terratest (a multi-week rewrite for reporting bats
provides directly).

Verified on a live kind cluster: 18/18 phases green in 25m13s against real
ArgoCD/Gitea/argo-rollouts, plus the 29 offline tests and shellcheck clean.
