### PR TITLE
feat(server): fail fast when the image is not part of the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A deployment that requests an image the Argo CD application does not define now
+  fails immediately instead of staying active until the task timeout expires. The
+  usual cause is a misspelled image name or a registry prefix that does not match the
+  manifests; the failure reason lists the images the application does define, so the
+  correct value is visible without opening the Argo CD UI.
+
+  The check compares the request against the application's *desired state* (Argo CD's
+  managed resources), not its running pods, and runs once the application is synced
+  and healthy but the expected image is still missing. Using the desired state is what
+  makes it safe: `status.summary.images` reports only the images of live pods, so a
+  workload that has no pod yet — an untriggered `CronJob`, a `Deployment` scaled to
+  zero — still counts as defining its image and keeps waiting as before. Anything the
+  check cannot resolve keeps waiting too, including a failed lookup or an application
+  whose manifests declare no images at all.
+
+  It is skipped entirely when `ARGO_REFRESH_APP` is `false` or a task sets
+  `refresh: false`, because without a refresh the desired state may be older than the
+  deployment.
+
+  Two kinds of image are part of an application but never appear in the desired state
+  Argo CD reports: images used only by a sync hook (Argo CD omits hook resources), and
+  images named by a custom resource whose workload an operator creates out-of-band.
+  Deploying those would hit the new failure despite being correct, so applications that
+  do should carry the new annotation `argo-watcher/skip-image-validation: "true"`,
+  which turns the check off for that application and restores the previous
+  wait-for-the-timeout behaviour.
+
+### Changed
+
+- The client no longer tells you to check the logs for every failed deployment. The
+  message now defers to the server's reason, which may point at the application or at
+  the deployment request itself.
+
 ## [0.13.0] - 2026-07-30
 
 ### Added

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -25,7 +25,7 @@ A task in Argo Watcher moves through the following states:
 1. **Pending** — Task created, waiting for the expected image to appear in Argo CD.
 2. **In Progress** — Image detected in Argo CD, deployment is syncing or running.
 3. **Deployed** — Deployment succeeded; application is healthy and synced.
-4. **Failed** — Deployment did not become healthy and synced before `DEPLOYMENT_TIMEOUT` elapsed, or Argo CD reported a health/sync failure.
+4. **Failed** — Deployment did not become healthy and synced before `DEPLOYMENT_TIMEOUT` elapsed, Argo CD reported a health/sync failure, or the application finished rolling out without ever defining the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)).
 5. **App Not Found** — Argo CD has no application with the requested name (or the token lacks permission to see it).
 6. **Aborted** — Argo Watcher could not confirm the deployment's outcome: Argo CD (or a proxy in front of it) was unreachable during the check (connection refused, DNS failure, TLS error, a timed-out API request, or a 5xx response), or the task remained in progress past the staleness window. The status reason records the cause. An aborted deployment still counts as a failure (`failed_deployment`); the `argocd_unavailable` gauge indicates when Argo CD itself was the reason.
 7. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. A deployment can also only cancel one that presented no more authority than itself: a task submitted without a credential never cancels one submitted with a valid deploy token or JWT. Unlike Failed, a cancelled task is not counted as a deployment failure.
@@ -60,6 +60,7 @@ graph LR
     Task --> Check[Check Argo CD API]
     Check --> Decision{Expected Image?}
     Decision -->|Yes| Success[Success]
+    Decision -->|No, image not defined by the app| Failed
     Decision -->|No| Retry[Retry API Check]
     Retry --> Timeout{Timeout?}
     Timeout -->|Yes| Failed[Failed]
@@ -80,6 +81,7 @@ graph LR
     ImageUpdate --> Check[Check Argo CD API]
     Check --> Decision{Expected Image?}
     Decision -->|Yes| Success[Success]
+    Decision -->|No, image not defined by the app| Failed
     Decision -->|No| Retry[Retry API Check]
     Retry --> Timeout{Timeout?}
     Timeout -->|Yes| Failed[Failed]

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -60,6 +60,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 **Likely causes:**
 - The default `DEPLOYMENT_TIMEOUT` (900 seconds / 15 minutes) is too short for the workload.
 - Argo CD is not detecting the image update.
+- The requested image is not part of the application at all. This normally fails immediately rather than timing out — see [Image is not part of application](#image-is-not-part-of-application) for the cases where it cannot be detected.
 - When relying on the built-in GitOps updater: the task was submitted without a valid deploy token or JWT, so the write-back was silently skipped and Argo CD never received the new tag. (If image tags are committed by other means — Argo CD Image Updater, your CI — this is expected and not the cause.)
 
 **How to verify:**
@@ -71,6 +72,37 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 1. Increase `DEPLOYMENT_TIMEOUT` to accommodate your typical rollout duration.
 2. If using the built-in GitOps updater, verify the SSH key has write access to the target repository.
 3. Check Argo CD logs for sync errors: `kubectl logs -l app.kubernetes.io/name=argocd-application-controller`.
+
+---
+
+## Image is not part of application
+
+**Symptom:** The deployment fails immediately with `Image "<name>" is not part of application "<app>"`, followed by the list of images the application defines.
+
+**Meaning:** The application finished rolling out — synced and healthy — but its desired state does not declare the requested image at all, so waiting for that image to appear would only burn the task's timeout. Argo Watcher reads the desired state from Argo CD's managed resources, not from the running pods, so a workload that has no pod yet (an untriggered `CronJob`, a `Deployment` scaled to zero) still counts as declaring its image.
+
+**Likely causes:**
+- The image name is misspelled, or the registry prefix does not match what the manifests use.
+- The deployment targets a real but different application — one that exists, so it is not reported as `app not found`, but does not contain this image.
+
+**How to verify:** Compare the requested image with the list in the failure reason, or run `argocd app manifests <app> | grep image:`.
+
+**Fix:** Correct the image name, or the `ARGO_APP`, in the deployment request.
+
+**When the check does not run:** it needs a freshly reconciled application, so it is skipped entirely when `ARGO_REFRESH_APP` is `false` or the task sets `refresh: false`. Without a refresh the desired state may be older than the deployment, and a legitimate image could look absent.
+
+**When the check is wrong:** two kinds of image are part of an application but never appear in the desired state Argo CD reports, so deploying them would hit this failure even though the image name is correct:
+
+- **Images used only by a sync hook.** Argo CD omits hook resources from its managed-resources response, so an image that appears only in, say, a PreSync migration Job is invisible.
+- **Images named by a custom resource.** If the application manages a CR and an operator creates the actual workload from it, that workload is not a managed resource of the application, and the CR usually names the image in a field of its own rather than in a pod template.
+
+Annotate such an application to turn the check off for it. Its deployments then behave exactly as before: they keep polling for the image and fail only when the timeout expires.
+
+```yaml
+metadata:
+  annotations:
+    argo-watcher/skip-image-validation: "true"
+```
 
 ---
 

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -16,6 +16,7 @@ All annotations are prefixed with `argo-watcher/` and are optional unless otherw
 | `argo-watcher/write-back-path` | Application (multi-source only) | `sandbox/charts/demo` | Overrides the write-back path (multi-source only). |
 | `argo-watcher/write-back-filename` | Application | `values-override.yaml` | Overrides the override-file name (default is derived from the app name). |
 | `argo-watcher/fire-and-forget` | Application | `true` | Commits the tag and marks the deployment `deployed` without monitoring status. |
+| `argo-watcher/skip-image-validation` | Application | `true` | Turns off the [fail-fast image check](../operations/troubleshooting.md#image-is-not-part-of-application) for this application, so its deployments wait for the timeout instead. |
 
 See the [Git Integration guide](../guides/gitops-updater.md) for full usage and examples.
 

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -23,6 +23,7 @@ type ArgoApiInterface interface {
 	GetUserInfo() (*models.Userinfo, error)
 	GetApplication(ctx context.Context, app string, refresh bool) (*models.Application, error)
 	GetResourceTree(ctx context.Context, app string) (*models.ApplicationTree, error)
+	GetManagedResources(ctx context.Context, app string) (*models.ManagedResources, error)
 }
 
 type ArgoApi struct {
@@ -236,4 +237,29 @@ func (api *ArgoApi) GetResourceTree(ctx context.Context, app string) (*models.Ap
 	}
 
 	return &tree, nil
+}
+
+// GetManagedResources fetches the desired state of every resource the named application
+// manages, which is what tells whether an image belongs to the application at all.
+// ArgoCD serves it from its application state cache, so no manifests are rendered.
+// The context bounds the request. Like GetResourceTree it does not log: the caller
+// treats any failure as "cannot conclude".
+func (api *ArgoApi) GetManagedResources(ctx context.Context, app string) (*models.ManagedResources, error) {
+	apiUrl := fmt.Sprintf("%s/api/v1/applications/%s/managed-resources", api.baseUrl.String(), url.PathEscape(app))
+
+	body, statusCode, err := api.doGet(ctx, apiUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, parseArgoErrorResponse(statusCode, body)
+	}
+
+	var resources models.ManagedResources
+	if err = json.Unmarshal(body, &resources); err != nil {
+		return nil, fmt.Errorf("could not parse managed-resources response: %w", err)
+	}
+
+	return &resources, nil
 }

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -394,6 +394,52 @@ func TestArgoApiGetResourceTreeSuccess(t *testing.T) {
 	assert.Equal(t, `Back-off pulling image "demo:v2": ErrImagePull`, result.Nodes[0].Health.Message)
 }
 
+// TestArgoApiGetManagedResourcesSuccess verifies that GetManagedResources hits the
+// managed-resources endpoint and decodes the desired manifests.
+func TestArgoApiGetManagedResourcesSuccess(t *testing.T) {
+	manifest := `{"kind":"Deployment","spec":{"template":{"spec":{"containers":[{"image":"demo:v1"}]}}}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/applications/demo/managed-resources", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(models.ManagedResources{
+			Items: []models.ManagedResource{{TargetState: manifest}},
+		}))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = server.Client()
+	api.maxRetries = 1
+
+	result, err := api.GetManagedResources(context.Background(), "demo")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"demo"}, result.DesiredImageNames())
+}
+
+// TestArgoApiGetManagedResourcesError verifies a non-200 response surfaces as an error.
+func TestArgoApiGetManagedResourcesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	api := NewArgoApi()
+	api.baseUrl = *parsedURL
+	api.client = server.Client()
+	api.maxRetries = 1
+
+	_, err = api.GetManagedResources(context.Background(), "demo")
+	require.Error(t, err)
+}
+
 // TestArgoApiGetResourceTreeError verifies a non-200 response surfaces as an error.
 func TestArgoApiGetResourceTreeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -121,7 +121,11 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 
 	application, err := updater.waitForApplicationDeployment(task)
 
+	var imageErr *ImageNotPartOfAppError
+
 	switch {
+	case errors.As(err, &imageErr):
+		updater.monitor.HandleImageNotPartOfApp(&task, imageErr)
 	case errors.Is(err, errTaskSuperseded):
 		// A newer deployment for the same app already marked this task "cancelled"
 		// in the shared state (possibly on another replica). Stop without writing a

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -79,6 +79,7 @@ func zeroDelay(_ uint, _ error, _ *retry.Config) time.Duration {
 func newArgoApiMock(ctrl *gomock.Controller) *mocks.MockArgoApiInterface {
 	api := mocks.NewMockArgoApiInterface(ctrl)
 	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	api.EXPECT().GetManagedResources(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	return api
 }
 
@@ -1494,14 +1495,14 @@ func TestCheckRolloutStatus(t *testing.T) {
 	app.Status.Health.Status = "Healthy"
 
 	t.Run("returnsNilOnSuccess", func(t *testing.T) {
-		err := checkRolloutStatus(task, app, "", false)
+		err := checkRolloutStatus(task, app, app.GetRolloutStatus(task.ListImages(), "", false))
 		assert.NoError(t, err)
 	})
 
 	t.Run("returnsForceRetryOnPending", func(t *testing.T) {
 		pending := *app
 		pending.Status.Health.Status = "Progressing"
-		err := checkRolloutStatus(task, &pending, "", false)
+		err := checkRolloutStatus(task, &pending, pending.GetRolloutStatus(task.ListImages(), "", false))
 		require.Error(t, err)
 		assert.True(t, retry.IsRecoverable(err))
 	})
@@ -1514,7 +1515,7 @@ func TestCheckRolloutStatus(t *testing.T) {
 		taskCopy := task
 		taskCopy.SavedAppStatus.ImagesHash = helpers.GenerateHash("example.com/app:v1")
 
-		err := checkRolloutStatus(taskCopy, &degraded, "", false)
+		err := checkRolloutStatus(taskCopy, &degraded, degraded.GetRolloutStatus(taskCopy.ListImages(), "", false))
 		require.Error(t, err)
 		assert.False(t, retry.IsRecoverable(err))
 	})
@@ -1528,7 +1529,7 @@ func TestCheckRolloutStatus(t *testing.T) {
 		taskCopy := task
 		taskCopy.SavedAppStatus.ImagesHash = hash
 
-		err := checkRolloutStatus(taskCopy, &degraded, "", false)
+		err := checkRolloutStatus(taskCopy, &degraded, degraded.GetRolloutStatus(taskCopy.ListImages(), "", false))
 		require.Error(t, err)
 		assert.True(t, retry.IsRecoverable(err))
 	})

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -31,6 +31,33 @@ var errForceRetry = errors.New("force retry")
 // without overwriting the "cancelled" status the newer deployment already wrote.
 var errTaskSuperseded = errors.New("task superseded by a newer deployment")
 
+// ImageNotPartOfAppError reports that a task expects an image the application's desired
+// state never declares, so waiting for it to appear is pointless (issue #519).
+// Image is a repository name without tag or digest, as are DesiredImages.
+type ImageNotPartOfAppError struct {
+	App           string
+	Image         string
+	DesiredImages []string
+}
+
+func (err *ImageNotPartOfAppError) Error() string {
+	return fmt.Sprintf("image %q is not part of application %q", err.Image, err.App)
+}
+
+// Reason renders the user-facing task failure reason.
+func (err *ImageNotPartOfAppError) Reason() string {
+	return fmt.Sprintf(
+		"Application deployment failed. Image %q is not part of application %q.\n\n"+
+			"List of images defined in the application:\n"+
+			"\t%s\n\n"+
+			"The application finished rolling out without this image, so waiting for it would only "+
+			"end in a timeout. Check the image name in the deployment request.",
+		err.Image,
+		err.App,
+		strings.Join(err.DesiredImages, "\n\t"),
+	)
+}
+
 // DeploymentMonitor encapsulates the logic for tracking ArgoCD application rollouts.
 type DeploymentMonitor struct {
 	argo             Argo
@@ -142,6 +169,12 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 
 	slog.Debug("Waiting for rollout", "id", task.Id, "deadline", deadline)
 
+	// The desired-state image check runs at most once per task, on the first poll where
+	// the app has settled without the expected image. It requires refresh: without one
+	// the app status and the desired state both come from ArgoCD's last reconciliation,
+	// which may predate the commit that introduces the image.
+	imagesValidated := false
+
 	err := retry.Do(func() error {
 		// Stop before hitting ArgoCD if a newer deployment superseded this task.
 		// The check is per-iteration: a cancellation that lands mid-iteration is
@@ -163,7 +196,16 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 			return nil
 		}
 
-		return checkRolloutStatus(task, app, monitor.registryProxyUrl, monitor.acceptSuspended)
+		status := app.GetRolloutStatus(task.ListImages(), monitor.registryProxyUrl, monitor.acceptSuspended)
+
+		if !imagesValidated && refresh && shouldValidateDesiredImages(app, status) {
+			imagesValidated = true
+			if imageErr := monitor.validateDesiredImages(ctx, task, app); imageErr != nil {
+				return retry.Unrecoverable(imageErr)
+			}
+		}
+
+		return checkRolloutStatus(task, app, status)
 	}, retryOptions...)
 
 	// Once the retry budget or the wall-clock deadline is exhausted while still polling, surface the
@@ -258,6 +300,19 @@ func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err er
 	task.Status = finalStatus
 }
 
+// HandleImageNotPartOfApp fails the task immediately instead of letting it run out its
+// timeout waiting for an image the application will never have.
+func (monitor *DeploymentMonitor) HandleImageNotPartOfApp(task *models.Task, imageErr *ImageNotPartOfAppError) {
+	slog.Warn("App deployment failed: expected image is not part of the application.",
+		"image", imageErr.Image, "app", imageErr.App, "id", task.Id)
+	monitor.argo.metrics.AddFailedDeployment(task.App)
+
+	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, imageErr.Reason()); err != nil {
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
+	}
+	task.Status = models.StatusFailedMessage
+}
+
 func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
 	slog.Info("App is running on the expected version.", "id", task.Id)
 	monitor.argo.metrics.ResetFailedDeployment(task.App)
@@ -311,10 +366,49 @@ func handleApplicationFetchError(task models.Task, err error) error {
 	return err
 }
 
-// checkRolloutStatus checks if the application completed rollout successfully
-func checkRolloutStatus(task models.Task, application *models.Application, registryProxyUrl string, acceptSuspended bool) error {
-	status := application.GetRolloutStatus(task.ListImages(), registryProxyUrl, acceptSuspended)
+// shouldValidateDesiredImages reports whether the app has finished rolling out yet still
+// lacks an expected image. Only then is the image's absence worth investigating: while the
+// app is unsynced or unhealthy the image may still be on its way.
+func shouldValidateDesiredImages(app *models.Application, status string) bool {
+	return status == models.ArgoRolloutAppNotAvailable &&
+		app.Status.Sync.Status == "Synced" &&
+		app.Status.Health.Status == "Healthy"
+}
 
+// validateDesiredImages returns an *ImageNotPartOfAppError when an expected image is
+// provably absent from the application's desired state. Every uncertainty — the app
+// opted out, the lookup failed, or no images could be read — returns nil so the rollout
+// keeps polling; only positive proof of absence fails the task.
+func (monitor *DeploymentMonitor) validateDesiredImages(ctx context.Context, task models.Task, app *models.Application) error {
+	if app.IsImageValidationSkipped() {
+		return nil
+	}
+
+	resources, err := monitor.argo.api.GetManagedResources(ctx, task.App)
+	if err != nil {
+		slog.Debug("Could not fetch managed resources to validate images", "error", err, "id", task.Id)
+		return nil
+	}
+
+	desired := resources.DesiredImageNames()
+	if len(desired) == 0 {
+		slog.Debug("Application desired state declares no images; skipping validation", "id", task.Id)
+		return nil
+	}
+
+	for index := range task.Images {
+		name := helpers.ImageName(task.Images[index].Image)
+		if helpers.ImagesContains(desired, name, monitor.registryProxyUrl) {
+			continue
+		}
+		return &ImageNotPartOfAppError{App: task.App, Image: name, DesiredImages: desired}
+	}
+
+	return nil
+}
+
+// checkRolloutStatus checks if the application completed rollout successfully
+func checkRolloutStatus(task models.Task, application *models.Application, status string) error {
 	switch status {
 	case models.ArgoRolloutAppDegraded:
 		slog.Debug("Application is degraded", "id", task.Id)

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -1,0 +1,342 @@
+package argocd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// settledApp returns an application that finished rolling out without the expected image.
+func settledApp() *models.Application {
+	app := &models.Application{}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Healthy"
+	return app
+}
+
+// managedResources wraps target-state manifests in a managed-resources response.
+func managedResources(manifests ...string) *models.ManagedResources {
+	resources := &models.ManagedResources{}
+	for _, manifest := range manifests {
+		resources.Items = append(resources.Items, models.ManagedResource{TargetState: manifest})
+	}
+	return resources
+}
+
+// refreshMetrics returns a metrics mock tolerating the refresh timing a refreshed poll records.
+func refreshMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	metrics.EXPECT().ObserveRefreshDuration(gomock.Any(), gomock.Any()).AnyTimes()
+	return metrics
+}
+
+func deploymentWith(image string) string {
+	return `{"kind":"Deployment","spec":{"template":{"spec":{"containers":[{"image":"` + image + `"}]}}}}`
+}
+
+func TestShouldValidateDesiredImages(t *testing.T) {
+	tests := []struct {
+		name     string
+		sync     string
+		health   string
+		status   string
+		expected bool
+	}{
+		{"settledWithoutImage", "Synced", "Healthy", models.ArgoRolloutAppNotAvailable, true},
+		{"stillSyncing", "OutOfSync", "Healthy", models.ArgoRolloutAppNotAvailable, false},
+		{"stillProgressing", "Synced", "Progressing", models.ArgoRolloutAppNotAvailable, false},
+		{"imageAlreadyThere", "Synced", "Healthy", models.ArgoRolloutAppSuccess, false},
+		{"degraded", "Synced", "Degraded", models.ArgoRolloutAppDegraded, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := &models.Application{}
+			app.Status.Sync.Status = test.sync
+			app.Status.Health.Status = test.health
+			assert.Equal(t, test.expected, shouldValidateDesiredImages(app, test.status))
+		})
+	}
+}
+
+func TestValidateDesiredImages(t *testing.T) {
+	task := models.Task{
+		Id:     "task-id",
+		App:    "demo",
+		Images: []models.Image{{Image: "ghcr.io/shini4i/typo", Tag: "v1"}},
+	}
+
+	newMonitor := func(api ArgoApiInterface, registryProxyUrl string) *DeploymentMonitor {
+		return NewDeploymentMonitor(Argo{api: api}, registryProxyUrl, nil, false, time.Millisecond)
+	}
+
+	t.Run("failsWhenImageAbsentFromDesiredState", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(deploymentWith("ghcr.io/shini4i/app:v1")), nil)
+
+		err := newMonitor(api, "").validateDesiredImages(context.Background(), task, settledApp())
+
+		var imageErr *ImageNotPartOfAppError
+		require.ErrorAs(t, err, &imageErr)
+		assert.Equal(t, "ghcr.io/shini4i/typo", imageErr.Image)
+		assert.Equal(t, "demo", imageErr.App)
+		assert.Equal(t, []string{"ghcr.io/shini4i/app"}, imageErr.DesiredImages)
+	})
+
+	// The regression this whole check has to avoid: a CronJob that never fired contributes
+	// no image to the live pod set, but its manifest is part of the desired state.
+	t.Run("keepsWaitingWhenImageDeclaredButNotRunning", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		cronTask := task
+		cronTask.Images = []models.Image{{Image: "ghcr.io/shini4i/cleanup", Tag: "v2"}}
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(`{"kind":"CronJob","spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"image":"ghcr.io/shini4i/cleanup:v1"}]}}}}}}`), nil)
+
+		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), cronTask, settledApp()))
+	})
+
+	// The task's Image may already carry a tag; only the repository name is compared.
+	t.Run("ignoresTagOnTheRequestedImage", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		tagged := task
+		tagged.Images = []models.Image{{Image: "ghcr.io/shini4i/app:v1", Tag: "v2"}}
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(deploymentWith("ghcr.io/shini4i/app:v1")), nil)
+
+		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), tagged, settledApp()))
+	})
+
+	t.Run("reportsTheFirstImageMissingFromAMultiImageTask", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		multi := task
+		multi.Images = []models.Image{
+			{Image: "ghcr.io/shini4i/app", Tag: "v2"},
+			{Image: "ghcr.io/shini4i/typo", Tag: "v2"},
+		}
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(deploymentWith("ghcr.io/shini4i/app:v1")), nil)
+
+		err := newMonitor(api, "").validateDesiredImages(context.Background(), multi, settledApp())
+
+		var imageErr *ImageNotPartOfAppError
+		require.ErrorAs(t, err, &imageErr)
+		assert.Equal(t, "ghcr.io/shini4i/typo", imageErr.Image)
+	})
+
+	t.Run("matchesThroughRegistryProxy", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(deploymentWith("proxy.local/ghcr.io/shini4i/typo:v1")), nil)
+
+		assert.NoError(t, newMonitor(api, "proxy.local").validateDesiredImages(context.Background(), task, settledApp()))
+	})
+
+	t.Run("skipsWhenAppOptedOut", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		app := settledApp()
+		app.Metadata.Annotations = map[string]string{"argo-watcher/skip-image-validation": "true"}
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+
+		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), task, app))
+	})
+
+	t.Run("keepsWaitingWhenLookupFails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(nil, errors.New("unavailable"))
+
+		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), task, settledApp()))
+	})
+
+	t.Run("keepsWaitingWhenDesiredStateDeclaresNoImages", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mocks.NewMockArgoApiInterface(ctrl)
+		api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+			managedResources(`{"kind":"Service","spec":{"ports":[{"port":80}]}}`), nil)
+
+		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), task, settledApp()))
+	})
+}
+
+// TestWaitRolloutFailsFastOnImageNotPartOfApp verifies the poll loop aborts on the first
+// settled poll instead of burning the task's whole timeout, and that the desired-state
+// lookup happens only once.
+func TestWaitRolloutFailsFastOnImageNotPartOfApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	task := models.Task{
+		Id:      "task-id",
+		App:     "demo",
+		Timeout: 600,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/typo", Tag: "v1"}},
+	}
+
+	// Raw mock: newArgoApiMock's catch-all GetManagedResources would shadow the
+	// expectation this test is about.
+	api := mocks.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(settledApp(), nil).Times(1)
+	api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+		managedResources(deploymentWith("ghcr.io/shini4i/app:v1")), nil).Times(1)
+
+	monitor := NewDeploymentMonitor(
+		Argo{api: api, State: notSupersededState(ctrl), metrics: refreshMetrics(ctrl)},
+		"",
+		[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	monitor.refreshApp = true
+
+	_, err := monitor.WaitRollout(task)
+
+	var imageErr *ImageNotPartOfAppError
+	require.ErrorAs(t, err, &imageErr)
+}
+
+// TestWaitRolloutValidatesDesiredImagesOnce verifies an inconclusive lookup does not repeat
+// on every poll, and that the rollout keeps waiting.
+func TestWaitRolloutValidatesDesiredImagesOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	task := models.Task{
+		Id:      "task-id",
+		App:     "demo",
+		Timeout: 3,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/app", Tag: "v2"}},
+	}
+
+	// Raw mock: newArgoApiMock's catch-all GetManagedResources would shadow the
+	// expectation this test is about.
+	api := mocks.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(settledApp(), nil).MinTimes(2)
+	api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(nil, errors.New("unavailable")).Times(1)
+
+	monitor := NewDeploymentMonitor(
+		Argo{api: api, State: notSupersededState(ctrl), metrics: refreshMetrics(ctrl)},
+		"",
+		[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+	monitor.refreshApp = true
+
+	_, err := monitor.WaitRollout(task)
+	require.NoError(t, err)
+}
+
+// TestWaitRolloutSkipsValidationWithoutRefresh pins the safety condition: without a
+// refresh the app status and the desired state both come from ArgoCD's last
+// reconciliation, which may predate the commit that introduces the image, so the check
+// must not run and the rollout must keep polling.
+func TestWaitRolloutSkipsValidationWithoutRefresh(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	task := models.Task{
+		Id:      "task-id",
+		App:     "demo",
+		Timeout: 3,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/typo", Tag: "v1"}},
+	}
+
+	api := mocks.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	api.EXPECT().GetApplication(gomock.Any(), task.App, false).Return(settledApp(), nil).MinTimes(1)
+
+	monitor := NewDeploymentMonitor(
+		Argo{api: api, State: notSupersededState(ctrl)},
+		"",
+		[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)},
+		false,
+		time.Millisecond,
+	)
+
+	// No GetManagedResources expectation: any call is a failure.
+	_, err := monitor.WaitRollout(task)
+	require.NoError(t, err)
+}
+
+// TestHandleImageNotPartOfApp pins the terminal wiring: the task is marked failed with the
+// actionable reason and the failure is counted.
+func TestHandleImageNotPartOfApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	state := mocks.NewMockTaskRepository(ctrl)
+
+	monitor := NewDeploymentMonitor(Argo{metrics: metrics, State: state}, "", nil, false, time.Millisecond)
+	task := models.Task{Id: "task-id", App: "demo"}
+
+	var capturedReason string
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	monitor.HandleImageNotPartOfApp(&task, &ImageNotPartOfAppError{
+		App:           "demo",
+		Image:         "ghcr.io/shini4i/typo",
+		DesiredImages: []string{"ghcr.io/shini4i/app"},
+	})
+
+	assert.Equal(t, models.StatusFailedMessage, task.Status)
+	assert.Contains(t, capturedReason, `Image "ghcr.io/shini4i/typo" is not part of application "demo"`)
+	assert.Contains(t, capturedReason, "List of images defined in the application:")
+}
+
+func TestImageNotPartOfAppErrorReason(t *testing.T) {
+	err := &ImageNotPartOfAppError{
+		App:           "demo",
+		Image:         "ghcr.io/shini4i/typo",
+		DesiredImages: []string{"ghcr.io/shini4i/app", "ghcr.io/shini4i/cleanup"},
+	}
+
+	assert.Equal(t, `image "ghcr.io/shini4i/typo" is not part of application "demo"`, err.Error())
+
+	reason := err.Reason()
+	assert.Contains(t, reason, `Image "ghcr.io/shini4i/typo" is not part of application "demo"`)
+	assert.Contains(t, reason, "\tghcr.io/shini4i/app\n\tghcr.io/shini4i/cleanup")
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -153,7 +153,7 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 
 		switch taskInfo.Status {
 		case models.StatusFailedMessage:
-			return fmt.Errorf("The deployment has failed, please check logs.\n%s", taskInfo.StatusReason)
+			return fmt.Errorf("The deployment has failed. See the reason below.\n%s", taskInfo.StatusReason)
 		case models.StatusCancelledMessage:
 			return fmt.Errorf("The deployment was cancelled because a newer deployment superseded it.\n%s", taskInfo.StatusReason)
 		case models.StatusInProgressMessage:

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -28,6 +28,9 @@ var (
 	cancelledTaskId     = "be8c42c0-a645-11ec-8ea5-f2c4bb72758e"
 	abortedTaskId       = "be8c42c0-a645-11ec-8ea5-f2c4bb727590"
 	unhandledStatusId   = "be8c42c0-a645-11ec-8ea5-f2c4bb72758f"
+
+	failedTaskReason = "Application deployment failed. Image \"ghcr.io/shini4i/typo\" is not part of application \"demo\".\n\n" +
+		"List of images defined in the application:\n\tghcr.io/shini4i/app"
 )
 
 func addTaskHandler(w http.ResponseWriter, r *http.Request) {
@@ -86,11 +89,20 @@ func getTaskStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(models.TaskStatus{
-		Status: status,
-		Id:     taskId,
+		Status:       status,
+		Id:           taskId,
+		StatusReason: statusReason(status),
 	}); err != nil {
 		panic(err)
 	}
+}
+
+// statusReason mirrors the server attaching an actionable reason to a terminal status.
+func statusReason(status string) string {
+	if status == models.StatusFailedMessage {
+		return failedTaskReason
+	}
+	return ""
 }
 
 func TestAddTaskServerError(t *testing.T) {
@@ -430,7 +442,14 @@ func TestWaitForDeployment(t *testing.T) {
 		{
 			name:          "Failed deployment",
 			taskId:        failedTaskId,
-			expectedError: "The deployment has failed, please check logs.",
+			expectedError: "The deployment has failed. See the reason below.",
+		},
+		{
+			// The server's reason is the only place the actionable detail lives, so the
+			// client must print it verbatim rather than swallowing it.
+			name:          "Failed deployment surfaces the server reason",
+			taskId:        failedTaskId,
+			expectedError: `Image "ghcr.io/shini4i/typo" is not part of application "demo"`,
 		},
 		{
 			name:          "Application not found",

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -23,6 +23,20 @@ func ImagesContains(images []string, image string, registryProxy string) bool {
 	}
 }
 
+// ImageName returns the repository part of a container image reference, with any
+// tag and digest removed ("registry:5000/team/app:v1" -> "registry:5000/team/app").
+// A colon only introduces a tag when it appears after the last path separator, so a
+// registry host's port is preserved.
+func ImageName(reference string) string {
+	name, _, _ := strings.Cut(reference, "@")
+
+	if colon := strings.LastIndex(name, ":"); colon > strings.LastIndex(name, "/") {
+		name = name[:colon]
+	}
+
+	return name
+}
+
 // CurlCommandFromRequest renders an HTTP request as an equivalent cURL command
 // (method, headers, body, URL). The value of any header whose name matches
 // redactHeaders (case-insensitively) is replaced with "<redacted>" so secrets

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -42,6 +42,28 @@ func TestImageContains(t *testing.T) {
 	}
 }
 
+// TestImageName verifies that ImageName strips tags and digests while leaving a
+// registry host's port intact.
+func TestImageName(t *testing.T) {
+	tests := []struct {
+		reference string
+		expected  string
+	}{
+		{"nginx", "nginx"},
+		{"nginx:1.21.6", "nginx"},
+		{"ghcr.io/shini4i/argo-watcher:v0.13.0", "ghcr.io/shini4i/argo-watcher"},
+		{"registry.example.local:5000/team/app:v1", "registry.example.local:5000/team/app"},
+		{"registry.example.local:5000/team/app", "registry.example.local:5000/team/app"},
+		{"ghcr.io/shini4i/argo-watcher@sha256:" + strings.Repeat("a", 64), "ghcr.io/shini4i/argo-watcher"},
+		{"registry.example.local:5000/team/app:v1@sha256:" + strings.Repeat("b", 64), "registry.example.local:5000/team/app"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, ImageName(test.reference), "ImageName(%q)", test.reference)
+	}
+}
+
 // TestCurlCommandFromRequest verifies that CurlCommandFromRequest generates
 // a valid cURL command from an HTTP request with headers and body.
 func TestCurlCommandFromRequest(t *testing.T) {

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -22,6 +22,10 @@ const (
 	managedGitPath          = "argo-watcher/write-back-path"
 	managedGitFile          = "argo-watcher/write-back-filename"
 	fireAndForgetAnnotation = "argo-watcher/fire-and-forget"
+	// skipImageValidationAnnotation opts out of the desired-state image check for apps
+	// whose images it cannot see: used only by sync hooks (ArgoCD omits those resources),
+	// or named by a custom resource whose workload an operator creates out-of-band.
+	skipImageValidationAnnotation = "argo-watcher/skip-image-validation"
 )
 
 type ApplicationOperationResource struct {
@@ -379,6 +383,15 @@ func (app *Application) IsFireAndForgetModeActive() bool {
 		return false
 	}
 	return app.Metadata.Annotations[fireAndForgetAnnotation] == "true"
+}
+
+// IsImageValidationSkipped reports whether the app opted out of the desired-state
+// image check via the "argo-watcher/skip-image-validation=true" annotation.
+func (app *Application) IsImageValidationSkipped() bool {
+	if app.Metadata.Annotations == nil {
+		return false
+	}
+	return app.Metadata.Annotations[skipImageValidationAnnotation] == "true"
 }
 
 type Userinfo struct {

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -721,3 +721,23 @@ func TestIsFireAndForgetModeActive(t *testing.T) {
 		})
 	}
 }
+
+func TestIsImageValidationSkipped(t *testing.T) {
+	tt := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{"opted out", map[string]string{skipImageValidationAnnotation: "true"}, true},
+		{"explicitly enabled", map[string]string{skipImageValidationAnnotation: "false"}, false},
+		{"other annotations only", map[string]string{managedAnnotation: "true"}, false},
+		{"annotations are nil", nil, false},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			app := Application{Metadata: ApplicationMetadata{Annotations: tc.annotations}}
+			assert.Equal(t, tc.want, app.IsImageValidationSkipped())
+		})
+	}
+}

--- a/internal/models/managed_resources.go
+++ b/internal/models/managed_resources.go
@@ -19,16 +19,16 @@ type ManagedResources struct {
 }
 
 // ManagedResource carries a resource's desired manifest, JSON-serialized as rendered
-// from the application source. TargetState is empty for a resource that exists only
-// in the cluster.
+// from the application source. TargetState is the string "null" for a resource that
+// exists only in the cluster.
 type ManagedResource struct {
 	TargetState string `json:"targetState"`
 }
 
 // DesiredImageNames returns the sorted, de-duplicated repository names (tags and
 // digests stripped) of every container image declared in the application's desired
-// state. An item whose target state is empty or unparsable is skipped, so one bad
-// manifest never hides the images the rest of them declare.
+// state. An unreadable item is skipped rather than aborting the walk: ArgoCD marshals
+// every target state, so an item that fails to decode carries nothing to read anyway.
 func (resources *ManagedResources) DesiredImageNames() []string {
 	if resources == nil {
 		return nil

--- a/internal/models/managed_resources.go
+++ b/internal/models/managed_resources.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"encoding/json"
+	"slices"
+
+	"github.com/shini4i/argo-watcher/internal/helpers"
+)
+
+// ManagedResources is the response of ArgoCD's
+// /api/v1/applications/{name}/managed-resources endpoint: the desired state of every
+// resource the application manages. It is the only reliable answer to "does this image
+// belong to the application at all" — Application.Status.Summary.Images is derived
+// exclusively from live Pods, so a workload with no running pod (an untriggered CronJob,
+// a Deployment scaled to zero) is absent from it. ArgoCD filters hook resources out of
+// this response, so images used only by sync hooks are absent here.
+type ManagedResources struct {
+	Items []ManagedResource `json:"items"`
+}
+
+// ManagedResource carries a resource's desired manifest, JSON-serialized as rendered
+// from the application source. TargetState is empty for a resource that exists only
+// in the cluster.
+type ManagedResource struct {
+	TargetState string `json:"targetState"`
+}
+
+// DesiredImageNames returns the sorted, de-duplicated repository names (tags and
+// digests stripped) of every container image declared in the application's desired
+// state. An item whose target state is empty or unparsable is skipped, so one bad
+// manifest never hides the images the rest of them declare.
+func (resources *ManagedResources) DesiredImageNames() []string {
+	if resources == nil {
+		return nil
+	}
+
+	found := make(map[string]struct{})
+
+	for index := range resources.Items {
+		targetState := resources.Items[index].TargetState
+		if targetState == "" {
+			continue
+		}
+
+		var manifest any
+		if err := json.Unmarshal([]byte(targetState), &manifest); err != nil {
+			continue
+		}
+
+		collectImages(manifest, found)
+	}
+
+	names := make([]string, 0, len(found))
+	for name := range found {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	return names
+}
+
+// collectImages records the repository name of every string stored under an "image"
+// key, at any depth. Matching on the key alone rather than on known pod-template paths
+// keeps Deployments, CronJobs, Rollouts and image-bearing CRDs on one code path.
+// A stray match widens the accepted set, but it also makes the set non-empty, which is
+// what lets the caller conclude at all — see DesiredImageNames' callers for how an empty
+// set is treated.
+func collectImages(node any, found map[string]struct{}) {
+	switch value := node.(type) {
+	case map[string]any:
+		for key, child := range value {
+			if image, ok := child.(string); ok {
+				if key == "image" && image != "" {
+					found[helpers.ImageName(image)] = struct{}{}
+				}
+				continue
+			}
+			collectImages(child, found)
+		}
+	case []any:
+		for _, item := range value {
+			collectImages(item, found)
+		}
+	}
+}

--- a/internal/models/managed_resources_test.go
+++ b/internal/models/managed_resources_test.go
@@ -1,0 +1,101 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// resource builds a ManagedResource around a raw target-state manifest.
+func resource(targetState string) ManagedResource {
+	return ManagedResource{TargetState: targetState}
+}
+
+const deploymentManifest = `{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "spec": {
+    "template": {
+      "spec": {
+        "initContainers": [{"name": "wait", "image": "busybox:1.36"}],
+        "containers": [{"name": "app", "image": "ghcr.io/shini4i/app:v1"}]
+      }
+    }
+  }
+}`
+
+// cronJobManifest is the case argo-watcher must not get wrong: a CronJob that has
+// never fired contributes no image to the application's live pod set.
+const cronJobManifest = `{
+  "apiVersion": "batch/v1",
+  "kind": "CronJob",
+  "spec": {
+    "jobTemplate": {
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [{"name": "cleanup", "image": "ghcr.io/shini4i/cleanup:v1"}]
+          }
+        }
+      }
+    }
+  }
+}`
+
+const serviceManifest = `{"apiVersion": "v1", "kind": "Service", "spec": {"ports": [{"port": 80}]}}`
+
+// TestDesiredImageNamesCollectsWorkloadKinds verifies that images are extracted from
+// arbitrarily nested pod templates, that tags are stripped, and that duplicates are
+// collapsed into a single sorted list.
+func TestDesiredImageNamesCollectsWorkloadKinds(t *testing.T) {
+	resources := ManagedResources{Items: []ManagedResource{
+		resource(deploymentManifest),
+		resource(cronJobManifest),
+		resource(serviceManifest),
+		// A second workload repeating an image already seen must not duplicate it.
+		resource(deploymentManifest),
+	}}
+
+	assert.Equal(t, []string{
+		"busybox",
+		"ghcr.io/shini4i/app",
+		"ghcr.io/shini4i/cleanup",
+	}, resources.DesiredImageNames())
+}
+
+// TestDesiredImageNamesSkipsUnusableItems verifies that an unparsable or empty
+// target state is ignored rather than aborting the whole extraction — a single bad
+// manifest must not blind the check to the images it can read.
+func TestDesiredImageNamesSkipsUnusableItems(t *testing.T) {
+	resources := ManagedResources{Items: []ManagedResource{
+		resource(""),
+		resource("not json"),
+		resource(`{"kind": "Deployment", "spec": {"template": {"spec": {"containers": "not-a-list"}}}}`),
+		resource(`{"kind": "Deployment", "spec": {"template": {"spec": {"containers": [{"name": "no-image"}]}}}}`),
+		resource(deploymentManifest),
+	}}
+
+	assert.Equal(t, []string{"busybox", "ghcr.io/shini4i/app"}, resources.DesiredImageNames())
+}
+
+// TestDesiredImageNamesCollectsNonTemplateImages verifies that an image declared outside a
+// pod template — an operator CR is the common case — still counts as part of the application.
+func TestDesiredImageNamesCollectsNonTemplateImages(t *testing.T) {
+	resources := ManagedResources{Items: []ManagedResource{
+		resource(`{"kind":"Workflow","spec":{"templates":[{"container":{"image":"ghcr.io/shini4i/step:v1"}}]}}`),
+		// An "image" key holding an object, not a reference, must not be recorded.
+		resource(`{"kind":"ConfigMap","data":{"image":{"repository":"ignored"}}}`),
+	}}
+
+	assert.Equal(t, []string{"ghcr.io/shini4i/step"}, resources.DesiredImageNames())
+}
+
+// TestDesiredImageNamesEmpty verifies that an application whose manifests declare no
+// images yields an empty list, which callers treat as "cannot conclude".
+func TestDesiredImageNamesEmpty(t *testing.T) {
+	resources := ManagedResources{Items: []ManagedResource{resource(serviceManifest)}}
+	assert.Empty(t, resources.DesiredImageNames())
+
+	empty := ManagedResources{}
+	assert.Empty(t, empty.DesiredImageNames())
+}

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -13,6 +13,7 @@
 #   task=<json>            deploy payload (app/author/project/timeout/images)  (required)
 #   token=<0|1>            send the deploy token (enables write-back); default 1
 #   expect=<substring>     a substring that MUST appear in the client output (repeatable)
+#   max_seconds=<n>        optional: the client must return within n seconds
 #   setup / teardown       optional: names of functions run before/after the scenario
 # The runner runs the client, captures its combined output + exit code, and greps.
 #
@@ -121,10 +122,31 @@ scenario_failed_presync_hook() {
 setup_failed_presync_hook()    { "${here}/hook-fixture.sh" add app3; return; }
 teardown_failed_presync_hook() { "${here}/hook-fixture.sh" remove app3; restore_good_tag app3; return; }
 
+# An image name the app never declares must fail RIGHT AWAY (issue #519) instead of burning
+# the task timeout. token=0 keeps the app green and synced, which is exactly the state the
+# desired-state check requires. max_seconds guards the point of the feature: the generous
+# timeout below must NOT be waited out.
+#
+# Contrast with scenario_unvalidated_not_available above, which uses the app's REAL image name
+# with an unreachable tag — that one must still wait, because the name is in the desired state.
+#
+# Depends on the lab leaving ARGO_REFRESH_APP at its default (true): the check is skipped
+# without a refresh, and this scenario would then wait out its timeout and trip max_seconds.
+scenario_image_not_part_of_app() {
+  echo "task={\"app\":\"app2\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":120,\"images\":[{\"image\":\"ghcr.io/shini4i/not-in-this-app\",\"tag\":\"v1\"}]}"
+  echo "token=0"
+  echo "expect=is not part of application"
+  echo "expect=List of images defined in the application:"
+  echo "expect=${IMAGE}"
+  echo "max_seconds=60"
+  return
+}
+
 SCENARIOS=(
   scenario_bad_image
   scenario_unvalidated_not_available
   scenario_failed_presync_hook
+  scenario_image_not_part_of_app
 )
 
 # --- runner -----------------------------------------------------------------
@@ -135,12 +157,15 @@ for scenario in "${SCENARIOS[@]}"; do
   token=$(sed -n 's/^token=//p' <<<"$spec"); token="${token:-1}"
   setup=$(sed -n 's/^setup=//p' <<<"$spec")
   teardown=$(sed -n 's/^teardown=//p' <<<"$spec")
+  max_seconds=$(sed -n 's/^max_seconds=//p' <<<"$spec")
   mapfile -t expects < <(sed -n 's/^expect=//p' <<<"$spec")
 
   [[ -n "$setup" ]] && { echo "  setup: $setup"; "$setup"; }
 
+  started=$(date +%s)
   out=$(scenario_client "$task" "$token"); rc=$?
-  echo "  client exit=${rc}"
+  elapsed=$(( $(date +%s) - started ))
+  echo "  client exit=${rc} elapsed=${elapsed}s"
   # shellcheck disable=SC2001  # per-line prefix needs a regex anchor; ${//} can't do it
   echo "  client output: $(sed 's/^/    | /' <<<"$out")"
 
@@ -152,6 +177,14 @@ for scenario in "${SCENARIOS[@]}"; do
       bad "client output missing «${want}»"
     fi
   done
+
+  if [[ -n "$max_seconds" ]]; then
+    if [[ "$elapsed" -le "$max_seconds" ]]; then
+      ok "client returned in ${elapsed}s (<= ${max_seconds}s)"
+    else
+      bad "client took ${elapsed}s, expected <= ${max_seconds}s"
+    fi
+  fi
 
   [[ -n "$teardown" ]] && { echo "  teardown: $teardown"; "$teardown"; }
 done


### PR DESCRIPTION
A task whose image the application never defines stayed active until its timeout expired, since the image could never appear. It now fails as soon as the application is synced and healthy without it, reporting the images the application does define.

The check reads the desired state from ArgoCD's managed-resources endpoint rather than Status.Summary.Images, which ArgoCD derives exclusively from live Pods: a workload with no pod yet (an untriggered CronJob, a Deployment scaled to zero) is absent from it and would otherwise look like a missing image.

Every uncertainty keeps polling as before — only positive proof of absence fails the task. The check needs a refreshed application, so it is skipped when ARGO_REFRESH_APP or a task's refresh override is off; without one the desired state may predate the commit that introduces the image. It is also skipped on a failed lookup, on an empty image set, and for applications annotated with argo-watcher/skip-image-validation, which covers images ArgoCD never reports as part of the desired state: those used only by sync hooks, and those named by a custom resource whose workload an operator creates out-of-band.

Closes #519