### PR TITLE
fix(server): stop logging an absent task timeout as non-positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The client no longer tells you to check the logs for every failed deployment. The
   message now defers to the server's reason, which may point at the application or at
   the deployment request itself.
+- A deployment that carries no `timeout` no longer logs that the task timeout is
+  "non-positive", which read as a rejected value even though omitting the field is the
+  normal case for clients that leave `TASK_TIMEOUT` unset. Debug logs now say the
+  instance default is in use. A genuinely negative `timeout` is a malformed request and
+  is logged as a warning, naming the value that was ignored.
 
 ### Fixed
 
@@ -50,13 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tab whose status had none — and the per-status counts were fetched once and never
   refreshed, so a pill could keep claiming a task was in progress after it finished.
   While the counts are still loading, the pills show `—` rather than `0`.
-
 - An image tag in the recent-tasks list no longer spills out of its badge. A tag
   containing a hyphen, such as `895-public`, could break after the hyphen and draw its
   second half below the badge; tags now stay on one line. A tag too long to fit is
   trimmed with an ellipsis instead of squeezing the image name out of the column, and
   the untrimmed value is available as a tooltip.
-
 - On the task details page, a project that is a URL now starts on its own line below
   the `PROJECT` label instead of running on from it, and a long URL wraps rather than
   overflowing the card.

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -20,7 +20,7 @@ The Argo Watcher client is a lightweight CLI tool distributed as a Docker image 
 | `ARGO_WATCHER_DEPLOY_TOKEN` | Deploy token for Git image override (required when using the built-in GitOps updater)            |
 | `BEARER_TOKEN`              | JWT for authentication. Set the raw token (e.g. `eyJhbGci...`) so it is maskable as a GitLab CI variable; a legacy `Bearer <token>` value is still accepted. |
 | `TIMEOUT`                   | HTTP request timeout (e.g. `60s`, `2m`)                                                         |
-| `TASK_TIMEOUT`              | Maximum time (in seconds) to wait for a task to complete                                        |
+| `TASK_TIMEOUT`              | Maximum time (in seconds) to wait for a task to complete; unset keeps the server's `DEPLOYMENT_TIMEOUT` |
 | `TASK_REFRESH`              | Override the server's refresh setting for this deployment (`true`/`false`); unset keeps the server default |
 | `RETRY_INTERVAL`            | Interval between status polling attempts (e.g. `15s`, `1m`)                                    |
 | `EXPECTED_DEPLOY_TIME`      | Expected deployment duration; affects polling behavior (e.g. `15m`, `30m`)                     |

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -1,13 +1,17 @@
 package argocd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1778,6 +1782,133 @@ func TestDeploymentMonitor_configureRetryOptions(t *testing.T) {
 		assert.Equal(t, 5, attempts, "Should use the configured defaultAttempts when timeout is zero")
 		assert.Equal(t, 5*ArgoSyncRetryDelay, deadline, "Default-attempts deadline should be attempts*delay")
 	})
+}
+
+// TestDeploymentMonitor_configureRetryOptionsLogging pins the log severity for a missing
+// versus a malformed per-task timeout. Omitting "timeout" is the common case for clients
+// that never set TASK_TIMEOUT, so it must stay at debug; a negative value is a bad request
+// and has to be visible at warn level.
+func TestDeploymentMonitor_configureRetryOptionsLogging(t *testing.T) {
+	newMonitor := func() *DeploymentMonitor {
+		monitor := NewDeploymentMonitor(
+			Argo{},
+			"",
+			[]retry.Option{retry.DelayType(retry.FixedDelay), retry.Delay(0)},
+			false,
+			ArgoSyncRetryDelay,
+		)
+		monitor.defaultAttempts = 61
+		return monitor
+	}
+
+	t.Run("missingTimeoutLogsAtDebug", func(t *testing.T) {
+		logs := captureDebugLogs(t)
+
+		newMonitor().configureRetryOptions(models.Task{Id: "test-id", Timeout: 0})
+
+		record := findLogRecord(t, logs, "No per-task timeout override, using the instance default")
+		assert.Equal(t, "DEBUG", record["level"])
+		assert.Equal(t, float64(61), record["attempts"], "the substituted budget must be visible")
+		assert.Equal(t, "test-id", record["id"])
+		assert.NotContains(t, logs.String(), "Ignoring negative task timeout")
+	})
+
+	t.Run("negativeTimeoutLogsAtWarn", func(t *testing.T) {
+		logs := captureDebugLogs(t)
+
+		newMonitor().configureRetryOptions(models.Task{Id: "test-id", Timeout: -5})
+
+		record := findLogRecord(t, logs, "Ignoring negative task timeout, falling back to the instance default")
+		assert.Equal(t, "WARN", record["level"])
+		assert.Equal(t, float64(-5), record["timeout_seconds"], "the rejected value must be named")
+		assert.Equal(t, float64(61), record["attempts"])
+		assert.Equal(t, "test-id", record["id"], "the warning is only actionable with the task id")
+	})
+
+	// A timeout that is set must keep taking the override path at debug: mis-scoping the
+	// new condition would warn on every normal deployment while leaving the attempt math
+	// — and therefore every other test here — untouched.
+	t.Run("positiveTimeoutLogsOverrideAtDebug", func(t *testing.T) {
+		logs := captureDebugLogs(t)
+
+		newMonitor().configureRetryOptions(models.Task{Id: "test-id", Timeout: 30})
+
+		record := findLogRecord(t, logs, "Overriding task timeout")
+		assert.Equal(t, "DEBUG", record["level"])
+		assert.Equal(t, float64(30), record["timeout_seconds"])
+		assert.NotContains(t, logs.String(), "Ignoring negative task timeout")
+		assert.NotContains(t, logs.String(), "No per-task timeout override")
+	})
+}
+
+// findLogRecord returns the captured JSON log record whose "msg" equals want, failing the
+// test when none matches. Matching per record keeps a level assertion tied to the message
+// it describes, rather than to whatever else shared the global logger during the test.
+func findLogRecord(t *testing.T, logs *logBuffer, want string) map[string]any {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record), "captured log line is not JSON: %s", line)
+		if record["msg"] == want {
+			return record
+		}
+	}
+
+	require.FailNowf(t, "log record not found", "no record with msg %q in:\n%s", want, logs.String())
+	return nil
+}
+
+// captureDebugLogs redirects the default logger into a buffer at debug level for the
+// duration of the test, verifying the capture is live before returning so an assertion
+// on the buffer cannot pass vacuously.
+//
+// Not safe under t.Parallel: it swaps the process-global default logger, so anything
+// else running concurrently in this binary logs into the same buffer. Assert on the
+// specific message, not on a bare level. Call it after registering any cleanup that
+// logs: t.Cleanup runs LIFO, so registering the capture last restores the real logger
+// before that cleanup logging runs.
+func captureDebugLogs(t *testing.T) *logBuffer {
+	t.Helper()
+
+	logs := &logBuffer{}
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	slog.Debug("capture-live")
+	require.Contains(t, logs.String(), "capture-live", "debug log capture is not working")
+	logs.reset()
+
+	return logs
+}
+
+// logBuffer is a concurrency-safe io.Writer holding everything the logger emitted.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// String returns everything captured so far.
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *logBuffer) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -246,7 +246,16 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 	}
 
 	if task.Timeout <= 0 {
-		slog.Debug("Task timeout is non-positive, defaulting to a fixed attempt count", "attempts", defaultAttempts, "id", task.Id)
+		// A zero timeout is the norm: the field is omitted whenever a client leaves TASK_TIMEOUT
+		// unset, so it stays at debug. A negative one can only come from a malformed request and
+		// is worth surfacing.
+		if task.Timeout < 0 {
+			slog.Warn("Ignoring negative task timeout, falling back to the instance default",
+				"timeout_seconds", task.Timeout, "attempts", defaultAttempts, "id", task.Id)
+		} else {
+			slog.Debug("No per-task timeout override, using the instance default",
+				"attempts", defaultAttempts, "id", task.Id)
+		}
 		return append(retryOptions, retry.Attempts(defaultAttempts)), helpers.MulDurationSaturating(defaultAttempts, delay)
 	}
 


### PR DESCRIPTION
Task.Timeout is an int with `omitempty`, so a deployment that does not set `TASK_TIMEOUT` — the normal case — arrives as 0 and took the same branch as a negative value, logging "Task timeout is non-positive" on every task. The message read like a rejected request even though the instance default was being applied correctly.

The absent case now logs that the instance default is in use, at debug. A negative timeout can only come from a malformed request, so it is logged as a warning naming the value that was ignored and the attempt budget substituted for it. Attempt-count and deadline computation are unchanged.

The client reference now states that leaving `TASK_TIMEOUT` unset keeps the server's `DEPLOYMENT_TIMEOUT`, which is the ambiguity the log line exposed.