### PR TITLE
fix(web): stop the back button relogin loop on a direct task url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- With OIDC enabled, opening a task detail page from a shared link and pressing Back no
+  longer bounces through a fresh sign-in that lands back on the same page; it returns to
+  the task list. The provider's authorize URL is also no longer left in browser history,
+  so the browser's own Back button behaves the same way.
 - The Duration column of the tasks table now counts up while a deployment is in
   progress, instead of showing `0s` until the task reaches a final status.
 - A deployment that fails with `Rollout status is not synced` now names what is

--- a/web/src/auth/authProvider.test.ts
+++ b/web/src/auth/authProvider.test.ts
@@ -131,6 +131,18 @@ describe('authProvider', () => {
     expect(userManagerMock.signoutRedirect).not.toHaveBeenCalled();
   });
 
+  it('replaces the current history entry when leaving for the provider', async () => {
+    mockConfig(enabledConfig());
+    userManagerMock.getUser.mockResolvedValue(null);
+    const provider = await loadAuthProvider();
+
+    await provider.checkAuth({});
+
+    expect(MockUserManager).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectMethod: 'replace' }),
+    );
+  });
+
   it('never rejects checkAuth when the login redirect fails', async () => {
     mockConfig(enabledConfig());
     userManagerMock.getUser.mockResolvedValue(null);
@@ -376,7 +388,9 @@ describe('authProvider', () => {
       expect(userManagerMock.signinRedirectCallback).toHaveBeenCalledTimes(1);
       expect(getAccessToken()).toBe('token');
       // The ?code&state query is stripped so a reload does not re-trigger the callback.
-      expect(replaceSpy).toHaveBeenCalled();
+      // The empty history state matters too: react-router derives its location key from
+      // it, and the `default` key is what tells the task screen it has no in-app history.
+      expect(replaceSpy).toHaveBeenCalledWith({}, expect.anything(), module.__testing.appBaseUrl());
       replaceSpy.mockRestore();
     });
 

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -160,6 +160,10 @@ const ensureUserManager = async (): Promise<UserManager | null> => {
       redirect_uri: redirectUri,
       post_logout_redirect_uri: redirectUri,
       response_type: 'code',
+      // Applies to both provider redirects. The default ('assign') would leave the
+      // authorize URL in browser history, where a Back press re-authorizes off the
+      // SSO cookie and forwards straight back.
+      redirectMethod: 'replace',
       // Request only universally-valid standard scopes. Requesting a `groups`
       // scope would break login on any provider (e.g. a Keycloak client without
       // a registered `groups` client scope) that rejects unknown scopes with

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -42,12 +42,14 @@ vi.mock('../../../auth/tokenStore', () => ({
   getAccessToken: () => mockGetAccessToken(),
 }));
 
-const renderWithRouter = async (path: string) => {
+const renderWithHistory = async (entries: string[], initialIndex?: number) => {
   const result = render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter initialEntries={entries} initialIndex={initialIndex}>
       <Routes>
         <Route path="/task/:id" element={<TaskShow />} />
         <Route path="/" element={<div data-testid="home-route" />} />
+        <Route path="/tasks" element={<div data-testid="tasks-route" />} />
+        <Route path="/history" element={<div data-testid="history-route" />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -56,6 +58,8 @@ const renderWithRouter = async (path: string) => {
   });
   return result;
 };
+
+const renderWithRouter = async (path: string) => renderWithHistory([path]);
 
 const buildTask = (overrides: Partial<TaskStatus> = {}): TaskStatus => ({
   id: 'task-1',
@@ -111,6 +115,33 @@ describe('TaskShow', () => {
     expect(screen.getByText('task-1')).toBeInTheDocument();
     expect(screen.getByText('Images')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Refresh/i })).toBeInTheDocument();
+  });
+
+  describe('back navigation', () => {
+    beforeEach(() => {
+      mockUseGetOne.mockReturnValue({
+        data: buildTask(),
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+    });
+
+    it('returns to the previous in-app screen when one exists', async () => {
+      await renderWithHistory(['/history', '/task/task-1'], 1);
+
+      fireEvent.click(screen.getByRole('button', { name: /^Back$/ }));
+
+      expect(await screen.findByTestId('history-route')).toBeInTheDocument();
+    });
+
+    it('goes to the task list when the detail page is the first history entry', async () => {
+      await renderWithHistory(['/task/task-1']);
+
+      fireEvent.click(screen.getByRole('button', { name: /^Back$/ }));
+
+      expect(await screen.findByTestId('tasks-route')).toBeInTheDocument();
+    });
   });
 
   describe('project field', () => {

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -26,7 +26,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useGetIdentity, useGetOne, useNotify, usePermissions } from 'react-admin';
-import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { TaskStatus } from '../../../data/types';
 import { formatDuration, formatRelativeTime } from '../../../shared/utils/time';
 import { describeTaskStatus } from '../utils/statusPresentation';
@@ -180,6 +180,7 @@ export const TaskShow = () => {
   const { id } = useParams<{ id: string }>();
   const notify = useNotify();
   const navigate = useNavigate();
+  const location = useLocation();
   const deployLock = useDeployLockState();
   const oidcEnabled = useOidcEnabled();
   const { permissions } = usePermissions();
@@ -269,8 +270,15 @@ export const TaskShow = () => {
   }, [id, refetch, status]);
 
   const handleBack = useCallback(() => {
+    // A `default` key means this is the router's first entry (direct task URL):
+    // there is no in-app screen behind it, and stepping out of the SPA forces a
+    // fresh OIDC sign-in that lands the user right back here.
+    if (location.key === 'default') {
+      navigate('/tasks');
+      return;
+    }
     navigate(-1);
-  }, [navigate]);
+  }, [location.key, navigate]);
 
   const handleRefresh = useCallback(() => {
     const result = refetch();


### PR DESCRIPTION
Opening a task detail page from a shared link and pressing Back bounced the user through a fresh sign-in that landed back on the same page.

The Back button called navigate(-1). On a direct url the detail page is the router's first history entry, so that stepped out of the SPA to the pre-sign-in document. Tokens live only in memory, so leaving forces a new top-level OIDC redirect, which url_state returns to the page just left.

Back now goes to the task list when location.key is 'default', and the UserManager uses redirectMethod 'replace' so the provider's authorize url never enters browser history — covering the browser's own Back button, which the component guard cannot reach.