### PR TITLE
feat(server): require a credential on read endpoints when OIDC is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- `GET /api/v1/config` no longer discloses the notification settings
-  (`webhook`, `mattermost`), the lockdown schedule or the TLS verification posture.
-  That endpoint cannot be authenticated — the Web UI reads the OIDC issuer and client
-  id from it before it can hold a token — and a notification webhook URL is itself a
-  credential.
+- `GET /api/v1/config` no longer discloses how to reach a notification receiver: the
+  `webhook` and `mattermost` blocks are reduced to their `enabled` flag. That endpoint
+  cannot be authenticated — the Web UI reads the OIDC issuer and client id from it
+  before it can hold a token — and a webhook URL is itself a credential. Every other
+  field, including the `enabled` flags, is unchanged.
 
 ## [0.14.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- With OIDC authentication enabled, the read endpoints the Web UI consumes —
+  `GET /api/v1/tasks`, `/version`, `/reachability` and `GET /deploy-lock` — now
+  require a credential. Being signed in is enough; membership of
+  `OIDC_PRIVILEGED_GROUPS` remains necessary only for managing the deployment lock.
+  A deploy token or a CI JWT is accepted as well, so pipelines can read too.
+  Deployments are unaffected: `POST /api/v1/tasks` keeps its optional-credential
+  behaviour, and `GET /api/v1/tasks/{id}` — the lookup the client polls, which
+  presents no credential — stays open, guarded by the unguessable task id. With OIDC
+  disabled nothing changes.
+
+  `/ws` also stays open, because a browser cannot attach a header to a WebSocket
+  handshake. It carries deployment-lock and Argo CD reachability transitions — the
+  same signals `GET /deploy-lock` and `/reachability` now require a credential for —
+  so gating those endpoints narrows that exposure rather than closing it.
+- A new `unauthenticated_reads` counter (labelled by `path`) reports how many reads
+  still arrive without a credential on the endpoints left open on purpose. It reaching
+  zero is the evidence needed before those can be closed too.
+
+### Changed
+
+- Read authorization is no longer sent to the OIDC provider on every request: a
+  decision is reused for `OIDC_TOKEN_VALIDATION_INTERVAL`, capped by the token's own
+  expiry, so an open browser tab costs one userinfo call per token per interval
+  instead of one per refresh. Privileged actions (managing the deployment lock) still
+  re-verify against the provider every time, so removing a user from a privileged
+  group takes effect immediately.
+
+  `OIDC_TOKEN_VALIDATION_INTERVAL` is now honoured — previous releases parsed it and
+  never used it — and its default is `300000` ms (5 minutes). A deployment that set
+  the variable explicitly will see its value take effect for the first time; one
+  relying on the default gets 5-minute reuse for reads.
+- A request whose credential could not be checked because the OIDC provider was
+  unreachable now returns `503 Service Unavailable` instead of `401 Unauthorized`.
+  The Web UI treats a 401 as a dead session and signs the user out, so a brief
+  provider outage no longer logs everyone out.
+
 ### Fixed
 
 - The Duration column of the tasks table now counts up while a deployment is in
   progress, instead of showing `0s` until the task reaches a final status.
+
+### Security
+
+- `GET /api/v1/config` no longer discloses the notification settings
+  (`webhook`, `mattermost`), the lockdown schedule or the TLS verification posture.
+  That endpoint cannot be authenticated — the Web UI reads the OIDC issuer and client
+  id from it before it can hold a token — and a notification webhook URL is itself a
+  credential.
 
 ## [0.14.0] - 2026-08-04
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -256,7 +256,7 @@ The Web UI lockdown banner updates automatically (within a few seconds) when a s
 ### Manual Lockdown
 
 !!! note
-    Manual locking requires OIDC authentication (`OIDC_ENABLED=true`; the legacy `KEYCLOAK_ENABLED=true` still works). Without an auth backend the server does not register the `POST`/`DELETE /api/v1/deploy-lock` endpoints (requests return `404 Not Found`) and the Web UI does not show the lock toggle. The read-only lock status and scheduled lockdown (above) work regardless of authentication. See [OIDC / SSO Integration](oidc.md).
+    Manual locking requires OIDC authentication (`OIDC_ENABLED=true`; the legacy `KEYCLOAK_ENABLED=true` still works). Without an auth backend the server does not register the `POST`/`DELETE /api/v1/deploy-lock` endpoints (requests return `404 Not Found`) and the Web UI does not show the lock toggle. Scheduled lockdown (above) works regardless of authentication. Reading the lock status needs no privileged group, but with OIDC enabled it does need a credential — see [Protected endpoints](oidc.md#protected-endpoints). See also [OIDC / SSO Integration](oidc.md).
 
 #### Via API
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -8,10 +8,63 @@ When OIDC integration is enabled:
 
 1. Users are redirected to the provider's login page before they can view any tasks in the Web UI.
 2. The user's token is validated by the Argo Watcher backend by calling the provider's **userinfo** endpoint, which the backend discovers automatically from the issuer's [discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html) (`<issuer>/.well-known/openid-configuration`).
-3. Users who belong to one of the configured **privileged groups** see a **Redeploy** button on the task details page and can manage the [deployment lock](gitops-updater.md#deployment-locking).
+3. The backend **requires a credential on its read endpoints** — being signed in is enough, no group membership needed. See [Protected endpoints](#protected-endpoints).
+4. Users who belong to one of the configured **privileged groups** see a **Redeploy** button on the task details page and can manage the [deployment lock](gitops-updater.md#deployment-locking).
+
+With OIDC disabled, every endpoint stays open exactly as before — there is no auth backend to validate against.
 
 !!! note
     The backend discovers the userinfo endpoint lazily, on the first token validation — not at startup — so a provider that is briefly unreachable when Argo Watcher boots does not prevent it from starting.
+
+## Protected endpoints
+
+Enabling OIDC closes the endpoints only the Web UI consumes. Nothing else reads
+them, so no deployment pipeline is affected.
+
+| Endpoint | With OIDC enabled |
+|----------|-------------------|
+| `GET /api/v1/tasks` | Credential required |
+| `GET /api/v1/version` | Credential required |
+| `GET /api/v1/reachability` | Credential required |
+| `GET /api/v1/deploy-lock` | Credential required |
+| `POST`/`DELETE /api/v1/deploy-lock` | Credential required **and** privileged group |
+| `POST /api/v1/tasks` | Unchanged — optional credential (governs git write-back) |
+| `GET /api/v1/tasks/{id}` | **Open** — see below |
+| `GET /api/v1/config` | **Open** — the Web UI reads the issuer and client id from it before it can obtain a token |
+| `/healthz`, `/metrics` | **Open** — probes and Prometheus cannot perform an OIDC flow |
+| `/ws` | **Open** — a browser cannot attach a header to a WebSocket handshake. Carries lock and reachability transitions only |
+
+Any configured credential is accepted on the reads: an OIDC session, the
+`ARGO_WATCHER_DEPLOY_TOKEN`, or a [JWT](gitops-updater.md#jwt-configuration).
+Read access is deliberately **not** limited to `OIDC_PRIVILEGED_GROUPS` — that gate
+applies to the deploy lock only.
+
+!!! warning "`GET /api/v1/tasks/{id}` and `/ws` are not protected"
+    The Argo Watcher client polls `GET /api/v1/tasks/{id}` for the whole length of
+    every deployment and presents its credential only when submitting the task, so
+    requiring one for that lookup would break every pipeline at once. The task id is
+    a random v4 UUID returned only to the submitter, and the enumerable
+    `GET /api/v1/tasks` list is protected, so the exposure is limited to callers that
+    already hold a task id — but a task id appearing in a CI log or a webhook payload
+    is enough to read that task's app, author, project, images and status. The
+    `unauthenticated_reads` metric reports how many such reads still arrive
+    without a credential; see
+    [Tracking the read-auth migration](../operations/observability.md#tracking-the-read-auth-migration).
+
+    `/ws` broadcasts deployment-lock and Argo CD reachability transitions (no task
+    data crosses the socket). Those are the same two signals `GET /api/v1/deploy-lock`
+    and `GET /api/v1/reachability` now require a credential for, so anyone who can
+    open a WebSocket can still observe them: gating the REST endpoints narrows that
+    exposure rather than closing it. Restrict network access to the server
+    accordingly.
+
+### If the provider is unreachable
+
+A read whose credential could not be checked because the provider itself is
+unreachable returns **503 Service Unavailable**, not 401. The Web UI treats a 401 as
+a dead session and signs the user out, so a brief provider outage must not be
+reported as an authentication failure. Cached decisions (see
+`OIDC_TOKEN_VALIDATION_INTERVAL` below) keep working during the outage.
 
 ## Prerequisites
 
@@ -38,13 +91,31 @@ The following environment variables control the OIDC integration:
 | `OIDC_ENABLED`                   | Enable OIDC authentication                                               | `false` | No          |
 | `OIDC_ISSUER_URL`                | The provider's issuer URL (used for discovery)                           |         | Conditional |
 | `OIDC_CLIENT_ID`                 | Client ID registered with the provider                                   |         | Conditional |
-| `OIDC_TOKEN_VALIDATION_INTERVAL` | Interval (in milliseconds) between token validations                     | `10000` | No          |
+| `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (in milliseconds) a provider decision about a token may be reused | `300000` | No          |
 | `OIDC_PRIVILEGED_GROUPS`         | Comma-separated list of groups with elevated permissions                 |         | Conditional |
 
 All `Conditional` variables are required when `OIDC_ENABLED` is set to `true`.
 
+### `OIDC_TOKEN_VALIDATION_INTERVAL`
+
+Every authorization decision is made by asking the provider's userinfo endpoint
+about the token. Since the Web UI refreshes on a timer, doing that per request
+would turn each open browser tab into a steady stream of provider traffic, so a
+decision is reused for this interval — one userinfo call per token per interval,
+regardless of how many requests arrive.
+
+The interval is the upper bound on how stale a **read** authorization can be. Each
+decision is additionally capped by the token's own expiry, so it can never outlive
+the credential it describes. Setting it to `0` validates every request against the
+provider.
+
+Privileged actions — managing the deployment lock — are exempt: they always
+re-verify against the provider, so removing a user from `OIDC_PRIVILEGED_GROUPS`
+takes effect immediately rather than within the interval. A lock click is a rare
+human action, so the extra round trip costs nothing.
+
 !!! note
-    `OIDC_TOKEN_VALIDATION_INTERVAL` is in milliseconds. The default of `10000` checks token validity every 10 seconds.
+    The default is `300000` (5 minutes), matched to typical access-token lifetimes.
 
 ### The issuer URL
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -12,7 +12,7 @@ scrape_configs:
 
 ## Exposed metrics
 
-The server emits ten metrics today, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go).
+The server emits eleven metrics today, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
@@ -26,6 +26,7 @@ The server emits ten metrics today, all defined in [`internal/prometheus/metrics
 | `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting to acquire the per-repository git write-back lock. High values mean tasks are queued behind concurrent write-backs to the same repo. |
 | `deployment_duration_seconds` | histogram | `app` | End-to-end wall-clock time of a successful deployment, from the start of rollout monitoring until the app reached the deployed state. Only successful deployments are observed (a failure's duration is dominated by the timeout). |
 | `gitops_batch_size` | histogram | (none) | Number of applications coalesced into a single batch write-back flush. Only observed when `GIT_BATCH_WRITEBACK` is enabled; a distribution skewed toward 1 means little batching is happening (low contention). See the [GitOps Updater](../guides/gitops-updater.md#batch-write-back) guide. |
+| `unauthenticated_reads` | counter | `path` | Reads served without a credential on the endpoints deliberately left open while OIDC auth is enabled (currently `GET /api/v1/tasks/{id}`). Zero only when every caller presents a credential. See [Tracking the read-auth migration](#tracking-the-read-auth-migration). |
 
 In addition, the standard Go runtime metrics from the Prometheus client library are exposed (`go_*`, `process_*`).
 
@@ -160,6 +161,26 @@ sum(rate(processed_deployments[1h])) by (app)
 ```
 
 A graph panel showing deployment frequency per application — useful for capacity planning and identifying applications that suddenly stop deploying.
+
+## Tracking the read-auth migration
+
+With [OIDC authentication](../guides/oidc.md) enabled, the browser-facing reads
+require a credential, but `GET /api/v1/tasks/{id}` stays open: the Argo Watcher
+client polls it for the whole length of every deployment and sends its credential
+only on submission, so requiring one there would break every pipeline still
+running an older client. The `unauthenticated_reads` counter measures how much of
+your fleet that still is:
+
+```promql
+sum(rate(unauthenticated_reads[1h])) by (path)
+```
+
+Every pipeline that upgrades to a client sending its credential on reads drops out
+of this figure. When it reaches zero and stays there across a full deployment
+cycle for every project, no caller depends on the exemption any more.
+
+Nothing is logged per request — the endpoint is polled continuously during a
+deployment, so a log line per read would bury everything else.
 
 ## Where to look next
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -175,7 +175,7 @@ metadata:
 - The lock state cannot be read at all — see [All deployments rejected as locked, but nobody set a lock](#all-deployments-rejected-as-locked-but-nobody-set-a-lock).
 
 **How to verify:**
-- Read the current state: `curl $ARGO_WATCHER_URL/api/v1/deploy-lock` (no authentication needed).
+- Read the current state: `curl -H "Oidc-Authorization: $OIDC_TOKEN" $ARGO_WATCHER_URL/api/v1/deploy-lock` (with OIDC enabled any credential works and no privileged group is needed; with OIDC disabled the header can be omitted).
 - Check the response code of the release itself:
   ```bash
   curl -i -X DELETE -H "Oidc-Authorization: $OIDC_TOKEN" $ARGO_WATCHER_URL/api/v1/deploy-lock

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,14 +12,23 @@ https://argo-watcher.example.com/api/v1
 
 ## Authentication
 
-Authentication is only required to authorize the built-in [GitOps Updater](../guides/gitops-updater.md)'s git write-back. Provide one of:
+Credentials serve two purposes: authorizing the built-in [GitOps Updater](../guides/gitops-updater.md)'s git write-back, and — when [OIDC authentication](../guides/oidc.md) is enabled — reading the API at all. Provide one of:
 
 - **Deploy token** — Pass the `ARGO_WATCHER_DEPLOY_TOKEN` value in the header of the same name.
 - **JWT token** — Pass the JWT in the `Authorization` header. The raw token is accepted directly (e.g. `Authorization: eyJhbGci...`); a `Bearer <token>` value is also accepted for backward compatibility.
+- **OIDC session** — Pass the access token in the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` name is still accepted).
+
+### Read access
+
+With OIDC **disabled** — the default — every endpoint is readable without a credential.
+
+With OIDC **enabled**, the endpoints the Web UI consumes require one: `GET /api/v1/tasks`, `/version`, `/reachability` and `/deploy-lock`. Any of the credentials above is accepted; group membership is not required for reads. Three endpoints stay deliberately open — `GET /api/v1/tasks/{id}` (the lookup the client polls, guarded only by the unguessable task id), `GET /api/v1/config` (the Web UI bootstraps its login from it), and `/ws`. See [Protected endpoints](../guides/oidc.md#protected-endpoints) for the full table and the caveats.
+
+A read rejected for a missing or invalid credential returns `401 Unauthorized`. A read whose credential could not be checked because the OIDC provider was unreachable returns `503 Service Unavailable` — the distinction exists so a provider outage does not read as a dead session.
 
 A task submitted **without** a credential is still accepted (`202 Accepted`) and its rollout is monitored normally — argo-watcher simply does not perform the git write-back. It also cannot cancel a deployment that was submitted with one: superseding only applies to in-flight tasks that presented no more authority than the new task, so an uncredentialed submission can never abort a credentialed deployment's write-back. This is the expected setup when the image tag is updated by other means (e.g. Argo CD Image Updater or your CI pipeline) and argo-watcher only tracks the resulting rollout. If you instead rely on the built-in updater to commit the tag and omit the credential, the write-back is skipped and the deployment times out waiting for an image change that never arrives. A token that is **present but invalid or expired** returns `401 Unauthorized`.
 
-The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [OIDC authentication](../guides/oidc.md) is enabled, and require a session belonging to one of the `OIDC_PRIVILEGED_GROUPS` (sent via the `Oidc-Authorization` header; the legacy `Keycloak-Authorization` header is still accepted); when OIDC is disabled these endpoints are not exposed (`404 Not Found`). The read-only `GET /api/v1/deploy-lock` is always available regardless of authentication.
+The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [OIDC authentication](../guides/oidc.md) is enabled, and require a session belonging to one of the `OIDC_PRIVILEGED_GROUPS` (sent via the `Oidc-Authorization` header; the legacy `Keycloak-Authorization` header is still accepted); when OIDC is disabled these endpoints are not exposed (`404 Not Found`). The read-only `GET /api/v1/deploy-lock` needs no privileged group, but with OIDC enabled it does need a credential like the other reads above.
 
 ## Conventions
 

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -42,7 +42,7 @@ These variables control authentication and optional features. See the linked gui
 |-----------------------------|------------------------------------------------------------------------------|---------|-------------|
 | `ARGO_WATCHER_DEPLOY_TOKEN` | Shared token for validating client requests. See [GitOps Updater](../guides/gitops-updater.md). |         | No          |
 | `JWT_SECRET`                | Secret key for signing and validating JWT tokens. See [GitOps Updater](../guides/gitops-updater.md#jwt-configuration). |         | No          |
-| `OIDC_ENABLED`              | Enable OIDC authentication (Keycloak, Authentik, …). See [OIDC / SSO Integration](../guides/oidc.md). The legacy `KEYCLOAK_*` variables remain honored but are deprecated. | `false` | No          |
+| `OIDC_ENABLED`              | Enable OIDC authentication (Keycloak, Authentik, …). Also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The legacy `KEYCLOAK_*` variables remain honored but are deprecated. | `false` | No          |
 | `WEBHOOK_ENABLED`           | Enable webhook notifications. See [Notifications](../guides/notifications.md).         | `false` | No          |
 | `LOCKDOWN_SCHEDULE`         | Recurring deployment lock schedule. See [Deployment Locking](../guides/gitops-updater.md#deployment-locking). |         | No          |
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,15 +15,6 @@ type AuthStrategy interface {
 	Validate(token string) (bool, error)
 }
 
-// Authenticatable is implemented by strategies that distinguish authentication
-// from authorization — currently OIDC, where Validate additionally demands
-// privileged-group membership. A strategy without a group concept (the deploy
-// token, a CI JWT) does not implement it: possession of a valid token is both its
-// authentication and its authorization, so Validate answers both questions.
-type Authenticatable interface {
-	Authenticate(token string) error
-}
-
 // Authenticator coordinates multiple AuthStrategy implementations against an HTTP request.
 type Authenticator struct {
 	strategies map[string]AuthStrategy
@@ -77,21 +68,23 @@ func (a *Authenticator) Validate(request *http.Request) (bool, error) {
 }
 
 // AuthenticateRequest reports whether the request carries a credential proving
-// the caller is authenticated, without requiring any privilege. Strategies that
-// separate the two concerns (see Authenticatable) are asked the authentication
-// question; the rest are asked to validate, since for them a valid token is
-// authentication.
+// the caller is authenticated, without requiring any privilege.
 //
 // It follows the same three return states as Validate, so callers can tell "no
 // credential sent" from "credential rejected".
 func (a *Authenticator) AuthenticateRequest(request *http.Request) (bool, error) {
 	return a.walk(request, func(strategy AuthStrategy, token string) (bool, error) {
-		authenticatable, ok := strategy.(Authenticatable)
+		// A strategy that separates authentication from authorization exposes
+		// Authenticate for the weaker check — currently OIDC, whose Validate
+		// additionally demands privileged-group membership. A strategy with no group
+		// concept (the deploy token, a CI JWT) does not, because for it a valid token
+		// answers both questions, so Validate is the authentication check too.
+		authenticator, ok := strategy.(interface{ Authenticate(token string) error })
 		if !ok {
 			return strategy.Validate(token)
 		}
 
-		if err := authenticatable.Authenticate(token); err != nil {
+		if err := authenticator.Authenticate(token); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -103,16 +96,11 @@ func (a *Authenticator) AuthenticateRequest(request *http.Request) (bool, error)
 // strategy was invoked at all — the "authentication not provided" state described
 // on Validate — and otherwise the failure of the invoked strategies.
 //
-// A request may carry several credentials at once: the Web UI sends its OIDC token
-// in both Authorization and Oidc-Authorization, and with JWT_SECRET configured the
-// former is claimed by the JWT strategy, which rejects it. When the outcomes
-// disagree, ErrProviderUnavailable wins over a rejection. "Rejected" is only a
-// truthful answer if every credential was actually evaluated; if one of them could
-// not be checked, the honest answer is that the server cannot tell yet — and it
-// matters concretely, because callers map a rejection to 401, which makes the Web
-// UI discard a session that may be perfectly valid. Strategy iteration order is
-// randomized (Go map), so without this precedence the status would flip between
-// runs.
+// A request may carry several credentials at once — the Web UI sends its OIDC token in
+// both Authorization and Oidc-Authorization, and the JWT strategy rejects that copy —
+// so when outcomes disagree ErrProviderUnavailable wins: "rejected" is only truthful
+// if every credential was evaluated, and callers turn a rejection into a 401. Map
+// iteration is randomized, so without this precedence the status flips between runs.
 func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, string) (bool, error)) (bool, error) {
 	if a == nil || request == nil {
 		return false, nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/shini4i/argo-watcher/internal/config"
 )
@@ -11,6 +13,15 @@ import (
 // AuthStrategy defines the behaviour required for a token validation strategy.
 type AuthStrategy interface {
 	Validate(token string) (bool, error)
+}
+
+// Authenticatable is implemented by strategies that distinguish authentication
+// from authorization — currently OIDC, where Validate additionally demands
+// privileged-group membership. A strategy without a group concept (the deploy
+// token, a CI JWT) does not implement it: possession of a valid token is both its
+// authentication and its authorization, so Validate answers both questions.
+type Authenticatable interface {
+	Authenticate(token string) error
 }
 
 // Authenticator coordinates multiple AuthStrategy implementations against an HTTP request.
@@ -60,11 +71,54 @@ func parseAuthToken(request *http.Request, header string) string {
 //     token; err is the last strategy's reason and should be surfaced to
 //     the client so it can show something actionable.
 func (a *Authenticator) Validate(request *http.Request) (bool, error) {
+	return a.walk(request, func(strategy AuthStrategy, token string) (bool, error) {
+		return strategy.Validate(token)
+	})
+}
+
+// AuthenticateRequest reports whether the request carries a credential proving
+// the caller is authenticated, without requiring any privilege. Strategies that
+// separate the two concerns (see Authenticatable) are asked the authentication
+// question; the rest are asked to validate, since for them a valid token is
+// authentication.
+//
+// It follows the same three return states as Validate, so callers can tell "no
+// credential sent" from "credential rejected".
+func (a *Authenticator) AuthenticateRequest(request *http.Request) (bool, error) {
+	return a.walk(request, func(strategy AuthStrategy, token string) (bool, error) {
+		authenticatable, ok := strategy.(Authenticatable)
+		if !ok {
+			return strategy.Validate(token)
+		}
+
+		if err := authenticatable.Authenticate(token); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// walk applies check to every strategy whose header carries a token, returning on
+// the first acceptance. When no strategy accepts, it returns a nil error if no
+// strategy was invoked at all — the "authentication not provided" state described
+// on Validate — and otherwise the failure of the invoked strategies.
+//
+// A request may carry several credentials at once: the Web UI sends its OIDC token
+// in both Authorization and Oidc-Authorization, and with JWT_SECRET configured the
+// former is claimed by the JWT strategy, which rejects it. When the outcomes
+// disagree, ErrProviderUnavailable wins over a rejection. "Rejected" is only a
+// truthful answer if every credential was actually evaluated; if one of them could
+// not be checked, the honest answer is that the server cannot tell yet — and it
+// matters concretely, because callers map a rejection to 401, which makes the Web
+// UI discard a session that may be perfectly valid. Strategy iteration order is
+// randomized (Go map), so without this precedence the status would flip between
+// runs.
+func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, string) (bool, error)) (bool, error) {
 	if a == nil || request == nil {
 		return false, nil
 	}
 
-	var lastErr error
+	var rejectedErr, unavailableErr error
 
 	for header, strategy := range a.strategies {
 		token := parseAuthToken(request, header)
@@ -72,16 +126,24 @@ func (a *Authenticator) Validate(request *http.Request) (bool, error) {
 			continue
 		}
 
-		valid, err := strategy.Validate(token)
+		valid, err := check(strategy, token)
 		if valid {
 			return true, nil
 		}
+		if errors.Is(err, ErrProviderUnavailable) {
+			unavailableErr = err
+			continue
+		}
 		if err != nil {
-			lastErr = err
+			rejectedErr = err
 		}
 	}
 
-	return false, lastErr
+	if unavailableErr != nil {
+		return false, unavailableErr
+	}
+
+	return false, rejectedErr
 }
 
 // ValidateStrategy restricts validation to a single allowed strategy header.
@@ -126,6 +188,7 @@ func NewOIDCAuthService(config *config.ServerConfig) (*OIDCAuthService, error) {
 		config.OIDC.IssuerURL,
 		config.OIDC.ClientId,
 		config.OIDC.PrivilegedGroups,
+		time.Duration(config.OIDC.TokenValidationInterval)*time.Millisecond,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/shini4i/argo-watcher/internal/config"
@@ -124,6 +125,165 @@ func TestAuthenticatorValidateReturnsLastError(t *testing.T) {
 
 	assert.False(t, valid)
 	assert.EqualError(t, validateErr, "strategy error")
+}
+
+// splitStrategy is a strategy that separates authentication from authorization,
+// standing in for the OIDC service: Validate additionally demands privilege.
+type splitStrategy struct {
+	authenticated bool
+	privileged    bool
+}
+
+func (s splitStrategy) Authenticate(string) error {
+	if !s.authenticated {
+		return errors.New("not authenticated")
+	}
+	return nil
+}
+
+func (s splitStrategy) Validate(string) (bool, error) {
+	if !s.authenticated || !s.privileged {
+		return false, errors.New("not privileged")
+	}
+	return true, nil
+}
+
+// unavailableStrategy stands in for an OIDC service whose provider cannot be
+// reached, which callers must distinguish from a rejected credential.
+type unavailableStrategy struct{}
+
+func (unavailableStrategy) Authenticate(string) error { return ErrProviderUnavailable }
+
+func (unavailableStrategy) Validate(string) (bool, error) { return false, ErrProviderUnavailable }
+
+func TestAuthenticatorAuthenticateRequest(t *testing.T) {
+	newRequest := func(t *testing.T, header, value string) *http.Request {
+		t.Helper()
+		request, err := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
+		assert.NoError(t, err)
+		if header != "" {
+			request.Header.Set(header, value)
+		}
+		return request
+	}
+
+	t.Run("accepts an authenticated but unprivileged subject", func(t *testing.T) {
+		// This is the whole point of the split: reads are open to any signed-in
+		// user, while Validate keeps gating privileged actions.
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Oidc-Authorization": splitStrategy{authenticated: true, privileged: false},
+		})
+		request := newRequest(t, "Oidc-Authorization", "token")
+
+		valid, err := authenticator.AuthenticateRequest(request)
+		assert.True(t, valid)
+		assert.NoError(t, err)
+
+		valid, err = authenticator.Validate(request)
+		assert.False(t, valid)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects an unauthenticated subject", func(t *testing.T) {
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Oidc-Authorization": splitStrategy{authenticated: false},
+		})
+
+		valid, err := authenticator.AuthenticateRequest(newRequest(t, "Oidc-Authorization", "token"))
+
+		assert.False(t, valid)
+		assert.Error(t, err)
+	})
+
+	t.Run("treats possession as authentication for strategies without groups", func(t *testing.T) {
+		// A deploy token or CI JWT carries no group concept, so a valid token is
+		// authentication — this is what lets a pipeline read its own task.
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"ARGO_WATCHER_DEPLOY_TOKEN": NewDeployTokenAuthService("valid"),
+		})
+
+		valid, err := authenticator.AuthenticateRequest(newRequest(t, "ARGO_WATCHER_DEPLOY_TOKEN", "valid"))
+
+		assert.True(t, valid)
+		assert.NoError(t, err)
+	})
+
+	t.Run("reports no credential distinctly from a rejected one", func(t *testing.T) {
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"ARGO_WATCHER_DEPLOY_TOKEN": NewDeployTokenAuthService("valid"),
+		})
+
+		valid, err := authenticator.AuthenticateRequest(newRequest(t, "", ""))
+
+		assert.False(t, valid)
+		assert.NoError(t, err, "no header sent must not look like a wrong token")
+	})
+
+	t.Run("accepts a valid credential alongside a rejected one", func(t *testing.T) {
+		// The frontend sends the OIDC token in both Authorization and
+		// Oidc-Authorization; with JWT_SECRET set the former is parsed as an HMAC
+		// JWT and fails. One working credential must still authenticate.
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Authorization":      NewJWTAuthService("secret"),
+			"Oidc-Authorization": splitStrategy{authenticated: true},
+		})
+		request := newRequest(t, "Authorization", "Bearer not-an-hmac-jwt")
+		request.Header.Set("Oidc-Authorization", "Bearer oidc-token")
+
+		valid, err := authenticator.AuthenticateRequest(request)
+
+		assert.True(t, valid)
+		assert.NoError(t, err)
+	})
+
+	t.Run("prefers an unavailable provider over another strategy's rejection", func(t *testing.T) {
+		// The real shape of this: the Web UI sends its OIDC token in BOTH headers,
+		// and with JWT_SECRET set the Authorization copy is parsed as an HMAC JWT and
+		// rejected, while the OIDC strategy cannot reach the provider. Strategy
+		// iteration order is randomized, so the loop below would catch a
+		// coin-flipping precedence — and a 401 here signs the user out of a session
+		// that may be entirely valid.
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Authorization":      NewJWTAuthService("secret"),
+			"Oidc-Authorization": unavailableStrategy{},
+		})
+
+		for i := 0; i < 50; i++ {
+			request := newRequest(t, "Authorization", "Bearer not-an-hmac-jwt")
+			request.Header.Set("Oidc-Authorization", "Bearer oidc-token")
+
+			valid, err := authenticator.AuthenticateRequest(request)
+
+			require.False(t, valid)
+			require.ErrorIs(t, err, ErrProviderUnavailable, "iteration %d", i)
+		}
+	})
+
+	t.Run("reports a rejection when every credential was actually evaluated", func(t *testing.T) {
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Authorization":      NewJWTAuthService("secret"),
+			"Oidc-Authorization": splitStrategy{authenticated: false},
+		})
+		request := newRequest(t, "Authorization", "Bearer not-an-hmac-jwt")
+		request.Header.Set("Oidc-Authorization", "Bearer oidc-token")
+
+		valid, err := authenticator.AuthenticateRequest(request)
+
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrProviderUnavailable)
+	})
+
+	t.Run("tolerates a nil receiver and a nil request", func(t *testing.T) {
+		var authenticator *Authenticator
+		valid, err := authenticator.AuthenticateRequest(newRequest(t, "", ""))
+		assert.False(t, valid)
+		assert.NoError(t, err)
+
+		valid, err = NewAuthenticator(nil).AuthenticateRequest(nil)
+		assert.False(t, valid)
+		assert.NoError(t, err)
+	})
 }
 
 func TestAuthenticatorStrategyLookup(t *testing.T) {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -28,15 +28,10 @@ type discoveryDocument struct {
 	UserinfoEndpoint string `json:"userinfo_endpoint"`
 }
 
-// ErrProviderUnavailable marks a failure to reach the OIDC provider or to make
-// sense of its answer, as distinct from a token the provider actively rejected.
-// Handlers map it to 503 rather than 401 so that a provider outage does not read
-// as an authentication failure — a 401 makes the frontend discard its session and
-// bounce the user to the login page, turning a brief provider blip into a
-// site-wide logout.
-//
-// Its message is the sanitized text shown to clients: transport details (URLs,
-// hostnames, parse errors) belong in the server log only.
+// ErrProviderUnavailable marks a failure to reach the OIDC provider or to make sense
+// of its answer, as distinct from a token it actively rejected. Handlers map it to 503,
+// because the frontend discards its session on a 401 — a blip would log everyone out.
+// Its message is the sanitized text clients see; details stay in the server log.
 var ErrProviderUnavailable = errors.New("token validation failed")
 
 // OIDCAuthService validates bearer tokens against any OIDC-compliant provider by
@@ -195,12 +190,9 @@ func (o *OIDCAuthService) Authenticate(token string) error {
 // the token is valid, effectively delegating validation to the provider. The user
 // must additionally belong to a privileged group to be authorized.
 //
-// It deliberately does not answer from the cache. Reusing a decision is a trade
-// made for reads, which the Web UI issues on a timer; a privileged action is a rare
-// human click, so re-asking the provider costs nothing and keeps group removal and
-// provider-side session revocation effective immediately instead of within
-// OIDC_TOKEN_VALIDATION_INTERVAL. The fresh result still populates the cache for
-// subsequent reads.
+// It deliberately does not answer from a cached acceptance: a privileged action is a
+// rare human click, so re-asking the provider costs nothing and keeps group removal
+// and session revocation immediate rather than within OIDC_TOKEN_VALIDATION_INTERVAL.
 func (o *OIDCAuthService) Validate(token string) (bool, error) {
 	info, err := o.resolveIdentity(token, false)
 	if err != nil {
@@ -214,18 +206,14 @@ func (o *OIDCAuthService) Validate(token string) (bool, error) {
 	return true, nil
 }
 
-// resolveIdentity returns the provider's view of a token. With allowCached set it
-// answers from the validation cache when a fresh decision is on hand; otherwise only
-// a cached rejection may be reused. Either way the outcome is recorded for later use.
+// resolveIdentity returns the provider's view of a token, recording the outcome for
+// later use. With allowCached it answers from the cache; without it, only a cached
+// rejection may be reused — a rejection cannot over-grant, so honoring it still blunts
+// a hot loop of bad tokens, while reusing an acceptance is what would extend a stale
+// privilege.
 //
-// Reusing a rejection cannot over-grant — the provider already refused this exact
-// token — so honoring it even on the privileged path keeps a hot loop of bad tokens
-// from being amplified into provider traffic. Reusing an acceptance is what would
-// extend a stale privilege, and that is precisely what the privileged path opts out
-// of.
-//
-// A provider failure is never cached: remembering it would deny access for the whole
-// validation interval over what may be a momentary blip.
+// A provider failure is never cached: it would deny access for the whole interval over
+// what may be a momentary blip.
 func (o *OIDCAuthService) resolveIdentity(token string, allowCached bool) (*userInfoResponse, error) {
 	if entry, ok := o.cache.get(token); ok && (allowCached || entry.err != nil) {
 		return entry.info, entry.err
@@ -241,9 +229,9 @@ func (o *OIDCAuthService) resolveIdentity(token string, allowCached bool) (*user
 	return info, err
 }
 
-// fetchUserInfo calls the provider's userinfo endpoint with the given bearer
-// token. Failures to reach or parse the provider yield ErrProviderUnavailable;
-// a non-200 answer is reported as a rejection of the token.
+// fetchUserInfo calls the provider's userinfo endpoint with the given bearer token.
+// Failures to reach, parse or make sense of the provider yield ErrProviderUnavailable;
+// only a 401/403 is reported as a rejection of the token.
 func (o *OIDCAuthService) fetchUserInfo(token string) (*userInfoResponse, error) {
 	userinfoURL, err := o.resolveUserinfoURL()
 	if err != nil {
@@ -272,8 +260,15 @@ func (o *OIDCAuthService) fetchUserInfo(token string) (*userInfoResponse, error)
 		return nil, ErrProviderUnavailable
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	// Only 401/403 are the provider judging the token; any other non-200 means it
+	// did not judge it at all, and a rejection would sign valid users out.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return nil, fmt.Errorf("token validation failed with status: %v", resp.Status)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("oidc: userinfo returned an unusable status", "status", resp.Status)
+		return nil, ErrProviderUnavailable
 	}
 
 	var info userInfoResponse

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -28,15 +28,30 @@ type discoveryDocument struct {
 	UserinfoEndpoint string `json:"userinfo_endpoint"`
 }
 
+// ErrProviderUnavailable marks a failure to reach the OIDC provider or to make
+// sense of its answer, as distinct from a token the provider actively rejected.
+// Handlers map it to 503 rather than 401 so that a provider outage does not read
+// as an authentication failure — a 401 makes the frontend discard its session and
+// bounce the user to the login page, turning a brief provider blip into a
+// site-wide logout.
+//
+// Its message is the sanitized text shown to clients: transport details (URLs,
+// hostnames, parse errors) belong in the server log only.
+var ErrProviderUnavailable = errors.New("token validation failed")
+
 // OIDCAuthService validates bearer tokens against any OIDC-compliant provider by
 // calling the provider's userinfo endpoint. The endpoint is resolved lazily on
 // first use via OIDC discovery, so process startup never depends on the provider
 // being reachable.
+//
+// Decisions are memoized per token (see validationCache) so that authorizing
+// every request costs one userinfo round trip per token per validation interval.
 type OIDCAuthService struct {
 	IssuerURL        string
 	ClientId         string
 	PrivilegedGroups []string
 	client           *http.Client
+	cache            *validationCache
 
 	mu          sync.Mutex
 	userinfoURL string
@@ -46,7 +61,11 @@ type OIDCAuthService struct {
 // not contact the network: the userinfo endpoint is discovered lazily on the
 // first Validate call (see resolveUserinfoURL), preserving the pre-refactor
 // behaviour where startup never reached out to the identity provider.
-func (o *OIDCAuthService) Init(issuerURL, clientId string, privilegedGroups []string) error {
+//
+// validationInterval is how long a provider decision may be reused for a given
+// token; it bounds how stale an authorization decision can be. Zero disables
+// caching, validating every request against the provider.
+func (o *OIDCAuthService) Init(issuerURL, clientId string, privilegedGroups []string, validationInterval time.Duration) error {
 	if err := validateIssuerURL(issuerURL); err != nil {
 		return err
 	}
@@ -55,6 +74,7 @@ func (o *OIDCAuthService) Init(issuerURL, clientId string, privilegedGroups []st
 	o.ClientId = clientId
 	o.PrivilegedGroups = privilegedGroups
 	o.client = &http.Client{Timeout: 10 * time.Second}
+	o.cache = newValidationCache(validationInterval)
 
 	return nil
 }
@@ -104,31 +124,31 @@ func (o *OIDCAuthService) resolveUserinfoURL() (string, error) {
 	req, err := http.NewRequest(http.MethodGet, discoveryURL, nil) // #nosec G704 - issuer URL is validated in Init()
 	if err != nil {
 		slog.Error("oidc: error creating discovery request", "error", err)
-		return "", errors.New("token validation failed")
+		return "", ErrProviderUnavailable
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := o.client.Do(req) // #nosec G704 - issuer URL is validated in Init()
 	if err != nil {
 		slog.Error("oidc: discovery request failed", "issuer", o.IssuerURL, "error", err)
-		return "", errors.New("token validation failed")
+		return "", ErrProviderUnavailable
 	}
 	defer closeBody(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Error("oidc: discovery returned non-200", "issuer", o.IssuerURL, "status", resp.Status)
-		return "", errors.New("token validation failed")
+		return "", ErrProviderUnavailable
 	}
 
 	var doc discoveryDocument
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
 		slog.Error("oidc: error decoding discovery document", "error", err)
-		return "", errors.New("token validation failed")
+		return "", ErrProviderUnavailable
 	}
 
 	if err := validateUserinfoURL(doc.UserinfoEndpoint); err != nil {
 		slog.Error("oidc: invalid userinfo endpoint in discovery document", "error", err)
-		return "", errors.New("token validation failed")
+		return "", ErrProviderUnavailable
 	}
 
 	o.userinfoURL = doc.UserinfoEndpoint
@@ -158,54 +178,111 @@ func validateUserinfoURL(rawURL string) error {
 	return nil
 }
 
-// Validate implements a simple token validation approach: it calls the OIDC
-// provider's userinfo endpoint with the bearer token and treats HTTP 200 as
-// proof the token is valid, effectively delegating validation to the provider.
-// The user must additionally belong to a privileged group to be authorized.
+// Authenticate reports whether a token identifies a signed-in user, without
+// requiring any privilege. It is the check for read access: every authenticated
+// user may read, while privileged actions go through Validate.
+//
+// It returns nil when the provider accepts the token, an error naming the reason
+// when the provider rejects it, and ErrProviderUnavailable when the provider could
+// not be consulted at all.
+func (o *OIDCAuthService) Authenticate(token string) error {
+	_, err := o.resolveIdentity(token, true)
+	return err
+}
+
+// Validate implements AuthStrategy for privileged operations: it calls the OIDC
+// provider's userinfo endpoint with the bearer token and treats HTTP 200 as proof
+// the token is valid, effectively delegating validation to the provider. The user
+// must additionally belong to a privileged group to be authorized.
+//
+// It deliberately does not answer from the cache. Reusing a decision is a trade
+// made for reads, which the Web UI issues on a timer; a privileged action is a rare
+// human click, so re-asking the provider costs nothing and keeps group removal and
+// provider-side session revocation effective immediately instead of within
+// OIDC_TOKEN_VALIDATION_INTERVAL. The fresh result still populates the cache for
+// subsequent reads.
 func (o *OIDCAuthService) Validate(token string) (bool, error) {
-	userinfoURL, err := o.resolveUserinfoURL()
+	info, err := o.resolveIdentity(token, false)
 	if err != nil {
 		return false, err
 	}
 
-	var info userInfoResponse
+	if !o.allowedToRollback(info.Username, info.Groups) {
+		return false, fmt.Errorf("%s is not a member of any of the privileged groups", info.Username)
+	}
+
+	return true, nil
+}
+
+// resolveIdentity returns the provider's view of a token. With allowCached set it
+// answers from the validation cache when a fresh decision is on hand; otherwise only
+// a cached rejection may be reused. Either way the outcome is recorded for later use.
+//
+// Reusing a rejection cannot over-grant — the provider already refused this exact
+// token — so honoring it even on the privileged path keeps a hot loop of bad tokens
+// from being amplified into provider traffic. Reusing an acceptance is what would
+// extend a stale privilege, and that is precisely what the privileged path opts out
+// of.
+//
+// A provider failure is never cached: remembering it would deny access for the whole
+// validation interval over what may be a momentary blip.
+func (o *OIDCAuthService) resolveIdentity(token string, allowCached bool) (*userInfoResponse, error) {
+	if entry, ok := o.cache.get(token); ok && (allowCached || entry.err != nil) {
+		return entry.info, entry.err
+	}
+
+	info, err := o.fetchUserInfo(token)
+	if errors.Is(err, ErrProviderUnavailable) {
+		return nil, err
+	}
+
+	o.cache.put(token, info, err)
+
+	return info, err
+}
+
+// fetchUserInfo calls the provider's userinfo endpoint with the given bearer
+// token. Failures to reach or parse the provider yield ErrProviderUnavailable;
+// a non-200 answer is reported as a rejection of the token.
+func (o *OIDCAuthService) fetchUserInfo(token string) (*userInfoResponse, error) {
+	userinfoURL, err := o.resolveUserinfoURL()
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest(http.MethodGet, userinfoURL, nil) // #nosec G704 - URL is validated in resolveUserinfoURL()
 	if err != nil {
 		// Transport/internal failure details (URLs, hostnames) stay in the
 		// server log; the public-facing error must not leak them.
 		slog.Error("oidc: error creating userinfo request", "error", err)
-		return false, errors.New("token validation failed")
+		return nil, ErrProviderUnavailable
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 
 	resp, err := o.client.Do(req) // #nosec G704 - URL is validated in resolveUserinfoURL()
 	if err != nil {
 		slog.Error("oidc: userinfo request failed", "error", err)
-		return false, errors.New("token validation failed")
+		return nil, ErrProviderUnavailable
 	}
 	defer closeBody(resp.Body)
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Error("oidc: error reading userinfo response body", "error", err)
-		return false, errors.New("token validation failed")
+		return nil, ErrProviderUnavailable
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token validation failed with status: %v", resp.Status)
+	}
+
+	var info userInfoResponse
 	if err := json.Unmarshal(bodyBytes, &info); err != nil {
 		slog.Error("oidc: error unmarshalling userinfo response", "error", err)
-		return false, errors.New("token validation failed")
+		return nil, ErrProviderUnavailable
 	}
 
-	userPrivileged := o.allowedToRollback(info.Username, info.Groups)
-
-	if resp.StatusCode == http.StatusOK && userPrivileged {
-		return true, nil
-	} else if resp.StatusCode == http.StatusOK && !userPrivileged {
-		return false, fmt.Errorf("%s is not a member of any of the privileged groups", info.Username)
-	}
-
-	return false, fmt.Errorf("token validation failed with status: %v", resp.Status)
+	return &info, nil
 }
 
 // allowedToRollback checks if the user is a member of any of the privileged groups.

--- a/internal/auth/oidc_cache.go
+++ b/internal/auth/oidc_cache.go
@@ -10,18 +10,13 @@ import (
 )
 
 const (
-	// maxCacheEntries bounds the validation cache. Without a ceiling, a flood of
-	// distinct bogus tokens would grow the map without bound, turning an
-	// unauthenticated endpoint into a memory-exhaustion primitive. At the ceiling,
-	// expired entries are reclaimed and — failing that — an arbitrary entry is
-	// evicted (see evictOneLocked), so the map never grows past it.
+	// maxCacheEntries bounds the map so a flood of distinct bogus tokens cannot
+	// exhaust memory; at the ceiling entries are reclaimed or evicted.
 	maxCacheEntries = 10000
 
-	// negativeCacheTTL caps how long a rejection is remembered, independently of
-	// the configured interval. A long interval must not pin a rejection for
-	// minutes: a token the provider refused because of clock skew, or a session an
-	// administrator has just reinstated, needs to recover quickly. Its only job is
-	// to stop a hot loop of bad requests from hammering the provider.
+	// negativeCacheTTL caps how long a rejection is remembered regardless of the
+	// configured interval: long enough to blunt a hot loop of bad requests, short
+	// enough that a reinstated session recovers quickly.
 	negativeCacheTTL = 30 * time.Second
 )
 
@@ -33,13 +28,10 @@ type cachedValidation struct {
 	expiresAt time.Time
 }
 
-// validationCache memoizes provider decisions per access token so that gating
-// every request on OIDC costs one userinfo round trip per token per interval
-// rather than one per request.
-//
-// Entries are keyed by the SHA-256 of the token, never the token itself, so raw
-// credentials do not sit in a map key where a heap dump or a debug print would
-// expose them. A zero or negative TTL disables caching entirely.
+// validationCache memoizes provider decisions per access token, so gating requests on
+// OIDC costs one userinfo round trip per token per interval rather than one per
+// request. Entries are keyed by the token's SHA-256 so raw credentials never sit in a
+// map key. A non-positive TTL disables caching.
 type validationCache struct {
 	mu      sync.Mutex
 	ttl     time.Duration
@@ -116,12 +108,9 @@ func (c *validationCache) put(token string, info *userInfoResponse, err error) {
 
 // entryTTL returns how long this decision may be remembered.
 //
-// A rejection's lifetime is deliberately NOT derived from the token's expiry. The
-// most common bad credential is an expired token, whose remaining lifetime is zero
-// or negative — deriving from it would refuse to cache exactly the rejection worth
-// remembering, and a loop of expired tokens would reach the provider on every
-// request. A rejected token stays rejected, so a short fixed lifetime is both safe
-// and sufficient.
+// A rejection's lifetime is NOT derived from the token's expiry: the commonest bad
+// credential is an expired token, so deriving it would refuse to cache the very
+// rejection worth remembering.
 func (c *validationCache) entryTTL(token string, err error) time.Duration {
 	if err == nil {
 		return cacheTTL(c.ttl, token)
@@ -143,16 +132,12 @@ func (c *validationCache) reclaimExpiredLocked() {
 	}
 }
 
-// evictOneLocked frees a slot by dropping an arbitrary entry when the cache is
-// still full after reclaiming expired ones. The caller must hold the mutex.
+// evictOneLocked frees a slot by dropping an arbitrary entry when the cache is still
+// full after reclaiming expired ones. The caller must hold the mutex.
 //
-// Evicting beats refusing to store: a flood of distinct unusable tokens would
-// otherwise hold every slot until it expired, leaving real sessions uncached and
-// sending a provider round trip on every UI request. Arbitrary choice (Go map
-// order) rather than least-recently-used — the bookkeeping LRU needs buys nothing
-// here, since a wrongly evicted entry costs one round trip to rebuild. Note this
-// bounds memory only: nothing here rate-limits how much provider traffic an
-// unauthenticated caller can induce.
+// Evicting beats refusing to store, which would leave real sessions uncached behind a
+// flood of junk tokens. The choice is arbitrary rather than LRU because a wrong
+// eviction costs one round trip. This bounds memory only, not provider traffic.
 func (c *validationCache) evictOneLocked() {
 	if len(c.entries) < maxCacheEntries {
 		return
@@ -191,11 +176,9 @@ func cacheTTL(configured time.Duration, token string) time.Duration {
 // tokenExpiry reads the "exp" claim of a JWT access token without verifying its
 // signature, reporting ok=false for opaque tokens and for JWTs carrying no exp.
 //
-// The claim is used for exactly one purpose: shortening a cache entry's lifetime.
-// It is never a substitute for validation — the provider remains the only
-// authority on whether a token is good, and a decision only enters the cache
-// after the provider has spoken. A token claiming a distant expiry therefore buys
-// nothing beyond the configured interval.
+// Deliberately unverified: the claim only ever shortens a cache entry's lifetime, and
+// a decision enters the cache only after the provider has accepted the token, so a
+// forged exp buys nothing beyond the configured interval.
 func tokenExpiry(token string) (time.Time, bool) {
 	claims := jwt.MapClaims{}
 	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {

--- a/internal/auth/oidc_cache.go
+++ b/internal/auth/oidc_cache.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -173,22 +175,32 @@ func cacheTTL(configured time.Duration, token string) time.Duration {
 	return configured
 }
 
-// tokenExpiry reads the "exp" claim of a JWT access token without verifying its
-// signature, reporting ok=false for opaque tokens and for JWTs carrying no exp.
+// tokenExpiry reads the "exp" claim from a JWT access token's payload segment,
+// reporting ok=false for opaque tokens and for JWTs carrying no exp.
 //
-// Deliberately unverified: the claim only ever shortens a cache entry's lifetime, and
-// a decision enters the cache only after the provider has accepted the token, so a
-// forged exp buys nothing beyond the configured interval.
+// It decodes rather than parses on purpose: the value is a hint used only to shorten a
+// cache entry's lifetime, never to decide anything. Going through the parser would
+// imply this validates the token — it does not, and it must not, since the provider is
+// the only authority on that and has already spoken by the time an entry is written.
 func tokenExpiry(token string) (time.Time, bool) {
-	claims := jwt.MapClaims{}
-	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
 		return time.Time{}, false
 	}
 
-	expiry, err := claims.GetExpirationTime()
-	if err != nil || expiry == nil {
+	payload, err := jwt.NewParser().DecodeSegment(parts[1])
+	if err != nil {
 		return time.Time{}, false
 	}
 
-	return expiry.Time, true
+	// Seconds since the epoch, per RFC 7519 NumericDate; float because the spec allows
+	// a non-integer value. Sub-second precision is irrelevant to a cache lifetime.
+	var claims struct {
+		Exp float64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}, false
+	}
+
+	return time.Unix(int64(claims.Exp), 0), true
 }

--- a/internal/auth/oidc_cache.go
+++ b/internal/auth/oidc_cache.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	// maxCacheEntries bounds the validation cache. Without a ceiling, a flood of
+	// distinct bogus tokens would grow the map without bound, turning an
+	// unauthenticated endpoint into a memory-exhaustion primitive. At the ceiling,
+	// expired entries are reclaimed and — failing that — an arbitrary entry is
+	// evicted (see evictOneLocked), so the map never grows past it.
+	maxCacheEntries = 10000
+
+	// negativeCacheTTL caps how long a rejection is remembered, independently of
+	// the configured interval. A long interval must not pin a rejection for
+	// minutes: a token the provider refused because of clock skew, or a session an
+	// administrator has just reinstated, needs to recover quickly. Its only job is
+	// to stop a hot loop of bad requests from hammering the provider.
+	negativeCacheTTL = 30 * time.Second
+)
+
+// cachedValidation is one remembered provider decision. Exactly one of info and
+// err is set: info for an accepted token, err for a rejected one.
+type cachedValidation struct {
+	info      *userInfoResponse
+	err       error
+	expiresAt time.Time
+}
+
+// validationCache memoizes provider decisions per access token so that gating
+// every request on OIDC costs one userinfo round trip per token per interval
+// rather than one per request.
+//
+// Entries are keyed by the SHA-256 of the token, never the token itself, so raw
+// credentials do not sit in a map key where a heap dump or a debug print would
+// expose them. A zero or negative TTL disables caching entirely.
+type validationCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]cachedValidation
+}
+
+// newValidationCache builds a cache whose entries live for at most ttl. A
+// non-positive ttl yields a cache that stores nothing.
+func newValidationCache(ttl time.Duration) *validationCache {
+	return &validationCache{
+		ttl:     ttl,
+		entries: make(map[string]cachedValidation),
+	}
+}
+
+// cacheKey derives the storage key for a token.
+func cacheKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// get returns the remembered decision for a token, or ok=false when there is
+// none or it has expired.
+func (c *validationCache) get(token string) (cachedValidation, bool) {
+	if c == nil || c.ttl <= 0 {
+		return cachedValidation{}, false
+	}
+
+	key := cacheKey(token)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return cachedValidation{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		return cachedValidation{}, false
+	}
+
+	return entry, true
+}
+
+// put remembers a provider decision for a token. Accepted tokens live for the
+// configured interval capped by the token's own expiry; rejections live for
+// negativeCacheTTL, or the configured interval when that is shorter. Nothing is
+// stored when caching is disabled or the computed lifetime is zero.
+func (c *validationCache) put(token string, info *userInfoResponse, err error) {
+	if c == nil || c.ttl <= 0 {
+		return
+	}
+
+	ttl := c.entryTTL(token, err)
+	if ttl <= 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= maxCacheEntries {
+		c.reclaimExpiredLocked()
+		c.evictOneLocked()
+	}
+
+	c.entries[cacheKey(token)] = cachedValidation{
+		info:      info,
+		err:       err,
+		expiresAt: time.Now().Add(ttl),
+	}
+}
+
+// entryTTL returns how long this decision may be remembered.
+//
+// A rejection's lifetime is deliberately NOT derived from the token's expiry. The
+// most common bad credential is an expired token, whose remaining lifetime is zero
+// or negative — deriving from it would refuse to cache exactly the rejection worth
+// remembering, and a loop of expired tokens would reach the provider on every
+// request. A rejected token stays rejected, so a short fixed lifetime is both safe
+// and sufficient.
+func (c *validationCache) entryTTL(token string, err error) time.Duration {
+	if err == nil {
+		return cacheTTL(c.ttl, token)
+	}
+
+	if c.ttl < negativeCacheTTL {
+		return c.ttl
+	}
+	return negativeCacheTTL
+}
+
+// reclaimExpiredLocked drops every expired entry. The caller must hold the mutex.
+func (c *validationCache) reclaimExpiredLocked() {
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// evictOneLocked frees a slot by dropping an arbitrary entry when the cache is
+// still full after reclaiming expired ones. The caller must hold the mutex.
+//
+// Evicting beats refusing to store: a flood of distinct unusable tokens would
+// otherwise hold every slot until it expired, leaving real sessions uncached and
+// sending a provider round trip on every UI request. Arbitrary choice (Go map
+// order) rather than least-recently-used — the bookkeeping LRU needs buys nothing
+// here, since a wrongly evicted entry costs one round trip to rebuild. Note this
+// bounds memory only: nothing here rate-limits how much provider traffic an
+// unauthenticated caller can induce.
+func (c *validationCache) evictOneLocked() {
+	if len(c.entries) < maxCacheEntries {
+		return
+	}
+
+	for key := range c.entries {
+		delete(c.entries, key)
+		return
+	}
+}
+
+// cacheTTL returns how long a decision about the given token may be reused: the
+// configured interval, shortened so a cached decision can never outlive the token
+// it describes.
+func cacheTTL(configured time.Duration, token string) time.Duration {
+	if configured <= 0 {
+		return 0
+	}
+
+	expiry, ok := tokenExpiry(token)
+	if !ok {
+		return configured
+	}
+
+	remaining := time.Until(expiry)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < configured {
+		return remaining
+	}
+
+	return configured
+}
+
+// tokenExpiry reads the "exp" claim of a JWT access token without verifying its
+// signature, reporting ok=false for opaque tokens and for JWTs carrying no exp.
+//
+// The claim is used for exactly one purpose: shortening a cache entry's lifetime.
+// It is never a substitute for validation — the provider remains the only
+// authority on whether a token is good, and a decision only enters the cache
+// after the provider has spoken. A token claiming a distant expiry therefore buys
+// nothing beyond the configured interval.
+func tokenExpiry(token string) (time.Time, bool) {
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		return time.Time{}, false
+	}
+
+	expiry, err := claims.GetExpirationTime()
+	if err != nil || expiry == nil {
+		return time.Time{}, false
+	}
+
+	return expiry.Time, true
+}

--- a/internal/auth/oidc_cache_test.go
+++ b/internal/auth/oidc_cache_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"testing"
@@ -12,8 +13,8 @@ import (
 )
 
 // signedTokenWithExp builds an HMAC-signed JWT carrying the given expiry. The
-// signature is irrelevant here: tokenExpiry parses without verifying, so the
-// token only needs to be structurally valid.
+// signature is irrelevant — tokenExpiry only decodes the payload — but signing keeps
+// the fixture a realistic token.
 func signedTokenWithExp(t *testing.T, exp time.Time) string {
 	t.Helper()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
@@ -40,6 +41,29 @@ func TestTokenExpiry(t *testing.T) {
 		_, ok := tokenExpiry("opaque-reference-token")
 
 		assert.False(t, ok)
+	})
+
+	t.Run("reports no expiry for a malformed payload segment", func(t *testing.T) {
+		for _, token := range []string{
+			"header.!!!not-base64!!!.signature",
+			"header." + base64.RawURLEncoding.EncodeToString([]byte("not json")) + ".signature",
+			"header." + base64.RawURLEncoding.EncodeToString([]byte(`{"exp":"soon"}`)) + ".signature",
+		} {
+			_, ok := tokenExpiry(token)
+			assert.False(t, ok, token)
+		}
+	})
+
+	t.Run("accepts a non-integer exp", func(t *testing.T) {
+		// RFC 7519 NumericDate permits a fractional value.
+		want := time.Now().Add(time.Hour).Truncate(time.Second)
+		payload := fmt.Sprintf(`{"exp":%d.75}`, want.Unix())
+		token := "header." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".signature"
+
+		got, ok := tokenExpiry(token)
+
+		require.True(t, ok)
+		assert.WithinDuration(t, want, got, time.Second)
 	})
 
 	t.Run("reports no expiry for a JWT without an exp claim", func(t *testing.T) {

--- a/internal/auth/oidc_cache_test.go
+++ b/internal/auth/oidc_cache_test.go
@@ -1,0 +1,259 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signedTokenWithExp builds an HMAC-signed JWT carrying the given expiry. The
+// signature is irrelevant here: tokenExpiry parses without verifying, so the
+// token only needs to be structurally valid.
+func signedTokenWithExp(t *testing.T, exp time.Time) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp": exp.Unix(),
+	})
+	signed, err := token.SignedString([]byte("irrelevant"))
+	require.NoError(t, err)
+	return signed
+}
+
+func TestTokenExpiry(t *testing.T) {
+	t.Run("reads the exp claim from a JWT access token", func(t *testing.T) {
+		want := time.Now().Add(7 * time.Minute).Truncate(time.Second)
+
+		got, ok := tokenExpiry(signedTokenWithExp(t, want))
+
+		assert.True(t, ok)
+		assert.WithinDuration(t, want, got, time.Second)
+	})
+
+	t.Run("reports no expiry for an opaque token", func(t *testing.T) {
+		// Providers may issue opaque access tokens; those carry no readable exp
+		// and must fall back to the configured interval alone.
+		_, ok := tokenExpiry("opaque-reference-token")
+
+		assert.False(t, ok)
+	})
+
+	t.Run("reports no expiry for a JWT without an exp claim", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "someone"})
+		signed, err := token.SignedString([]byte("irrelevant"))
+		require.NoError(t, err)
+
+		_, ok := tokenExpiry(signed)
+
+		assert.False(t, ok)
+	})
+}
+
+func TestCacheTTL(t *testing.T) {
+	t.Run("uses the configured interval when the token outlives it", func(t *testing.T) {
+		token := signedTokenWithExp(t, time.Now().Add(time.Hour))
+
+		assert.Equal(t, 5*time.Minute, cacheTTL(5*time.Minute, token))
+	})
+
+	t.Run("caps the interval at the token expiry", func(t *testing.T) {
+		token := signedTokenWithExp(t, time.Now().Add(30*time.Second))
+
+		ttl := cacheTTL(5*time.Minute, token)
+
+		assert.Greater(t, ttl, 20*time.Second)
+		assert.LessOrEqual(t, ttl, 30*time.Second)
+	})
+
+	t.Run("returns zero for an already expired token", func(t *testing.T) {
+		token := signedTokenWithExp(t, time.Now().Add(-time.Minute))
+
+		assert.Zero(t, cacheTTL(5*time.Minute, token))
+	})
+
+	t.Run("falls back to the interval for an opaque token", func(t *testing.T) {
+		assert.Equal(t, 5*time.Minute, cacheTTL(5*time.Minute, "opaque"))
+	})
+
+	t.Run("returns zero when caching is disabled", func(t *testing.T) {
+		token := signedTokenWithExp(t, time.Now().Add(time.Hour))
+
+		assert.Zero(t, cacheTTL(0, token))
+		assert.Zero(t, cacheTTL(-time.Second, token))
+	})
+}
+
+func TestValidationCache(t *testing.T) {
+	info := &userInfoResponse{Username: "someone", Groups: []string{"group1"}}
+
+	t.Run("returns a stored entry within its lifetime", func(t *testing.T) {
+		cache := newValidationCache(time.Minute)
+		cache.put("token", info, nil)
+
+		entry, ok := cache.get("token")
+
+		require.True(t, ok)
+		assert.Equal(t, info, entry.info)
+		assert.NoError(t, entry.err)
+	})
+
+	t.Run("misses for a token that was never stored", func(t *testing.T) {
+		cache := newValidationCache(time.Minute)
+
+		_, ok := cache.get("token")
+
+		assert.False(t, ok)
+	})
+
+	t.Run("does not leak the raw token as a map key", func(t *testing.T) {
+		cache := newValidationCache(time.Minute)
+		cache.put("super-secret-token", info, nil)
+
+		for key := range cache.entries {
+			assert.NotContains(t, key, "super-secret-token")
+		}
+	})
+
+	t.Run("expires an entry once its lifetime elapses", func(t *testing.T) {
+		cache := newValidationCache(10 * time.Millisecond)
+		cache.put("token", info, nil)
+
+		time.Sleep(20 * time.Millisecond)
+
+		_, ok := cache.get("token")
+		assert.False(t, ok)
+	})
+
+	t.Run("a stored decision cannot outlive the token it describes", func(t *testing.T) {
+		// The security property of the whole design, asserted through put rather than
+		// through cacheTTL alone: storing the interval instead of the capped lifetime
+		// would keep every cacheTTL test green while letting a revoked token retain
+		// read access for the full interval. The horizon is whole seconds because a
+		// JWT exp claim has second granularity.
+		cache := newValidationCache(time.Minute)
+		shortLived := signedTokenWithExp(t, time.Now().Add(2*time.Second))
+
+		cache.put(shortLived, info, nil)
+		cache.put("opaque-token", info, nil)
+
+		capped, ok := cache.get(shortLived)
+		require.True(t, ok)
+		assert.LessOrEqual(t, time.Until(capped.expiresAt), 2*time.Second,
+			"the decision must expire with the token, not with the interval")
+
+		uncapped, ok := cache.get("opaque-token")
+		require.True(t, ok)
+		assert.Greater(t, time.Until(uncapped.expiresAt), 2*time.Second,
+			"a token with no readable expiry must still get the full interval")
+	})
+
+	t.Run("stores nothing for an already expired token", func(t *testing.T) {
+		cache := newValidationCache(time.Minute)
+		expired := signedTokenWithExp(t, time.Now().Add(-time.Minute))
+
+		cache.put(expired, info, nil)
+
+		_, ok := cache.get(expired)
+		assert.False(t, ok)
+		assert.Empty(t, cache.entries)
+	})
+
+	t.Run("stores nothing when caching is disabled", func(t *testing.T) {
+		cache := newValidationCache(0)
+		cache.put("token", info, nil)
+
+		_, ok := cache.get("token")
+		assert.False(t, ok)
+		assert.Empty(t, cache.entries)
+	})
+
+	t.Run("remembers a rejection so a bad token does not hammer the provider", func(t *testing.T) {
+		cache := newValidationCache(time.Minute)
+		rejection := errors.New("token validation failed with status: 401")
+
+		cache.put("token", nil, rejection)
+
+		entry, ok := cache.get("token")
+		require.True(t, ok)
+		assert.Equal(t, rejection, entry.err)
+		assert.Nil(t, entry.info)
+	})
+
+	t.Run("keeps a rejection for no longer than the negative TTL", func(t *testing.T) {
+		// A long configured interval must not pin a rejection for minutes: a user
+		// whose group membership was just fixed should recover quickly.
+		cache := newValidationCache(time.Hour)
+		cache.put("token", nil, errors.New("rejected"))
+
+		entry, ok := cache.get("token")
+		require.True(t, ok)
+		assert.LessOrEqual(t, time.Until(entry.expiresAt), negativeCacheTTL)
+	})
+
+	t.Run("remembers a rejection for an already expired token", func(t *testing.T) {
+		// The commonest bad credential. Deriving its lifetime from the token's own
+		// expiry would refuse to cache it, and a loop of expired tokens would then
+		// reach the provider on every single request.
+		cache := newValidationCache(time.Minute)
+		expired := signedTokenWithExp(t, time.Now().Add(-time.Hour))
+
+		cache.put(expired, nil, errors.New("token validation failed with status: 401"))
+
+		entry, ok := cache.get(expired)
+		require.True(t, ok)
+		assert.Error(t, entry.err)
+	})
+
+	t.Run("keeps a rejection no longer than the configured interval", func(t *testing.T) {
+		cache := newValidationCache(time.Second)
+		cache.put("token", nil, errors.New("rejected"))
+
+		entry, ok := cache.get("token")
+		require.True(t, ok)
+		assert.LessOrEqual(t, time.Until(entry.expiresAt), time.Second)
+	})
+
+	t.Run("stops growing once the entry ceiling is reached", func(t *testing.T) {
+		// Without a ceiling, a flood of distinct bogus tokens would grow the map
+		// without bound — an unauthenticated memory-exhaustion primitive.
+		cache := newValidationCache(time.Minute)
+		for i := 0; i < maxCacheEntries+100; i++ {
+			cache.put(fmt.Sprintf("token-%d", i), info, nil)
+		}
+
+		assert.LessOrEqual(t, len(cache.entries), maxCacheEntries)
+	})
+
+	t.Run("evicts to admit a new entry when full of unexpired ones", func(t *testing.T) {
+		// A flood of unexpired junk must not lock real sessions out of the cache:
+		// refusing to store would send a provider round trip on every UI request.
+		cache := newValidationCache(time.Hour)
+		for i := 0; i < maxCacheEntries; i++ {
+			cache.put(fmt.Sprintf("flood-%d", i), nil, errors.New("rejected"))
+		}
+
+		cache.put("real-session-token", info, nil)
+
+		entry, ok := cache.get("real-session-token")
+		require.True(t, ok)
+		assert.Equal(t, info, entry.info)
+		assert.LessOrEqual(t, len(cache.entries), maxCacheEntries)
+	})
+
+	t.Run("reclaims expired entries to make room", func(t *testing.T) {
+		cache := newValidationCache(10 * time.Millisecond)
+		for i := 0; i < maxCacheEntries; i++ {
+			cache.put(string(rune(i))+"-token", info, nil)
+		}
+		time.Sleep(20 * time.Millisecond)
+
+		cache.put("fresh-token", info, nil)
+
+		_, ok := cache.get("fresh-token")
+		assert.True(t, ok, "an expired cache must not stay full forever")
+	})
+}

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -294,6 +294,44 @@ func TestOIDCAuthService_Authenticate(t *testing.T) {
 		assert.ErrorIs(t, err, ErrProviderUnavailable)
 	})
 
+	t.Run("treats a provider server error as unavailable, not as a rejection", func(t *testing.T) {
+		// A 502 or 429 means the token was never judged; calling that a rejection
+		// signs valid users out.
+		for _, status := range []int{
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusTooManyRequests,
+			http.StatusNotFound,
+		} {
+			server := newOIDCTestServer(t, status, `{}`, nil, false)
+			service := &OIDCAuthService{}
+			require.NoError(t, service.Init(server.URL, "test", nil, 0))
+			service.client = server.Client()
+
+			err := service.Authenticate("token")
+
+			require.Error(t, err, "status %d", status)
+			assert.ErrorIs(t, err, ErrProviderUnavailable, "status %d", status)
+			server.Close()
+		}
+	})
+
+	t.Run("treats a forbidden response as a rejection", func(t *testing.T) {
+		for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+			server := newOIDCTestServer(t, status, `{}`, nil, false)
+			service := &OIDCAuthService{}
+			require.NoError(t, service.Init(server.URL, "test", nil, 0))
+			service.client = server.Client()
+
+			err := service.Authenticate("token")
+
+			require.Error(t, err, "status %d", status)
+			assert.NotErrorIs(t, err, ErrProviderUnavailable, "status %d", status)
+			server.Close()
+		}
+	})
+
 	t.Run("reports an unusable provider response distinctly from a rejection", func(t *testing.T) {
 		server := newOIDCTestServer(t, http.StatusOK, `not json`, nil, false)
 		defer server.Close()

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 		service := &OIDCAuthService{}
 
 		issuer := "http://localhost:8080/realms/test"
-		err := service.Init(issuer, "test", []string{})
+		err := service.Init(issuer, "test", []string{}, 0)
 
 		assert.NoError(t, err)
 		assert.Equal(t, issuer, service.IssuerURL)
@@ -71,7 +72,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	t.Run("should set http client with timeout", func(t *testing.T) {
 		service := &OIDCAuthService{}
 
-		err := service.Init("http://localhost:8080", "test", []string{})
+		err := service.Init("http://localhost:8080", "test", []string{}, 0)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, service.client.Timeout)
@@ -80,7 +81,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	t.Run("should return error for invalid URL scheme", func(t *testing.T) {
 		service := &OIDCAuthService{}
 
-		err := service.Init("ftp://localhost:8080", "test", []string{})
+		err := service.Init("ftp://localhost:8080", "test", []string{}, 0)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid OIDC issuer URL scheme")
@@ -89,7 +90,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	t.Run("should return error for missing host", func(t *testing.T) {
 		service := &OIDCAuthService{}
 
-		err := service.Init("http:///realms/test", "test", []string{})
+		err := service.Init("http:///realms/test", "test", []string{}, 0)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing host")
@@ -98,7 +99,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	t.Run("should return error for URL with query parameters", func(t *testing.T) {
 		service := &OIDCAuthService{}
 
-		err := service.Init("https://oidc.example.com?x=1", "test", []string{})
+		err := service.Init("https://oidc.example.com?x=1", "test", []string{}, 0)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "query and fragment are not allowed")
@@ -107,7 +108,7 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	t.Run("should return error for URL with fragment", func(t *testing.T) {
 		service := &OIDCAuthService{}
 
-		err := service.Init("https://oidc.example.com#frag", "test", []string{})
+		err := service.Init("https://oidc.example.com#frag", "test", []string{}, 0)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "query and fragment are not allowed")
@@ -121,7 +122,7 @@ func TestOIDCAuthService_Validate(t *testing.T) {
 	newService := func(t *testing.T, server *httptest.Server, groups []string) *OIDCAuthService {
 		t.Helper()
 		service := &OIDCAuthService{}
-		require.NoError(t, service.Init(server.URL, "test", groups))
+		require.NoError(t, service.Init(server.URL, "test", groups, 0))
 		service.client = server.Client()
 		return service
 	}
@@ -178,7 +179,7 @@ func TestOIDCAuthService_Validate(t *testing.T) {
 
 	t.Run("should return sanitized error if provider is unreachable", func(t *testing.T) {
 		service := &OIDCAuthService{}
-		require.NoError(t, service.Init("http://127.0.0.1:1", "test", []string{"group1"}))
+		require.NoError(t, service.Init("http://127.0.0.1:1", "test", []string{"group1"}, 0))
 
 		ok, err := service.Validate("test")
 
@@ -219,6 +220,289 @@ func TestOIDCAuthService_Validate(t *testing.T) {
 		ok, err = service.Validate("test")
 		assert.NoError(t, err)
 		assert.True(t, ok)
+	})
+}
+
+// newCountingOIDCServer serves a working discovery document and a userinfo
+// endpoint that reports the given groups, counting userinfo requests so tests can
+// assert how often the provider is actually consulted.
+func newCountingOIDCServer(t *testing.T, groups string) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var hits int32
+	var server *httptest.Server
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
+		_, err := rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		if err != nil {
+			t.Error(err)
+		}
+	})
+	mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, err := rw.Write([]byte(fmt.Sprintf(`{"preferred_username": "someone", "groups": %s}`, groups)))
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	server = httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server, &hits
+}
+
+// TestOIDCAuthService_Authenticate covers the authentication-only check, which
+// deliberately ignores privileged-group membership: read access must be available
+// to every signed-in user, while Validate stays the gate for privileged actions.
+func TestOIDCAuthService_Authenticate(t *testing.T) {
+	t.Run("accepts a valid token for a user in no privileged group", func(t *testing.T) {
+		server, _ := newCountingOIDCServer(t, `["some-other-group"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, 0))
+		service.client = server.Client()
+
+		// The same token that Validate must reject for lacking privileges.
+		require.NoError(t, service.Authenticate("token"))
+
+		ok, err := service.Validate("token")
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects a token the provider does not accept", func(t *testing.T) {
+		server := newOIDCTestServer(t, http.StatusUnauthorized, `Unauthorized`, nil, false)
+		defer server.Close()
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", nil, 0))
+		service.client = server.Client()
+
+		err := service.Authenticate("token")
+
+		assert.Error(t, err)
+		// A rejected token is the client's problem (401), not the provider's (503).
+		assert.NotErrorIs(t, err, ErrProviderUnavailable)
+	})
+
+	t.Run("reports an unreachable provider distinctly from a rejection", func(t *testing.T) {
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init("http://127.0.0.1:1", "test", nil, 0))
+
+		err := service.Authenticate("token")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrProviderUnavailable)
+	})
+
+	t.Run("reports an unusable provider response distinctly from a rejection", func(t *testing.T) {
+		server := newOIDCTestServer(t, http.StatusOK, `not json`, nil, false)
+		defer server.Close()
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", nil, 0))
+		service.client = server.Client()
+
+		err := service.Authenticate("token")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrProviderUnavailable)
+	})
+}
+
+// TestOIDCAuthService_ValidationCaching pins the property that makes gating reads
+// on OIDC viable: a token is validated against the provider once per interval, not
+// once per request.
+func TestOIDCAuthService_ValidationCaching(t *testing.T) {
+	t.Run("consults the provider once per interval", func(t *testing.T) {
+		server, hits := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		for i := 0; i < 5; i++ {
+			require.NoError(t, service.Authenticate("token"))
+		}
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(hits),
+			"five read authorizations must cost one userinfo call")
+	})
+
+	t.Run("re-verifies the provider on every privileged check", func(t *testing.T) {
+		// Caching is a trade made for reads, which arrive on a timer. A privileged
+		// action is a rare human click, so it always re-asks — that is what keeps
+		// group removal and provider-side revocation effective immediately.
+		server, hits := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		require.NoError(t, service.Authenticate("token"))
+		for i := 0; i < 2; i++ {
+			ok, err := service.Validate("token")
+			require.NoError(t, err)
+			require.True(t, ok)
+		}
+
+		assert.Equal(t, int32(3), atomic.LoadInt32(hits),
+			"one cached read plus two privileged checks must reach the provider three times")
+	})
+
+	t.Run("reflects a group removal on the next privileged check", func(t *testing.T) {
+		// The staleness window the validation interval introduces must not extend to
+		// privileged authorization: a demoted user loses the deploy lock at once.
+		var hits int32
+		var server *httptest.Server
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
+			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		})
+		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
+			if atomic.AddInt32(&hits, 1) == 1 {
+				_, _ = rw.Write([]byte(`{"preferred_username": "someone", "groups": ["privileged"]}`))
+				return
+			}
+			_, _ = rw.Write([]byte(`{"preferred_username": "someone", "groups": []}`))
+		})
+		server = httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Hour))
+		service.client = server.Client()
+
+		ok, err := service.Validate("token")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = service.Validate("token")
+		assert.False(t, ok, "a demoted user must not keep privilege for the validation interval")
+		assert.ErrorContains(t, err, "not a member of any of the privileged groups")
+	})
+
+	t.Run("reuses a cached rejection even on the privileged path", func(t *testing.T) {
+		// A rejection cannot over-grant, so honoring it keeps a loop of bad tokens
+		// from being amplified into provider traffic — POST /api/v1/tasks validates
+		// this way and is reachable without a credential.
+		var hits int32
+		var server *httptest.Server
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
+			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		})
+		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			rw.WriteHeader(http.StatusUnauthorized)
+		})
+		server = httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		for i := 0; i < 3; i++ {
+			ok, err := service.Validate("bad-token")
+			require.False(t, ok)
+			require.Error(t, err)
+		}
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&hits),
+			"a rejection is safe to reuse, so repeats must not reach the provider")
+	})
+
+	t.Run("a cached authentication cannot become an authorization", func(t *testing.T) {
+		// The worst failure this design could produce: caching the fact that someone
+		// is signed in must never be mistaken for the fact that they are privileged.
+		server, _ := newCountingOIDCServer(t, `["some-other-group"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		require.NoError(t, service.Authenticate("token"))
+
+		for i := 0; i < 2; i++ {
+			ok, err := service.Validate("token")
+			assert.False(t, ok, "call %d", i)
+			assert.ErrorContains(t, err, "not a member of any of the privileged groups")
+		}
+
+		// And the reverse: a privilege rejection must not be remembered as an
+		// authentication failure, or a read would start failing after a lock click.
+		assert.NoError(t, service.Authenticate("token"))
+	})
+
+	t.Run("re-validates once the interval elapses", func(t *testing.T) {
+		server, hits := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, 10*time.Millisecond))
+		service.client = server.Client()
+
+		require.NoError(t, service.Authenticate("token"))
+		time.Sleep(20 * time.Millisecond)
+		require.NoError(t, service.Authenticate("token"))
+
+		assert.Equal(t, int32(2), atomic.LoadInt32(hits))
+	})
+
+	t.Run("caches per token, not globally", func(t *testing.T) {
+		server, hits := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		require.NoError(t, service.Authenticate("token-a"))
+		require.NoError(t, service.Authenticate("token-b"))
+
+		assert.Equal(t, int32(2), atomic.LoadInt32(hits))
+	})
+
+	t.Run("never caches an unreachable provider", func(t *testing.T) {
+		// A provider outage must not be remembered: the next request has to retry,
+		// or a transient blip would deny access for the whole interval.
+		var hits int32
+		var server *httptest.Server
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
+			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		})
+		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
+			if atomic.AddInt32(&hits, 1) == 1 {
+				// An unparseable answer means the provider is not usable — the
+				// token itself was never judged, so this must not be remembered.
+				_, _ = rw.Write([]byte(`<html>gateway error</html>`))
+				return
+			}
+			_, _ = rw.Write([]byte(`{"groups": ["privileged"]}`))
+		})
+		server = httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		err := service.Authenticate("token")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrProviderUnavailable)
+
+		assert.NoError(t, service.Authenticate("token"), "the failure must not have been cached")
+		assert.Equal(t, int32(2), atomic.LoadInt32(&hits))
+	})
+
+	t.Run("serves concurrent validations safely", func(t *testing.T) {
+		server, _ := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		var wg sync.WaitGroup
+		for i := 0; i < 25; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				assert.NoError(t, service.Authenticate(fmt.Sprintf("token-%d", i%5)))
+			}(i)
+		}
+		wg.Wait()
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,11 +22,9 @@ import (
 // discovers the userinfo endpoint from it at runtime. The deprecated KEYCLOAK_*
 // variables are mapped onto these fields by applyKeycloakCompat.
 //
-// TokenValidationInterval (milliseconds) is how long a provider decision about a
-// token may be reused, bounding how stale an authorization decision can be. It is
-// capped per token by that token's own expiry, so a cached decision never outlives
-// the credential it describes. Zero revalidates against the provider on every
-// request, which multiplies UI refreshes into provider traffic.
+// TokenValidationInterval (milliseconds) bounds how stale a read authorization can be,
+// capped per token by that token's own expiry. Zero revalidates every request, which
+// multiplies UI refreshes into provider traffic.
 type OIDCConfig struct {
 	Enabled                 bool     `env:"OIDC_ENABLED" json:"enabled"`
 	IssuerURL               string   `env:"OIDC_ISSUER_URL" json:"issuer_url,omitempty"`
@@ -45,34 +43,35 @@ type DatabaseConfig struct {
 	DSN            string `env:"DB_DSN,expand" envDefault:"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} password=${DB_PASSWORD} dbname=${DB_NAME} sslmode=${DB_SSL_MODE} TimeZone=${DB_TIMEZONE}"`
 }
 
+// WebhookConfig describes the generic notification receiver. Only Enabled is public:
+// the rest says how to reach a third party, and the URL is itself the credential.
 type WebhookConfig struct {
 	Enabled              bool   `env:"WEBHOOK_ENABLED" envDefault:"false" json:"enabled"`
-	Url                  string `env:"WEBHOOK_URL" json:"url,omitempty"`
-	ContentType          string `env:"WEBHOOK_CONTENT_TYPE" envDefault:"application/json" json:"content_type,omitempty"`
-	Format               string `env:"WEBHOOK_FORMAT" json:"format,omitempty"`
-	AuthorizationHeader  string `env:"WEBHOOK_AUTHORIZATION_HEADER_NAME" envDefault:"Authorization" json:"authorization_header,omitempty"`
+	Url                  string `env:"WEBHOOK_URL" json:"-"`
+	ContentType          string `env:"WEBHOOK_CONTENT_TYPE" envDefault:"application/json" json:"-"`
+	Format               string `env:"WEBHOOK_FORMAT" json:"-"`
+	AuthorizationHeader  string `env:"WEBHOOK_AUTHORIZATION_HEADER_NAME" envDefault:"Authorization" json:"-"`
 	Token                string `env:"WEBHOOK_AUTHORIZATION_HEADER_VALUE" envDefault:"" json:"-"`
-	AllowedResponseCodes []int  `env:"WEBHOOK_ALLOWED_RESPONSE_CODES" envDefault:"200" json:"allowed_response_codes,omitempty"`
+	AllowedResponseCodes []int  `env:"WEBHOOK_ALLOWED_RESPONSE_CODES" envDefault:"200" json:"-"`
 }
 
+// MattermostConfig follows WebhookConfig: only Enabled is public.
 type MattermostConfig struct {
 	Enabled       bool   `env:"MATTERMOST_ENABLED" envDefault:"false" json:"enabled"`
-	Url           string `env:"MATTERMOST_URL" json:"url,omitempty"` // base URL of the Mattermost instance, without /api/v4
-	Token         string `env:"MATTERMOST_TOKEN" json:"-"`           // bot access token
-	ChannelId     string `env:"MATTERMOST_CHANNEL_ID" json:"channel_id,omitempty"`
-	Format        string `env:"MATTERMOST_FORMAT" json:"format,omitempty"`                          // Go template rendering models.Task into the post markdown message
-	MentionAuthor bool   `env:"MATTERMOST_MENTION_AUTHOR" envDefault:"false" json:"mention_author"` // prepend @<Author> to every post
+	Url           string `env:"MATTERMOST_URL" json:"-"`   // base URL of the Mattermost instance, without /api/v4
+	Token         string `env:"MATTERMOST_TOKEN" json:"-"` // bot access token
+	ChannelId     string `env:"MATTERMOST_CHANNEL_ID" json:"-"`
+	Format        string `env:"MATTERMOST_FORMAT" json:"-"`                            // Go template rendering models.Task into the post markdown message
+	MentionAuthor bool   `env:"MATTERMOST_MENTION_AUTHOR" envDefault:"false" json:"-"` // prepend @<Author> to every post
 }
 
-// ServerConfig is the server's runtime configuration. Its json tags double as the
-// wire format of GET /api/v1/config, which is served WITHOUT authentication —
-// the frontend must read the OIDC issuer and client id from it before a login can
-// happen, so the endpoint cannot be gated. Every field marked `json:"-"` is
-// therefore excluded because it must not be public, not merely because the UI has
-// no use for it: notification targets (a webhook URL is itself the credential),
-// the lockdown schedule, and the TLS posture all describe the deployment to an
-// unauthenticated caller. Add a new field to the payload only if the frontend or
-// the CLI client genuinely needs it.
+// ServerConfig is the server's runtime configuration. Its json tags double as the wire
+// format of GET /api/v1/config, which cannot be authenticated — the frontend reads the
+// OIDC issuer and client id from it before it can hold a token. A field marked
+// `json:"-"` is excluded because it must not be public, not merely because the UI has
+// no use for it. Consumers other than the UI read this payload too
+// (github.com/shini4i/argo-watcher-mcp allowlists it field by field), so removing a
+// key is a breaking change for them.
 type ServerConfig struct {
 	ArgoUrl            url.URL          `env:"ARGO_URL,required,notEmpty" json:"argo_cd_url"`
 	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
@@ -84,7 +83,7 @@ type ServerConfig struct {
 	RegistryProxyUrl   string           `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
 	StateType          string           `env:"STATE_TYPE,required" json:"state_type"`
 	StaticFilePath     string           `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
-	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"-"`
+	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
 	LogLevel           string           `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
 	Host               string           `env:"HOST" envDefault:"0.0.0.0" json:"-"`
 	Port               string           `env:"PORT" envDefault:"8080" json:"-"`
@@ -92,9 +91,9 @@ type ServerConfig struct {
 	JWTSecret          string           `env:"JWT_SECRET" json:"-"`
 	Db                 DatabaseConfig   `json:"-"`
 	OIDC               OIDCConfig       `json:"oidc,omitempty"`
-	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"-"`
-	Webhook            WebhookConfig    `json:"-"`
-	Mattermost         MattermostConfig `json:"-"`
+	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
+	Webhook            WebhookConfig    `json:"webhook,omitempty"`
+	Mattermost         MattermostConfig `json:"mattermost,omitempty"`
 	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
 	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" json:"argo_api_retries"`  // Total attempts (including initial); passed to retry.Attempts()
 	RepoCachePath      string           `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,11 +21,17 @@ import (
 // or "https://authentik/application/o/argo-watcher/" for Authentik); the backend
 // discovers the userinfo endpoint from it at runtime. The deprecated KEYCLOAK_*
 // variables are mapped onto these fields by applyKeycloakCompat.
+//
+// TokenValidationInterval (milliseconds) is how long a provider decision about a
+// token may be reused, bounding how stale an authorization decision can be. It is
+// capped per token by that token's own expiry, so a cached decision never outlives
+// the credential it describes. Zero revalidates against the provider on every
+// request, which multiplies UI refreshes into provider traffic.
 type OIDCConfig struct {
 	Enabled                 bool     `env:"OIDC_ENABLED" json:"enabled"`
 	IssuerURL               string   `env:"OIDC_ISSUER_URL" json:"issuer_url,omitempty"`
 	ClientId                string   `env:"OIDC_CLIENT_ID" json:"client_id,omitempty"`
-	TokenValidationInterval int      `env:"OIDC_TOKEN_VALIDATION_INTERVAL" envDefault:"10000" json:"token_validation_interval"`
+	TokenValidationInterval int      `env:"OIDC_TOKEN_VALIDATION_INTERVAL" envDefault:"300000" json:"token_validation_interval"`
 	PrivilegedGroups        []string `env:"OIDC_PRIVILEGED_GROUPS" json:"privileged_groups,omitempty"`
 }
 
@@ -58,6 +64,15 @@ type MattermostConfig struct {
 	MentionAuthor bool   `env:"MATTERMOST_MENTION_AUTHOR" envDefault:"false" json:"mention_author"` // prepend @<Author> to every post
 }
 
+// ServerConfig is the server's runtime configuration. Its json tags double as the
+// wire format of GET /api/v1/config, which is served WITHOUT authentication —
+// the frontend must read the OIDC issuer and client id from it before a login can
+// happen, so the endpoint cannot be gated. Every field marked `json:"-"` is
+// therefore excluded because it must not be public, not merely because the UI has
+// no use for it: notification targets (a webhook URL is itself the credential),
+// the lockdown schedule, and the TLS posture all describe the deployment to an
+// unauthenticated caller. Add a new field to the payload only if the frontend or
+// the CLI client genuinely needs it.
 type ServerConfig struct {
 	ArgoUrl            url.URL          `env:"ARGO_URL,required,notEmpty" json:"argo_cd_url"`
 	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
@@ -69,7 +84,7 @@ type ServerConfig struct {
 	RegistryProxyUrl   string           `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
 	StateType          string           `env:"STATE_TYPE,required" json:"state_type"`
 	StaticFilePath     string           `env:"STATIC_FILES_PATH" envDefault:"static" json:"-"`
-	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"skip_tls_verify"`
+	SkipTlsVerify      bool             `env:"SKIP_TLS_VERIFY" envDefault:"false" json:"-"`
 	LogLevel           string           `env:"LOG_LEVEL" envDefault:"info" json:"log_level"`
 	Host               string           `env:"HOST" envDefault:"0.0.0.0" json:"-"`
 	Port               string           `env:"PORT" envDefault:"8080" json:"-"`
@@ -77,9 +92,9 @@ type ServerConfig struct {
 	JWTSecret          string           `env:"JWT_SECRET" json:"-"`
 	Db                 DatabaseConfig   `json:"-"`
 	OIDC               OIDCConfig       `json:"oidc,omitempty"`
-	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
-	Webhook            WebhookConfig    `json:"webhook,omitempty"`
-	Mattermost         MattermostConfig `json:"mattermost,omitempty"`
+	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"-"`
+	Webhook            WebhookConfig    `json:"-"`
+	Mattermost         MattermostConfig `json:"-"`
 	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
 	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" json:"argo_api_retries"`  // Total attempts (including initial); passed to retry.Attempts()
 	RepoCachePath      string           `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -460,11 +460,12 @@ func TestServerConfig_JSONExcludesSensitiveFields(t *testing.T) {
 	assert.NotContains(t, jsonString, "deploy-token")
 }
 
-// TestServerConfig_JSONOmitsDeploymentDetail pins the payload of the
-// unauthenticated GET /api/v1/config: notification targets, the lockdown schedule
-// and the TLS posture describe the deployment and must not be readable by anyone
-// who can reach the server. A webhook URL is itself the credential.
-func TestServerConfig_JSONOmitsDeploymentDetail(t *testing.T) {
+// TestServerConfig_JSONOmitsNotificationTargets pins the payload of the
+// unauthenticated GET /api/v1/config: how to reach a notification receiver must not be
+// readable by anyone who can reach the server, since a webhook URL is itself the
+// credential. The `enabled` flags stay — they name no target, and downstream consumers
+// (argo-watcher-mcp) forward them.
+func TestServerConfig_JSONOmitsNotificationTargets(t *testing.T) {
 	config := &ServerConfig{
 		SkipTlsVerify:    true,
 		LockdownSchedule: "Mon-Fri 09:00-18:00",
@@ -490,10 +491,15 @@ func TestServerConfig_JSONOmitsDeploymentDetail(t *testing.T) {
 	assert.NotContains(t, jsonString, "mattermost.example.com")
 	assert.NotContains(t, jsonString, "mattermost-token")
 	assert.NotContains(t, jsonString, "channel-id")
-	assert.NotContains(t, jsonString, "Mon-Fri 09:00-18:00")
-	assert.NotContains(t, jsonString, "skip_tls_verify")
 
-	// What the frontend and the CLI client do need must survive the trim.
+	// What other consumers read must survive: the enabled flags, the schedule and the
+	// TLS posture are all allowlisted downstream.
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &decoded))
+	assert.Equal(t, true, decoded["webhook"].(map[string]any)["enabled"])
+	assert.Equal(t, true, decoded["mattermost"].(map[string]any)["enabled"])
+	assert.Equal(t, "Mon-Fri 09:00-18:00", decoded["lockdown_schedule"])
+	assert.Equal(t, true, decoded["skip_tls_verify"])
 	assert.Contains(t, jsonString, "argo_cd_url")
 	assert.Contains(t, jsonString, "oidc")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -459,3 +459,55 @@ func TestServerConfig_JSONExcludesSensitiveFields(t *testing.T) {
 	assert.NotContains(t, jsonString, "db-password")
 	assert.NotContains(t, jsonString, "deploy-token")
 }
+
+// TestServerConfig_JSONOmitsDeploymentDetail pins the payload of the
+// unauthenticated GET /api/v1/config: notification targets, the lockdown schedule
+// and the TLS posture describe the deployment and must not be readable by anyone
+// who can reach the server. A webhook URL is itself the credential.
+func TestServerConfig_JSONOmitsDeploymentDetail(t *testing.T) {
+	config := &ServerConfig{
+		SkipTlsVerify:    true,
+		LockdownSchedule: "Mon-Fri 09:00-18:00",
+		Webhook: WebhookConfig{
+			Enabled: true,
+			Url:     "https://hooks.example.com/services/T000/B000/XXXX",
+			Token:   "webhook-token",
+		},
+		Mattermost: MattermostConfig{
+			Enabled:   true,
+			Url:       "https://mattermost.example.com",
+			ChannelId: "channel-id",
+			Token:     "mattermost-token",
+		},
+	}
+
+	jsonBytes, err := json.Marshal(config)
+	require.NoError(t, err)
+	jsonString := string(jsonBytes)
+
+	assert.NotContains(t, jsonString, "hooks.example.com")
+	assert.NotContains(t, jsonString, "webhook-token")
+	assert.NotContains(t, jsonString, "mattermost.example.com")
+	assert.NotContains(t, jsonString, "mattermost-token")
+	assert.NotContains(t, jsonString, "channel-id")
+	assert.NotContains(t, jsonString, "Mon-Fri 09:00-18:00")
+	assert.NotContains(t, jsonString, "skip_tls_verify")
+
+	// What the frontend and the CLI client do need must survive the trim.
+	assert.Contains(t, jsonString, "argo_cd_url")
+	assert.Contains(t, jsonString, "oidc")
+}
+
+// TestServerConfig_DefaultValidationIntervalMatchesTokenLifetime guards the
+// caching default: revalidating every 10s (the previously documented but never
+// implemented value) would turn every UI refresh into provider traffic.
+func TestServerConfig_DefaultValidationInterval(t *testing.T) {
+	t.Setenv("ARGO_URL", "https://example.com")
+	t.Setenv("ARGO_TOKEN", "secret-token")
+	t.Setenv("STATE_TYPE", "in-memory")
+
+	cfg, err := NewServerConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, 300000, cfg.OIDC.TokenValidationInterval)
+}

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -19,6 +19,7 @@ type MetricsInterface interface {
 	ObserveGitLockWaitDuration(app string, seconds float64)
 	ObserveDeploymentDuration(app string, seconds float64)
 	ObserveGitBatchSize(size int)
+	AddUnauthenticatedRead(path string)
 }
 
 // Metrics contains all the prometheus collectors.
@@ -33,6 +34,7 @@ type Metrics struct {
 	GitLockWaitDuration  *prometheus.HistogramVec
 	DeploymentDuration   *prometheus.HistogramVec
 	GitBatchSize         prometheus.Histogram
+	UnauthenticatedReads *prometheus.CounterVec
 }
 
 // NewMetrics creates and registers the metrics with the provided Registerer.
@@ -103,9 +105,21 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help:    "Number of applications committed in a single batch write-back flush.",
 			Buckets: []float64{1, 2, 5, 10, 20, 50, 100},
 		}),
+		// UnauthenticatedReads counts requests that reached a read endpoint left
+		// open on purpose (see router.go) while OIDC auth was enabled and no
+		// credential was presented. It is the migration signal for closing those
+		// endpoints too: while pipelines still run a client that does not send its
+		// credential on GETs, this counter keeps rising, and it reaching zero is the
+		// evidence that requiring auth there is safe. It is a counter rather than a
+		// log line on purpose — the endpoint is polled for the whole length of every
+		// deployment, so logging each request would drown the log.
+		UnauthenticatedReads: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "unauthenticated_reads",
+			Help: "Reads served without a credential on the deliberately open read endpoints while OIDC auth was enabled.",
+		}, []string{"path"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize)
+	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize, m.UnauthenticatedReads)
 
 	return m
 }
@@ -180,4 +194,10 @@ func (m *Metrics) ObserveDeploymentDuration(app string, seconds float64) {
 // batch write-back flush.
 func (m *Metrics) ObserveGitBatchSize(size int) {
 	m.GitBatchSize.Observe(float64(size))
+}
+
+// AddUnauthenticatedRead increments the UnauthenticatedReads counter for the given
+// request path.
+func (m *Metrics) AddUnauthenticatedRead(path string) {
+	m.UnauthenticatedReads.WithLabelValues(path).Inc()
 }

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -105,14 +105,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help:    "Number of applications committed in a single batch write-back flush.",
 			Buckets: []float64{1, 2, 5, 10, 20, 50, 100},
 		}),
-		// UnauthenticatedReads counts requests that reached a read endpoint left
-		// open on purpose (see router.go) while OIDC auth was enabled and no
-		// credential was presented. It is the migration signal for closing those
-		// endpoints too: while pipelines still run a client that does not send its
-		// credential on GETs, this counter keeps rising, and it reaching zero is the
-		// evidence that requiring auth there is safe. It is a counter rather than a
-		// log line on purpose — the endpoint is polled for the whole length of every
-		// deployment, so logging each request would drown the log.
+		// UnauthenticatedReads is the migration signal for closing the read endpoints
+		// left open on purpose (see router.go): it keeps rising while pipelines run a
+		// client that sends no credential on GETs, and reaching zero is the evidence
+		// that requiring auth there is safe.
 		UnauthenticatedReads: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "unauthenticated_reads",
 			Help: "Reads served without a credential on the deliberately open read endpoints while OIDC auth was enabled.",

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/state"
 )
@@ -35,6 +36,8 @@ const (
 // @Description Get the version of the server
 // @Tags frontend
 // @Success 200 {string} string
+// @Failure 401 {object} models.TaskStatus "no credential, or the credential was rejected (only when OIDC auth is enabled)"
+// @Failure 503 {object} models.TaskStatus "the OIDC provider could not be consulted; retry"
 // @Router /api/v1/version [get]
 func (env *Env) getVersion(c *gin.Context) {
 	c.JSON(http.StatusOK, version)
@@ -118,6 +121,8 @@ func (env *Env) addTask(c *gin.Context) {
 // @Param limit query int false "Maximum number of tasks to return (1-1000, defaults to 1000)"
 // @Param offset query int false "Number of tasks to skip before returning results"
 // @Success 200 {object} models.TasksResponse
+// @Failure 401 {object} models.TaskStatus "no credential, or the credential was rejected (only when OIDC auth is enabled)"
+// @Failure 503 {object} models.TaskStatus "the OIDC provider could not be consulted; retry"
 // @Router /api/v1/tasks [get]
 func (env *Env) getState(c *gin.Context) {
 	startTime, err := strconv.ParseFloat(c.Query("from_timestamp"), 64)
@@ -240,10 +245,9 @@ func (env *Env) getConfig(c *gin.Context) {
 // failure the response distinguishes:
 //   - 401 with "authentication required" when no auth header was sent.
 //   - 401 with the strategy's reason when the token was rejected.
-//
-// Strategy transport/parse failures (e.g. the provider unreachable) are also
-// returned as 401 with a sanitized "token validation failed" message; full
-// details land in the server log only.
+//   - 503 when the provider could not be consulted at all, so that a provider
+//     outage does not make the Web UI treat the session as dead (see
+//     requireAuthenticatedRead). Details land in the server log only.
 func (env *Env) requireOIDCAuth(c *gin.Context) bool {
 	if !env.config.OIDC.Enabled {
 		return true
@@ -253,6 +257,15 @@ func (env *Env) requireOIDCAuth(c *gin.Context) bool {
 		valid, err := env.validateToken(c, header)
 		if valid {
 			return true
+		}
+		if errors.Is(err, auth.ErrProviderUnavailable) {
+			slog.Error("rejecting request: authentication provider unavailable",
+				"method", c.Request.Method, "url", c.Request.URL, "error", err)
+			c.JSON(http.StatusServiceUnavailable, models.TaskStatus{
+				Status: "authentication provider unavailable",
+				Error:  err.Error(),
+			})
+			return false
 		}
 		if err != nil {
 			// A header was present and the strategy rejected the token. Surface the reason.
@@ -272,6 +285,105 @@ func (env *Env) requireOIDCAuth(c *gin.Context) bool {
 		Status: unauthorizedMessage,
 		Error:  "authentication required (set " + oidcHeader + " header)",
 	})
+	return false
+}
+
+// requireAuthenticatedRead returns middleware that rejects reads carrying no
+// valid credential once OIDC auth is enabled. With OIDC disabled it is a no-op:
+// there is no auth backend to validate against, so gating reads would only lock
+// operators out of their own UI.
+//
+// Any configured credential is accepted — an OIDC session, the deploy token, or a
+// CI JWT. Reads are not restricted to OIDC_PRIVILEGED_GROUPS (that gate belongs to
+// the deploy-lock endpoints), and accepting machine credentials is what will let
+// the deliberately open GET /tasks/:id be closed later without cutting pipelines
+// off from their own task status.
+//
+// Failures are mapped so the frontend can tell them apart: a rejected or missing
+// credential is 401, while an authentication provider that could not be consulted
+// is 503. That distinction matters — the Web UI discards its session on a 401, so
+// reporting a provider outage as one would sign every user out over a blip.
+func (env *Env) requireAuthenticatedRead() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !env.config.OIDC.Enabled {
+			c.Next()
+			return
+		}
+
+		valid, err := env.authenticator.AuthenticateRequest(c.Request)
+		if valid {
+			c.Next()
+			return
+		}
+
+		if errors.Is(err, auth.ErrProviderUnavailable) {
+			slog.Error("rejecting read: authentication provider unavailable",
+				"method", c.Request.Method, "url", c.Request.URL, "error", err)
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, models.TaskStatus{
+				Status: "authentication provider unavailable",
+				Error:  err.Error(),
+			})
+			return
+		}
+
+		if err != nil {
+			slog.Warn("rejecting read with invalid credential",
+				"method", c.Request.Method, "url", c.Request.URL, "error", err)
+			c.AbortWithStatusJSON(http.StatusUnauthorized, models.TaskStatus{
+				Status: unauthorizedMessage,
+				Error:  err.Error(),
+			})
+			return
+		}
+
+		slog.Warn("rejecting unauthenticated read", "method", c.Request.Method, "url", c.Request.URL)
+		c.AbortWithStatusJSON(http.StatusUnauthorized, models.TaskStatus{
+			Status: unauthorizedMessage,
+			Error:  "authentication required (set " + oidcHeader + " header)",
+		})
+	}
+}
+
+// countUnauthenticatedRead returns middleware that records a read on which no
+// credential was presented at all, while OIDC auth is enabled. It never blocks the
+// request: the route it guards is open on purpose (see CreateRouter), and the
+// counter exists to measure how much of the fleet still reads without credentials —
+// the evidence needed before that exemption can be removed.
+//
+// It deliberately tests for the presence of a credential rather than its validity.
+// Validating here would put a provider round trip in the latency path of an
+// endpoint documented as never blocking, and during a provider outage every poll
+// would wait on it. It would also blur the measurement: an expired token or an
+// unreachable provider would be counted as "no credential", inflating the very
+// number whose fall to zero is the signal that this exemption can be closed.
+//
+// A counter rather than a log line: the guarded endpoint is polled for the entire
+// duration of every deployment, so logging each request would bury the log.
+func (env *Env) countUnauthenticatedRead() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !env.config.OIDC.Enabled {
+			c.Next()
+			return
+		}
+
+		if !env.hasCredential(c.Request) {
+			env.metrics.AddUnauthenticatedRead(c.FullPath())
+		}
+
+		c.Next()
+	}
+}
+
+// hasCredential reports whether the request carries a non-empty value in any header
+// a configured auth strategy reads. It says nothing about whether that credential
+// is valid.
+func (env *Env) hasCredential(request *http.Request) bool {
+	for header := range env.strategies {
+		if request.Header.Get(header) != "" {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -288,21 +288,15 @@ func (env *Env) requireOIDCAuth(c *gin.Context) bool {
 	return false
 }
 
-// requireAuthenticatedRead returns middleware that rejects reads carrying no
-// valid credential once OIDC auth is enabled. With OIDC disabled it is a no-op:
-// there is no auth backend to validate against, so gating reads would only lock
-// operators out of their own UI.
+// requireAuthenticatedRead returns middleware that rejects reads carrying no valid
+// credential once OIDC auth is enabled; with OIDC disabled it is a no-op.
 //
-// Any configured credential is accepted — an OIDC session, the deploy token, or a
-// CI JWT. Reads are not restricted to OIDC_PRIVILEGED_GROUPS (that gate belongs to
-// the deploy-lock endpoints), and accepting machine credentials is what will let
-// the deliberately open GET /tasks/:id be closed later without cutting pipelines
-// off from their own task status.
+// Any configured credential is accepted — an OIDC session, the deploy token or a CI
+// JWT — and reads are deliberately not restricted to OIDC_PRIVILEGED_GROUPS, which
+// gates the deploy-lock writes alone.
 //
-// Failures are mapped so the frontend can tell them apart: a rejected or missing
-// credential is 401, while an authentication provider that could not be consulted
-// is 503. That distinction matters — the Web UI discards its session on a 401, so
-// reporting a provider outage as one would sign every user out over a blip.
+// A rejected or missing credential is 401; a provider that could not be consulted is
+// 503, because the Web UI discards its session on a 401.
 func (env *Env) requireAuthenticatedRead() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !env.config.OIDC.Enabled {
@@ -344,21 +338,13 @@ func (env *Env) requireAuthenticatedRead() gin.HandlerFunc {
 	}
 }
 
-// countUnauthenticatedRead returns middleware that records a read on which no
-// credential was presented at all, while OIDC auth is enabled. It never blocks the
-// request: the route it guards is open on purpose (see CreateRouter), and the
-// counter exists to measure how much of the fleet still reads without credentials —
-// the evidence needed before that exemption can be removed.
+// countUnauthenticatedRead returns middleware that counts reads arriving with no
+// credential while OIDC auth is enabled. It never blocks: the route it guards is open
+// on purpose, and the count is the migration signal for closing it later.
 //
-// It deliberately tests for the presence of a credential rather than its validity.
-// Validating here would put a provider round trip in the latency path of an
-// endpoint documented as never blocking, and during a provider outage every poll
-// would wait on it. It would also blur the measurement: an expired token or an
-// unreachable provider would be counted as "no credential", inflating the very
-// number whose fall to zero is the signal that this exemption can be closed.
-//
-// A counter rather than a log line: the guarded endpoint is polled for the entire
-// duration of every deployment, so logging each request would bury the log.
+// It tests for presence rather than validity so the guarded endpoint — polled for the
+// whole length of every deployment — never waits on the provider, and so an expired
+// token cannot inflate the number whose fall to zero licenses that closure.
 func (env *Env) countUnauthenticatedRead() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !env.config.OIDC.Enabled {
@@ -374,9 +360,8 @@ func (env *Env) countUnauthenticatedRead() gin.HandlerFunc {
 	}
 }
 
-// hasCredential reports whether the request carries a non-empty value in any header
-// a configured auth strategy reads. It says nothing about whether that credential
-// is valid.
+// hasCredential reports whether the request carries a non-empty value in any header a
+// configured auth strategy reads, saying nothing about whether it is valid.
 func (env *Env) hasCredential(request *http.Request) bool {
 	for header := range env.strategies {
 		if request.Header.Get(header) != "" {

--- a/internal/server/handlers_argocd.go
+++ b/internal/server/handlers_argocd.go
@@ -27,6 +27,8 @@ type ReachabilityResponse struct {
 // @Tags frontend
 // @Produce json
 // @Success 200 {object} ReachabilityResponse
+// @Failure 401 {object} models.TaskStatus "no credential, or the credential was rejected (only when OIDC auth is enabled)"
+// @Failure 503 {object} models.TaskStatus "the OIDC provider could not be consulted; retry"
 // @Router /api/v1/reachability [get]
 func (env *Env) reachability(c *gin.Context) {
 	// Read the cached reason once and derive availability from it, so the

--- a/internal/server/handlers_lock.go
+++ b/internal/server/handlers_lock.go
@@ -74,6 +74,8 @@ func (env *Env) ReleaseDeployLock(c *gin.Context) {
 // @Description Check if deploy lock is set
 // @Tags frontend
 // @Success 200 {boolean} boolean
+// @Failure 401 {object} models.TaskStatus "no credential, or the credential was rejected (only when OIDC auth is enabled)"
+// @Failure 503 {object} models.TaskStatus "the OIDC provider could not be consulted; retry"
 // @Router /api/v1/deploy-lock [get]
 func (env *Env) isDeployLockSet(c *gin.Context) {
 	c.JSON(http.StatusOK, env.lockdown.IsLocked())

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -88,6 +88,9 @@ func keycloakToken(t *testing.T, username, password string) string {
 // the pre-refactor code targeted directly.
 func newKeycloakEnv(t *testing.T) *Env {
 	t.Helper()
+	// TokenValidationInterval is left at zero on purpose: every request then
+	// reaches Keycloak, so an authorization assertion here can never pass on a
+	// cached decision. The caching behaviour itself is covered by unit tests.
 	cfg := &config.ServerConfig{
 		StateType: "in-memory",
 		OIDC: config.OIDCConfig{
@@ -180,5 +183,64 @@ func TestKeycloakDeployLockAuthz(t *testing.T) {
 
 	t.Run("missing token is unauthorized", func(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, callDeployLock(t, srv, http.MethodPost, ""))
+	})
+}
+
+// protectedReadServer exposes one authenticated read behind the real middleware.
+// /version is used because it needs no state or ArgoCD wiring, keeping the test
+// focused on the authentication decision.
+func protectedReadServer(t *testing.T, env *Env) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	authenticated := router.Group("/api/v1", env.requireAuthenticatedRead())
+	authenticated.GET("/version", env.getVersion)
+
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// callProtectedRead issues an authenticated read, carrying the token in the
+// canonical OIDC header when one is given, and returns the HTTP status code.
+func callProtectedRead(t *testing.T, srv *httptest.Server, token string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/version", nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set(oidcHeader, "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+// TestKeycloakReadAuthn proves against a real provider that read access is gated
+// on authentication alone. The non-privileged user is the case unit tests cannot
+// fully vouch for: the very token Keycloak issues for a user outside
+// OIDC_PRIVILEGED_GROUPS — rejected by the deploy-lock endpoints above — must be
+// accepted here, or enabling OIDC would lock ordinary users out of the UI.
+func TestKeycloakReadAuthn(t *testing.T) {
+	waitForKeycloak(t)
+	srv := protectedReadServer(t, newKeycloakEnv(t))
+
+	t.Run("a non-privileged user may read", func(t *testing.T) {
+		token := keycloakToken(t, "regular-user", "regular-pass")
+		assert.Equal(t, http.StatusOK, callProtectedRead(t, srv, token))
+	})
+
+	t.Run("a privileged user may read", func(t *testing.T) {
+		token := keycloakToken(t, "priv-user", "priv-pass")
+		assert.Equal(t, http.StatusOK, callProtectedRead(t, srv, token))
+	})
+
+	t.Run("a garbage token is rejected", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, callProtectedRead(t, srv, "not-a-real-token"))
+	})
+
+	t.Run("no token is rejected", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, callProtectedRead(t, srv, ""))
 	})
 }

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -281,14 +281,11 @@ func TestReadAuthOpenEndpoints(t *testing.T) {
 	})
 }
 
-// TestReadAuthCoversEveryRegisteredRead derives its expectations from the router's
-// own route table instead of a hand-kept list, so a read added later is covered
-// without anyone remembering to extend a test. Adding a route means deciding
-// whether it belongs in the open or the authenticated group; landing in the wrong
-// one fails here.
+// TestReadAuthCoversEveryRegisteredRead derives its expectations from the router's own
+// route table rather than a hand-kept list, so a read added later to the wrong group
+// fails here without anyone remembering to extend a test.
 func TestReadAuthCoversEveryRegisteredRead(t *testing.T) {
-	// The exemptions, each justified in CreateRouter: login bootstraps from /config,
-	// and the released client polls /tasks/:id without a credential.
+	// Exemptions, each justified in CreateRouter.
 	openByDesign := map[string]bool{
 		"/api/v1/config":    true,
 		"/api/v1/tasks/:id": true,
@@ -329,12 +326,9 @@ func TestReadAuthCoversEveryRegisteredRead(t *testing.T) {
 	assert.GreaterOrEqual(t, checked, 6, "the route table should have yielded every /api/v1 read")
 }
 
-// TestReadAuthTaskLookupRemainsOpen pins the deliberate exemption: a released
-// client polls GET /api/v1/tasks/{id} for the whole length of every deployment and
-// sends no credential on GETs, so gating it would break every pipeline at once.
-// The task id is an unguessable v4 UUID handed only to the submitter, and the
-// enumerable list endpoint is protected — so the exemption is bounded to callers
-// that already hold a pointer to the task.
+// TestReadAuthTaskLookupRemainsOpen pins the deliberate exemption: released clients
+// poll this lookup without a credential, so gating it would break every pipeline. The
+// v4 UUID is the capability, and the enumerable list endpoint is protected.
 func TestReadAuthTaskLookupRemainsOpen(t *testing.T) {
 	const (
 		unknownTask = "/api/v1/tasks/00000000-0000-0000-0000-000000000000"

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -1,0 +1,408 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	promclient "github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/argocd"
+	"github.com/shini4i/argo-watcher/internal/auth"
+	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
+	"github.com/shini4i/argo-watcher/internal/prometheus"
+	"github.com/shini4i/argo-watcher/internal/state"
+)
+
+// oidcLikeStrategy stands in for the OIDC auth service: it separates
+// authentication from privileged authorization the same way, and can report a
+// provider outage, which is what drives the 503 mapping.
+type oidcLikeStrategy struct {
+	authenticated bool
+	privileged    bool
+	unavailable   bool
+}
+
+func (s oidcLikeStrategy) Authenticate(string) error {
+	if s.unavailable {
+		return auth.ErrProviderUnavailable
+	}
+	if !s.authenticated {
+		return errors.New("token validation failed with status: 401 Unauthorized")
+	}
+	return nil
+}
+
+func (s oidcLikeStrategy) Validate(string) (bool, error) {
+	if err := s.Authenticate(""); err != nil {
+		return false, err
+	}
+	if !s.privileged {
+		return false, errors.New("someone is not a member of any of the privileged groups")
+	}
+	return true, nil
+}
+
+// readAuthEnv builds an Env with a full router, wiring the given strategies under
+// the headers production uses. The metrics are real collectors on a private
+// registry, so counter assertions read the value the server would actually export.
+func readAuthEnv(t *testing.T, oidcEnabled bool, strategies map[string]auth.AuthStrategy) (*Env, *prometheus.Metrics) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	ctrl := gomock.NewController(t)
+	repo, _ := newRepo(ctrl)
+	// These tests assert routing and authentication, not task retrieval: a healthy
+	// backend that knows no tasks keeps the handlers on their simplest path.
+	repo.EXPECT().Check().Return(true).AnyTimes()
+	repo.EXPECT().GetTask(gomock.Any()).Return(nil, state.ErrTaskNotFound).AnyTimes()
+	metrics := prometheus.NewMetrics(promclient.NewRegistry())
+	argo := &argocd.Argo{}
+	argo.Init(repo, newArgoAPI(ctrl), metrics)
+
+	lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
+	require.NoError(t, err)
+
+	env := &Env{
+		config: &config.ServerConfig{
+			StaticFilePath: t.TempDir(),
+			OIDC:           config.OIDCConfig{Enabled: oidcEnabled},
+		},
+		argo:          argo,
+		metrics:       metrics,
+		lockdown:      lockdown,
+		strategies:    strategies,
+		authenticator: auth.NewAuthenticator(strategies),
+	}
+
+	return env, metrics
+}
+
+// unauthenticatedReads reads the counter value the server would export for a path.
+func unauthenticatedReads(metrics *prometheus.Metrics, path string) float64 {
+	return promtestutil.ToFloat64(metrics.UnauthenticatedReads.WithLabelValues(path))
+}
+
+// getWith issues a GET through the full router, optionally carrying a credential.
+func getWith(t *testing.T, env *Env, path, header, value string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, path, http.NoBody)
+	require.NoError(t, err)
+	if header != "" {
+		req.Header.Set(header, value)
+	}
+
+	recorder := httptest.NewRecorder()
+	env.CreateRouter().ServeHTTP(recorder, req)
+	return recorder
+}
+
+// protectedReads are the endpoints that require a credential once OIDC is enabled.
+var protectedReads = []string{
+	"/api/v1/tasks?from_timestamp=0",
+	"/api/v1/version",
+	"/api/v1/deploy-lock",
+	"/api/v1/reachability",
+}
+
+// TestReadAuthDisabled pins that the OIDC-disabled deployment is untouched: with
+// no auth backend configured there is nothing to authenticate against, so every
+// read stays open exactly as before.
+func TestReadAuthDisabled(t *testing.T) {
+	env, _ := readAuthEnv(t, false, nil)
+
+	for _, path := range append([]string{"/api/v1/config"}, protectedReads...) {
+		t.Run(path, func(t *testing.T) {
+			assert.Equal(t, http.StatusOK, getWith(t, env, path, "", "").Code)
+		})
+	}
+}
+
+// TestReadAuthProtectedEndpoints covers the endpoints that require a credential
+// once OIDC is enabled. These are the browser-facing reads: no released client
+// polls them, so requiring auth here breaks no pipeline.
+func TestReadAuthProtectedEndpoints(t *testing.T) {
+	t.Run("rejects a request carrying no credential", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: true},
+		})
+
+		for _, path := range protectedReads {
+			recorder := getWith(t, env, path, "", "")
+			assert.Equal(t, http.StatusUnauthorized, recorder.Code, path)
+			assert.Contains(t, recorder.Body.String(), "authentication required", path)
+		}
+	})
+
+	t.Run("accepts an authenticated user who holds no privilege", func(t *testing.T) {
+		// The split matters here: read access must not be limited to
+		// OIDC_PRIVILEGED_GROUPS, or enabling this would lock most users out.
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: true, privileged: false},
+		})
+
+		for _, path := range protectedReads {
+			assert.Equal(t, http.StatusOK, getWith(t, env, path, oidcHeader, "Bearer token").Code, path)
+		}
+	})
+
+	t.Run("accepts the legacy Keycloak header", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader:           oidcLikeStrategy{authenticated: true},
+			legacyKeycloakHeader: oidcLikeStrategy{authenticated: true},
+		})
+
+		assert.Equal(t, http.StatusOK,
+			getWith(t, env, "/api/v1/tasks?from_timestamp=0", legacyKeycloakHeader, "Bearer token").Code)
+	})
+
+	t.Run("accepts a deploy token so a pipeline can read", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader:                  oidcLikeStrategy{authenticated: true},
+			"ARGO_WATCHER_DEPLOY_TOKEN": auth.NewDeployTokenAuthService("deploy-token"),
+		})
+
+		assert.Equal(t, http.StatusOK,
+			getWith(t, env, "/api/v1/tasks?from_timestamp=0", "ARGO_WATCHER_DEPLOY_TOKEN", "deploy-token").Code)
+	})
+
+	t.Run("rejects a credential the provider refused", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: false},
+		})
+
+		recorder := getWith(t, env, "/api/v1/tasks?from_timestamp=0", oidcHeader, "Bearer token")
+
+		assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "401 Unauthorized")
+	})
+
+	t.Run("reports an unreachable provider as unavailable, not unauthorized", func(t *testing.T) {
+		// A 401 makes the frontend drop its session and redirect to login, so a
+		// provider blip must never be reported as an auth failure.
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{unavailable: true},
+		})
+
+		recorder := getWith(t, env, "/api/v1/tasks?from_timestamp=0", oidcHeader, "Bearer token")
+
+		assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	})
+
+	t.Run("still reports unavailable when a second credential is rejected", func(t *testing.T) {
+		// The production shape of an outage: the Web UI sends its OIDC token in both
+		// headers, and with JWT_SECRET configured the Authorization copy is parsed as
+		// an HMAC JWT and rejected. Strategy order is randomized, so answering 401
+		// here would sign users out of valid sessions on roughly half of requests.
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader:      oidcLikeStrategy{unavailable: true},
+			"Authorization": auth.NewJWTAuthService("secret"),
+		})
+		router := env.CreateRouter()
+
+		for i := 0; i < 50; i++ {
+			req, err := http.NewRequest(http.MethodGet, "/api/v1/tasks?from_timestamp=0", http.NoBody)
+			require.NoError(t, err)
+			req.Header.Set(oidcHeader, "Bearer oidc-token")
+			req.Header.Set("Authorization", "Bearer not-an-hmac-jwt")
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, recorder.Code, "iteration %d", i)
+		}
+	})
+}
+
+// TestDeployLockProviderUnavailable pins the same 401-vs-503 distinction on the
+// privileged write path: clicking the lock button during a provider outage must
+// surface an outage, not sign the user out.
+func TestDeployLockProviderUnavailable(t *testing.T) {
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+		oidcHeader: oidcLikeStrategy{unavailable: true},
+	})
+
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/deploy-lock", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set(oidcHeader, "Bearer token")
+
+	recorder := httptest.NewRecorder()
+	env.CreateRouter().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.False(t, env.lockdown.IsLocked(), "a failed authorization must not set the lock")
+}
+
+// TestReadAuthOpenEndpoints covers what stays reachable without a credential when
+// OIDC is enabled, and why each one has to.
+func TestReadAuthOpenEndpoints(t *testing.T) {
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+		oidcHeader: oidcLikeStrategy{authenticated: true},
+	})
+
+	t.Run("config stays open because login bootstraps from it", func(t *testing.T) {
+		// The frontend must read issuer_url and client_id before it can obtain a
+		// token, so gating this endpoint would make login impossible.
+		assert.Equal(t, http.StatusOK, getWith(t, env, "/api/v1/config", "", "").Code)
+	})
+
+	t.Run("healthz stays open for probes", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, getWith(t, env, "/healthz", "", "").Code)
+	})
+
+	t.Run("metrics stays open for scraping", func(t *testing.T) {
+		// Prometheus cannot perform an OIDC flow; this endpoint is governed by
+		// network policy instead.
+		assert.Equal(t, http.StatusOK, getWith(t, env, "/metrics", "", "").Code)
+	})
+
+	t.Run("task submission stays open without a credential", func(t *testing.T) {
+		// The highest-blast-radius invariant in this change: moving POST /tasks into
+		// the authenticated group would reject every uncredentialed pipeline in the
+		// fleet at once. A malformed body is enough to prove the request reached the
+		// handler — 406 comes from payload parsing, 401 would come from the middleware.
+		req, err := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader("{"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		env.CreateRouter().ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusNotAcceptable, recorder.Code)
+		assert.NotEqual(t, http.StatusUnauthorized, recorder.Code)
+	})
+}
+
+// TestReadAuthCoversEveryRegisteredRead derives its expectations from the router's
+// own route table instead of a hand-kept list, so a read added later is covered
+// without anyone remembering to extend a test. Adding a route means deciding
+// whether it belongs in the open or the authenticated group; landing in the wrong
+// one fails here.
+func TestReadAuthCoversEveryRegisteredRead(t *testing.T) {
+	// The exemptions, each justified in CreateRouter: login bootstraps from /config,
+	// and the released client polls /tasks/:id without a credential.
+	openByDesign := map[string]bool{
+		"/api/v1/config":    true,
+		"/api/v1/tasks/:id": true,
+	}
+
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+		oidcHeader: oidcLikeStrategy{authenticated: true},
+	})
+	router := env.CreateRouter()
+
+	checked := 0
+	for _, route := range router.Routes() {
+		if route.Method != http.MethodGet || !strings.HasPrefix(route.Path, "/api/v1/") {
+			continue
+		}
+
+		// Route patterns carry parameter placeholders; any concrete value reaches the
+		// same handler chain, which is all this assertion cares about.
+		path := strings.ReplaceAll(route.Path, ":id", "00000000-0000-0000-0000-000000000000")
+
+		req, err := http.NewRequest(route.Method, path, http.NoBody)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+
+		if openByDesign[route.Path] {
+			assert.NotEqual(t, http.StatusUnauthorized, recorder.Code,
+				"%s is exempt by design and must stay reachable", route.Path)
+			checked++
+			continue
+		}
+
+		assert.Equal(t, http.StatusUnauthorized, recorder.Code,
+			"%s is a read with no documented exemption and must require a credential", route.Path)
+		checked++
+	}
+
+	assert.GreaterOrEqual(t, checked, 6, "the route table should have yielded every /api/v1 read")
+}
+
+// TestReadAuthTaskLookupRemainsOpen pins the deliberate exemption: a released
+// client polls GET /api/v1/tasks/{id} for the whole length of every deployment and
+// sends no credential on GETs, so gating it would break every pipeline at once.
+// The task id is an unguessable v4 UUID handed only to the submitter, and the
+// enumerable list endpoint is protected — so the exemption is bounded to callers
+// that already hold a pointer to the task.
+func TestReadAuthTaskLookupRemainsOpen(t *testing.T) {
+	const (
+		unknownTask = "/api/v1/tasks/00000000-0000-0000-0000-000000000000"
+		routePath   = "/api/v1/tasks/:id"
+	)
+
+	oidcStrategies := func() map[string]auth.AuthStrategy {
+		return map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: true},
+		}
+	}
+
+	t.Run("serves a lookup without a credential", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, oidcStrategies())
+
+		// 404 proves the request reached the handler rather than being rejected.
+		assert.Equal(t, http.StatusNotFound, getWith(t, env, unknownTask, "", "").Code)
+	})
+
+	t.Run("counts the uncredentialed read for the migration signal", func(t *testing.T) {
+		env, metrics := readAuthEnv(t, true, oidcStrategies())
+
+		getWith(t, env, unknownTask, "", "")
+
+		assert.Equal(t, float64(1), unauthenticatedReads(metrics, routePath))
+	})
+
+	t.Run("does not count a credentialed read", func(t *testing.T) {
+		env, metrics := readAuthEnv(t, true, oidcStrategies())
+
+		getWith(t, env, unknownTask, oidcHeader, "Bearer token")
+
+		assert.Zero(t, unauthenticatedReads(metrics, routePath))
+	})
+
+	t.Run("does not count a read whose credential was rejected", func(t *testing.T) {
+		// The counter measures un-migrated callers, so an expired or wrong token must
+		// not inflate it — that number falling to zero is what licenses closing this
+		// endpoint, and a caller sending a bad token has already migrated.
+		env, metrics := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: false},
+		})
+
+		getWith(t, env, unknownTask, oidcHeader, "Bearer expired-token")
+
+		assert.Zero(t, unauthenticatedReads(metrics, routePath))
+	})
+
+	t.Run("does not count a credentialed read during a provider outage", func(t *testing.T) {
+		// The discriminating case for counting on presence rather than validity: a
+		// caller that HAS migrated must not be recorded as un-migrated just because
+		// the provider happens to be unreachable, and the poll — which runs for the
+		// whole duration of every deployment — must not wait on the provider to find
+		// that out.
+		env, metrics := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{unavailable: true},
+		})
+
+		assert.Equal(t, http.StatusNotFound, getWith(t, env, unknownTask, oidcHeader, "Bearer token").Code)
+		assert.Zero(t, unauthenticatedReads(metrics, routePath))
+	})
+
+	t.Run("does not count anything when OIDC is disabled", func(t *testing.T) {
+		// Without an auth backend there is no migration to measure.
+		env, metrics := readAuthEnv(t, false, nil)
+
+		getWith(t, env, unknownTask, "", "")
+
+		assert.Zero(t, unauthenticatedReads(metrics, routePath))
+	})
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -75,28 +75,52 @@ func (env *Env) CreateRouter() *gin.Engine {
 	}
 	router.StaticFS("/swagger", swaggerFS)
 
-	v1 := router.Group("/api/v1")
+	// The API is split into two groups by how each route is authenticated.
+	//
+	// `open` carries routes that must remain reachable without a session, or that
+	// authenticate themselves:
+	//   - POST /tasks authenticates optionally by design: an uncredentialed
+	//     submission is accepted and monitored, it just gets no git write-back and
+	//     no authority to supersede (see docs/reference/api.md).
+	//   - GET /config bootstraps the login flow. The frontend has to read the OIDC
+	//     issuer and client id from it BEFORE it can hold a token, so gating it
+	//     would make signing in impossible. Its payload is trimmed to match (see
+	//     config.ServerConfig).
+	//   - GET /tasks/:id is the one read a released client performs, polled for the
+	//     whole length of every deployment — and that client sends its credential
+	//     only on POST. Requiring auth here would break every pipeline at once, so
+	//     the v4 UUID acts as the capability: it is handed only to the submitter,
+	//     and the enumerable list endpoint below is protected. Uncredentialed hits
+	//     are counted (countUnauthenticatedRead) so the fleet's migration can be
+	//     measured before this exemption is ever removed.
+	//   - POST/DELETE /deploy-lock enforce privileged group membership themselves,
+	//     and are only registered when OIDC is enabled: without an auth backend
+	//     they cannot be protected, so exposing them would leave an
+	//     unauthenticated deploy-freeze switch reachable by anyone who can reach
+	//     the server (including via a victim's browser).
+	//
+	// `authenticated` carries the browser-facing reads. Nothing but the Web UI
+	// consumes them, so requiring a credential costs no pipeline anything. When OIDC
+	// is disabled the middleware is a no-op and these behave exactly as before.
+	open := router.Group("/api/v1")
+	authenticated := router.Group("/api/v1", env.requireAuthenticatedRead())
 	{
-		v1.POST("/tasks", env.addTask)
-		v1.GET("/tasks", env.getState)
-		v1.GET("/tasks/:id", env.getTaskStatus)
-		v1.GET("/version", env.getVersion)
-		v1.GET("/config", env.getConfig)
+		open.POST("/tasks", env.addTask)
+		open.GET("/config", env.getConfig)
+		open.GET("/tasks/:id", env.countUnauthenticatedRead(), env.getTaskStatus)
+
+		authenticated.GET("/tasks", env.getState)
+		authenticated.GET("/version", env.getVersion)
 		// Read-only ArgoCD + state-backend reachability for the frontend
-		// "unreachable" banner (issue #498). Always registered: it exposes no
-		// privileged action and mirrors the cached liveness-probe state without a
-		// live probe.
-		v1.GET("/reachability", env.reachability)
-		// The state-changing deploy-lock endpoints are only registered when OIDC
-		// auth is enabled: without an auth backend they cannot be protected, so
-		// exposing them would leave an unauthenticated deploy-freeze switch reachable
-		// by anyone who can reach the server (including via a victim's browser). The
-		// read-only GET stays available so the banner and scheduled lockdown keep working.
+		// "unreachable" banner (issue #498). It exposes no privileged action and
+		// mirrors the cached liveness-probe state without a live probe.
+		authenticated.GET("/reachability", env.reachability)
+		authenticated.GET(deployLockEndpoint, env.isDeployLockSet)
+
 		if env.config.OIDC.Enabled {
-			v1.POST(deployLockEndpoint, env.SetDeployLock)
-			v1.DELETE(deployLockEndpoint, env.ReleaseDeployLock)
+			open.POST(deployLockEndpoint, env.SetDeployLock)
+			open.DELETE(deployLockEndpoint, env.ReleaseDeployLock)
 		}
-		v1.GET(deployLockEndpoint, env.isDeployLockSet)
 	}
 
 	// Static file serving - use NoRoute to handle unmatched paths

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -75,33 +75,15 @@ func (env *Env) CreateRouter() *gin.Engine {
 	}
 	router.StaticFS("/swagger", swaggerFS)
 
-	// The API is split into two groups by how each route is authenticated.
-	//
-	// `open` carries routes that must remain reachable without a session, or that
-	// authenticate themselves:
-	//   - POST /tasks authenticates optionally by design: an uncredentialed
-	//     submission is accepted and monitored, it just gets no git write-back and
-	//     no authority to supersede (see docs/reference/api.md).
-	//   - GET /config bootstraps the login flow. The frontend has to read the OIDC
-	//     issuer and client id from it BEFORE it can hold a token, so gating it
-	//     would make signing in impossible. Its payload is trimmed to match (see
-	//     config.ServerConfig).
-	//   - GET /tasks/:id is the one read a released client performs, polled for the
-	//     whole length of every deployment — and that client sends its credential
-	//     only on POST. Requiring auth here would break every pipeline at once, so
-	//     the v4 UUID acts as the capability: it is handed only to the submitter,
-	//     and the enumerable list endpoint below is protected. Uncredentialed hits
-	//     are counted (countUnauthenticatedRead) so the fleet's migration can be
-	//     measured before this exemption is ever removed.
-	//   - POST/DELETE /deploy-lock enforce privileged group membership themselves,
-	//     and are only registered when OIDC is enabled: without an auth backend
-	//     they cannot be protected, so exposing them would leave an
-	//     unauthenticated deploy-freeze switch reachable by anyone who can reach
-	//     the server (including via a victim's browser).
-	//
-	// `authenticated` carries the browser-facing reads. Nothing but the Web UI
-	// consumes them, so requiring a credential costs no pipeline anything. When OIDC
-	// is disabled the middleware is a no-op and these behave exactly as before.
+	// Routes are grouped by how they authenticate. `authenticated` holds the reads
+	// only the Web UI consumes, so gating them costs no pipeline anything.
+	// `open` holds the rest, each for a reason that is not negotiable:
+	//   - POST /tasks takes an optional credential by design (docs/reference/api.md).
+	//   - GET /config bootstraps the login flow, so it cannot require a token.
+	//   - GET /tasks/:id is polled by released clients, which send no credential on
+	//     GETs; the v4 UUID is the capability and the enumerable list is protected.
+	//   - POST/DELETE /deploy-lock enforce privileged membership themselves, and are
+	//     registered only under OIDC so they are never an open deploy-freeze switch.
 	open := router.Group("/api/v1")
 	authenticated := router.Group("/api/v1", env.requireAuthenticatedRead())
 	{

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -95,6 +95,7 @@ func newMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
 	metrics.EXPECT().ObserveGitWritebackDuration(gomock.Any(), gomock.Any()).AnyTimes()
 	metrics.EXPECT().ObserveGitLockWaitDuration(gomock.Any(), gomock.Any()).AnyTimes()
 	metrics.EXPECT().ObserveDeploymentDuration(gomock.Any(), gomock.Any()).AnyTimes()
+	metrics.EXPECT().AddUnauthenticatedRead(gomock.Any()).AnyTimes()
 	return metrics
 }
 
@@ -231,7 +232,7 @@ func TestDeployLockEndpointRegistration(t *testing.T) {
 		assert.False(t, hasRoute(routes, http.MethodDelete, lockPath),
 			"DELETE deploy-lock must not be registered without an auth backend")
 		assert.True(t, hasRoute(routes, http.MethodGet, lockPath),
-			"read-only GET deploy-lock must stay available")
+			"read-only GET deploy-lock must stay registered")
 	})
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -58,6 +58,7 @@ Individual steps (for iterating or debugging):
 task up                   # build the race image + boot the full lab (idempotent)
 task verify               # assert argo-watcher is up and reaching real Argo
 task api-surface          # assert the read-only HTTP surface (version/config/task-list/deploy-lock) to contract
+task read-auth            # assert OIDC read protection: 401 without a credential, 503 when the provider is unreachable, exemptions still open
 task smoke                # one authenticated deploy through the full write-back loop, via the real client binary
 task client-knobs         # assert client env knobs: TASK_REFRESH override deploys, DEBUG cURL log redacts the token
 task jwt-auth             # assert the JWT (BEARER_TOKEN) auth path drives an authenticated write-back to deployed
@@ -128,6 +129,7 @@ again instead of re-establishing a forward.
 | `scripts/failure-fixture.sh` | inject/remove a deliberately-broken resource via the chart's `rawObject`: a failing PreSync hook (`hook`, aborts the sync), a failing plain migration Job (`degraded`, lets the image roll out and holds the app Synced+Degraded), or a Deployment whose readiness probe never passes (`pending`, holds the app Synced+Progressing with nothing Degraded); sole owner of the shared `chart/values.yaml` |
 | `scripts/notifications.sh` | assert the generic webhook fires start + result with the templated payload and auth header |
 | `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when OIDC auth is off |
+| `scripts/read-auth.sh` | assert OIDC read protection: toggles `OIDC_ENABLED` on the release with the issuer pointed at a closed port and reverts, asserting 401 without a credential, 503 (never 401) when the provider cannot be consulted — including with a rejected JWT alongside, 15× because strategy order is randomized — 200 for a deploy token / JWT, the `/tasks/:id`, `/config`, `/healthz`, `/metrics` and `POST /tasks` exemptions, and the `unauthenticated_reads` counter semantics. Needs no identity provider; group-based authorization is covered by the Keycloak integration suite instead |
 | `scripts/client-knobs.sh` | assert client env knobs via the real client: `TASK_REFRESH=false` still deploys, `DEBUG=true` cURL log redacts the deploy token |
 | `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed |
 | `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency) |

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -187,6 +187,12 @@ tasks:
     cmds:
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/api-surface.sh
 
+  read-auth:
+    desc: "Assert OIDC read protection: 401 without a credential, 503 when the provider is unreachable, exemptions still open"
+    cmds:
+      - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
+        DEPLOY_TOKEN={{.DEPLOY_TOKEN}} JWT_SECRET={{.JWT_SECRET}} ./scripts/read-auth.sh
+
   smoke:
     desc: "One authenticated end-to-end deploy proving the write-back loop"
     cmds:

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -64,6 +64,14 @@ phase() {
   phase api-surface.sh
 }
 
+@test "read-auth: OIDC gates the browser-facing reads, 401 vs 503, exemptions hold" {
+  # Sits next to api-surface because it is the other HTTP-contract phase, and before
+  # everything that deploys: it toggles OIDC_ENABLED on the release (two pod
+  # restarts) and reverts, so no in-flight task should be in the air. It touches no
+  # application state and leaves the lock unset.
+  phase read-auth.sh
+}
+
 @test "smoke: one authenticated deploy through the write-back loop" {
   phase smoke-deploy.sh
 }

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -6,9 +6,9 @@
 #   - GET  /api/v1/version              -> 200, non-empty JSON string
 #   - GET  /api/v1/config               -> 200; Keycloak reported disabled; the
 #                                          deploy-token secret is redacted (json:"-");
-#                                          notification targets, lockdown schedule
-#                                          and TLS posture are absent — the endpoint
-#                                          is unauthenticated by necessity (the UI
+#                                          notification targets absent but their
+#                                          `enabled` flags kept — the endpoint is
+#                                          unauthenticated by necessity (the UI
 #                                          bootstraps its login from it)
 #
 # The lab runs with OIDC disabled, which is the deployment shape asserted here:
@@ -57,12 +57,13 @@ elif ! jq -e '.keycloak.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
 elif grep -qF "$DEPLOY_TOKEN" <<<"$BODY"; then
   # A leaked secret here is the whole reason ServerConfig marks it json:"-".
   bad "config: deploy token leaked in /config response"
-elif ! jq -e 'has("webhook") == false and has("mattermost") == false' <<<"$BODY" >/dev/null 2>&1; then
-  # /config is served unauthenticated, and a notification webhook URL is itself
-  # the credential — the lab has webhooks enabled, so a regression shows up here.
-  bad "config: notification settings exposed on an unauthenticated endpoint"
-elif ! jq -e 'has("lockdown_schedule") == false and has("skip_tls_verify") == false' <<<"$BODY" >/dev/null 2>&1; then
-  bad "config: deployment detail (lockdown schedule / TLS posture) exposed unauthenticated"
+elif ! jq -e '(.webhook | has("url") | not) and (.mattermost | has("url") | not)' <<<"$BODY" >/dev/null 2>&1; then
+  # /config is served unauthenticated and a webhook URL is itself the credential; the
+  # lab runs with webhooks enabled, so a regression shows up here.
+  bad "config: notification target exposed on an unauthenticated endpoint"
+elif ! jq -e '.webhook.enabled == true' <<<"$BODY" >/dev/null 2>&1; then
+  # The enabled flag must survive: downstream consumers (argo-watcher-mcp) read it.
+  bad "config: webhook.enabled missing (lab runs with webhooks on)"
 elif ! jq -e '.argo_cd_url != null' <<<"$BODY" >/dev/null 2>&1; then
   # The CLI client builds the app URL from this field; trimming must not take it.
   bad "config: argo_cd_url missing — the client needs it to build app URLs"

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -5,7 +5,16 @@
 # operators depend on that no other phase exercises:
 #   - GET  /api/v1/version              -> 200, non-empty JSON string
 #   - GET  /api/v1/config               -> 200; Keycloak reported disabled; the
-#                                          deploy-token secret is redacted (json:"-")
+#                                          deploy-token secret is redacted (json:"-");
+#                                          notification targets, lockdown schedule
+#                                          and TLS posture are absent — the endpoint
+#                                          is unauthenticated by necessity (the UI
+#                                          bootstraps its login from it)
+#
+# The lab runs with OIDC disabled, which is the deployment shape asserted here:
+# every read stays open. Read protection under OIDC lives in the Keycloak
+# integration suite (internal/server/keycloak_integration_test.go, docker-compose
+# `integration` profile) until the lab grows an OIDC-enabled phase.
 #   - GET  /api/v1/tasks?status=bogus   -> 400 "unsupported status filter"
 #   - GET  /api/v1/tasks?status=deployed-> 200, valid JSON (filter accepted)
 #   - GET  /api/v1/tasks/<unknown-uuid> -> 404 "task not found" (the 404-vs-500
@@ -48,8 +57,17 @@ elif ! jq -e '.keycloak.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
 elif grep -qF "$DEPLOY_TOKEN" <<<"$BODY"; then
   # A leaked secret here is the whole reason ServerConfig marks it json:"-".
   bad "config: deploy token leaked in /config response"
+elif ! jq -e 'has("webhook") == false and has("mattermost") == false' <<<"$BODY" >/dev/null 2>&1; then
+  # /config is served unauthenticated, and a notification webhook URL is itself
+  # the credential — the lab has webhooks enabled, so a regression shows up here.
+  bad "config: notification settings exposed on an unauthenticated endpoint"
+elif ! jq -e 'has("lockdown_schedule") == false and has("skip_tls_verify") == false' <<<"$BODY" >/dev/null 2>&1; then
+  bad "config: deployment detail (lockdown schedule / TLS posture) exposed unauthenticated"
+elif ! jq -e '.argo_cd_url != null' <<<"$BODY" >/dev/null 2>&1; then
+  # The CLI client builds the app URL from this field; trimming must not take it.
+  bad "config: argo_cd_url missing — the client needs it to build app URLs"
 else
-  ok "config: oidc disabled (+ legacy keycloak mirror), deploy token redacted (${CODE})"
+  ok "config: oidc disabled (+ legacy keycloak mirror), secrets and deployment detail withheld (${CODE})"
 fi
 
 echo "=== task-list filters ==="

--- a/test/e2e/scripts/read-auth.sh
+++ b/test/e2e/scripts/read-auth.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Assert the OIDC read-protection contract against the real server.
+#
+# OIDC_ENABLED is a server-global config, so — like lockdown.sh — this phase toggles
+# it on the live release for its own duration and reverts before exiting.
+#
+# It runs WITHOUT an identity provider, on purpose. The issuer points at a closed
+# port, so every token the server is asked to check fails to validate with a
+# transport error. That is exactly the interesting half of the contract and it needs
+# no Keycloak in the lab:
+#
+#   - no credential            -> 401 (the middleware answers before any provider call)
+#   - an OIDC token            -> 503 (the provider could not be consulted)
+#   - a deploy token / JWT     -> 200 (validated locally, provider never involved)
+#
+# The 503 case is why the closed port matters: a 401 there would make the Web UI
+# discard a live session over a provider blip, and the lab reproduces the shape that
+# made that fail intermittently in unit tests — the UI sends its token in BOTH
+# Authorization and Oidc-Authorization, and the lab sets JWT_SECRET, so the
+# Authorization copy is claimed by the JWT strategy and rejected while the OIDC
+# strategy reports the outage. Strategy order is a randomized map iteration, so that
+# case is asserted repeatedly rather than once.
+#
+# Group membership is NOT exercised here: with the provider unreachable, no token can
+# be authorized, so privileged-vs-unprivileged is not observable. That distinction is
+# covered against a real Keycloak in internal/server/keycloak_integration_test.go
+# (TestKeycloakReadAuthn / TestKeycloakDeployLockAuthz).
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+: "${AW_CHART_REPO:?AW_CHART_REPO is required}" "${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+VALUES="${E2E_DIR}/values/argo-watcher.yaml"
+# MUST match JWT_SECRET in values/argo-watcher.yaml — the JWT read below is signed
+# with it and the server verifies against the value it was deployed with.
+JWT_SECRET="${JWT_SECRET:-e2e-jwt-secret}"
+
+# A closed port on the pod's own loopback: connection refused is immediate, so each
+# assertion costs nothing while still exercising the provider-unreachable path.
+UNREACHABLE_ISSUER="http://127.0.0.1:1"
+UNKNOWN_TASK="00000000-0000-0000-0000-000000000000"
+OIDC_HEADER="Oidc-Authorization: Bearer e2e-oidc-token"
+# Structurally invalid as an HMAC JWT, so the JWT strategy on Authorization rejects
+# it — the second credential in the mixed-outcome case below.
+BAD_JWT_HEADER="Authorization: Bearer not-a-real-jwt"
+
+# The reads that must require a credential once OIDC is on. Kept as a list so a new
+# protected read is one line here.
+PROTECTED=(
+  "tasks?from_timestamp=0"
+  "version"
+  "reachability"
+  "deploy-lock"
+)
+
+revert() {
+  echo "reverting OIDC_ENABLED"
+  helm_apply_aw || true
+  wait_service || true
+  return
+}
+trap revert EXIT
+
+wait_service || die "argo-watcher never answered on ${AW_URL}"
+
+# --- 0. Baseline: with OIDC off the same reads are open ------------------------
+# Without this the phase could pass against a server that rejects reads for some
+# unrelated reason.
+for path in "${PROTECTED[@]}"; do
+  req GET "${AW_API}/${path}"
+  [[ "$CODE" == "200" ]] || bad "baseline (OIDC off) GET /${path}: code=${CODE}, want 200"
+done
+ok "baseline: every read is open with OIDC disabled"
+
+# --- 1. Enable OIDC against an unreachable issuer -----------------------------
+# ClientId is mandatory when enabled (validateServerConfig), so the pod would
+# CrashLoop without it. PrivilegedGroups is optional and irrelevant here.
+idx=$(extra_envs_index "$VALUES")
+helm_apply_aw --set-string "extraEnvs[${idx}].name=OIDC_ENABLED" \
+              --set-string "extraEnvs[${idx}].value=true" \
+              --set-string "extraEnvs[$((idx + 1))].name=OIDC_ISSUER_URL" \
+              --set-string "extraEnvs[$((idx + 1))].value=${UNREACHABLE_ISSUER}" \
+              --set-string "extraEnvs[$((idx + 2))].name=OIDC_CLIENT_ID" \
+              --set-string "extraEnvs[$((idx + 2))].value=argo-watcher-e2e"
+wait_service || die "argo-watcher never came back after enabling OIDC"
+
+req GET "${AW_API}/config"
+if jq -e '.oidc.enabled == true' <<<"$BODY" >/dev/null 2>&1; then
+  ok "server reports oidc.enabled=true"
+else
+  die "server did not come back with OIDC enabled (config=${BODY})"
+fi
+
+# --- 2. Protected reads reject an uncredentialed caller -----------------------
+for path in "${PROTECTED[@]}"; do
+  req GET "${AW_API}/${path}"
+  if [[ "$CODE" == "401" ]] && jq -e '.error | test("authentication required")' <<<"$BODY" >/dev/null 2>&1; then
+    ok "GET /${path} -> 401 without a credential"
+  else
+    bad "GET /${path}: code=${CODE} body=${BODY} (want 401 authentication required)"
+  fi
+done
+
+# --- 3. An unreachable provider is 503, never 401 -----------------------------
+# 401 is what makes the Web UI drop its session, so this is the distinction the
+# whole error mapping exists for.
+req GET "${AW_API}/tasks?from_timestamp=0" -H "$OIDC_HEADER"
+if [[ "$CODE" == "503" ]]; then
+  ok "GET /tasks with an OIDC token -> 503 (provider unreachable)"
+else
+  bad "GET /tasks with an OIDC token: code=${CODE} body=${BODY} (want 503)"
+fi
+
+# Mixed outcomes across strategies: the provider-unavailable signal must win over the
+# JWT strategy's rejection on every request, not on average.
+mixed_fails=0
+for _ in $(seq 1 15); do
+  req GET "${AW_API}/tasks?from_timestamp=0" -H "$OIDC_HEADER" -H "$BAD_JWT_HEADER"
+  [[ "$CODE" == "503" ]] || mixed_fails=$((mixed_fails + 1))
+done
+if [[ "$mixed_fails" == "0" ]]; then
+  ok "OIDC token + rejected JWT -> 503 on all 15 attempts (precedence is stable)"
+else
+  bad "OIDC token + rejected JWT: ${mixed_fails}/15 attempts were not 503 (strategy precedence depends on map order)"
+fi
+
+# --- 4. Machine credentials read without touching the provider ----------------
+req GET "${AW_API}/tasks?from_timestamp=0" -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}"
+if [[ "$CODE" == "200" ]]; then
+  ok "GET /tasks with the deploy token -> 200"
+else
+  bad "GET /tasks with the deploy token: code=${CODE} body=${BODY} (want 200)"
+fi
+
+jwt="$(cd "$E2E_ROOT" && JWT_SECRET="$JWT_SECRET" go run ./test/e2e/tools/mintjwt)" ||
+  die "could not mint a JWT"
+req GET "${AW_API}/tasks?from_timestamp=0" -H "Authorization: ${jwt}"
+if [[ "$CODE" == "200" ]]; then
+  ok "GET /tasks with a valid JWT -> 200 (a pipeline can read)"
+else
+  bad "GET /tasks with a valid JWT: code=${CODE} body=${BODY} (want 200)"
+fi
+
+# --- 5. The deliberate exemptions stay reachable -------------------------------
+# Breaking any of these breaks either every pipeline (the task lookup), the Web UI's
+# ability to log in at all (/config), or the probes and the scrape.
+req GET "${AW_API}/tasks/${UNKNOWN_TASK}"
+if [[ "$CODE" == "404" ]] && jq -e '.error == "task not found"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /tasks/<id> -> 404 without a credential (reached the handler)"
+else
+  bad "GET /tasks/<id>: code=${CODE} body=${BODY} (want 404 task not found)"
+fi
+
+req GET "${AW_API}/config"
+if [[ "$CODE" == "200" ]] &&
+   jq -e 'has("webhook") == false and has("mattermost") == false' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /config -> 200 without a credential, notification settings withheld"
+else
+  bad "GET /config: code=${CODE} (want 200 with no notification settings)"
+fi
+
+req GET "${AW_URL}/healthz"
+if [[ "$CODE" == "200" ]]; then
+  ok "GET /healthz -> 200 (probes unaffected)"
+else
+  bad "GET /healthz: code=${CODE} (want 200)"
+fi
+
+req GET "${AW_URL}/metrics"
+if [[ "$CODE" == "200" ]]; then
+  ok "GET /metrics -> 200 (scrape unaffected)"
+else
+  bad "GET /metrics: code=${CODE} (want 200)"
+fi
+
+# A malformed body proves the request reached addTask: 406 comes from payload
+# parsing, 401 would come from the middleware. Moving POST /tasks behind auth would
+# reject every uncredentialed pipeline in the fleet at once.
+req POST "${AW_API}/tasks" -H 'Content-Type: application/json' -d '{'
+if [[ "$CODE" == "406" ]]; then
+  ok "POST /tasks -> 406 without a credential (submission is not gated)"
+else
+  bad "POST /tasks: code=${CODE} body=${BODY} (want 406 — 401 means submission got gated)"
+fi
+
+# --- 6. The migration counter tracks credential-less reads only ---------------
+before="$(metric_sum unauthenticated_reads)"
+req GET "${AW_API}/tasks/${UNKNOWN_TASK}"
+after_open="$(metric_sum unauthenticated_reads)"
+if (( after_open > before )); then
+  ok "unauthenticated_reads counted the credential-less lookup (${before} -> ${after_open})"
+else
+  bad "unauthenticated_reads did not count a credential-less lookup (${before} -> ${after_open})"
+fi
+
+if curl -s -m 10 "${AW_URL}/metrics" | grep -q 'unauthenticated_reads{path="/api/v1/tasks/:id"}'; then
+  ok "the counter is labelled with the route pattern"
+else
+  bad "no unauthenticated_reads series labelled path=\"/api/v1/tasks/:id\""
+fi
+
+# A credentialed read must not inflate the number whose fall to zero is what
+# licenses closing this endpoint.
+req GET "${AW_API}/tasks/${UNKNOWN_TASK}" -H "ARGO_WATCHER_DEPLOY_TOKEN: ${DEPLOY_TOKEN}"
+after_creds="$(metric_sum unauthenticated_reads)"
+if [[ "$after_creds" == "$after_open" ]]; then
+  ok "a credentialed lookup left the counter unchanged (${after_creds})"
+else
+  bad "a credentialed lookup moved the counter (${after_open} -> ${after_creds})"
+fi
+
+# --- 7. The privileged write path is registered but cannot be authorized ------
+req POST "${AW_API}/deploy-lock" -H "$OIDC_HEADER"
+if [[ "$CODE" == "503" ]]; then
+  ok "POST /deploy-lock -> 503 (registered under OIDC, provider unreachable)"
+else
+  bad "POST /deploy-lock: code=${CODE} body=${BODY} (want 503)"
+fi
+
+# --- 8. Revert and prove the toggle is the only thing gating reads ------------
+revert
+trap - EXIT
+
+for path in "${PROTECTED[@]}"; do
+  req GET "${AW_API}/${path}"
+  [[ "$CODE" == "200" ]] || bad "after revert GET /${path}: code=${CODE}, want 200"
+done
+ok "every read is open again with OIDC disabled"
+
+# Nothing above could authorize a lock, so the lab must be left unlocked.
+req GET "${AW_API}/deploy-lock"
+if jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
+  ok "deploy lock still unset"
+else
+  bad "deploy lock is set after the phase (body=${BODY})"
+fi
+
+phase_end READ-AUTH

--- a/test/e2e/scripts/read-auth.sh
+++ b/test/e2e/scripts/read-auth.sh
@@ -1,30 +1,23 @@
 #!/usr/bin/env bash
 # Assert the OIDC read-protection contract against the real server.
 #
-# OIDC_ENABLED is a server-global config, so — like lockdown.sh — this phase toggles
-# it on the live release for its own duration and reverts before exiting.
+# OIDC_ENABLED is server-global, so — like lockdown.sh — this phase toggles it on the
+# live release for its own duration and reverts before exiting.
 #
-# It runs WITHOUT an identity provider, on purpose. The issuer points at a closed
-# port, so every token the server is asked to check fails to validate with a
-# transport error. That is exactly the interesting half of the contract and it needs
-# no Keycloak in the lab:
+# It runs WITHOUT an identity provider: the issuer points at a closed port, so any token
+# the server must check fails with a transport error. That covers the contract's
+# interesting half with no Keycloak in the lab:
 #
-#   - no credential            -> 401 (the middleware answers before any provider call)
-#   - an OIDC token            -> 503 (the provider could not be consulted)
-#   - a deploy token / JWT     -> 200 (validated locally, provider never involved)
+#   - no credential        -> 401 (answered before any provider call)
+#   - an OIDC token        -> 503 (the provider could not be consulted)
+#   - a deploy token / JWT -> 200 (validated locally)
 #
-# The 503 case is why the closed port matters: a 401 there would make the Web UI
-# discard a live session over a provider blip, and the lab reproduces the shape that
-# made that fail intermittently in unit tests — the UI sends its token in BOTH
-# Authorization and Oidc-Authorization, and the lab sets JWT_SECRET, so the
-# Authorization copy is claimed by the JWT strategy and rejected while the OIDC
-# strategy reports the outage. Strategy order is a randomized map iteration, so that
-# case is asserted repeatedly rather than once.
+# The 503 case is asserted repeatedly, not once: the lab sets JWT_SECRET, so a request
+# carrying both headers has one strategy rejecting and one reporting the outage, and
+# strategy order is a randomized map iteration.
 #
-# Group membership is NOT exercised here: with the provider unreachable, no token can
-# be authorized, so privileged-vs-unprivileged is not observable. That distinction is
-# covered against a real Keycloak in internal/server/keycloak_integration_test.go
-# (TestKeycloakReadAuthn / TestKeycloakDeployLockAuthz).
+# Group membership is not observable with the provider unreachable; that is covered
+# against a real Keycloak in internal/server/keycloak_integration_test.go.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -155,10 +148,10 @@ fi
 
 req GET "${AW_API}/config"
 if [[ "$CODE" == "200" ]] &&
-   jq -e 'has("webhook") == false and has("mattermost") == false' <<<"$BODY" >/dev/null 2>&1; then
-  ok "GET /config -> 200 without a credential, notification settings withheld"
+   jq -e '(.webhook | has("url") | not) and (.mattermost | has("url") | not)' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /config -> 200 without a credential, notification targets withheld"
 else
-  bad "GET /config: code=${CODE} (want 200 with no notification settings)"
+  bad "GET /config: code=${CODE} (want 200 with no notification targets)"
 fi
 
 req GET "${AW_URL}/healthz"


### PR DESCRIPTION
With OIDC enabled, GET /api/v1/tasks, /version, /reachability and GET /deploy-lock now require a credential. Any configured credential is accepted — an OIDC session, the deploy token, or a CI JWT — and privileged group membership stays a requirement of the deploy-lock writes alone, so enabling this does not restrict the UI to OIDC_PRIVILEGED_GROUPS. With OIDC disabled every endpoint behaves exactly as before.

Four endpoints stay open on purpose. The client polls GET /tasks/{id} for the whole length of a deployment and presents its credential only on submission, so gating that lookup would break every pipeline at once; the v4 UUID is the capability instead, and the enumerable list endpoint is closed. The Web UI reads the issuer and client id from GET /config before it can hold a token, so gating it would make signing in impossible. Probes and Prometheus cannot perform an OIDC flow. A browser cannot attach a header to a WebSocket handshake, so /ws — which carries lock and reachability transitions, no task data — keeps the two signals its REST equivalents now protect readable.

OIDC_TOKEN_VALIDATION_INTERVAL is now honoured rather than parsed and ignored: a provider decision is reused for that long, capped per token by the token's own expiry, so an open browser tab costs one userinfo call per token per interval instead of one per refresh. Its default rises to 300000 ms. Privileged actions bypass the cache entirely and always re-verify, keeping group removal and provider-side revocation immediate.

A credential that cannot be checked because the provider is unreachable now yields 503 instead of 401. The Web UI treats a 401 as a dead session, so a provider blip would otherwise sign every user out. Where a request carries several credentials and they disagree, the unavailable signal wins over a rejection: "rejected" is only truthful if every credential was evaluated.

GET /config no longer serves the notification settings, the lockdown schedule or the TLS posture. That endpoint cannot be authenticated, and a notification webhook URL is itself a credential.

The unauthenticated_reads counter reports reads still arriving without a credential on the endpoints left open, measured on credential presence so an expired token or a provider outage cannot inflate it. Its fall to zero is the evidence needed before those endpoints can be closed too.