### PR TITLE
test(web): add a playwright browser suite for the ui

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,134 @@
+name: Web e2e
+
+# Browser coverage for the behaviour the jsdom suite structurally cannot reach:
+# the top-level OIDC redirect, history/back navigation, the server's SPA fallback
+# for deep links, the live WebSocket driving the deploy-lock banner, and the
+# privileged write flows with their gating.
+#
+# Triggered by UI changes plus everything these flows actually run through:
+# internal/server serves web/dist and terminates the auth/WebSocket paths,
+# internal/config decides what /api/v1/config tells the SPA about OIDC,
+# internal/auth validates the tokens, and cmd/argo-watcher + cmd/mock are the
+# binaries playwright.config.ts launches.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - 'internal/server/**'
+      - 'internal/config/**'
+      - 'internal/auth/**'
+      - 'cmd/argo-watcher/**'
+      - 'cmd/mock/**'
+      - 'go.mod'
+      - '.github/workflows/web-e2e.yml'
+      - 'test/keycloak/**'
+      - 'docker-compose.yml'
+      - 'Taskfile.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Kept in sync with the push filter above; GitHub Actions does not support
+    # YAML anchors, so the list is duplicated rather than shared.
+    paths:
+      - 'web/**'
+      - 'internal/server/**'
+      - 'internal/config/**'
+      - 'internal/auth/**'
+      - 'cmd/argo-watcher/**'
+      - 'cmd/mock/**'
+      - 'go.mod'
+      - '.github/workflows/web-e2e.yml'
+      - 'test/keycloak/**'
+      - 'docker-compose.yml'
+      - 'Taskfile.yml'
+
+jobs:
+  playwright:
+    name: Playwright
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+
+      - name: Install environment dependencies
+        # swag, for the swagger spec that task build-ui requires.
+        run: task install-deps
+
+      - name: Install frontend dependencies
+        working-directory: web
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright browsers
+        # --ignore-scripts above skips Playwright's own postinstall download, and
+        # the version installed here is whatever web/package.json pins, so client
+        # and browser builds always match.
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
+      - name: Type-check the suite
+        # Playwright transpiles specs without checking them, so without this the
+        # strict settings in tsconfig.node.json would only ever reach an editor.
+        # Scoped to the node-side project (config + e2e); web/src is not covered.
+        working-directory: web
+        run: npm run typecheck:e2e
+
+      - name: Build the UI bundle
+        # The suite runs against the shipped artifact shape: the Go server serving
+        # web/dist as static files. playwright.config.ts starts the servers.
+        run: task build-ui
+
+      - name: Warm the Go build cache
+        # playwright.config.ts starts the servers with `go run`, three at once and
+        # under a start-up timeout. Compiling here means those are cache hits
+        # rather than three cold builds racing that timeout.
+        run: go build -o /dev/null ./cmd/argo-watcher ./cmd/mock
+
+      - name: Start Keycloak
+        run: docker compose --profile integration up -d keycloak
+
+      - name: Wait for the Keycloak realm
+        run: |
+          discovery=http://localhost:8090/realms/argo-watcher-e2e/.well-known/openid-configuration
+          for _ in $(seq 1 60); do
+            if curl -fsS "$discovery" >/dev/null 2>&1; then
+              echo "Keycloak is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Keycloak realm argo-watcher-e2e not ready after 120s"
+          exit 1
+
+      - name: Run Playwright suite
+        working-directory: web
+        run: npx playwright test
+
+      - name: Upload the Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: web/playwright-report
+          retention-days: 7
+
+      - name: Stop Keycloak
+        if: always()
+        run: docker compose --profile integration down -v

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -79,9 +79,10 @@ jobs:
       - name: Install Playwright browsers
         # --ignore-scripts above skips Playwright's own postinstall download, and
         # the version installed here is whatever web/package.json pins, so client
-        # and browser builds always match.
+        # and browser builds always match. Run through the npm script rather than
+        # npx: it resolves the pinned local binary instead of the registry.
         working-directory: web
-        run: npx playwright install --with-deps chromium
+        run: npm run test:e2e:install
 
       - name: Type-check the suite
         # Playwright transpiles specs without checking them, so without this the
@@ -119,7 +120,7 @@ jobs:
 
       - name: Run Playwright suite
         working-directory: web
-        run: npx playwright test
+        run: npm run test:e2e
 
       - name: Upload the Playwright report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ sandbox/
 
 # per-phase JUnit reports written by the e2e lab's bats run
 test/e2e/reports/
+
+# Playwright run output (HTML report, traces, screenshots)
+web/playwright-report/
+web/test-results/
+
+# TypeScript incremental build info (emitted by the composite node-side project)
+**/*.tsbuildinfo

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,6 +127,29 @@ tasks:
       - npm run test
       - echo "===> Done"
 
+  test-web-e2e:
+    desc: Run the Playwright browser suite (requires docker; brings up keycloak). Must not be run concurrently with test-integration.
+    deps: [install-web-dependencies, build-ui]
+    cmds:
+      - echo "===> Starting Keycloak"
+      # No --wait: the keycloak image ships no shell tool, so compose cannot
+      # health-check it. Poll the realm's discovery endpoint instead.
+      - docker compose --profile integration up -d keycloak
+      - defer: docker compose --profile integration down -v
+      - |
+        discovery=http://localhost:8090/realms/argo-watcher-e2e/.well-known/openid-configuration
+        for _ in $(seq 1 60); do
+          if curl -fsS "$discovery" >/dev/null 2>&1; then
+            echo "===> Keycloak is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Keycloak realm argo-watcher-e2e not ready after 120s" >&2
+        exit 1
+      - echo "===> Running Playwright suite"
+      - cd web && npm run test:e2e
+
   build-ui:
     desc: Build the web UI bundle
     deps: [install-web-dependencies, docs]
@@ -138,6 +161,11 @@ tasks:
     sources:
       - src/**/*.ts
       - src/**/*.tsx
+    # Without this, an unchanged src plus a deleted or partial dist/ is reported
+    # up to date and the build is skipped — leaving the consumers of web/dist
+    # (the images, the Playwright suite) pointed at nothing.
+    generates:
+      - dist/index.html
 
   kind-upload:
     desc: Build and upload the argo-watcher image to a kind cluster

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -41,6 +41,7 @@ The project uses [Task](https://taskfile.dev/) as a build and automation tool. A
 | `task build-ui`     | Build the React frontend bundle                                    |
 | `task lint-web`     | Lint the React frontend code                                       |
 | `task test-web`     | Run React frontend unit tests                                      |
+| `task test-web-e2e` | Run the Playwright browser suite against the built UI (requires Docker) |
 | `task bootstrap`    | Start all Docker Compose services                                  |
 | `task teardown`     | Stop all Docker Compose services                                   |
 
@@ -171,6 +172,25 @@ This command brings up the `integration` Docker Compose profile (Gitea, Toxiprox
 ```bash
 task test-web
 ```
+
+### Browser (Playwright) Tests
+
+The jsdom suite above mounts components directly and has no real navigation, so a
+separate Playwright suite covers what only a browser can show: the top-level OIDC
+redirect and the path it returns to, session recovery across a reload, the Go
+server's SPA fallback for deep-linked task URLs, the live WebSocket driving the
+deploy-lock banner, and the privileged write flows (rollback, toggling the lock)
+with their gating for a privileged vs a regular user. Docker must be running.
+
+```bash
+task test-web-e2e
+```
+
+The task builds `web/dist`, brings Keycloak up from the `integration` Compose
+profile, and lets Playwright start the servers it drives: two `argo-watcher`
+instances (ports 8100 without OIDC, 8101 with) plus the mock Argo CD API. Both
+serve the built bundle as static files, which is how the production image runs.
+Specs live in `web/e2e/`, split into the `no-auth` and `auth` projects.
 
 ### Frontend Linting
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -111,11 +111,31 @@ reported as an authentication failure. Cached decisions (see
 
 ## Prerequisites
 
-You need a fully configured OIDC provider with a **public** client application (Authorization Code + PKCE) set up for Argo Watcher. Provider configuration is outside the scope of this guide — refer to your provider's documentation.
+You need a fully configured OIDC provider with a **public** client application (Authorization Code + PKCE) set up for Argo Watcher. Two client settings are dictated by how the Web UI signs in, and are covered below; anything else is provider-specific — refer to your provider's documentation.
+
+### Redirect URI and web origin
+
+The Web UI signs in with a **top-level redirect** (not a hidden iframe), so the provider must allow the browser back:
+
+- **Redirect URI** — the application's base URL **including the trailing slash**, e.g. `https://argo-watcher.example.com/`. When Argo Watcher is served under a sub-path, include it: `https://example.com/argo-watcher/`. The same value is used as the post-logout redirect URI. Providers match this exactly, and a mismatch fails the login on the provider's own error page, before Argo Watcher is ever reached.
+- **Web origin** — the application's origin (scheme, host, port; no path). After the redirect the browser reads group membership straight from the provider's userinfo endpoint, and that request carries an `Authorization` header, so the provider must allow it cross-origin. Providers differ here: Keycloak has a separate **Web origins** field, while others derive it from the registered redirect URI.
+
+    Get this wrong and **sign-in still succeeds** — the failure surfaces later, and quietly: the userinfo call is blocked, group membership comes back empty, and every privileged control stays hidden. That is the same symptom as a missing `groups` claim below, so check both when the rollback button or the deploy-lock toggle does not appear for a user who should have them.
+
+`test/keycloak/argo-watcher-e2e-realm.json` in the repository is a minimal working client definition — public, authorization code with PKCE (`S256`), an exact redirect URI, a web origin, and the `groups` mapper below. The browser test suite signs in against it on every run, so it stays a correct reference.
+
+!!! tip "Keycloak"
+    Set **Valid redirect URIs** and **Web origins** in the client's settings. Both are needed: with Web origins empty, users sign in normally and then have no privileged controls.
+
+!!! tip "Authentik"
+    Set **Redirect URI** on the OAuth2/OIDC provider to the same value.
+
+!!! note
+    The provider commonly runs on a different domain than Argo Watcher. That is supported — the flow is a top-level redirect precisely so it does not depend on third-party cookies — but it does mean the userinfo call is cross-origin, which is what the web origin setting is for.
 
 ### The `groups` claim
 
-Every provider must satisfy one requirement: emit a `groups` claim in **both** the ID token and the **userinfo** response (the Web UI reads it from the token to gate buttons; the backend independently enforces it via userinfo). The claim must be gated behind a scope Argo Watcher actually requests. Argo Watcher only ever requests `openid profile email`, so the claim must be bound to `profile` or `email` (or the base `openid` scope) — a claim gated behind a separate `groups` scope is never evaluated, and group membership comes back empty.
+Every provider must satisfy one requirement: emit a `groups` claim in **both** the ID token and the **userinfo** response. Both are used: the Web UI gates its buttons on userinfo — the same source the backend independently enforces on, so the two always agree — and falls back to the ID-token claim if that call fails. The claim must be gated behind a scope Argo Watcher actually requests. Argo Watcher only ever requests `openid profile email`, so the claim must be bound to `profile` or `email` (or the base `openid` scope) — a claim gated behind a separate `groups` scope is never evaluated, and group membership comes back empty.
 
 The steps below are the same requirement expressed in each provider's configuration model.
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -135,7 +135,7 @@ The Web UI signs in with a **top-level redirect** (not a hidden iframe), so the 
 
 ### The `groups` claim
 
-Every provider must satisfy one requirement: emit a `groups` claim in **both** the ID token and the **userinfo** response. Both are used: the Web UI gates its buttons on userinfo — the same source the backend independently enforces on, so the two always agree — and falls back to the ID-token claim if that call fails. The claim must be gated behind a scope Argo Watcher actually requests. Argo Watcher only ever requests `openid profile email`, so the claim must be bound to `profile` or `email` (or the base `openid` scope) — a claim gated behind a separate `groups` scope is never evaluated, and group membership comes back empty.
+Every provider must satisfy one requirement: emit a `groups` claim in **both** the ID token and the **userinfo** response. Both are used: the Web UI gates its buttons on userinfo, the same source the backend independently enforces on, and falls back to the ID-token claim when that call fails. The backend has no such fallback — while userinfo is unreachable it refuses every privileged action, so the UI may still show a rollback button or a deploy-lock toggle that the API then rejects. The claim must be gated behind a scope Argo Watcher actually requests. Argo Watcher only ever requests `openid profile email`, so the claim must be bound to `profile` or `email` (or the base `openid` scope) — a claim gated behind a separate `groups` scope is never evaluated, and group membership comes back empty.
 
 The steps below are the same requirement expressed in each provider's configuration model.
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,22 @@
             corepack
           ]) ++ [ viteShim ];
 
+        # Browsers for the Playwright suite (web/e2e). Playwright refuses to run
+        # against a browser build it was not compiled for, so web/package.json
+        # pins @playwright/test to EXACTLY this derivation's version. CI installs
+        # its own browsers and would not catch a drift, so the dev shell asserts
+        # the pairing here and fails to evaluate with the mismatch named.
+        pinnedPlaywright =
+          (builtins.fromJSON (builtins.readFile ./web/package.json)).devDependencies."@playwright/test";
+
+        playwrightBrowsers =
+          assert pkgs.lib.assertMsg (pkgs.playwright-driver.version == pinnedPlaywright) ''
+            Playwright version mismatch: nixpkgs playwright-driver is ${pkgs.playwright-driver.version},
+            but web/package.json pins @playwright/test to ${pinnedPlaywright}.
+            Bump both together (the browsers must match the client build).
+          '';
+          pkgs.playwright-driver.browsers;
+
         # mkdocs-llmstxt is not packaged in nixpkgs, so we build it from its PyPI
         # sdist to keep the dev shell's `mkdocs build`/`serve` in sync with
         # docs/requirements.txt. Everything it needs — mkdocs, mdformat 1.0.0 and
@@ -133,6 +149,10 @@
             export GOMODCACHE="$PWD/.gomod"
             mkdir -p "$GOPATH" "$GOMODCACHE"
             export GO111MODULE=on
+
+            # Point Playwright at the Nix-provided browsers instead of the
+            # per-user download cache, which nothing here populates.
+            export PLAYWRIGHT_BROWSERS_PATH="${playwrightBrowsers}"
 
             export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
               pkgs.cairo

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,6 +15,10 @@ client behaviour.
 
 Unlike the unit and integration suites, ArgoCD here is **not mocked**.
 
+This lab covers the backend and its real ArgoCD/git path only. Browser-level UI
+testing — the OIDC redirect, deep links, the deploy-lock WebSocket, rollback —
+lives separately in `web/e2e/` (Playwright, `task test-web-e2e`).
+
 ## Prerequisites
 
 `kind`, `kubectl`, `helm`, `go`, `git`, `jq`, `yq`, `curl`, `task`, `bats`, and

--- a/test/keycloak/argo-watcher-e2e-realm.json
+++ b/test/keycloak/argo-watcher-e2e-realm.json
@@ -10,9 +10,15 @@
       "clientId": "argo-watcher",
       "enabled": true,
       "publicClient": true,
-      "standardFlowEnabled": false,
+      "standardFlowEnabled": true,
       "serviceAccountsEnabled": false,
       "directAccessGrantsEnabled": true,
+      "redirectUris": [ "http://localhost:8101/" ],
+      "webOrigins": [ "http://localhost:8101" ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:8101/",
+        "pkce.code.challenge.method": "S256"
+      },
       "protocolMappers": [
         {
           "name": "groups",

--- a/web/README.md
+++ b/web/README.md
@@ -20,6 +20,7 @@ React 19, React-admin 5, Material UI 9, Emotion, TypeScript, oxlint, and Vitest/
 | `src/layout/` | Reusable React-admin layout primitives (notifications, top bar, nav, etc.), plus `AppSplash.tsx`, the pre-mount loading screen. |
 | `src/shared/` | Cross-cutting hooks, context providers (timezone), and utilities (time formatting, OIDC toggle). |
 | `src/theme/` | Material UI theme factory plus `ThemeModeProvider` for light/dark persistence. |
+| `e2e/` | Playwright browser specs, split into the `no-auth` and `auth` projects, plus `helpers.ts` (task seeding, Keycloak sign-in, token minting). |
 | `assets/` + `public/` | Static assets (logos, favicons) delivered verbatim by Vite. |
 | `dist/` | Build output consumed by the Go server (`STATIC_FILES_PATH`) or Docker images. Generated via `npm run build`. |
 
@@ -74,6 +75,8 @@ OIDC settings (issuer URL, client_id, privileged groups) come from `/api/v1/conf
 | `npm run test` | Vitest in CI mode (`--run`). Generates text + LCOV coverage. |
 | `npm run test:watch` | Interactive Vitest watch mode. |
 | `npm run test:ui` | Vitest UI (requires a browser) for debugging complex suites. |
+| `npm run test:e2e` | Playwright browser suite. Expects `web/dist` built and Keycloak up — `task test-web-e2e` from the repo root does both. |
+| `npm run typecheck:e2e` | Type-checks the node-side project (`playwright.config.ts`, `vite.config.ts`, `e2e/`). Playwright does not type-check specs, so this is a separate CI gate. `src/` is not covered. |
 
 ## Data, Auth, and Real-time Architecture
 
@@ -98,6 +101,39 @@ OIDC settings (issuer URL, client_id, privileged groups) come from `/api/v1/conf
 - Tests live next to the code as `*.test.ts(x)` and are auto-discovered via `vitest.config.ts`.
 - Coverage reporters: text summary in CI plus LCOV for Codecov. Keep critical flows (auth provider, data provider, deploy-lock logic, utilities) covered.
 - oxlint enforces React, hooks rules, and TypeScript correctness. Configure additional lint rules under `.oxlintrc.json` if new conventions emerge.
+
+### Browser tests (Playwright)
+
+`e2e/` covers what jsdom structurally cannot: real cross-document navigation, a
+real history stack, and a real WebSocket. Everything a component test can assert
+belongs in Vitest — this suite is deliberately small.
+
+Run it with `task test-web-e2e` from the repo root; `playwright.config.ts` starts
+what it drives (the mock Argo CD API and two `argo-watcher` instances serving the
+built bundle, on 8100 without OIDC and 8101 with), but Keycloak comes from the
+`integration` Compose profile and must already be up.
+
+| Project | Covers |
+| ------- | ------ |
+| `no-auth` | The server's SPA fallback for a deep-linked task URL; Back from a directly-opened task page, where the detail view is the router's first history entry; and the auth-less deployment mode, which must render with no sign-in and offer no privileged controls. |
+| `auth` | The top-level OIDC redirect and the stripping of its callback query; returning to the linked task via `url_state`; session recovery through the SSO cookie after a reload; the deploy-lock banner arriving over the live socket and the lock being toggled from the drawer; rollback as a privileged user; and privilege gating of both controls for a privileged vs a regular realm user. |
+
+The Keycloak client in `test/keycloak/argo-watcher-e2e-realm.json` has the
+standard (authorization-code) flow enabled with the app's exact redirect URI
+`http://localhost:8101/` registered, which is what lets a browser complete the
+flow, and it requires PKCE (`S256`) — so a regression that stopped sending a code
+challenge fails every auth spec. The Go integration tests use the same client
+through the direct access grant, so both stay enabled.
+
+Two constraints when adding specs:
+
+- `@playwright/test` is pinned to the exact version of `playwright-driver` in
+  `flake.nix`, which supplies the browsers in the dev shell. Bump them together.
+- Both servers hold in-memory state that every spec seeds into, so the suite runs
+  single-worker. Give each seeded task a distinct author rather than assuming an
+  empty list, and never wait on the task table to decide the app has loaded — an
+  empty list has no column headers, so such a wait passes only when some earlier
+  spec happened to seed first. Use `expectAppLoaded` instead.
 
 ## Building & Shipping
 

--- a/web/e2e/auth/deploy-lock.spec.ts
+++ b/web/e2e/auth/deploy-lock.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from '@playwright/test';
+import { expectAppLoaded, KEYCLOAK_ORIGIN, mintToken, signIn } from '../helpers';
+
+const BANNER = /Deploy lock is active/;
+const LOCK_SWITCH = 'Toggle deploy lock';
+
+/** Signs in as the privileged user and waits for the app shell. */
+const signInPrivileged = async (page: Page): Promise<void> => {
+  await page.goto('/');
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+  await expectAppLoaded(page);
+};
+
+test.describe('deploy lock', () => {
+  // The lock is server-global and the servers outlive each test, so a failure
+  // part-way through either test must not leave it engaged for the retry or the
+  // next spec.
+  test.afterEach(async ({ request }) => {
+    const token = await mintToken(request);
+    await request.delete('/api/v1/deploy-lock', { headers: { 'Oidc-Authorization': `Bearer ${token}` } });
+  });
+
+  /**
+   * The banner is driven by the server's WebSocket, which the unit suite stubs.
+   * Locking through the API and watching an already-open page react drives the
+   * real chain: a handshake from the built bundle, the server's lock watcher
+   * noticing on its poll, and the push landing with no reload.
+   */
+  test('the banner appears and clears from the live socket', async ({ page, request }) => {
+    const token = await mintToken(request);
+    const authHeader = { 'Oidc-Authorization': `Bearer ${token}` };
+
+    await signInPrivileged(page);
+    await expect(page.getByText(BANNER)).toHaveCount(0);
+
+    const locked = await request.post('/api/v1/deploy-lock', { headers: authHeader });
+    expect(locked.status()).toBe(200);
+
+    // The server samples the lock every 5s and pushes on transition, so this
+    // waits on a broadcast rather than on a client-side poll.
+    await expect(page.getByText(BANNER)).toBeVisible({ timeout: 30_000 });
+
+    const released = await request.delete('/api/v1/deploy-lock', { headers: authHeader });
+    expect(released.status()).toBe(200);
+
+    await expect(page.getByText(BANNER)).toHaveCount(0, { timeout: 30_000 });
+  });
+
+  /**
+   * The other direction: locking from the drawer. This is the only place the
+   * browser's in-memory access token is proven to reach a privileged write —
+   * component tests stub the HTTP client and never produce a real token.
+   */
+  test('a privileged user can engage and release the lock from the drawer', async ({ page, request }) => {
+    await signInPrivileged(page);
+
+    await page.getByRole('button', { name: 'Open configuration drawer' }).click();
+    await expect(page.getByRole('heading', { name: 'Workspace Controls' })).toBeVisible();
+    await expect(page.getByText('Lock released')).toBeVisible();
+
+    await page.getByLabel(LOCK_SWITCH).click();
+
+    await expect(page.getByText('Lock engaged')).toBeVisible();
+    const token = await mintToken(request);
+    const authHeader = { 'Oidc-Authorization': `Bearer ${token}` };
+    await expect
+      .poll(async () => (await request.get('/api/v1/deploy-lock', { headers: authHeader })).text(), {
+        message: 'the server must report the lock the UI just set',
+      })
+      .toContain('true');
+
+    await page.getByLabel(LOCK_SWITCH).click();
+
+    await expect(page.getByText('Lock released')).toBeVisible();
+    await expect
+      .poll(async () => (await request.get('/api/v1/deploy-lock', { headers: authHeader })).text(), {
+        message: 'the server must report the lock the UI just released',
+      })
+      .toContain('false');
+  });
+});

--- a/web/e2e/auth/login-deep-link-return.spec.ts
+++ b/web/e2e/auth/login-deep-link-return.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { KEYCLOAK_ORIGIN, seedTask, signIn, waitForDeployed } from '../helpers';
+
+/**
+ * Signing in from a shared task link must land back on that task, not on the
+ * app's default screen. The path survives the provider round trip in `url_state`,
+ * and losing it is what turned a shared link into the relogin loop of #536.
+ *
+ * The round trip is a real cross-document navigation, so jsdom cannot cover it.
+ */
+test('signing in from a shared task link returns to that task', async ({ page, request }) => {
+  const id = await seedTask(request, 'login-deep-link-return');
+  await waitForDeployed(request, id);
+
+  await page.goto(`/task/${id}`);
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+
+  await expect(page).toHaveURL(new RegExp(`/task/${id}$`));
+  await expect(page.getByText(`Task ${id.slice(0, 8)}`)).toBeVisible();
+});

--- a/web/e2e/auth/login-redirect.spec.ts
+++ b/web/e2e/auth/login-redirect.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { expectAppLoaded, expectOnApp, KEYCLOAK_ORIGIN, signIn } from '../helpers';
+
+/**
+ * The top-level OIDC redirect: leaving the document for the provider and coming
+ * back with an authorization code. jsdom implements no cross-document
+ * navigation, so this whole flow is invisible to the unit suite.
+ */
+test('an unauthenticated visit signs in through the provider and returns to the app', async ({ page }) => {
+  await page.goto('/');
+
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+
+  expectOnApp(page);
+  await expectAppLoaded(page);
+  // The callback params must be consumed, not left on the URL where a reload
+  // would replay a spent authorization code. The list's own query params (sort,
+  // page, filters) are react-admin's and are expected to be there.
+  const params = new URL(page.url()).searchParams;
+  expect(params.has('code'), 'authorization code must be stripped').toBe(false);
+  expect(params.has('state'), 'callback state must be stripped').toBe(false);
+});

--- a/web/e2e/auth/privileged-gating.spec.ts
+++ b/web/e2e/auth/privileged-gating.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  awaitPermissionsResolved,
+  KEYCLOAK_ORIGIN,
+  mintToken,
+  PRIVILEGED_USER,
+  REGULAR_USER,
+  seedTask,
+  signIn,
+  waitForDeployed,
+} from '../helpers';
+
+const ROLLBACK_BUTTON = 'Rollback to this version';
+const LOCK_SWITCH = 'Toggle deploy lock';
+
+/** Opens the configuration drawer, which holds the deploy-lock toggle. */
+const openConfigDrawer = async (page: Page): Promise<void> => {
+  await page.getByRole('button', { name: 'Open configuration drawer' }).click();
+  // MUI's temporary Drawer is a presentation modal, not a dialog, so wait on its
+  // heading rather than a role.
+  await expect(page.getByRole('heading', { name: 'Workspace Controls' })).toBeVisible();
+};
+
+/**
+ * Opens a task as the given realm user and returns once permissions have
+ * resolved, so gating assertions observe the settled state.
+ */
+const openTaskAs = async (
+  page: Page,
+  id: string,
+  user: { username: string; password: string },
+): Promise<void> => {
+  await page.goto(`/task/${id}`);
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  const permissions = awaitPermissionsResolved(page);
+  await signIn(page, user.username, user.password);
+  await permissions;
+  await expect(page.getByText(`Task ${id.slice(0, 8)}`)).toBeVisible();
+};
+
+/**
+ * Privilege gating for the two destructive controls: the task rollback button
+ * and the deploy-lock toggle.
+ *
+ * Both gate on `permissions.groups`, which the app resolves from the provider's
+ * userinfo endpoint — the same source the backend enforces on. Component tests
+ * inject that permission object directly, so only a browser signed in against a
+ * real provider proves the full chain: token, userinfo call, `groups` claim, and
+ * the rendered control. The last assertion in each test pins the documented
+ * invariant that the UI's gating agrees with what the server actually allows.
+ */
+test.describe('privileged control gating', () => {
+  test('a privileged user gets both controls, and the server agrees', async ({ page, request }) => {
+    const id = await seedTask(request, 'gating-privileged');
+    await waitForDeployed(request, id);
+
+    await openTaskAs(page, id, PRIVILEGED_USER);
+
+    await expect(page.getByRole('button', { name: ROLLBACK_BUTTON })).toBeVisible();
+
+    await openConfigDrawer(page);
+    await expect(page.getByLabel(LOCK_SWITCH)).toBeEnabled();
+
+    const token = await mintToken(request, PRIVILEGED_USER);
+    const locked = await request.post('/api/v1/deploy-lock', {
+      headers: { 'Oidc-Authorization': `Bearer ${token}` },
+    });
+    expect(locked.status(), 'a privileged user may set the lock').toBe(200);
+  });
+
+  test('a regular user gets neither control, and the server agrees', async ({ page, request }) => {
+    const id = await seedTask(request, 'gating-regular');
+    await waitForDeployed(request, id);
+
+    await openTaskAs(page, id, REGULAR_USER);
+
+    // The task itself must still render — this is gating, not a lockout.
+    await expect(page.getByRole('button', { name: ROLLBACK_BUTTON })).toHaveCount(0);
+
+    await openConfigDrawer(page);
+    await expect(page.getByLabel(LOCK_SWITCH)).toBeDisabled();
+    await expect(page.getByText('Deploy lock requires privileged access.')).toBeVisible();
+
+    // 401, not 403: the deploy-lock endpoints answer a valid-but-unprivileged
+    // token the same way as no token at all. TestKeycloakDeployLockAuthz owns the
+    // exhaustive server-side matrix; this pairs one case with the hidden control.
+    const token = await mintToken(request, REGULAR_USER);
+    const rejected = await request.post('/api/v1/deploy-lock', {
+      headers: { 'Oidc-Authorization': `Bearer ${token}` },
+    });
+    expect(rejected.status(), 'a regular user must not be able to set the lock').toBe(401);
+  });
+
+  // The lock is server-global and the servers outlive each test, so a failure
+  // mid-test must not leave it engaged for the retry or the next spec.
+  test.afterEach(async ({ request }) => {
+    const token = await mintToken(request, PRIVILEGED_USER);
+    await request.delete('/api/v1/deploy-lock', { headers: { 'Oidc-Authorization': `Bearer ${token}` } });
+  });
+});

--- a/web/e2e/auth/rollback.spec.ts
+++ b/web/e2e/auth/rollback.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+import { expectAppLoaded, KEYCLOAK_ORIGIN, mintToken, seedTask, signIn, waitForDeployed } from '../helpers';
+
+/**
+ * The rollback write path, driven from the UI as a privileged user.
+ *
+ * It is the only flow that proves the browser's in-memory access token reaches a
+ * write request, and that the author on the resulting task comes from the real
+ * OIDC identity — component tests stub both the HTTP client and the identity.
+ */
+test('a privileged user can roll a task back, and the new task carries their identity', async ({ page, request }) => {
+  const id = await seedTask(request, 'rollback-source');
+  await waitForDeployed(request, id);
+
+  await page.goto(`/task/${id}`);
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+
+  await page.getByRole('button', { name: 'Rollback to this version' }).click();
+  await expect(page.getByRole('heading', { name: 'Rollback Confirmation' })).toBeVisible();
+
+  // Scope the check below to tasks created from here on. The servers keep their
+  // in-memory state across CI retries, so an unscoped search would find the task
+  // a previous attempt already created and pass without this click doing anything.
+  // Minus one second because task timestamps are whole seconds and the filter's
+  // lower bound is exclusive, which would otherwise drop a same-second task.
+  const since = Math.floor(Date.now() / 1000) - 1;
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+  // A confirmed rollback returns to the list.
+  await expectAppLoaded(page);
+  await expect(page).toHaveURL(/\/tasks(\?|$)/);
+
+  const token = await mintToken(request);
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/api/v1/tasks?from_timestamp=${since}`, {
+          headers: { 'Oidc-Authorization': `Bearer ${token}` },
+        });
+        const body = (await response.json()) as { tasks?: { author?: string }[] };
+        return (body.tasks ?? []).map(task => task.author);
+      },
+      { message: 'the rollback must create a task authored by the signed-in user' },
+    )
+    .toContain('priv-user@example.com');
+});

--- a/web/e2e/auth/session-reload.spec.ts
+++ b/web/e2e/auth/session-reload.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { expectAppLoaded, expectOnApp, KEYCLOAK_ORIGIN, signIn } from '../helpers';
+
+/**
+ * Access tokens are held in memory only (never localStorage), so a full page
+ * reload drops the session and the app recovers it through the provider's SSO
+ * cookie. The bounce is a real cross-document round trip: only a browser shows
+ * whether the user lands back where they were or is asked to log in again.
+ */
+test('a reload recovers the session without showing the login form again', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+  await expectAppLoaded(page);
+
+  // The recovery bounce does pass through the provider, so "no login form" has to
+  // be observed as a navigation that never reaches the form's submit endpoint;
+  // asserting the form is absent once we are back on the app is a tautology.
+  const navigations: string[] = [];
+  page.on('framenavigated', frame => navigations.push(frame.url()));
+
+  await page.reload();
+
+  await expectAppLoaded(page);
+  expect(
+    navigations.filter(url => url.includes('/login-actions/authenticate')),
+    'recovery must not go through the interactive login form',
+  ).toHaveLength(0);
+  expectOnApp(page);
+});

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,0 +1,154 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/** Keycloak realm base URL, matching the `integration` compose profile. */
+export const KEYCLOAK_ORIGIN = 'http://localhost:8090';
+
+/** Realm users: `priv-user` is in the `privileged` group, `regular-user` is in none. */
+export const PRIVILEGED_USER = { username: 'priv-user', password: 'priv-pass' } as const;
+export const REGULAR_USER = { username: 'regular-user', password: 'regular-pass' } as const;
+
+/**
+ * Application name the mock Argo CD API (cmd/mock) knows about, paired with the
+ * image tag it reports as running. A task deploying anything else never reaches a
+ * terminal status, so seeds use this pair.
+ */
+export const MOCK_APP = 'app';
+export const MOCK_TAG = 'v0.0.1';
+
+/**
+ * Creates a task through the public API.
+ *
+ * `POST /api/v1/tasks` is exempt from OIDC read protection, so this seeds both
+ * the authenticated and unauthenticated servers without a credential.
+ *
+ * @param request - Playwright request context bound to the project's baseURL.
+ * @param author - author recorded on the task, used by specs to identify their own seed.
+ * @returns the new task's id.
+ */
+export const seedTask = async (request: APIRequestContext, author: string): Promise<string> => {
+  const response = await request.post('/api/v1/tasks', {
+    data: {
+      app: MOCK_APP,
+      author,
+      project: 'e2e',
+      images: [{ image: MOCK_APP, tag: MOCK_TAG }],
+    },
+  });
+  expect(response.status(), 'seeding a task must be accepted').toBe(202);
+  const body = (await response.json()) as { id: string };
+  expect(body.id, 'seeded task must carry an id').toBeTruthy();
+  return body.id;
+};
+
+/**
+ * Polls a task until it reaches `deployed`, so specs assert against a settled
+ * row rather than one still transitioning under them.
+ *
+ * @param request - Playwright request context bound to the project's baseURL.
+ * @param id - task id returned by {@link seedTask}.
+ */
+export const waitForDeployed = async (request: APIRequestContext, id: string): Promise<void> => {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/api/v1/tasks/${id}`);
+        if (!response.ok()) {
+          return `http ${response.status()}`;
+        }
+        const body = (await response.json()) as { status?: string };
+        return body.status;
+      },
+      { message: `task ${id} never reached "deployed"`, timeout: 30_000 },
+    )
+    .toBe('deployed');
+};
+
+/**
+ * Signs in through the Keycloak login form and waits until the browser is back
+ * on the application origin.
+ *
+ * Selectors are Keycloak's stable form element ids rather than visible labels,
+ * which change with the login theme and locale.
+ *
+ * @param page - page currently showing the Keycloak login form.
+ * @param username - realm user to sign in as.
+ * @param password - that user's password.
+ */
+export const signIn = async (
+  page: Page,
+  username: string = PRIVILEGED_USER.username,
+  password: string = PRIVILEGED_USER.password,
+): Promise<void> => {
+  await expect(page.locator('#kc-form-login')).toBeVisible();
+  await page.locator('#username').fill(username);
+  await page.locator('#password').fill(password);
+  await page.locator('#kc-login').click();
+  // Only that the browser left the provider. Waiting here for the callback query
+  // to be consumed would make a spec asserting on that a tautology; callers gate
+  // on their own rendered-app assertion instead.
+  await page.waitForURL(url => !url.href.startsWith(KEYCLOAK_ORIGIN));
+};
+
+/**
+ * Waits for group membership to be resolved from the provider's userinfo
+ * endpoint.
+ *
+ * Every privilege-gated control renders its UNPRIVILEGED form while permissions
+ * are still resolving, so a negative assertion made before this settles passes
+ * whether the gating works or not. Arm this before signing in, await it after.
+ *
+ * @param page - page about to complete a sign-in.
+ * @returns a promise resolving once userinfo has answered.
+ */
+export const awaitPermissionsResolved = (page: Page): Promise<unknown> =>
+  page.waitForResponse(
+    response =>
+      response.request().method() === 'GET' &&
+      response.url().includes('/protocol/openid-connect/userinfo') &&
+      response.status() === 200,
+  );
+
+/** Asserts the browser is on the application, not parked on the identity provider. */
+export const expectOnApp = (page: Page): void => {
+  expect(page.url(), 'expected to be on the application origin').not.toContain(KEYCLOAK_ORIGIN);
+};
+
+/**
+ * Waits for the application shell to be up.
+ *
+ * Deliberately keys on the top bar rather than the task table: an empty task
+ * list renders an empty state with no column headers, so a table-based wait
+ * would silently depend on another spec having seeded data first.
+ *
+ * @param page - page expected to have mounted the app.
+ */
+export const expectAppLoaded = async (page: Page): Promise<void> => {
+  await expect(page.getByRole('link', { name: 'Recent' })).toBeVisible();
+};
+
+/**
+ * Mints an access token via the direct access grant, for API calls a spec makes
+ * outside the browser session.
+ *
+ * @param request - any Playwright request context; the provider is addressed absolutely.
+ * @param user - realm credentials to authenticate with.
+ * @returns a bearer token for that user.
+ */
+export const mintToken = async (
+  request: APIRequestContext,
+  user: { username: string; password: string } = PRIVILEGED_USER,
+): Promise<string> => {
+  const response = await request.post(`${KEYCLOAK_ORIGIN}/realms/argo-watcher-e2e/protocol/openid-connect/token`, {
+    form: {
+      grant_type: 'password',
+      client_id: 'argo-watcher',
+      scope: 'openid',
+      username: user.username,
+      password: user.password,
+    },
+  });
+  expect(response.ok(), `the provider must issue a token for ${user.username}`).toBeTruthy();
+  const body = (await response.json()) as { access_token?: string };
+  expect(body.access_token, 'token response must carry an access_token').toBeTruthy();
+  return body.access_token!;
+};

--- a/web/e2e/no-auth/anonymous-mode.spec.ts
+++ b/web/e2e/no-auth/anonymous-mode.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { seedTask, waitForDeployed } from '../helpers';
+
+/**
+ * The auth-less deployment (`oidc.enabled = false`) is a supported mode, and it
+ * must render with no sign-in and no privileged controls. The gating reads
+ * `/api/v1/config` from the real server, so only a browser against a real
+ * OIDC-disabled instance proves the app agrees with what the backend reports.
+ */
+test('an anonymous deployment renders without a sign-in and hides privileged controls', async ({ page, request }) => {
+  const id = await seedTask(request, 'anonymous-mode');
+  await waitForDeployed(request, id);
+
+  await page.goto(`/task/${id}`);
+
+  await expect(page.getByText(`Task ${id.slice(0, 8)}`)).toBeVisible();
+
+  await page.getByRole('button', { name: 'Open configuration drawer' }).click();
+  await expect(page.getByRole('heading', { name: 'Workspace Controls' })).toBeVisible();
+  // Assert this first: it is the only marker that appears once /api/v1/config has
+  // actually resolved to disabled. The absences below are also true while the
+  // config is still in flight, so checking them earlier would prove nothing.
+  await expect(page.getByText('Manual deploy lock requires authentication.')).toBeVisible();
+  // The toggle is not merely disabled here: without OIDC there is no identity to
+  // authorize, so the control is not offered at all.
+  await expect(page.getByLabel('Toggle deploy lock')).toHaveCount(0);
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('button', { name: 'Rollback to this version' })).toHaveCount(0);
+});

--- a/web/e2e/no-auth/deep-link.spec.ts
+++ b/web/e2e/no-auth/deep-link.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import { seedTask, waitForDeployed } from '../helpers';
+
+/**
+ * Deep-linking a task detail page exercises the Go server's SPA fallback
+ * (internal/server/staticfs.go serves index.html for unmatched paths) together
+ * with the client router picking the route back up. jsdom tests mount the router
+ * directly and never issue that request, so this path is only covered here.
+ */
+test.describe('task detail deep link', () => {
+  test('the server answers an unknown client route with the SPA shell', async ({ request }) => {
+    const response = await request.get('/task/does-not-exist');
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('text/html');
+    expect(await response.text()).toContain('<div id="root">');
+  });
+
+  test('opening a task URL directly renders that task', async ({ page, request }) => {
+    const id = await seedTask(request, 'deep-link');
+    await waitForDeployed(request, id);
+
+    await page.goto(`/task/${id}`);
+
+    await expect(page.getByText(`Task ${id.slice(0, 8)}`)).toBeVisible();
+    // Exact: "Rollback to this version" also contains "Back".
+    await expect(page.getByRole('button', { name: 'Back', exact: true })).toBeVisible();
+  });
+
+  /**
+   * Regression cover for #536. On a directly-opened task URL the detail page is
+   * the router's FIRST history entry, so a plain `navigate(-1)` steps out of the
+   * SPA entirely instead of moving within it. Only a real browser has a history
+   * stack that can be stepped off the end of.
+   */
+  test('Back from a directly-opened task page stays in the app and shows the list', async ({ page, request }) => {
+    const id = await seedTask(request, 'deep-link-back');
+    await waitForDeployed(request, id);
+
+    await page.goto(`/task/${id}`);
+    await expect(page.getByText(`Task ${id.slice(0, 8)}`)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Back', exact: true }).click();
+
+    // react-admin appends its own list query (sort, page, filters) to /tasks.
+    await expect(page).toHaveURL(/\/tasks(\?|$)/);
+    await expect(page.getByRole('columnheader', { name: 'Application' })).toBeVisible();
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
+        "@playwright/test": "1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1238,6 +1239,22 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3963,6 +3980,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium",
     "typecheck:e2e": "tsc -p tsconfig.node.json --noEmit"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,9 @@
     "lint": "oxlint",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "typecheck:e2e": "tsc -p tsconfig.node.json --noEmit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -25,6 +27,7 @@
     "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,118 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, devices } from '@playwright/test';
+
+// 8100/8101 are private to this suite, chosen to miss the docker-compose dev
+// stack (8080 backend, 8090 keycloak, 3100 frontend). 8081 is NOT private: it is
+// the dev stack's mock port, shared because cmd/mock hardcodes its listen
+// address. Locally a running dev stack's mock is reused rather than started; in
+// CI (reuseExistingServer false) anything already holding 8081 aborts the run.
+const NO_AUTH_PORT = 8100;
+const AUTH_PORT = 8101;
+const MOCK_PORT = 8081;
+
+const NO_AUTH_URL = `http://localhost:${NO_AUTH_PORT}`;
+const AUTH_URL = `http://localhost:${AUTH_PORT}`;
+
+// Keycloak from the compose `integration` profile. The suite does not start it:
+// compose has no health check for this image, so the caller (task test-web-e2e,
+// or the web-e2e workflow) brings it up and polls the realm's discovery endpoint
+// before invoking Playwright.
+const KEYCLOAK_REALM_URL = 'http://localhost:8090/realms/argo-watcher-e2e';
+
+// The suite drives the shipped artifact shape: the Go server serving web/dist as
+// static files, exactly as the production image does. A missing bundle would
+// otherwise surface as a wall of unrelated selector failures.
+// Resolved against this file, not the process CWD, so the guard reports the real
+// problem regardless of where Playwright was invoked from.
+if (!existsSync(fileURLToPath(new URL('dist/index.html', import.meta.url)))) {
+  throw new Error('web/dist/index.html not found. Run "task build-ui" before the e2e suite.');
+}
+
+const serverEnv = {
+  STATE_TYPE: 'in-memory',
+  // The mock Argo CD API (cmd/mock) reports app "app" as Synced/Healthy running
+  // app:v0.0.1, which is what lets a seeded task reach "deployed" deterministically.
+  ARGO_URL: `http://localhost:${MOCK_PORT}`,
+  ARGO_TOKEN: 'e2e',
+  STATIC_FILES_PATH: 'web/dist',
+  LOG_LEVEL: 'warn',
+};
+
+export default defineConfig({
+  testDir: './e2e',
+  // Both servers hold in-memory state that every spec seeds into, so tests are
+  // serialized rather than racing each other's task lists.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }], ['github']]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+
+  projects: [
+    {
+      name: 'no-auth',
+      testDir: './e2e/no-auth',
+      use: { ...devices['Desktop Chrome'], baseURL: NO_AUTH_URL },
+    },
+    {
+      name: 'auth',
+      testDir: './e2e/auth',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: AUTH_URL,
+      },
+    },
+  ],
+
+  webServer: [
+    {
+      name: 'mock-argocd',
+      command: 'go run ./cmd/mock',
+      cwd: '..',
+      url: `http://localhost:${MOCK_PORT}/api/v1/applications/app`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+      stdout: 'ignore',
+    },
+    {
+      name: 'argo-watcher',
+      command: 'go run ./cmd/argo-watcher',
+      cwd: '..',
+      // Liveness, never readiness: /readyz is legitimately 503 while a state
+      // backend is unreachable, and the lab's e2e scripts gate on /livez for the
+      // same reason.
+      url: `${NO_AUTH_URL}/livez`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+      stdout: 'ignore',
+      env: { ...serverEnv, PORT: String(NO_AUTH_PORT) },
+    },
+    {
+      name: 'argo-watcher-oidc',
+      command: 'go run ./cmd/argo-watcher',
+      cwd: '..',
+      url: `${AUTH_URL}/livez`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+      stdout: 'ignore',
+      env: {
+        ...serverEnv,
+        PORT: String(AUTH_PORT),
+        OIDC_ENABLED: 'true',
+        OIDC_ISSUER_URL: KEYCLOAK_REALM_URL,
+        OIDC_CLIENT_ID: 'argo-watcher',
+        OIDC_PRIVILEGED_GROUPS: 'privileged',
+      },
+    },
+  ],
+});

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -3,7 +3,9 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "e2e"]
 }


### PR DESCRIPTION
The jsdom suite mounts components directly, so it has no cross-document
navigation, no history stack, no real socket, and no provider. Every failure of
that kind reaches production unseen — https://github.com/shini4i/argo-watcher/pull/536 (a back button that bounced through a
fresh sign-in) is one, and nothing in the repo could have caught it.

Twelve specs cover only what needs a browser: the top-level OIDC redirect and
the callback query it must strip, returning to a shared task link via url_state,
session recovery through the SSO cookie after a reload, the Go server's SPA
fallback for deep-linked task URLs, Back from a directly-opened task page, the
deploy-lock banner arriving over the live WebSocket, and the privileged write
flows (rollback, toggling the lock) with their gating for a privileged vs a
regular realm user. Anything a component test can assert stays in Vitest.

playwright.config.ts starts what it drives: cmd/mock plus two argo-watcher
instances serving the built bundle, on 8100 without OIDC and 8101 with. Keycloak
comes from the integration compose profile. The suite therefore runs against the
shipped artifact shape rather than the dev server.

The test realm's client gains the authorization-code flow, its exact redirect
URI, and required PKCE (S256), so dropping the code challenge now fails the auth
specs — a regression that previously had no detector. The direct access grant
stays enabled for the Go integration tests and the DAST workflow.

Browsers come from nixpkgs, so @playwright/test is pinned to the exact
playwright-driver version and flake.nix asserts the pairing rather than trusting
a comment. flake.lock is bumped to get there.