### PR TITLE
fix(server): report what is out of sync when a rollout fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Duration column of the tasks table now counts up while a deployment is in
   progress, instead of showing `0s` until the task reaches a final status.
+- A deployment that fails with `Rollout status is not synced` now names what is
+  actually out of sync. The report previously showed only the last sync *operation*,
+  which routinely reads `Succeeded` / `successfully synced (all tasks run)` even
+  though the application is still out of sync — leaving no culprit and reading as a
+  contradiction. It now lists the drifted resources under `Out-of-sync resources:`
+  and, when Argo CD could not complete the comparison at all, the reason under
+  `Sync errors:`. An application that is degraded *and* out of sync is reported here
+  too — a pending sync may still recover it — so the failing pod behind it now appears
+  under `Unhealthy resources:` rather than only in the Argo CD UI. A failure with none
+  of the three keeps its previous output.
 
 ### Security
 

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -43,7 +43,10 @@ type ApplicationResource struct {
 	Kind      string `json:"kind"`      // example: Pod | Job
 	Name      string `json:"name"`      // example: app-migrations
 	Namespace string `json:"namespace"` // example: app
-	Health    struct {
+	// Status is the resource's current sync state (example: OutOfSync). ArgoCD omits it for
+	// resources it does not compare, so an empty value means "not assessed", not "in sync".
+	Status string `json:"status"`
+	Health struct {
 		Message string `json:"message"` // example: Job has reached the specified backoff limit
 		Status  string `json:"status"`  // example: Synced
 	} `json:"health"`
@@ -74,10 +77,19 @@ type ApplicationTreeNode struct {
 	} `json:"health"`
 }
 
+// ApplicationCondition is an entry of ArgoCD's status.conditions: either an error (a "*Error"
+// type) or an advisory warning (a "*Warning" type). A manifest-generation failure surfaces here
+// and nowhere in the sync status itself, which merely reports "Unknown".
+type ApplicationCondition struct {
+	Type    string `json:"type"`    // example: ComparisonError
+	Message string `json:"message"` // example: Failed to load target state
+}
+
 type ApplicationStatus struct {
 	Health struct {
 		Status string `json:"status"`
 	}
+	Conditions     []ApplicationCondition          `json:"conditions"`
 	OperationState ApplicationStatusOperationState `json:"operationState"`
 	Resources      []ApplicationResource           `json:"resources"`
 	Summary        struct {
@@ -152,7 +164,9 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 // The actionable diagnostics (terminal sync operation, failed hooks, unhealthy resources, and —
 // while the application is still Progressing — the resources that never became ready) are appended
 // to both the "not available" and "not healthy"/"degraded" failures so on-call users don't have to
-// context-switch into the ArgoCD UI regardless of how the rollout failed.
+// context-switch into the ArgoCD UI regardless of how the rollout failed. The "not synced" failure
+// gets its own set instead: it fails on current drift, which the health-oriented sections cannot
+// describe (see buildSyncFailureDiagnostics).
 func (app *Application) GetRolloutMessage(status string, rolloutImages []string, tree *ApplicationTree) string {
 	switch status {
 	// not all expected images were deployed
@@ -176,7 +190,10 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 			app.Status.OperationState.Phase,
 			app.Status.OperationState.Message,
 		)
-		return appendResourceListing(base, app.ListSyncResultResources())
+		return appendDiagnostics(
+			appendResourceListing(base, app.ListSyncResultResources()),
+			app.buildSyncFailureDiagnostics(tree),
+		)
 	// app is unhealthy or degraded
 	case ArgoRolloutAppNotHealthy, ArgoRolloutAppDegraded:
 		// display current health of the top-level resources, then append the same
@@ -262,6 +279,70 @@ func (app *Application) ListUnhealthyResources() []string {
 		list = append(list, formatHealthResource(resource))
 	}
 	return list
+}
+
+// listOutOfSyncResources returns one formatted line per top-level resource whose sync status is
+// not "Synced". Resources ArgoCD does not compare carry no status at all and are skipped: an empty
+// value means "not assessed" rather than "drifted", and reporting those would bury the real culprit.
+func (app *Application) listOutOfSyncResources() []string {
+	var list []string
+
+	for index := range app.Status.Resources {
+		resource := app.Status.Resources[index]
+		if resource.Status == "" || resource.Status == "Synced" {
+			continue
+		}
+		list = append(list, fmt.Sprintf("%s(%s) %s", resource.Kind, resource.Name, resource.Status))
+	}
+	return list
+}
+
+// listErrorConditions returns one formatted line per application condition reporting an error.
+// ArgoCD names every error condition with an "Error" suffix and every advisory one with a
+// "Warning" suffix, so the suffix decides what is actionable — a fixed list would go stale as
+// upstream adds condition types.
+func (app *Application) listErrorConditions() []string {
+	var list []string
+
+	for index := range app.Status.Conditions {
+		condition := app.Status.Conditions[index]
+		if !strings.HasSuffix(condition.Type, "Error") {
+			continue
+		}
+		list = append(list, fmt.Sprintf("%s: %s", condition.Type, condition.Message))
+	}
+	return list
+}
+
+// buildSyncFailureDiagnostics builds the optional diagnostics suffix appended to the "not synced"
+// rollout failure. The base message reports the last sync *operation*, which routinely succeeded
+// while the application drifted straight back out of sync; the drift itself lives in the current
+// resource statuses, and the reason a comparison failed outright lives only in the conditions.
+// Each section is included only when it has content, so a failure with neither keeps its legacy output.
+func (app *Application) buildSyncFailureDiagnostics(tree *ApplicationTree) string {
+	var sections []string
+
+	// Errors come first: the resource listing is unbounded, so the one line naming the
+	// cause must not trail dozens of drift lines.
+	if conditions := app.listErrorConditions(); len(conditions) > 0 {
+		sections = append(sections, "Sync errors:\n\t"+strings.Join(conditions, "\n\t"))
+	}
+
+	// GetRolloutStatus classifies a Degraded application that is still OutOfSync as "not synced",
+	// because a pending sync may yet recover it. This report is therefore the only one such a
+	// failure ever produces, and the pod-level cause of the degradation reaches the user only from
+	// the tree — Status.Resources carries no pod health.
+	if tree != nil {
+		if problems := tree.ListProblemNodes(); len(problems) > 0 {
+			sections = append(sections, "Unhealthy resources:\n\t"+strings.Join(problems, "\n\t"))
+		}
+	}
+
+	if resources := app.listOutOfSyncResources(); len(resources) > 0 {
+		sections = append(sections, "Out-of-sync resources:\n\t"+strings.Join(resources, "\n\t"))
+	}
+
+	return strings.Join(sections, "\n\n")
 }
 
 // isTerminalFailurePhase reports whether the given ArgoCD phase value indicates a terminal failure. The same

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -62,6 +62,35 @@ func TestListUnhealthyResources(t *testing.T) {
 	assert.Equal(t, expectedResources, unhealthyResources)
 }
 
+func TestNotSyncedDiagnosticsFromPayload(t *testing.T) {
+	// Decodes a captured ArgoCD payload so the struct tags the not-synced report depends on —
+	// status.resources[].status and status.conditions — are exercised. Tests that build the
+	// Application in Go cannot catch a wrong tag, which would leave both sections silently empty.
+	jsonData, err := os.ReadFile("testdata/out-of-sync-deployment.json")
+	if err != nil {
+		t.Fatalf("Failed to read JSON data file: %s", err)
+	}
+
+	var app Application
+	if err := json.Unmarshal(jsonData, &app); err != nil {
+		t.Fatalf("Failed to unmarshal JSON data: %s", err)
+	}
+
+	assert.Equal(t, ArgoRolloutAppNotSynced,
+		app.GetRolloutStatus([]string{"product-catalog:v0.0.2"}, "", false))
+
+	assert.Equal(t,
+		"App status \"Succeeded\"\n"+
+			"App message \"successfully synced (all tasks run)\"\n"+
+			"Resources:\n"+
+			"\tDeployment(product-catalog)  Running with message deployment.apps/product-catalog configured\n\n"+
+			"Sync errors:\n"+
+			"\tComparisonError: Failed to load target state: rpc error: code = Unknown\n\n"+
+			"Out-of-sync resources:\n"+
+			"\tDeployment(product-catalog) OutOfSync",
+		app.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"product-catalog:v0.0.2"}, nil))
+}
+
 func TestArgoRolloutStatus(t *testing.T) {
 	t.Run("Rollout status - ArgoRolloutAppNotAvailable", func(t *testing.T) {
 		// define application
@@ -123,6 +152,17 @@ func TestArgoRolloutStatus(t *testing.T) {
 		registryProxyUrl := ""
 		// test status
 		assert.Equal(t, ArgoRolloutAppDegraded, application.GetRolloutStatus(images, registryProxyUrl, false))
+	})
+
+	t.Run("Rollout status - a degraded app that is still OutOfSync is not synced", func(t *testing.T) {
+		// A pending sync may yet recover the app, so drift outranks degradation here. The
+		// not-synced failure report relies on this routing to know it must carry the pod cause.
+		application := Application{}
+		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
+		application.Status.Sync.Status = "OutOfSync"
+		application.Status.Health.Status = "Degraded"
+		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
+		assert.Equal(t, ArgoRolloutAppNotSynced, application.GetRolloutStatus(images, "", false))
 	})
 
 	t.Run("acceptSuspended is true", func(t *testing.T) {
@@ -604,6 +644,175 @@ func TestArgoRolloutMessage(t *testing.T) {
 		assert.Equal(t,
 			"App status \"NotWorking\"\n"+
 				"App message \"Not working test app\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced reports the pod-level cause when the app is also degraded", func(t *testing.T) {
+		// A Degraded application that is still OutOfSync is classified "not synced", so this arm is
+		// the only place the crashlooping pod behind such a failure is ever reported. The cause lives
+		// in the resource tree alone — Status.Resources carries no pod health.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "product-catalog-abcde", "Degraded", "back-off 5m0s restarting failed container=app"),
+			treeNode("Service", "product-catalog", "Healthy", ""),
+		}}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(product-catalog-abcde) Degraded with message back-off 5m0s restarting failed container=app\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
+	})
+
+	t.Run("Rollout message - not synced adds no Unhealthy block when the tree is clean", func(t *testing.T) {
+		// The tree is fetched on every failure, so a healthy one must leave the report untouched.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "product-catalog-abcde", "Healthy", ""),
+		}}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
+	})
+
+	t.Run("Rollout message - not synced omits the Sync errors block when only warnings are present", func(t *testing.T) {
+		// The conditions filter emptying out must leave no trace: no header, no separator. Warnings
+		// are the common case on a healthy app, so this is the path most likely to regress.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
+			{Type: "SharedResourceWarning", Message: "Resource is part of applications app-a and app-b"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced omits the Out-of-sync block when no resource has drifted", func(t *testing.T) {
+		// The app-level sync status can be non-Synced while every top-level resource compares clean
+		// (or is not compared at all), so the resource filter must be able to empty out silently.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
+			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced names the resources that are out of sync", func(t *testing.T) {
+		// The base message reports the last sync operation, which routinely succeeded while the app
+		// drifted straight back out of sync. Without this section the report names no culprit at all.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
+			{Kind: "ConfigMap", Name: "product-catalog", Namespace: "app", Status: "Unknown"},
+			// A resource ArgoCD does not compare carries no status: absent means "not assessed",
+			// not "drifted", so it must not be reported as a culprit.
+			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync\n"+
+				"\tConfigMap(product-catalog) Unknown",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced surfaces error conditions and ignores warnings", func(t *testing.T) {
+		// A sync status of "Unknown" means ArgoCD could not compare at all, and the reason lives
+		// only in the conditions. Warnings are advisory and would dilute the signal.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "ComparisonError", Message: "Failed to load target state: rpc error: code = Unknown"},
+			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
+			{Type: "InvalidSpecError", Message: "Application referencing project default which does not exist"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n\n"+
+				"Sync errors:\n"+
+				"\tComparisonError: Failed to load target state: rpc error: code = Unknown\n"+
+				"\tInvalidSpecError: Application referencing project default which does not exist",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced keeps the sync result listing alongside the drift diagnostics", func(t *testing.T) {
+		// The reported case: every resource applied cleanly ("configured"), the sync operation
+		// succeeded, and the app was still out of sync when the rollout timed out. Both blocks
+		// carry signal — the operation result and the drift that outlived it.
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
+			{
+				Kind:      "Deployment",
+				Name:      "product-catalog",
+				Namespace: "app",
+				Status:    "Synced",
+				HookPhase: "Running",
+				SyncPhase: "Sync",
+				Message:   "deployment.apps/product-catalog configured",
+			},
+		}
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n"+
+				"Resources:\n"+
+				"\tDeployment(product-catalog)  Running with message deployment.apps/product-catalog configured\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced reports drift and errors together", func(t *testing.T) {
+		application := Application{}
+		application.Status.OperationState.Phase = "Succeeded"
+		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "SyncError", Message: "Failed sync attempt to v1.2.3"},
+		}
+		assert.Equal(t,
+			"App status \"Succeeded\"\n"+
+				"App message \"successfully synced (all tasks run)\"\n\n"+
+				"Sync errors:\n"+
+				"\tSyncError: Failed sync attempt to v1.2.3\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 

--- a/internal/models/testdata/out-of-sync-deployment.json
+++ b/internal/models/testdata/out-of-sync-deployment.json
@@ -1,0 +1,62 @@
+{
+  "status": {
+    "health": {
+      "status": "Healthy"
+    },
+    "conditions": [
+      {
+        "type": "ComparisonError",
+        "message": "Failed to load target state: rpc error: code = Unknown"
+      },
+      {
+        "type": "OrphanedResourceWarning",
+        "message": "Application has 1 orphaned resource"
+      }
+    ],
+    "operationState": {
+      "phase": "Succeeded",
+      "message": "successfully synced (all tasks run)",
+      "syncResult": {
+        "resources": [
+          {
+            "hookPhase": "Running",
+            "hookType": "",
+            "kind": "Deployment",
+            "message": "deployment.apps/product-catalog configured",
+            "status": "Synced",
+            "syncPhase": "Sync",
+            "name": "product-catalog",
+            "namespace": "app"
+          }
+        ]
+      }
+    },
+    "resources": [
+      {
+        "kind": "Deployment",
+        "name": "product-catalog",
+        "namespace": "app",
+        "status": "OutOfSync"
+      },
+      {
+        "kind": "Service",
+        "name": "product-catalog",
+        "namespace": "app",
+        "status": "Synced"
+      },
+      {
+        "kind": "Endpoints",
+        "name": "product-catalog",
+        "namespace": "app"
+      }
+    ],
+    "summary": {
+      "images": [
+        "product-catalog:v0.0.2"
+      ]
+    },
+    "sync": {
+      "status": "OutOfSync"
+    }
+  }
+}


### PR DESCRIPTION
A deployment failing with "Rollout status is not synced" printed only the last sync operation's phase and message. Those describe a finished operation, not current drift, so the report routinely read "Succeeded" / "successfully synced (all tasks run)" while naming no culprit at all.

The report now carries three further sections, each emitted only when it has content: "Sync errors:" for the Argo CD conditions explaining a comparison that could not complete, "Unhealthy resources:" for the tree-sourced pod-level cause, and "Out-of-sync resources:" for the resources that drifted. Errors precede the unbounded resource listing so the line naming the cause is not buried.

The unhealthy section matters because an application that is Degraded and still OutOfSync is classified "not synced" rather than "degraded" — a pending sync may yet recover it — so this is the only report such a failure produces.

A failure with none of the three keeps its previous output byte for byte.