### PR TITLE
feat(server): split the health endpoint into liveness and readiness

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Wait for readiness
         run: |
           for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+            if curl -fsS http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
               echo "argo-watcher is up"
               exit 0
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `GET /healthz` is replaced by two endpoints with distinct meanings: `GET /livez`,
+  which reports only that the process is still serving and checks no dependency, and
+  `GET /readyz`, which reports whether this instance should receive traffic — down
+  while shutting down, and down when the state backend is unreachable. Both answer
+  `{"status":"up"}` or `503 {"status":"down","reason":"..."}`. The Helm chart points
+  each probe at the right endpoint, so upgrading needs no action. The practical gain is
+  that a database outage no longer fails the liveness probe: a restart cannot bring the
+  database back, so what used to end in a fleet-wide `CrashLoopBackoff` now just marks
+  the pods unready while they keep serving task history and the unreachable banner.
+  Argo CD reachability stays absent from both probes — `GET /api/v1/reachability` and
+  the `argocd_unavailable` metric report it instead.
+- Graceful shutdown now fails readiness and keeps serving for five seconds before
+  closing its listener, so an orchestrator can stop routing requests to the pod while
+  it is still able to answer them. Rolling updates previously ended with a tail of
+  connection resets, because endpoint removal is asynchronous and the listener closed
+  the instant `SIGTERM` arrived. The wait is charged to the existing 25-second shutdown
+  budget, so the whole sequence still fits the default 30-second grace period.
 - The client now presents its credential — `ARGO_WATCHER_DEPLOY_TOKEN` or
   `BEARER_TOKEN` — on the status polls as well as on the task submission, so it keeps
   working against a server that requires one on reads. A server that does not require

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -33,10 +33,13 @@ The first run takes a couple of minutes to compile the Go binaries. Subsequent r
 In a new terminal:
 
 ```bash
-curl -s http://localhost:8080/healthz
+curl -s http://localhost:8080/readyz
 ```
 
-You should see a `200 OK` response with health details for the database and Argo CD client.
+You should see a `200 OK` response with `{"status":"up"}`, meaning the server is
+serving and its state backend is reachable. See
+[Health and probe endpoints](../reference/api.md#health-and-probe-endpoints) for the
+full set.
 
 ## 3. Submit a task
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -31,7 +31,7 @@ them, so no deployment pipeline is affected.
 | `POST /api/v1/tasks` | Unchanged — optional credential (governs git write-back) |
 | `GET /api/v1/tasks/{id}` | **Open** unless `OIDC_REQUIRE_TASK_READ_AUTH=true` — see below |
 | `GET /api/v1/config` | **Open** — the Web UI reads the issuer and client id from it before it can obtain a token |
-| `/healthz`, `/metrics` | **Open** — probes and Prometheus cannot perform an OIDC flow |
+| `/livez`, `/readyz`, `/metrics` | **Open** — probes and Prometheus cannot perform an OIDC flow |
 | `/ws` | Credential required — as a subprotocol from a browser, see [The WebSocket handshake](#the-websocket-handshake) |
 
 Any configured credential is accepted on the reads: an OIDC session, the
@@ -62,8 +62,8 @@ OIDC_REQUIRE_TASK_READ_AUTH=true
 ```
 
 `GET /api/v1/tasks/{id}` then requires a credential like every other read, leaving
-`GET /api/v1/config` as the only open `/api/v1` read (alongside `/healthz` and
-`/metrics`, which cannot perform an OIDC flow).
+`GET /api/v1/config` as the only open `/api/v1` read (alongside the probe endpoints
+and `/metrics`, which cannot perform an OIDC flow).
 
 Two things to know before flipping it:
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -39,7 +39,7 @@ Each entry follows the same shape: **Symptom · Likely cause · How to verify ·
 
 **How to verify:**
 - Check the client logs in the CI output.
-- Manually test reachability: `curl $ARGO_WATCHER_URL/healthz` from the CI runner.
+- Manually test reachability: `curl $ARGO_WATCHER_URL/readyz` from the CI runner.
 - Verify the app name: `argocd app get <ARGO_APP>`.
 - Check the image that was pushed to the registry.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,6 +38,48 @@ The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only regist
 - Authentication failures return `401 Unauthorized` with an `error` field describing whether no credentials were provided or the token was rejected.
 - Unexpected server-side problems return `500 Internal Server Error`.
 
+## Health and probe endpoints
+
+Two unauthenticated endpoints report server health. They answer different questions,
+and wiring the wrong one to a Kubernetes probe has real consequences.
+
+| Endpoint | Checks | Use as |
+|----------|--------|--------|
+| `GET /livez` | Nothing but that the process is still serving requests | Liveness probe |
+| `GET /readyz` | Not shutting down, **and** the state backend answers | Readiness probe |
+
+Both return `{"status":"up"}` on success and `503` with `{"status":"down","reason":"..."}`
+otherwise — `shutting down` during a graceful shutdown, `state backend unreachable` when
+the database cannot be pinged.
+
+!!! warning "Do not point a liveness probe at `/readyz`"
+    A liveness failure gets the container restarted, and a restart cannot reach a
+    database that is down. Probing the state backend for liveness turns a recoverable
+    outage into a fleet-wide `CrashLoopBackoff` while every replica is still able to
+    serve task history and the unreachable banner. That is why `/livez` checks no
+    dependency at all.
+
+A startup probe is not needed and is not recommended. The server binds its listener
+only after its configuration, Argo CD client, and state backend are all initialised, so
+there is no window in which it answers requests but is not yet ready. If the state
+backend is unreachable at boot the process exits rather than starting degraded, which a
+startup probe could not observe anyway.
+
+**Argo CD reachability is deliberately absent from both probes.** An Argo CD outage
+degrades Argo Watcher — new deployments are rejected fast and the Web UI shows a banner
+naming the cause — but the server must keep serving precisely then. Alert on the
+`argocd_unavailable` metric or poll `GET /api/v1/reachability` instead.
+
+### Readiness during shutdown
+
+On `SIGTERM` the server fails `/readyz` immediately, keeps serving normally for five
+seconds so the endpoint removal can propagate through kube-proxy and any ingress
+controller, and only then closes its listener and drains in-flight requests, WebSocket
+connections, and queued git write-backs. A readiness probe is what makes that window
+useful; without one, traffic keeps arriving at a pod that has already stopped
+accepting it. The whole sequence is bounded to fit the default 30-second
+`terminationGracePeriodSeconds`.
+
 ## Endpoints
 
 The full endpoint catalog is rendered live from the OpenAPI spec maintained alongside the source code. Use the explorer below to inspect routes, request and response schemas, and try requests against your own server.

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -273,7 +273,7 @@ func imageSignature(task models.Task) string {
 // reachability (IsAvailable) so a deploy fails fast during an outage. The
 // background liveness probe (StartLivenessProbe) is therefore the single place
 // the argocd_unavailable metric and the cached state are refreshed. Note the
-// /healthz endpoint probes only the state backend (SimpleHealthCheck), not
+// /readyz endpoint probes only the state backend (SimpleHealthCheck), not
 // ArgoCD.
 func (argo *Argo) GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) models.TasksResponse {
 	tasks, total := argo.State.GetTasks(startTime, endTime, app, status, limit, offset)

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -79,8 +79,13 @@ type TasksResponse struct {
 	Total int64  `json:"total,omitempty"`
 }
 
+// HealthStatus is the payload of the probe endpoints. Status is "up" or "down";
+// Reason names the cause of a "down" and is omitted otherwise, so an operator
+// reading the endpoint during an incident can tell a graceful drain apart from an
+// unreachable state backend.
 type HealthStatus struct {
 	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type TaskStatus struct {

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/shini4i/argo-watcher/internal/argocd"
@@ -25,6 +26,11 @@ type Env struct {
 	authenticator *auth.Authenticator
 	// shutdownCh is closed to signal graceful shutdown to all WebSocket goroutines.
 	shutdownCh chan struct{}
+	// draining is set once graceful shutdown begins, so the readiness probe can
+	// report the pod out of service while it is still able to serve. It is separate
+	// from shutdownCh, which is closed later in the sequence (after the listener),
+	// and deliberately never reset: shutdown is terminal.
+	draining atomic.Bool
 	// shutdownOnce ensures Shutdown() can be called multiple times safely.
 	shutdownOnce sync.Once
 	// connWg tracks active WebSocket connection goroutines for graceful shutdown.
@@ -137,6 +143,19 @@ func watchArgoTransitions(stop <-chan struct{}, interval time.Duration, reason f
 // the context passed to Shutdown from it, so the phase can also end earlier if the
 // overall shutdown budget (see shutdownBudget) is already spent.
 const shutdownTimeout = 10 * time.Second
+
+// beginDraining marks the process as shutting down so the readiness probe starts
+// answering 503. It is called at the very start of the shutdown sequence, before
+// the listener closes, so an orchestrator has a window to stop routing new requests
+// here while the pod can still serve the ones already in flight.
+func (env *Env) beginDraining() {
+	env.draining.Store(true)
+}
+
+// isDraining reports whether graceful shutdown has begun.
+func (env *Env) isDraining() bool {
+	return env.draining.Load()
+}
 
 // Shutdown gracefully shuts down the server and all WebSocket connections.
 // This method is safe to call multiple times. It blocks until all WebSocket

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -211,25 +211,47 @@ func (env *Env) getTaskStatus(c *gin.Context) {
 	}
 }
 
-// healthz godoc
-// @Summary Check if the server is healthy
-// @Description Check if the argo-watcher is ready to process new tasks
+// Causes reported by the readiness probe. They are the response body only; the
+// status code is what an orchestrator acts on.
+const (
+	reasonDraining         = "shutting down"
+	reasonStateUnreachable = "state backend unreachable"
+)
+
+// livez godoc
+// @Summary Liveness probe
+// @Description Report whether the process itself is still serving. It checks no dependency, because a restart — the only remedy a failing liveness probe triggers — cannot fix one.
+// @Tags service
+// @Produce json
+// @Success 200 {object} models.HealthStatus
+// @Router /livez [get]
+func (env *Env) livez(c *gin.Context) {
+	c.JSON(http.StatusOK, models.HealthStatus{Status: "up"})
+}
+
+// readyz godoc
+// @Summary Readiness probe
+// @Description Report whether this instance should receive traffic: down while shutting down, and down when the state backend is unreachable. ArgoCD reachability is deliberately excluded — the API and Web UI must keep serving task history and the unreachable banner during an ArgoCD outage (see /api/v1/reachability).
 // @Tags service
 // @Produce json
 // @Success 200 {object} models.HealthStatus
 // @Failure 503 {object} models.HealthStatus
-// @Router /healthz [get]
-func (env *Env) healthz(c *gin.Context) {
-	if env.argo.SimpleHealthCheck() {
-		c.JSON(http.StatusOK, models.HealthStatus{
-			Status: "up",
-		})
-	} else {
-		c.JSON(http.StatusServiceUnavailable, models.HealthStatus{
-			Status: "down",
-		})
+// @Router /readyz [get]
+func (env *Env) readyz(c *gin.Context) {
+	// Ordered so a drain is reported as a drain: once shutdown starts the state
+	// backend is irrelevant, and reporting it would mislabel a planned rollout as an
+	// outage.
+	if env.isDraining() {
+		c.JSON(http.StatusServiceUnavailable, models.HealthStatus{Status: "down", Reason: reasonDraining})
+		return
 	}
 
+	if !env.argo.SimpleHealthCheck() {
+		c.JSON(http.StatusServiceUnavailable, models.HealthStatus{Status: "down", Reason: reasonStateUnreachable})
+		return
+	}
+
+	c.JSON(http.StatusOK, models.HealthStatus{Status: "up"})
 }
 
 // getConfig godoc

--- a/internal/server/probes_test.go
+++ b/internal/server/probes_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/argocd"
+)
+
+// probeEnv builds an Env whose state backend reports the given reachability, which
+// is the only dependency the readiness probe consults.
+func probeEnv(t *testing.T, stateUp bool) *Env {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	repo, _ := newRepo(ctrl)
+	repo.EXPECT().Check().Return(stateUp).AnyTimes()
+
+	argo := &argocd.Argo{}
+	argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+	return &Env{argo: argo}
+}
+
+// probeGet serves a request against a router carrying only the probe routes, so the
+// assertions cover the handlers rather than the surrounding middleware.
+func probeGet(t *testing.T, env *Env, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/livez", env.livez)
+	router.GET("/readyz", env.readyz)
+
+	req, err := http.NewRequest(http.MethodGet, path, http.NoBody)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+// TestLivenessIgnoresTheStateBackend is the whole reason the probes are split. A
+// liveness probe may only report conditions a restart can fix, and restarting the
+// process does not bring the database back. Wiring the state-backend check to
+// liveness turns a recoverable database outage into a fleet-wide CrashLoopBackoff
+// while every replica is still perfectly able to serve task history and the
+// unreachable banner.
+func TestLivenessIgnoresTheStateBackend(t *testing.T) {
+	env := probeEnv(t, false)
+
+	recorder := probeGet(t, env, "/livez")
+
+	assert.Equal(t, http.StatusOK, recorder.Code, "an unreachable state backend must not fail liveness")
+	assert.Contains(t, recorder.Body.String(), "up")
+}
+
+// TestLivenessSurvivesDraining keeps liveness answering through graceful shutdown.
+// Failing it there would invite the kubelet to restart a container that is
+// deliberately winding down, killing the write-back drain mid-flush.
+func TestLivenessSurvivesDraining(t *testing.T) {
+	env := probeEnv(t, true)
+	env.beginDraining()
+
+	assert.Equal(t, http.StatusOK, probeGet(t, env, "/livez").Code)
+}
+
+func TestReadinessReportsTheStateBackend(t *testing.T) {
+	t.Run("up when the state backend answers", func(t *testing.T) {
+		recorder := probeGet(t, probeEnv(t, true), "/readyz")
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "up")
+	})
+
+	t.Run("down when the state backend is unreachable", func(t *testing.T) {
+		recorder := probeGet(t, probeEnv(t, false), "/readyz")
+
+		assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), reasonStateUnreachable)
+	})
+}
+
+// TestReadinessFailsWhileDraining covers the signal the split exists to add: once
+// shutdown begins the pod must be pulled from the Service before its listener
+// closes, otherwise every rolling update ends with a tail of connection resets sent
+// to a pod that has already stopped accepting.
+func TestReadinessFailsWhileDraining(t *testing.T) {
+	env := probeEnv(t, true)
+	env.beginDraining()
+
+	recorder := probeGet(t, env, "/readyz")
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), reasonDraining,
+		"an operator curling the endpoint mid-incident must be able to tell a drain from an outage")
+}
+
+// TestProbeRoutesAreRegistered guards the wiring: the handlers above are useless if
+// CreateRouter never exposes them.
+func TestProbeRoutesAreRegistered(t *testing.T) {
+	env, _ := readAuthEnv(t, false, nil)
+
+	for _, path := range []string{"/livez", "/readyz"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, path, http.NoBody)
+			require.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			env.CreateRouter().ServeHTTP(recorder, req)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+		})
+	}
+}

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -267,8 +267,12 @@ func TestReadAuthOpenEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusOK, getWith(t, env, "/api/v1/config", "", "").Code)
 	})
 
-	t.Run("healthz stays open for probes", func(t *testing.T) {
-		assert.Equal(t, http.StatusOK, getWith(t, env, "/healthz", "", "").Code)
+	t.Run("probe endpoints stay open", func(t *testing.T) {
+		// A kubelet cannot perform an OIDC flow, so gating these would make every
+		// pod fail its probes the moment OIDC is enabled.
+		for _, path := range []string{"/livez", "/readyz"} {
+			assert.Equal(t, http.StatusOK, getWith(t, env, path, "", "").Code, path)
+		}
 	})
 
 	t.Run("metrics stays open for scraping", func(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -56,8 +56,10 @@ func (env *Env) CreateRouter() *gin.Engine {
 		c.String(http.StatusBadRequest, "WebSocket upgrade required")
 	})
 
-	// API routes
-	router.GET("/healthz", env.healthz)
+	// API routes. The probe endpoints stay unauthenticated: a kubelet cannot
+	// perform an OIDC flow, and they expose no state beyond up/down.
+	router.GET("/livez", env.livez)
+	router.GET("/readyz", env.readyz)
 	router.GET("/metrics", prometheusHandler())
 	swaggerPath := filepath.Join(env.config.StaticFilePath, "swagger")
 	absSwaggerPath, err := filepath.Abs(swaggerPath)

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1941,51 +1941,6 @@ func TestPrometheusHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestHealthzEndpoint tests the healthz endpoint.
-func TestHealthzEndpoint(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	t.Run("returns up when healthy", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		repo, _ := newRepo(ctrl)
-		repo.EXPECT().Check().Return(true).AnyTimes()
-		argo := &argocd.Argo{}
-		argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
-
-		env := &Env{argo: argo}
-
-		router := gin.New()
-		router.GET("/healthz", env.healthz)
-
-		req, _ := http.NewRequest(http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "up")
-	})
-
-	t.Run("returns down when unhealthy", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		repo, _ := newRepo(ctrl)
-		repo.EXPECT().Check().Return(false).AnyTimes()
-		argo := &argocd.Argo{}
-		argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
-
-		env := &Env{argo: argo}
-
-		router := gin.New()
-		router.GET("/healthz", env.healthz)
-
-		req, _ := http.NewRequest(http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
-		assert.Contains(t, w.Body.String(), "down")
-	})
-}
-
 // TestGetConfigEndpoint tests the getConfig endpoint.
 func TestGetConfigEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,10 +28,18 @@ const (
 	// (Kubernetes defaults to 30s) so every phase — including the batch write-back
 	// drain that runs last — gets to finish before the kubelet sends SIGKILL.
 	shutdownBudget = 25 * time.Second
+	// readinessDrainDelay is how long the process keeps serving after its readiness
+	// probe starts answering 503, before the listener closes. Removing a pod from a
+	// Service is asynchronous — kube-proxy and ingress controllers keep sending
+	// traffic for a short while after the endpoint is marked not-ready — so closing
+	// the listener immediately drops that traffic. It is charged to shutdownBudget
+	// rather than added on top, so the sequence still fits the pod grace period.
+	readinessDrainDelay = 5 * time.Second
 	// httpDrainBudget caps the HTTP-request drain so the phases after it are not
-	// starved. argo-watcher's handlers are short (task list, add task); long-lived
-	// WebSocket connections are hijacked and drained separately.
-	httpDrainBudget = 8 * time.Second
+	// starved. argo-watcher's handlers are short (task list, add task) and finish
+	// well inside it; long-lived WebSocket connections are hijacked and drained
+	// separately.
+	httpDrainBudget = 5 * time.Second
 )
 
 type Server struct {
@@ -42,6 +50,9 @@ type Server struct {
 	updater     *argocd.ArgoStatusUpdater
 	env         *Env
 	probeCancel context.CancelFunc
+	// drainDelay is how long shutdown waits after failing readiness before closing
+	// the listener. NewServer sets it to readinessDrainDelay; tests shorten it.
+	drainDelay time.Duration
 }
 
 // NewServer creates a new server instance with the given configuration and prometheus registerer.
@@ -136,6 +147,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		updater:     statusUpdater,
 		env:         env,
 		probeCancel: probeCancel,
+		drainDelay:  readinessDrainDelay,
 	}, nil
 }
 
@@ -185,10 +197,15 @@ type httpShutdowner interface {
 	Shutdown(ctx context.Context) error
 }
 
-// shutdown runs the ordered drain phases: outstanding HTTP requests, then WebSocket
-// goroutines, then queued git write-backs.
+// shutdown runs the ordered drain phases: fail readiness so no new traffic is
+// routed here, then outstanding HTTP requests, then WebSocket goroutines, then
+// queued git write-backs.
 //
-// Stop accepting new connections first and let outstanding HTTP requests drain,
+// Failing readiness before touching the listener is what keeps a rolling update
+// from resetting connections: the endpoint removal it triggers is asynchronous, so
+// the process must stay up long enough for that removal to propagate.
+//
+// Stop accepting new connections next and let outstanding HTTP requests drain,
 // then shut down the WebSocket goroutines. Closing the listener before env.Shutdown
 // means new handshakes can no longer arrive, which greatly narrows the window in
 // which a WebSocket handler could call connWg.Add(1) after env.Shutdown has begun
@@ -199,7 +216,7 @@ type httpShutdowner interface {
 // Hijacked WebSocket connections are not waited on by srv.Shutdown; they are drained
 // by env.Shutdown.
 //
-// The three phases run in sequence and share one deadline, so their total cannot
+// The phases run in sequence and share one deadline, so their total cannot
 // exceed shutdownBudget. Previously each carried its own independent timeout, letting
 // the sequence run far longer than any realistic terminationGracePeriodSeconds — the
 // kubelet then SIGKILLed the process partway through, which defeats the phase that
@@ -211,6 +228,18 @@ type httpShutdowner interface {
 func (s *Server) shutdown(srv httpShutdowner) {
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownBudget)
 	defer cancelShutdown()
+
+	// Phase 0: report not-ready and give the orchestrator time to stop routing new
+	// requests here. The process keeps serving normally throughout — this window is
+	// spent staying up, not winding down.
+	s.env.beginDraining()
+	if s.drainDelay > 0 {
+		slog.Info("readiness reported down, waiting for traffic to be routed away", "delay", s.drainDelay)
+		select {
+		case <-time.After(s.drainDelay):
+		case <-shutdownCtx.Done():
+		}
+	}
 
 	// Phase 1: let outstanding HTTP requests finish. Capped well below the total
 	// because argo-watcher's handlers are short-lived; hijacked WebSocket

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,6 +34,10 @@ func TestNewServer_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	assert.Equal(t, cfg, s.config)
+	// A zero drainDelay silently skips the readiness-propagation phase of shutdown,
+	// and every other test constructs Server directly — so this is the only place a
+	// dropped wiring line would be caught before the lab.
+	assert.Equal(t, readinessDrainDelay, s.drainDelay)
 }
 
 func TestNewServer_StateInitFailure(t *testing.T) {
@@ -92,9 +96,9 @@ func TestNewServer_PostgresConnectionFailure(t *testing.T) {
 func TestShutdownBudgetFitsGracePeriod(t *testing.T) {
 	assert.Less(t, shutdownBudget, 30*time.Second, "budget must fit the default pod grace period")
 
-	writebackDrainShare := shutdownBudget - (httpDrainBudget + shutdownTimeout)
+	writebackDrainShare := shutdownBudget - (readinessDrainDelay + httpDrainBudget + shutdownTimeout)
 	assert.GreaterOrEqual(t, writebackDrainShare, 5*time.Second,
-		"HTTP and WebSocket drains must leave the batch write-back drain a usable share")
+		"the readiness delay and the HTTP and WebSocket drains must leave the batch write-back drain a usable share")
 }
 
 // fakeHTTPShutdowner stands in for *http.Server so the phase budgeting can be
@@ -191,4 +195,46 @@ func TestShutdown_WebSocketDrainRunsAfterHTTPDrainFailure(t *testing.T) {
 	default:
 		t.Fatal("the WebSocket drain must still run after the HTTP drain fails")
 	}
+}
+
+// TestShutdown_ReadinessFailsBeforeTheListenerCloses is the ordering the readiness
+// probe exists for. Endpoint removal is asynchronous, so a pod that closes its
+// listener the instant SIGTERM lands is still receiving proxied requests — every
+// rolling update then ends in a tail of connection resets. Failing readiness first
+// is what lets the endpoints controller pull the pod while it can still serve.
+func TestShutdown_ReadinessFailsBeforeTheListenerCloses(t *testing.T) {
+	env := &Env{shutdownCh: make(chan struct{})}
+	s := &Server{env: env}
+
+	var readyAtListenerClose bool
+	srv := &fakeHTTPShutdowner{onShutdown: func() {
+		readyAtListenerClose = !env.isDraining()
+	}}
+
+	s.shutdown(srv)
+
+	assert.False(t, readyAtListenerClose, "readiness must already report down when the listener closes")
+	assert.True(t, env.isDraining(), "the drain flag must outlive the shutdown sequence")
+}
+
+// TestShutdown_ReadinessDelayPrecedesTheHTTPDrain proves the propagation window is
+// actually waited out rather than merely flagged. Flipping the probe and closing the
+// listener in the same breath leaves the race untouched, and nothing else in the
+// sequence would catch it.
+func TestShutdown_ReadinessDelayPrecedesTheHTTPDrain(t *testing.T) {
+	env := &Env{shutdownCh: make(chan struct{})}
+	// A real readinessDrainDelay would add its full wall-clock cost to the suite; the
+	// regression guarded here is "no wait at all", which any non-zero delay exposes.
+	s := &Server{env: env, drainDelay: 50 * time.Millisecond}
+
+	var elapsedAtShutdown time.Duration
+	start := time.Now()
+	srv := &fakeHTTPShutdowner{onShutdown: func() {
+		elapsedAtShutdown = time.Since(start)
+	}}
+
+	s.shutdown(srv)
+
+	assert.GreaterOrEqual(t, elapsedAtShutdown, s.drainDelay,
+		"the HTTP drain must not start until the readiness change has had time to propagate")
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -116,7 +116,7 @@ again instead of re-establishing a forward.
 | `scripts/lib.sh` | shared phase helpers: endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`, `helm_apply_aw`, `ok`/`bad`/`phase_end` |
 | `scripts/lib.bats` | unit tests for lib.sh's pure text-processing helpers (no cluster needed) |
 | `scripts/soak.sh` | the git-conflict soak: competitor + concurrent deploys, then the `collect.sh` gates |
-| `scripts/verify.sh` | post-`up` gate: healthz 200 and `argocd_unavailable` 0 |
+| `scripts/verify.sh` | post-`up` gate: readyz 200 and `argocd_unavailable` 0 |
 | `values/` | pinned Helm values for argocd / argo-watcher / gitea / webhook-tester |
 | `scripts/load-race-image.sh` | load a local image into the kind node |
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
@@ -128,8 +128,8 @@ again instead of re-establishing a forward.
 | `values/argo-watcher-postgres.yaml` | overlay layered over `values/argo-watcher.yaml` that enables `postgres` (sets `STATE_TYPE=postgres`, wires `DB_*`, triggers the migration Job) |
 | `scripts/failure-fixture.sh` | inject/remove a deliberately-broken resource via the chart's `rawObject`: a failing PreSync hook (`hook`, aborts the sync), a failing plain migration Job (`degraded`, lets the image roll out and holds the app Synced+Degraded), or a Deployment whose readiness probe never passes (`pending`, holds the app Synced+Progressing with nothing Degraded); sole owner of the shared `chart/values.yaml` |
 | `scripts/notifications.sh` | assert the generic webhook fires start + result with the templated payload and auth header |
-| `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when OIDC auth is off |
-| `scripts/read-auth.sh` | assert OIDC read protection: toggles `OIDC_ENABLED` on the release with the issuer pointed at a closed port and reverts, asserting 401 without a credential, 503 (never 401) when the provider cannot be consulted — including with a rejected JWT alongside, 15× because strategy order is randomized — 200 for a deploy token / JWT, the `/tasks/:id`, `/config`, `/healthz`, `/metrics` and `POST /tasks` exemptions, and the `unauthenticated_reads` counter semantics. Also asserts the /ws handshake: 401 with no credential, accepted with a deploy token, and 503 for a subprotocol-borne token whose provider is unreachable. Needs no identity provider; group-based authorization is covered by the Keycloak integration suite instead |
+| `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: the `/livez` + `/readyz` probes, version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when OIDC auth is off |
+| `scripts/read-auth.sh` | assert OIDC read protection: toggles `OIDC_ENABLED` on the release with the issuer pointed at a closed port and reverts, asserting 401 without a credential, 503 (never 401) when the provider cannot be consulted — including with a rejected JWT alongside, 15× because strategy order is randomized — 200 for a deploy token / JWT, the `/tasks/:id`, `/config`, `/livez`, `/readyz`, `/metrics` and `POST /tasks` exemptions, and the `unauthenticated_reads` counter semantics. Also asserts the /ws handshake: 401 with no credential, accepted with a deploy token, and 503 for a subprotocol-borne token whose provider is unreachable. Needs no identity provider; group-based authorization is covered by the Keycloak integration suite instead |
 | `scripts/client-knobs.sh` | assert client env knobs via the real client: `TASK_REFRESH=false` still deploys, `DEBUG=true` cURL log redacts the deploy token |
 | `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed |
 | `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency) |
@@ -144,16 +144,19 @@ again instead of re-establishing a forward.
 | `scripts/docker-proxy.sh` | assert `DOCKER_IMAGES_PROXY` matches a bare image against the proxy-prefixed running image |
 | `fixtures/proxy-app.yaml` | `proxyapp`: reuses the shared chart with the image repository overridden to `mirror.gcr.io/traefik/whoami` |
 | `scripts/lockdown.sh` | assert scheduled lockdown: toggles `LOCKDOWN_SCHEDULE` on the release (window opening ~3 min out) and reverts, asserting in-window deploys are rejected (406), `GET /deploy-lock` reports `true`, and the watcher broadcasts `"locked"` on the transition |
-| `scripts/shutdown-drain.sh` | assert graceful shutdown: hold WebSocket clients open, delete the pod, and assert every client sees a `1001 "server shutdown"` close and the logs show the ordered drain with no data race / panic / drain timeout |
+| `scripts/shutdown-drain.sh` | assert graceful shutdown: hold WebSocket clients open, delete the pod, and assert readiness fails before the listener closes (logged, and the sequence never finishes faster than the 5s propagation window), every client sees a `1001 "server shutdown"` close, and the logs show the ordered drain with no data race / panic / drain timeout |
 | `scripts/argocd-unreachable.sh` | assert the ArgoCD-unreachable signal (#498): scale `argocd-server` to 0, assert `GET /reachability` flips to `{"available":false,"reason":"argocd"}` (state backend stays up), the watcher broadcasts `"argocd_down:argocd"`, and `POST /tasks` fast-fails `503 {"status":"down"}` (well under the retry budget); then scale back up and assert recovery (`available:true`, `"argocd_up"`, `202`) |
 | `tools/wsprobe/` | tiny Go WebSocket probe used by `lockdown` (grep for the `"locked"` broadcast), `shutdown-drain` (assert the graceful GoingAway close), and `argocd-unreachable` (grep for `"argocd_down:argocd"`/`"argocd_up"`), streaming `MSG`/`CLOSED` events one per line |
 
 ## Gotchas (why the scripts exist)
 
-- **`/healthz` returns 503 while ArgoCD is unreachable**, so `wait_service` checks
-  only that a response arrives, never that it is 2xx. A `curl -f` there would hang
-  forever in `argocd-unreachable` (which severs ArgoCD on purpose) and can misfire in
-  `shutdown-drain` on a freshly-booted pod.
+- **`wait_service` gates on `/livez`, never `/readyz`.** Readiness is legitimately
+  503 while the server drains or its state backend is unreachable, so a phase that
+  induces either would hang on a readiness gate. Liveness answers 200 whenever the
+  process is serving, which is what the callers actually wait for.
+- **The lab overrides the chart's probe paths** (`values/argo-watcher.yaml`). The
+  chart still defaults both probes to the removed `/healthz`; without the override
+  every pod fails both probes and the lab never comes up.
 - **`kind load docker-image` is broken with podman + containerd 2.x** — kind
   passes `--all-platforms` to `ctr import`, which fails on a single-arch image
   ("no unpack platforms defined"). `load-race-image.sh` imports via `ctr` with

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -36,6 +36,21 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # stay redacted.
 wait_service || die "argo-watcher never answered on ${AW_URL}"
 
+echo "=== probe endpoints ==="
+# /livez must not consult any dependency (that it ignores an unreachable state
+# backend is a unit-level assertion — the base lab runs in-memory state, which
+# cannot be broken from here). What the lab can prove is that both routes are
+# registered and unauthenticated, and that neither reports the ArgoCD state the
+# argocd-unreachable phase induces.
+for path in livez readyz; do
+  req GET "${AW_URL}/${path}"
+  if [[ "$CODE" == "200" ]] && jq -e '.status == "up" and (has("reason") | not)' <<<"$BODY" >/dev/null 2>&1; then
+    ok "/${path} -> 200 up"
+  else
+    bad "/${path}: code=${CODE} body=${BODY} (want 200 {\"status\":\"up\"})"
+  fi
+done
+
 echo "=== version ==="
 req GET "${AW_API}/version"
 if [[ "$CODE" == "200" ]] && jq -e 'type == "string" and length > 0' <<<"$BODY" >/dev/null 2>&1; then

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -101,13 +101,13 @@ retry() {
 
 # wait_service [attempts]: block until argo-watcher answers on its HTTP port.
 #
-# Deliberately checks only that a response arrives, NOT that it is 2xx: /healthz
-# returns 503 while ArgoCD is unreachable (handlers.go healthz), which is a state
-# the argocd-unreachable phase induces on purpose and the shutdown-drain phase can
-# observe on a fresh pod. A `curl -f` here would hang in exactly those phases.
+# Gates on liveness, not readiness: /readyz is legitimately 503 while the server is
+# draining or its state backend is unreachable, so a phase that induces either would
+# hang here. /livez answers 200 whenever the process is serving, which is exactly
+# what callers are waiting for; phases assert readiness explicitly where it matters.
 wait_service() {
   local attempts="${1:-30}"
-  retry "$attempts" 2 curl -s -m 3 -o /dev/null "${AW_URL}/healthz"
+  retry "$attempts" 2 curl -fsS -m 3 -o /dev/null "${AW_URL}/livez"
   return
 }
 

--- a/test/e2e/scripts/read-auth.sh
+++ b/test/e2e/scripts/read-auth.sh
@@ -165,12 +165,14 @@ else
   bad "GET /config: code=${CODE} (want 200 with no notification targets)"
 fi
 
-req GET "${AW_URL}/healthz"
-if [[ "$CODE" == "200" ]]; then
-  ok "GET /healthz -> 200 (probes unaffected)"
-else
-  bad "GET /healthz: code=${CODE} (want 200)"
-fi
+for probe in livez readyz; do
+  req GET "${AW_URL}/${probe}"
+  if [[ "$CODE" == "200" ]]; then
+    ok "GET /${probe} -> 200 (probes unaffected)"
+  else
+    bad "GET /${probe}: code=${CODE} (want 200)"
+  fi
+done
 
 req GET "${AW_URL}/metrics"
 if [[ "$CODE" == "200" ]]; then

--- a/test/e2e/scripts/shutdown-drain.sh
+++ b/test/e2e/scripts/shutdown-drain.sh
@@ -7,8 +7,8 @@
 #
 #   1. Hold N WebSocket clients open (tools/wsprobe) against the live server.
 #   2. Follow the pod's logs, then delete the pod with a generous grace period so
-#      the container runs its full graceful shutdown (SIGTERM -> srv.Shutdown ->
-#      env.Shutdown drains the hijacked WS goroutines).
+#      the container runs its full graceful shutdown (SIGTERM -> fail readiness ->
+#      srv.Shutdown -> env.Shutdown drains the hijacked WS goroutines).
 #   3. Assert every WS client saw a graceful close: code 1001 (GoingAway) with
 #      reason "server shutdown" — the exact frame checkConnection sends on drain,
 #      NOT an abrupt socket drop.
@@ -22,11 +22,12 @@
 # the poller, not the HTTP request — asserting it would test the poller, not
 # shutdown. This phase asserts the shutdown/drain contract only.
 #
-# Shutdown runs three sequential phases sharing ONE 25s budget (shutdownBudget in
-# internal/server/server.go): srv.Shutdown (<=8s) -> WebSocket drain (<=10s) ->
-# batch git write-back drain (whatever remains). The budget is sized to fit the
-# Kubernetes default terminationGracePeriodSeconds of 30s, and step 4 below asserts
-# the whole sequence actually fits it.
+# Shutdown runs four sequential phases sharing ONE 25s budget (shutdownBudget in
+# internal/server/server.go): fail /readyz and wait for the endpoint removal to
+# propagate (5s) -> srv.Shutdown (<=5s) -> WebSocket drain (<=10s) -> batch git
+# write-back drain (whatever remains). The budget is sized to fit the Kubernetes
+# default terminationGracePeriodSeconds of 30s, and step 4 below asserts the whole
+# sequence fits it while still spending the propagation window.
 #
 # KNOWN GAP (deliberate, 2026-07-29): this phase runs with GIT_BATCH_WRITEBACK off, so
 # the third phase is a no-op and the batch write-back DRAIN — retry loops stopping at
@@ -119,6 +120,15 @@ if ((shutdown_elapsed < 30)); then
 else
   bad "shutdown took ${shutdown_elapsed}s — exceeds the default 30s grace period, would be SIGKILLed in a normal deployment"
 fi
+# The lower bound is the readiness-propagation window (readinessDrainDelay, 5s):
+# shutdown must not be able to finish faster than the wait it owes the endpoints
+# controller. Dropping that wait is the regression this catches, and it is invisible
+# to every other assertion here — the WebSocket drain works fine without it.
+if ((shutdown_elapsed >= 5)); then
+  ok "shutdown spent the readiness-propagation window before closing the listener"
+else
+  bad "shutdown finished in ${shutdown_elapsed}s — faster than the 5s readiness drain delay, so traffic was cut before the endpoint could be removed"
+fi
 kill "$log_pid" 2>/dev/null || true
 assert_log() {  # pattern human-label want(present|absent)
   local pattern="$1" label="$2" want="$3" found
@@ -130,6 +140,7 @@ assert_log() {  # pattern human-label want(present|absent)
   fi
 }
 assert_log "shutting down server..."                   "shutdown initiated"        present
+assert_log "readiness reported down"                   "readiness failed first"    present
 # This one line is Debug-level (env.go); it is asserted because the lab runs at
 # logLevel: debug (values/argo-watcher.yaml). If that is ever lowered to info this
 # check fails misleadingly — the drain itself would still be fine.
@@ -152,13 +163,13 @@ if ! retry 60 3 recreated_ready; then
 else
   # No port-forward to re-establish: the NodePort URL survived the pod swap.
   wait_service || die "argo-watcher never answered after the pod came back"
-  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/healthz")
+  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/readyz")
   # metric_raw, not metric_sum: an ABSENT gauge must fail this gate, not read as 0.
   unavail=$(metric_raw argocd_unavailable)
   if [[ "$code" == "200" && "$unavail" == "0" ]]; then
-    ok "recreated pod healthy and reaching Argo (healthz=200 argocd_unavailable=0)"
+    ok "recreated pod ready and reaching Argo (readyz=200 argocd_unavailable=0)"
   else
-    bad "recreated pod not healthy: healthz=${code} argocd_unavailable=${unavail:-<absent>}"
+    bad "recreated pod not ready: readyz=${code} argocd_unavailable=${unavail:-<absent>}"
   fi
 fi
 

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -109,7 +109,7 @@ if kubectl -n "$NS_AW" get job/argo-watcher-migration >/dev/null 2>&1; then
   ok "migration Job completed"
 fi
 
-wait_service || die "argo-watcher /healthz never came up on ${AW_URL}"
+wait_service || die "argo-watcher /livez never came up on ${AW_URL}"
 
 echo "=== asserting the server is actually on Postgres ==="
 st="$(curl -s -m 10 "${AW_API}/config" | jq -r '.state_type')"
@@ -140,7 +140,7 @@ echo "=== restarting the server; the task must survive (Postgres persistence) ==
 kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
 # No forward to re-establish: the NodePort URL is unaffected by the pod swap.
-wait_service || die "argo-watcher /healthz never came back after the restart"
+wait_service || die "argo-watcher /livez never came back after the restart"
 
 req GET "${AW_API}/tasks/${id}"
 status_after=$(jq -r '.status' <<<"$BODY")
@@ -183,7 +183,7 @@ ok "shared lock rejects deployments (406) on a replica that never set it"
 echo "  restarting the server; the lock must still be in effect"
 kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true
 kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s
-wait_service || die "argo-watcher /healthz never came back after the second restart"
+wait_service || die "argo-watcher /livez never came back after the second restart"
 
 curl -s -m 10 "${AW_API}/deploy-lock" | jq -e '. == true' >/dev/null 2>&1 \
   || die "the shared lock did not survive the restart"

--- a/test/e2e/scripts/verify.sh
+++ b/test/e2e/scripts/verify.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Assert the freshly-installed argo-watcher is up and actually talking to the real
-# ArgoCD: /healthz is 200 (it returns 503 when ArgoCD is unreachable) and the
-# argocd_unavailable gauge is 0. Run right after `task up` as the gate that the lab
-# is wired correctly before any phase drives a deploy.
+# ArgoCD: /readyz is 200 (it turns 503 when the state backend is unreachable) and
+# the argocd_unavailable gauge is 0. The gauge, not the probe, is what proves the
+# ArgoCD connection — reachability is deliberately absent from the probes. Run right
+# after `task up` as the gate that the lab is wired correctly before any phase
+# drives a deploy.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,11 +16,11 @@ wait_service || die "argo-watcher never answered on ${AW_URL}"
 # minutes in; prove its selector resolves here instead of failing late.
 wait_url "${WHT_URL}/healthz" || die "webhook-tester not reachable on ${WHT_URL} (check the nodeports selector)"
 
-code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/healthz")
+code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${AW_URL}/readyz")
 # metric_raw, not metric_sum: an ABSENT gauge must fail this gate, not read as 0.
 unavail=$(metric_raw argocd_unavailable)
-echo "healthz=${code} argocd_unavailable=${unavail:-<absent>}"
+echo "readyz=${code} argocd_unavailable=${unavail:-<absent>}"
 
-[[ "$code" == "200" ]]  || die "healthz=${code}, want 200"
+[[ "$code" == "200" ]]  || die "readyz=${code}, want 200"
 [[ "$unavail" == "0" ]] || die "argocd_unavailable=${unavail:-<absent>}, want 0 (not reaching ArgoCD)"
 echo "VERIFY: PASS"

--- a/test/e2e/values/argo-watcher.yaml
+++ b/test/e2e/values/argo-watcher.yaml
@@ -4,6 +4,15 @@
 # built race image, so it always reflects the code under test.
 logLevel: debug
 
+# Point the probes at the split endpoints. The chart still defaults both to
+# /healthz, which this server no longer serves — without these overrides every pod
+# fails both probes and never becomes Ready. Only `path` is overridden; the chart's
+# timings are merged in unchanged.
+livenessProbe:
+  path: /livez
+readinessProbe:
+  path: /readyz
+
 image:
   repository: ghcr.io/shini4i/argo-watcher
   # tag: injected by the Taskfile (the built `-race` image)


### PR DESCRIPTION
Replace /healthz with /livez and /readyz. Liveness checks nothing, because a restart cannot fix a dependency outage: probing the state backend for liveness turned a recoverable database outage into a fleet-wide CrashLoopBackoff while every replica was still able to serve task history and the unreachable banner. Readiness keeps that check and adds the state the split exists for.

Graceful shutdown now fails readiness and keeps serving for five seconds before closing its listener, so endpoint removal can propagate. Rolling updates previously ended in a tail of connection resets. The wait is charged to the existing 25s budget, so the sequence still fits the default grace period.

Argo CD reachability stays out of both probes — an outage there must not take the API and Web UI out of service.