### PR TITLE
fix(web): keep the status pill counts consistent across tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message now defers to the server's reason, which may point at the application or at
   the deployment request itself.
 
+### Fixed
+
+- The status pills above the recent-tasks list now report the same numbers on every
+  tab and reload together with the list. Selecting "In progress" or "Failed" used to
+  drop the "All" count to the number of tasks matching the selected status — 0 on a
+  tab whose status had none — and the per-status counts were fetched once and never
+  refreshed, so a pill could keep claiming a task was in progress after it finished.
+  While the counts are still loading, the pills show `—` rather than `0`.
+
 ## [0.13.0] - 2026-07-30
 
 ### Added

--- a/web/src/features/tasks/components/RecentTasksToolbar.test.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.test.tsx
@@ -7,6 +7,17 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Task } from '../../../data/types';
 import { RecentTasksToolbar } from './RecentTasksToolbar';
 
+// useRefresh needs a QueryClientProvider ancestor; stub just that hook so the
+// toolbar can render against a bare ListContextProvider. Its invalidate-and-
+// refetch semantics — what makes the status counts reload with the list — come
+// from ra-core/react-query and are out of reach at this level.
+const refreshMock = vi.fn();
+
+vi.mock('react-admin', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-admin')>()),
+  useRefresh: () => refreshMock,
+}));
+
 vi.mock('./ApplicationFilter', () => ({
   ApplicationFilter: ({ value, onChange }: { value: string; onChange: (next: string) => void }) => (
     <input
@@ -117,13 +128,14 @@ const renderToolbar = (initialEntry: string, filterValues: Record<string, unknow
     </MemoryRouter>,
   );
 
-  return { setFilters, refetch, ...result };
+  return { setFilters, ...result };
 };
 
 describe('RecentTasksToolbar', () => {
   beforeEach(() => {
     capturedLocation = undefined;
     localStorage.clear();
+    refreshMock.mockReset();
     taskListContextState.searchQuery = '';
     taskListContextState.setSearchQuery.mockReset();
   });
@@ -170,11 +182,10 @@ describe('RecentTasksToolbar', () => {
     expect(params.has('app')).toBe(false);
   });
 
-  it('forwards manual refresh to refetch', () => {
-    const { refetch } = renderToolbar('/');
-    refetch.mockClear();
+  it('delegates manual refresh to react-admin useRefresh', () => {
+    renderToolbar('/');
     fireEvent.click(screen.getByRole('button', { name: /refresh now/i }));
-    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
   it('writes filterValues.status when a status tab is selected', async () => {

--- a/web/src/features/tasks/components/RecentTasksToolbar.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Stack } from '@mui/material';
-import { useListContext } from 'react-admin';
+import { useListContext, useRefresh } from 'react-admin';
 import {
   ApplicationFilter,
   normalizeApplicationFilterValue,
@@ -36,8 +36,12 @@ const SCHEMA: FilterStateSchema<RecentFiltersValues> = {
 
 /** Toolbar with status tabs, application filter, search, and the refresh control. */
 export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?: string }) => {
-  const { data, refetch } = useListContext<Task>();
+  const { data } = useListContext<Task>();
   const records = useMemo(() => (Array.isArray(data) ? data : []), [data]);
+  // Refresh every active query, not just the list: the status pills are backed
+  // by their own useGetList, so the list's `refetch` would leave their counts
+  // frozen at whatever the first load saw.
+  const handleRefresh = useRefresh();
 
   const { values, applied, apply } = useFilterState<RecentFiltersValues>({
     storageKey,
@@ -60,17 +64,6 @@ export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?
     },
     [apply, values],
   );
-
-  const handleRefresh = useCallback(() => {
-    const result = refetch?.();
-    if (result && typeof (result as Promise<unknown>).catch === 'function') {
-      (result as Promise<unknown>).catch(error => {
-        if (import.meta.env.DEV) {
-          console.warn('RecentTasksToolbar refresh failed', error);
-        }
-      });
-    }
-  }, [refetch]);
 
   const chips: FilterChipDescriptor[] = [];
   if (applied.app) {

--- a/web/src/features/tasks/components/StatusTabs.test.tsx
+++ b/web/src/features/tasks/components/StatusTabs.test.tsx
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StatusTabs } from './StatusTabs';
 
 const useGetListMock = vi.fn();
+const listContext: { total: number; filterValues: Record<string, unknown> } = {
+  total: 412,
+  filterValues: { app: 'demo' },
+};
 
 vi.mock('react-admin', () => ({
-  useListContext: () => ({ total: 412, filterValues: { app: 'demo' } }),
+  useListContext: () => listContext,
   useGetList: (...args: unknown[]) => useGetListMock(...args),
 }));
 
@@ -25,16 +29,34 @@ const sampleData = [
 
 describe('StatusTabs', () => {
   beforeEach(() => {
+    listContext.total = 412;
+    listContext.filterValues = { app: 'demo' };
     useGetListMock.mockReset();
-    useGetListMock.mockReturnValue({ data: sampleData });
+    useGetListMock.mockReturnValue({ data: sampleData, total: sampleData.length });
   });
+
+  // The count renders inside the tab button, so each tab's accessible name is
+  // "<label> <count>" — asserting on the whole name pins a number to its pill.
+  const expectTabCounts = (all: string, inProgress: string, failed: string) => {
+    expect(screen.getByRole('tab', { name: `All ${all}` })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: `In progress ${inProgress}` })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: `Failed ${failed}` })).toBeInTheDocument();
+  };
 
   it('renders three tabs with their counts', () => {
     render(<StatusTabs value={null} onChange={() => {}} />);
-    expect(screen.getByRole('tab', { name: /All/ })).toBeInTheDocument();
-    expect(screen.getByText('412')).toBeInTheDocument(); // All
-    expect(screen.getByText('3')).toBeInTheDocument(); // In progress
-    expect(screen.getByText('7')).toBeInTheDocument(); // Failed
+    expectTabCounts('11', '3', '7');
+  });
+
+  it('keeps every count independent of the selected status tab', () => {
+    // The list context reports only the tasks matching the active status
+    // filter; every pill must come from the status-agnostic count query.
+    listContext.total = 7;
+    listContext.filterValues = { app: 'demo', status: 'failed' };
+
+    render(<StatusTabs value="failed" onChange={() => {}} />);
+
+    expectTabCounts('11', '3', '7');
   });
 
   it('marks the active tab as selected', () => {
@@ -58,7 +80,8 @@ describe('StatusTabs', () => {
   });
 
   it('issues a single useGetList query inheriting parent filters minus status', () => {
-    render(<StatusTabs value={null} onChange={() => {}} />);
+    listContext.filterValues = { app: 'demo', status: 'failed' };
+    render(<StatusTabs value="failed" onChange={() => {}} />);
     expect(useGetListMock).toHaveBeenCalledTimes(1);
     const [resource, params] = useGetListMock.mock.calls[0];
     expect(resource).toBe('tasks');
@@ -67,38 +90,41 @@ describe('StatusTabs', () => {
     expect(params.pagination).toEqual({ page: 1, perPage: 1000 });
   });
 
-  it('shows zero counts when no data is loaded yet', () => {
+  it('shows a placeholder instead of zero when no snapshot has loaded yet', () => {
     useGetListMock.mockReturnValue({ data: undefined });
     render(<StatusTabs value={null} onChange={() => {}} />);
-    const counts = screen.getAllByText('0');
-    expect(counts.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('—')).toHaveLength(3);
+    expect(screen.queryByText('0')).toBeNull();
   });
 
   it('appends "+" to status counts when the loaded page is truncated', () => {
     useGetListMock.mockReturnValue({ data: sampleData, total: 5000 });
     render(<StatusTabs value={null} onChange={() => {}} />);
 
-    // Status pills surface the lower-bound suffix; the All pill comes from
-    // useListContext.total and stays exact.
-    expect(screen.getByText('3+')).toBeInTheDocument(); // In progress
-    expect(screen.getByText('7+')).toBeInTheDocument(); // Failed
-    expect(screen.getByText('412')).toBeInTheDocument(); // All — no "+"
-    expect(screen.queryByText('412+')).toBeNull();
+    // Status pills surface the lower-bound suffix; the All pill is the query's
+    // own total and stays exact.
+    expectTabCounts('5000', '3+', '7+');
+    expect(screen.queryByText('5000+')).toBeNull();
   });
 
   it('does not suffix counts when data.length matches total', () => {
     useGetListMock.mockReturnValue({ data: sampleData, total: sampleData.length });
     render(<StatusTabs value={null} onChange={() => {}} />);
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('7')).toBeInTheDocument();
+    expectTabCounts('11', '3', '7');
     expect(screen.queryByText('3+')).toBeNull();
   });
 
-  it('does not suffix loading-state counts when data is undefined', () => {
+  it('keeps the placeholder when a total arrives without rows', () => {
     useGetListMock.mockReturnValue({ data: undefined, total: 5000 });
     render(<StatusTabs value={null} onChange={() => {}} />);
-    const counts = screen.getAllByText('0');
-    expect(counts.length).toBeGreaterThan(0);
+    expect(screen.getAllByText('—')).toHaveLength(3);
     expect(screen.queryByText('0+')).toBeNull();
+  });
+
+  it('renders a genuine zero once a snapshot with no matching tasks loads', () => {
+    useGetListMock.mockReturnValue({ data: [], total: 0 });
+    render(<StatusTabs value={null} onChange={() => {}} />);
+    expect(screen.getAllByText('0')).toHaveLength(3);
+    expect(screen.queryByText('—')).toBeNull();
   });
 });

--- a/web/src/features/tasks/components/StatusTabs.tsx
+++ b/web/src/features/tasks/components/StatusTabs.tsx
@@ -23,30 +23,32 @@ const TABS: ReadonlyArray<TabSpec> = [
   { id: 'failed', label: 'Failed', statusFilter: 'failed' },
 ];
 
+// staleTime only dedupes mounts and tab switches: the toolbar's refresh
+// invalidates the query, and invalidation refetches regardless of staleTime, so
+// this is not a ceiling on how often the wide page below is fetched.
 const STATUS_QUERY_OPTS = {
   staleTime: 30_000,
   retry: false,
   refetchOnWindowFocus: false,
 } as const;
 
-/**
- * Single `useGetList` call (no status filter) with a wide page so we can
- * group statuses client-side. Cached for 30 s. When the deployment has more
- * tasks than `perPage`, `data.length < total` and the returned `truncated`
- * flag tells the caller to append a "+" so the user knows the pill is a
- * lower bound rather than an exact count.
- */
+/** Page size of the count query — the ceiling on client-side status grouping. */
 const TASK_COUNT_PAGE_SIZE = 1000;
 
 interface StatusCountSnapshot {
+  /** Task count for the parent filters with the status filter ignored. */
+  readonly total: number;
   readonly counts: Map<string, number>;
+  /** True when the counts are lower bounds because the page cut the result set. */
   readonly truncated: boolean;
+  /** True until the first snapshot lands, so pills can avoid claiming zero. */
+  readonly unavailable: boolean;
 }
 
 /**
- * Strips the status entry from the parent list filter so per-status counts
- * reflect every status (instead of only the currently selected pill) while
- * still respecting the user's app/time-range filters.
+ * Strips the status entry from the parent list filter so all counts reflect
+ * every status (instead of only the currently selected pill) while still
+ * respecting the user's app/time-range filters.
  */
 const dropStatusFilter = (filter: Record<string, unknown>): Record<string, unknown> => {
   if (!('status' in filter)) return filter;
@@ -55,10 +57,18 @@ const dropStatusFilter = (filter: Record<string, unknown>): Record<string, unkno
   return next;
 };
 
+/**
+ * Counts tasks per status from a single `useGetList` call that inherits the
+ * parent list's filters minus `status`, so one query feeds every pill.
+ *
+ * `total` is the backend's own count and stays exact whatever the page size.
+ * The per-status counts are grouped from the fetched rows, so a result set wider
+ * than `TASK_COUNT_PAGE_SIZE` makes them lower bounds and sets `truncated`.
+ */
 const useTaskStatusCounts = (): StatusCountSnapshot => {
   const { filterValues } = useListContext<Task>();
   // Re-issue the count query whenever the parent's non-status filters change so
-  // counts stay scoped to the same tasks the All pill reports via listTotal.
+  // every pill stays scoped to the same set of tasks.
   const filter = useMemo(
     () => dropStatusFilter((filterValues ?? {}) as Record<string, unknown>),
     [filterValues],
@@ -75,25 +85,34 @@ const useTaskStatusCounts = (): StatusCountSnapshot => {
       if (!task.status) return;
       counts.set(task.status, (counts.get(task.status) ?? 0) + 1);
     });
-    const truncated = Array.isArray(data) && typeof total === 'number' && data.length < total;
-    return { counts, truncated };
+    const resolvedTotal = typeof total === 'number' ? total : 0;
+    const loaded = Array.isArray(data);
+    const truncated = loaded && data.length < resolvedTotal;
+    return { total: resolvedTotal, counts, truncated, unavailable: !loaded };
   }, [data, total]);
 };
+
+// A pending or failed count query must not render as "0" — that reads as "no
+// such tasks" next to a populated grid. `retry` is off, so a failed first fetch
+// keeps the placeholder until the next refresh; once a snapshot has landed,
+// react-query keeps it and later failures leave the last known counts on screen.
+const COUNT_UNAVAILABLE = '—';
 
 const formatCount = (n: number, truncated: boolean) => (truncated ? `${n}+` : String(n));
 
 /**
- * Pill-tab row for filtering the recent list by status. The "All" total comes
- * from the parent list context; per-status counts come from one cached
- * `useGetList` query that we group by status in memory.
+ * Pill-tab row for filtering the recent list by status. Every count — "All"
+ * included — comes from one cached `useGetList` query that ignores the status
+ * filter, so selecting a pill never rewrites the other pills' numbers. The
+ * parent list context is deliberately not used for "All": its total honours the
+ * active status filter and would read 0 on a tab whose status has no tasks.
  */
 export const StatusTabs = ({ value, onChange }: StatusTabsProps) => {
   const theme = useTheme();
-  const { total: listTotal = 0 } = useListContext<Task>();
-  const { counts: statusCounts, truncated } = useTaskStatusCounts();
+  const { total, counts: statusCounts, truncated, unavailable } = useTaskStatusCounts();
 
   const counts: Record<string, number> = {
-    all: listTotal,
+    all: total,
     'in progress': statusCounts.get('in progress') ?? 0,
     failed: statusCounts.get('failed') ?? 0,
   };
@@ -115,9 +134,9 @@ export const StatusTabs = ({ value, onChange }: StatusTabsProps) => {
       {TABS.map(tab => {
         const isActive = (value ?? null) === (tab.id ?? null);
         const count = counts[tab.id ?? 'all'] ?? 0;
-        // The "All" pill comes from useListContext.total which is exact for
-        // the visible page; only the status-grouped pills are subject to the
-        // perPage truncation, so don't suffix the All count with "+".
+        // The "All" pill is the query's own total, which is exact regardless of
+        // perPage; only the status-grouped pills are counted from the fetched
+        // rows and thus subject to truncation, so only they get the "+".
         const showTruncation = tab.id !== null && truncated;
         const isDark = theme.palette.mode === 'dark';
         const activeBg = isDark ? theme.palette.background.paper : tokens.surface;
@@ -149,9 +168,14 @@ export const StatusTabs = ({ value, onChange }: StatusTabsProps) => {
               transition: 'background-color 150ms ease, color 150ms ease',
             }}
           >
-            {tab.label}
+            {/* Whitespace-only text nodes generate no flex item, so this
+                separates label from count in the accessible name only. */}
+            {tab.label}{' '}
             <Typography
               component="span"
+              // The placeholder glyph is announced as "em dash" at best, so give
+              // screen readers the reason for the missing number instead.
+              aria-label={unavailable ? 'count unavailable' : undefined}
               sx={{
                 fontFamily: tokens.fontMono,
                 fontSize: 11,
@@ -162,7 +186,7 @@ export const StatusTabs = ({ value, onChange }: StatusTabsProps) => {
                 color: isActive ? tokens.accent : 'inherit',
               }}
             >
-              {formatCount(count, showTruncation)}
+              {unavailable ? COUNT_UNAVAILABLE : formatCount(count, showTruncation)}
             </Typography>
           </button>
         );

--- a/web/src/features/tasks/components/TaskListLayout.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.test.tsx
@@ -44,9 +44,12 @@ const {
   };
 });
 
+const refreshMock = vi.fn();
+
 vi.mock('react-admin', () => ({
   List: ListMock,
   Pagination: PaginationMock,
+  useRefresh: () => refreshMock,
   // SearchFilteredView + TaskListLayout body both read useListContext; expose a
   // mutable stub so individual tests can drive the empty/populated branches.
   useListContext: () => listContextRef.current,
@@ -65,6 +68,7 @@ describe('TaskListLayout', () => {
     listCalls.length = 0;
     listContextRef.current = { data: [] };
     readPersistentPerPageMock.mockReset();
+    refreshMock.mockReset();
   });
 
   it('fills react-admin list props and renders header content when provided', () => {
@@ -199,8 +203,10 @@ describe('TaskListLayout', () => {
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
 
+    // Retry must reload every active query: the toolbar's status counts come
+    // from their own query, and a list-only refetch would leave them stuck.
     screen.getByRole('button', { name: 'Retry' }).click();
-    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the populated grid (not the error panel) when a refetch fails with rows already loaded', () => {

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -1,6 +1,6 @@
 import { Children, isValidElement, type ReactNode } from 'react';
 import { Box, Stack } from '@mui/material';
-import { List, Pagination, useListContext, type ListProps } from 'react-admin';
+import { List, Pagination, useListContext, useRefresh, type ListProps } from 'react-admin';
 import { PerPagePersistence, readPersistentPerPage } from '../../../shared/hooks/usePersistentPerPage';
 import { EmptyState, EmptyStateCta } from './EmptyState';
 import { SearchFilteredView } from './SearchFilteredView';
@@ -40,6 +40,8 @@ interface TaskListLayoutProps {
  * there is nothing to show. react-admin keeps the previously loaded rows across
  * a refetch, so a transient auto-refresh failure keeps the populated grid (the
  * error is surfaced via react-admin's notification) instead of blanking it.
+ * Its retry reloads every active query so the header's status counts recover
+ * along with the rows.
  */
 const ListBody = ({
   emptyComponent,
@@ -48,8 +50,12 @@ const ListBody = ({
   emptyComponent: ReactNode | false;
   children: ReactNode;
 }) => {
-  const { isPending, total, filterValues, error, refetch } = useListContext();
+  const { isPending, total, filterValues, error } = useListContext();
   const hasFilters = Object.keys(filterValues ?? {}).length > 0;
+  // Retry has to reload every active query, not just the list: the toolbar's
+  // status counts come from their own query, and a list-only refetch would
+  // repopulate the grid while the pills stayed stuck on the failed fetch.
+  const refresh = useRefresh();
 
   if (error && !isPending && total === 0) {
     return (
@@ -57,7 +63,7 @@ const ListBody = ({
         icon="error"
         title="Couldn’t load tasks"
         description="The request failed or timed out. Check that the server is reachable, then try again."
-        cta={<EmptyStateCta label="Retry" onClick={() => refetch()} />}
+        cta={<EmptyStateCta label="Retry" onClick={refresh} />}
       />
     );
   }


### PR DESCRIPTION
The "All" pill read the list context total, which honours the active status filter, so selecting "In progress" or "Failed" made it report that status' count instead of everything — 0 on a tab whose status had no tasks. All three pills now come from the single count query that drops the status filter, with "All" taking that query's own total, exact regardless of page size.

That count query was also fetched once and never again: refresh reloaded only the list query, leaving a pill able to claim a task was in progress long after it finished. The toolbar refresh and the error state's retry now invalidate every active query, so the counts reload with the rows.

Until the first count snapshot lands the pills render an em dash rather than 0, which would otherwise read as "no such tasks" beside a populated grid.