### PR TITLE
fix(web): stop long tags and project urls from breaking their layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   refreshed, so a pill could keep claiming a task was in progress after it finished.
   While the counts are still loading, the pills show `—` rather than `0`.
 
+- An image tag in the recent-tasks list no longer spills out of its badge. A tag
+  containing a hyphen, such as `895-public`, could break after the hyphen and draw its
+  second half below the badge; tags now stay on one line. A tag too long to fit is
+  trimmed with an ellipsis instead of squeezing the image name out of the column, and
+  the untrimmed value is available as a tooltip.
+
+- On the task details page, a project that is a URL now starts on its own line below
+  the `PROJECT` label instead of running on from it, and a long URL wraps rather than
+  overflowing the card.
+
 ## [0.13.0] - 2026-07-30
 
 ### Added

--- a/web/src/features/tasks/components/ImagesCell.test.tsx
+++ b/web/src/features/tasks/components/ImagesCell.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { ImagesCell, stripRegistryPrefix } from './ImagesCell';
+import { ImagesCell, stripRegistryPrefix, TAG_MAX_WIDTH } from './ImagesCell';
 
 describe('stripRegistryPrefix', () => {
   it('strips ghcr.io/<org>/ prefixes', () => {
@@ -70,5 +70,30 @@ describe('ImagesCell', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: '+1 more' }));
     expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('keeps a hyphenated tag on one line instead of shrinking its badge', () => {
+    render(<ImagesCell images={[{ image: 'web-frontend', tag: '895-public' }]} />);
+
+    const badge = screen.getByText('895-public');
+    expect(badge).toHaveStyle({ whiteSpace: 'nowrap', flexShrink: '0' });
+  });
+
+  it('trims an over-long tag and keeps the full value in the tooltip', () => {
+    const tag = 'release-a-very-long-build-identifier';
+    render(<ImagesCell images={[{ image: 'web-frontend', tag }]} />);
+
+    const badge = screen.getByText(tag);
+    expect(badge).toHaveStyle({
+      // inline-flex would ignore text-overflow and clip the tag mid-character.
+      display: 'inline-block',
+      maxWidth: `${TAG_MAX_WIDTH}px`,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      // With inline-block the line-height, not flex alignment, centers the text.
+      height: '18px',
+      lineHeight: '18px',
+    });
+    expect(badge).toHaveAttribute('title', tag);
   });
 });

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -19,7 +19,14 @@ interface ImageRowProps {
   readonly image: Image;
 }
 
-/** Single repo + tag-chip row, rendered identically for primary and expanded entries. */
+/** Widest, in px, a tag badge may grow before its label is trimmed with an ellipsis. */
+export const TAG_MAX_WIDTH = 120;
+
+/**
+ * Single repo + tag-chip row, rendered identically for primary and expanded entries.
+ * The tag badge never wraps or shrinks — a hyphenated tag would otherwise break after
+ * the hyphen and spill out of the fixed-height pill. The full tag stays in the tooltip.
+ */
 const ImageRow = ({ image }: ImageRowProps) => (
   <Stack
     direction="row"
@@ -34,6 +41,7 @@ const ImageRow = ({ image }: ImageRowProps) => (
         fontFamily: tokens.fontMono,
         fontSize: 11.5,
         color: 'text.primary',
+        minWidth: 0,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
@@ -44,10 +52,18 @@ const ImageRow = ({ image }: ImageRowProps) => (
     </Typography>
     <Box
       component="span"
+      title={image.tag}
       sx={{
-        display: 'inline-flex',
-        alignItems: 'center',
+        // inline-block, not inline-flex: text-overflow is ignored on a flex
+        // container, which clips the tag mid-character instead of ellipsizing.
+        display: 'inline-block',
+        flexShrink: 0,
+        maxWidth: TAG_MAX_WIDTH,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
         height: 18,
+        lineHeight: '18px',
         padding: '0 6px',
         borderRadius: tokens.radiusPill,
         backgroundColor: tokens.accentSoft,

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -113,6 +113,71 @@ describe('TaskShow', () => {
     expect(screen.getByRole('button', { name: /Refresh/i })).toBeInTheDocument();
   });
 
+  describe('project field', () => {
+    it('renders a plain project as text', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ project: 'demo' }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+      expect(screen.getByText('demo')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'demo' })).not.toBeInTheDocument();
+    });
+
+    it('starts the project link on its own line below the label', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ project: 'https://project.example.com/' }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+
+      // An inline value such as a link would otherwise share the label's line.
+      const label = screen.getByText('Project');
+      expect(label).toHaveStyle({ display: 'block' });
+      expect(label.nextElementSibling).toBe(
+        screen.getByRole('link', { name: 'project.example.com' }),
+      );
+    });
+
+    it('falls back to an em-dash when the task has no project', async () => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ project: '' }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+
+      expect(screen.getByText('Project').nextElementSibling).toHaveTextContent('—');
+      expect(screen.queryByRole('link', { name: /project/i })).not.toBeInTheDocument();
+    });
+
+    it('wraps a long project url instead of overflowing the card', async () => {
+      const project = 'https://a-very-long-project-hostname.example.com/some/deep/path';
+      mockUseGetOne.mockReturnValue({
+        data: buildTask({ project }),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+
+      await renderWithRouter('/task/task-1');
+
+      const link = screen.getByRole('link', {
+        name: 'a-very-long-project-hostname.example.com/some/deep/path',
+      });
+      expect(link).toHaveAttribute('href', project);
+      expect(link).toHaveStyle({ overflowWrap: 'anywhere' });
+    });
+  });
+
   describe('rollback details', () => {
     it('does not render the rollback field for a regular deployment', async () => {
       mockUseGetOne.mockReturnValue({

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -573,12 +573,15 @@ interface InfoFieldProps {
 
 /**
  * Displays a single piece of labeled metadata inside the task details view.
+ * The label is block-level so that an inline value node, such as a link, still
+ * starts on its own line below it.
  */
 const InfoField = ({ label, value }: InfoFieldProps) => (
   <Box>
     <Typography
       variant="caption"
       sx={{
+        display: 'block',
         color: 'text.secondary',
         textTransform: 'uppercase',
         letterSpacing: 0.6,
@@ -610,7 +613,12 @@ const ProjectReference = ({ project }: { project?: string | null }) => {
     label = label.slice(0, -1);
   }
   return (
-    <Link href={project} target="_blank" rel="noopener noreferrer">
+    <Link
+      href={project}
+      target="_blank"
+      rel="noopener noreferrer"
+      sx={{ overflowWrap: 'anywhere' }}
+    >
       {label}
     </Link>
   );


### PR DESCRIPTION
The image tag badge in the tasks list was a shrinkable flex item, so a tag containing a hyphen could break after the hyphen and draw its second line outside the fixed-height pill. It no longer shrinks or wraps; a tag too long to fit is capped at 120px and trimmed with an ellipsis, keeping the untrimmed value in a tooltip, so the image name ellipsizes instead of being squeezed out. The pill is inline-block rather than inline-flex because text-overflow is ignored on a flex container.

On the task details page the InfoField label was an inline element, so a value rendered as a link shared the label's line instead of starting below it. The label is now block-level, which covers the project URL and the rollback target link, and a long project URL wraps rather than overflowing the card.