### PR TITLE
fix(web): tick the tasks-table duration while a task is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The Duration column of the tasks table now counts up while a deployment is in
+  progress, instead of showing `0s` until the task reaches a final status.
+
 ## [0.14.0] - 2026-08-04
 
 ### Added

--- a/web/src/features/tasks/components/DurationField.test.tsx
+++ b/web/src/features/tasks/components/DurationField.test.tsx
@@ -3,6 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Task } from '../../../data/types';
 import { DurationField } from './DurationField';
 
+// getBrowserWindow is redirected so the ticker-lifecycle cases can observe
+// setInterval/clearInterval directly. It defaults to the real window, which the
+// fake timers already patch, so the text-based cases below behave normally.
+let browserWindow: Window | { setInterval: unknown; clearInterval: unknown } | undefined;
+
+vi.mock('../../../shared/utils', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../shared/utils')>()),
+  getBrowserWindow: () => browserWindow,
+}));
+
 const baseRecord: Task = {
   id: 'task-1',
   app: 'api',
@@ -18,6 +28,7 @@ describe('DurationField', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    browserWindow = globalThis.window;
   });
 
   afterEach(() => {
@@ -31,8 +42,7 @@ describe('DurationField', () => {
 
   it('ticks every second while the task is in progress', async () => {
     const startUnix = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
-    const record: Task = { ...baseRecord, created: startUnix, status: 'in progress' };
-    record.updated = null as unknown as number;
+    const record: Task = { ...baseRecord, created: startUnix, updated: 0, status: 'in progress' };
 
     render(<DurationField record={record} />);
     expect(screen.getByText('0s')).toBeInTheDocument();
@@ -41,5 +51,126 @@ describe('DurationField', () => {
       vi.advanceTimersByTime(3000);
     });
     expect(screen.getByText('3s')).toBeInTheDocument();
+  });
+
+  it('ticks while in progress even though the backend stamps updated on creation', async () => {
+    const startUnix = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
+    const record: Task = {
+      ...baseRecord,
+      created: startUnix,
+      updated: startUnix,
+      status: 'in progress',
+    };
+
+    render(<DurationField record={record} />);
+    expect(screen.getByText('0s')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('5s')).toBeInTheDocument();
+  });
+
+  it('ignores updated for in-progress tasks and keeps counting from created', async () => {
+    const startUnix = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
+    const record: Task = {
+      ...baseRecord,
+      created: startUnix - 120,
+      updated: startUnix - 60,
+      status: 'in progress',
+    };
+
+    render(<DurationField record={record} />);
+    expect(screen.getByText('2m 00s')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('2m 01s')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder when a finished task has no updated timestamp', () => {
+    render(<DurationField record={{ ...baseRecord, status: 'deployed', updated: 0 }} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('keeps the duration stable over time for completed tasks', async () => {
+    render(<DurationField record={{ ...baseRecord, status: 'deployed', updated: 130 }} />);
+    expect(screen.getByText('30s')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('30s')).toBeInTheDocument();
+  });
+
+  it('freezes the duration once the task reaches a final status', async () => {
+    const startUnix = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
+    const record: Task = {
+      ...baseRecord,
+      created: startUnix,
+      updated: startUnix,
+      status: 'in progress',
+    };
+
+    const { rerender } = render(<DurationField record={record} />);
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText('3s')).toBeInTheDocument();
+
+    rerender(
+      <DurationField record={{ ...record, status: 'deployed', updated: startUnix + 3 }} />,
+    );
+    expect(screen.getByText('3s')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('3s')).toBeInTheDocument();
+  });
+
+  it('clamps to 0s when the browser clock is behind the server', async () => {
+    const startUnix = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
+    const record: Task = {
+      ...baseRecord,
+      created: startUnix + 30,
+      updated: startUnix + 30,
+      status: 'in progress',
+    };
+
+    render(<DurationField record={record} />);
+    expect(screen.getByText('0s')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('0s')).toBeInTheDocument();
+  });
+
+  describe('ticker lifecycle', () => {
+    const setIntervalMock = vi.fn();
+    const clearIntervalMock = vi.fn();
+
+    beforeEach(() => {
+      setIntervalMock.mockReset().mockReturnValue(7);
+      clearIntervalMock.mockReset();
+      browserWindow = { setInterval: setIntervalMock, clearInterval: clearIntervalMock };
+    });
+
+    it('registers a one-second interval for an in-progress task and clears it on unmount', () => {
+      const { unmount } = render(
+        <DurationField record={{ ...baseRecord, status: 'in progress' }} />,
+      );
+      expect(setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+      unmount();
+      expect(clearIntervalMock).toHaveBeenCalledWith(7);
+    });
+
+    it('never registers an interval for a task in a final status', () => {
+      render(<DurationField record={{ ...baseRecord, status: 'deployed', updated: 130 }} />);
+      expect(setIntervalMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/features/tasks/components/DurationField.tsx
+++ b/web/src/features/tasks/components/DurationField.tsx
@@ -27,20 +27,26 @@ const useNowTicker = (enabled: boolean, intervalMs: number = 1000) => {
 
 /**
  * Live-updating duration in compact monospace form ("1m 04s").
- * In-progress tasks tick every second; completed tasks render statically.
+ *
+ * In-progress tasks tick every second and measure against the current time
+ * rather than `updated`: the backend stamps `updated` at creation and rewrites it
+ * only on a status change, so an in-progress task always has `updated == created`
+ * and deriving the duration from it would pin the cell at "0s". Tasks in a final
+ * status render statically from the stored `updated` timestamp, and show "—" when
+ * the API omits it because the end of such a task is unknowable.
  */
 export const DurationField = ({ record }: DurationFieldProps) => {
-  const inProgress = record.status === 'in progress' && !record.updated;
+  const inProgress = record.status === 'in progress';
   const now = useNowTicker(inProgress);
-  const effectiveUpdated = record.updated ?? (inProgress ? Math.floor(now / 1000) : record.created);
-  const seconds = Math.max(0, effectiveUpdated - record.created);
+  const endSeconds = inProgress ? Math.floor(now / 1000) : record.updated;
+  const seconds = endSeconds ? Math.max(0, endSeconds - record.created) : null;
 
   return (
     <Typography
       variant="body2"
       sx={{ fontFamily: tokens.fontMono, fontSize: 11.5, fontVariantNumeric: 'tabular-nums' }}
     >
-      {formatDurationCompact(seconds)}
+      {seconds === null ? '—' : formatDurationCompact(seconds)}
     </Typography>
   );
 };


### PR DESCRIPTION
The Duration column showed "0s" for the entire lifetime of an in-progress deployment. The live ticker was gated on `!record.updated`, but the backend stamps `updated` at creation and rewrites it only on a status change, so an in-progress task always has `updated == created` and the gate never armed.

Gate the ticker on the status instead, and measure in-progress tasks against the current time. A finished task whose `updated` is absent now renders "—" rather than a misleading "0s".