### PR TITLE
refactor(web): share one ws status protocol between both services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Web UI no longer leaks a WebSocket connection when a page remount closes and
+  immediately reopens its deployment-lock or Argo CD reachability subscription. A socket
+  reports closed asynchronously, so the closing one used to report back after its
+  replacement had already been opened, which discarded the replacement — leaving it
+  connected with nothing tracking it — and opened a third connection. Each remount could
+  do it again.
 - With OIDC enabled, opening a task detail page from a shared link and pressing Back no
   longer bounces through a fresh sign-in that lands back on the same page; it returns to
   the task list. The provider's authorize URL is also no longer left in browser history,

--- a/web/README.md
+++ b/web/README.md
@@ -15,11 +15,12 @@ React 19, React-admin 5, Material UI 9, Emotion, TypeScript, oxlint, and Vitest/
 | `src/main.tsx` | React entry point that mounts `AppSplash` immediately, runs `bootstrapAuth()` to consume any OIDC authorization-code callback before mounting React-admin, then wires React Router, shared providers, and the `App` component. |
 | `src/App.tsx` | Placeholder React-admin shell; extend this file with `<Admin>` resources as migration phases land. |
 | `src/auth/` | Authentication helpers. `authProvider.ts` drives the OIDC provider (via `oidc-client-ts`) using config from `/api/v1/config`, and `tokenStore.ts` holds the bearer token in memory. |
-| `src/data/` | HTTP layer and React-admin `dataProvider` implementation that targets `/api/v1/tasks` and related endpoints. |
+| `src/data/` | HTTP layer, React-admin `dataProvider` implementation targeting `/api/v1/tasks` and related endpoints, and `wsStatusService.ts`, the shared base for signals mirrored over REST + `/ws`. |
 | `src/features/` | Feature modules (currently `tasks/` and `deployLock/`). Each folder owns its components, hooks, and service logic. |
 | `src/layout/` | Reusable React-admin layout primitives (notifications, top bar, nav, etc.), plus `AppSplash.tsx`, the pre-mount loading screen. |
 | `src/shared/` | Cross-cutting hooks, context providers (timezone), and utilities (time formatting, OIDC toggle). |
 | `src/theme/` | Material UI theme factory plus `ThemeModeProvider` for light/dark persistence. |
+| `src/test/` | Test doubles shared across suites (currently the WebSocket stand-in). |
 | `e2e/` | Playwright browser specs, split into the `no-auth` and `auth` projects, plus `helpers.ts` (task seeding, Keycloak sign-in, token minting). |
 | `assets/` + `public/` | Static assets (logos, favicons) delivered verbatim by Vite. |
 | `dist/` | Build output consumed by the Go server (`STATIC_FILES_PATH`) or Docker images. Generated via `npm run build`. |
@@ -85,7 +86,7 @@ OIDC settings (issuer URL, client_id, privileged groups) come from `/api/v1/conf
 - **Auth provider (`src/auth/authProvider.ts`)** – fetches `/api/v1/config` and, when OIDC is enabled, drives an `oidc-client-ts` `UserManager` (Authorization Code + PKCE). `bootstrapAuth()` (called from `main.tsx` before React mounts) consumes the `?code=…&state=…` callback before the router's index redirect can strip it. It uses a top-level login redirect, relies on `automaticSilentRenew` for token renewal, keeps tokens in memory only, and reads group membership from the userinfo endpoint (the same source the backend enforces on) to expose permissions to React-admin. `checkAuth` never rejects for an unauthenticated user (which would trigger a logout loop) — it redirects instead. When OIDC is disabled, `bootstrapAuth()` is a no-op and the app renders immediately. `bootstrapAuth()` accepts an optional `onOidcEnabled` callback, invoked only once the config reports OIDC enabled and before any provider round trip; `main.tsx` uses it to narrow the splash status line from "Loading…" to "Signing in…", so an auth-less deployment is never told it is signing in.
 - **Pre-mount loading screen (`src/layout/AppSplash.tsx`)** – covers the window between page load and the React-admin mount, which is otherwise blank while `bootstrapAuth()` resolves the session. It brings its own dark theme and issues no requests: it must render outside `AppProviders`, whose deploy-lock and ArgoCD-status providers start polling the API on mount, before any token exists.
 - **OIDC toggle hook (`src/shared/hooks/useOidcEnabled.ts`)** – tiny helper for gating UI affordances when running without identity.
-- **Deploy lock service (`src/features/deployLock/deployLockService.ts`)** – shares lock state through REST endpoints plus the `/ws` channel. Automatic retries and subscriber management keep the UI in sync even if the socket drops.
+- **Live status services (`src/data/wsStatusService.ts`)** – shared base for a server-owned signal the UI mirrors: bootstrap over REST, then track transitions pushed on the `/ws` channel, with one socket per signal while listeners exist, reconnect-and-reconcile when the socket drops, and ordering guards so a slow REST response cannot overwrite a fresher push. `deployLockService` (`src/features/deployLock/`) extends it and adds the imperative lock/release operations; `argocdStatusService` (`src/features/argocdStatus/`) extends it read-only for ArgoCD reachability.
 - **Global providers (`src/shared/providers/AppProviders.tsx`)** – wraps the app with the theme mode, timezone, and deploy-lock providers, plus a global banner that reflects lock status.
 
 ## Shared UX Infrastructure
@@ -99,7 +100,7 @@ OIDC settings (issuer URL, client_id, privileged groups) come from `/api/v1/conf
 
 - Vitest runs in `jsdom` with globals + `vitest.setup.ts` (place shared mocks, `@testing-library/jest-dom`, etc.).
 - Tests live next to the code as `*.test.ts(x)` and are auto-discovered via `vitest.config.ts`.
-- Coverage reporters: text summary in CI plus LCOV for Codecov. Keep critical flows (auth provider, data provider, deploy-lock logic, utilities) covered.
+- Coverage reporters: text summary in CI plus LCOV for Codecov. Keep critical flows (auth provider, data provider, the shared WS status protocol, utilities) covered.
 - oxlint enforces React, hooks rules, and TypeScript correctness. Configure additional lint rules under `.oxlintrc.json` if new conventions emerge.
 
 ### Browser tests (Playwright)

--- a/web/src/data/wsStatusService.test.ts
+++ b/web/src/data/wsStatusService.test.ts
@@ -348,6 +348,36 @@ describe('WsStatusService', () => {
     expect(listener).toHaveBeenLastCalledWith('changed while down');
   });
 
+  it('ignores a delayed close from a socket a re-subscribe already replaced', async () => {
+    // A real socket reports closed asynchronously, so a connection retired by
+    // teardown can deliver its close after a re-subscribe opened the replacement.
+    // React remounting a subscriber makes that sequence routine.
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const retired = MockWebSocket.instances[0];
+    retired.deferClose = true;
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    unsubscribe();
+    const unsubscribeReplacement = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+    const replacement = MockWebSocket.instances[1];
+
+    retired.fireClose();
+
+    // No third socket, and no reconnect armed to open one later.
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(browserWindow.setTimeout).not.toHaveBeenCalled();
+
+    // The replacement is still the tracked socket, so teardown can still close
+    // it; had the stale close won, it would stay open with nobody holding it.
+    const closeSpy = vi.spyOn(replacement, 'close');
+    unsubscribeReplacement();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
   it('does not reconnect when the socket closes after the last listener left', async () => {
     const service = new TestService();
     const unsubscribe = service.subscribe(vi.fn());

--- a/web/src/data/wsStatusService.test.ts
+++ b/web/src/data/wsStatusService.test.ts
@@ -1,0 +1,491 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WsStatusService } from './wsStatusService';
+import { resolveWebSocketUrl, webSocketProtocols } from './webSocketUrl';
+import { MockWebSocket } from '../test/mockWebSocket';
+import * as sharedUtils from '../shared/utils';
+
+/** Promise whose settlement a test drives by hand, to hold a fetch in flight. */
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+/**
+ * Concrete subclass exercising the shared protocol. `fetchState` is a spy so a
+ * test can count bootstraps and hold one in flight; `parseMessage` recognises
+ * only `state:<value>` frames, standing in for a real service ignoring the other
+ * signals that share the `/ws` socket.
+ */
+class TestService extends WsStatusService<string> {
+  public readonly fetchState = vi.fn<() => Promise<string>>(() => Promise.resolve('initial'));
+
+  constructor(logPrefix = 'test-signal') {
+    super(logPrefix);
+  }
+
+  protected parseMessage(payload: string): string | undefined {
+    return payload.startsWith('state:') ? payload.slice('state:'.length) : undefined;
+  }
+
+  /** Stands in for a feature service's imperative action (e.g. deploy-lock's setLock). */
+  public push(state: string) {
+    this.applyAuthoritative(state);
+  }
+}
+
+/** Subclass over a falsy-capable state, guarding the `false` vs `undefined` distinction. */
+class BooleanService extends WsStatusService<boolean> {
+  public readonly fetchState = vi.fn<() => Promise<boolean>>(() => Promise.resolve(false));
+
+  constructor() {
+    super('bool-signal');
+  }
+
+  protected parseMessage(payload: string): boolean | undefined {
+    if (payload === 'on') {
+      return true;
+    }
+    if (payload === 'off') {
+      return false;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Window stub that records armed timers and lets the test fire them with
+ * `flush()`. A browser never runs the callback before `setTimeout` returns, so
+ * firing it synchronously would leave the service's timer handle assigned after
+ * the timer had already run — hiding whether a second reconnect can be armed.
+ */
+const recordingWindow = () => {
+  const pendingTimers: Array<() => void> = [];
+  let nextHandle = 1;
+  return {
+    setTimeout: vi.fn((cb: () => void) => {
+      pendingTimers.push(cb);
+      return nextHandle++ as unknown as number;
+    }),
+    clearTimeout: vi.fn(),
+    /** Runs every timer armed since the last flush, as the event loop would. */
+    flush: () => {
+      pendingTimers.splice(0, pendingTimers.length).forEach(cb => cb());
+    },
+  };
+};
+
+describe('WsStatusService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    MockWebSocket.reset();
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  const subscribedService = async () => {
+    const service = new TestService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    return { service, listener, socket: MockWebSocket.instances[0] };
+  };
+
+  it('bootstraps over REST on the first subscribe and notifies the listener', async () => {
+    const { service, listener } = await subscribedService();
+
+    expect(listener).toHaveBeenCalledWith('initial');
+    expect(service.fetchState).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays the cached state to a later subscriber without refetching', async () => {
+    const { service } = await subscribedService();
+
+    const second = vi.fn();
+    service.subscribe(second);
+
+    expect(second).toHaveBeenCalledWith('initial');
+    expect(service.fetchState).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a single socket however many listeners subscribe', async () => {
+    const { service } = await subscribedService();
+
+    service.subscribe(vi.fn());
+    service.subscribe(vi.fn());
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('applies parsed WebSocket payloads and ignores unrecognised ones', async () => {
+    const { listener, socket } = await subscribedService();
+    listener.mockClear();
+
+    socket.emit('state:changed');
+    expect(listener).toHaveBeenLastCalledWith('changed');
+
+    // Frames belonging to another signal on the shared socket.
+    socket.emit('locked');
+    socket.emit('argocd_down:argocd');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a frame whose payload is not text', async () => {
+    // A binary frame must be treated as unrelated traffic: no state change, and
+    // no invalidation of a reconcile in flight.
+    const { service, listener, socket } = await subscribedService();
+    listener.mockClear();
+
+    const pending = deferred<string>();
+    service.fetchState.mockReturnValueOnce(pending.promise);
+    const inFlight = service.fetchStatus();
+
+    socket.emitRaw(new ArrayBuffer(8));
+
+    pending.resolve('reconciled');
+    await inFlight;
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith('reconciled');
+  });
+
+  it('applies a parsed falsy state instead of mistaking it for an unrelated frame', async () => {
+    const service = new BooleanService();
+    const listener = vi.fn();
+    service.subscribe(listener);
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+
+    MockWebSocket.instances[0].emit('on');
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    MockWebSocket.instances[0].emit('off');
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
+
+  it('replays a cached falsy state without refetching', async () => {
+    const service = new BooleanService();
+    const first = vi.fn();
+    service.subscribe(first);
+    await vi.waitUntil(() => first.mock.calls.length > 0);
+    expect(first).toHaveBeenCalledWith(false);
+
+    const second = vi.fn();
+    service.subscribe(second);
+
+    expect(second).toHaveBeenCalledWith(false);
+    expect(service.fetchState).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a slow fetch clobber a newer WebSocket transition', async () => {
+    const { service, listener, socket } = await subscribedService();
+
+    const pending = deferred<string>();
+    service.fetchState.mockReturnValueOnce(pending.promise);
+    const inFlight = service.fetchStatus();
+
+    socket.emit('state:live');
+    expect(listener).toHaveBeenLastCalledWith('live');
+
+    pending.resolve('stale');
+    await inFlight;
+    expect(listener).toHaveBeenLastCalledWith('live');
+  });
+
+  it('does not let a slow fetch clobber a newer imperative update', async () => {
+    const { service, listener } = await subscribedService();
+
+    const pending = deferred<string>();
+    service.fetchState.mockReturnValueOnce(pending.promise);
+    const inFlight = service.fetchStatus();
+
+    service.push('operator');
+    expect(listener).toHaveBeenLastCalledWith('operator');
+
+    pending.resolve('stale');
+    await inFlight;
+    expect(listener).toHaveBeenLastCalledWith('operator');
+  });
+
+  it('lets an unrecognised frame pass without invalidating an in-flight fetch', async () => {
+    // Frames for the other signals on /ws are far more frequent than this
+    // service's own. Treating them as transitions would cancel every reconcile.
+    const { service, listener, socket } = await subscribedService();
+    listener.mockClear();
+
+    const pending = deferred<string>();
+    service.fetchState.mockReturnValueOnce(pending.promise);
+    const inFlight = service.fetchStatus();
+
+    socket.emit('argocd_up');
+
+    pending.resolve('reconciled');
+    await inFlight;
+    expect(listener).toHaveBeenLastCalledWith('reconciled');
+  });
+
+  it('drops an older concurrent fetch that resolves last and reports the winning state', async () => {
+    const { service, listener } = await subscribedService();
+    listener.mockClear();
+
+    const older = deferred<string>();
+    const newer = deferred<string>();
+    service.fetchState.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+    const olderCall = service.fetchStatus();
+    const newerCall = service.fetchStatus();
+
+    newer.resolve('winner');
+    await expect(newerCall).resolves.toBe('winner');
+
+    older.resolve('loser');
+    await expect(olderCall).resolves.toBe('winner');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith('winner');
+  });
+
+  it('reconciles over REST whenever the socket connects', async () => {
+    // The server only pushes on transitions, so a change made while the socket
+    // was down is visible only through a reconnect refetch.
+    const { service, listener, socket } = await subscribedService();
+    listener.mockClear();
+    service.fetchState.mockResolvedValueOnce('reconnected');
+
+    socket.open();
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith('reconnected');
+  });
+
+  it('schedules a reconnect when the socket closes with listeners still attached', async () => {
+    const { socket } = await subscribedService();
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    socket.close();
+
+    expect(browserWindow.setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    browserWindow.flush();
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('arms only one reconnect timer while one is already pending', async () => {
+    // Repeated close events must not fan out into parallel sockets to /ws.
+    const { socket } = await subscribedService();
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    socket.close();
+    socket.close();
+
+    expect(browserWindow.setTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('arms a fresh reconnect after an earlier drop already reconnected', async () => {
+    const { socket } = await subscribedService();
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    socket.close();
+    browserWindow.flush();
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+
+    // The replacement socket drops too: the timer handle must have been released
+    // when the first one fired, or this reconnect is never armed.
+    MockWebSocket.instances[1].close();
+    expect(browserWindow.setTimeout).toHaveBeenCalledTimes(2);
+
+    browserWindow.flush();
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it('arms a reconnect again after a teardown cancelled a pending one', async () => {
+    // Teardown must release the handle it cancels; leaving it set would make
+    // scheduleReconnect early-return forever and freeze subscribers on stale state.
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    MockWebSocket.instances[0].close();
+    expect(browserWindow.setTimeout).toHaveBeenCalledTimes(1);
+    unsubscribe();
+
+    service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+    MockWebSocket.instances[1].close();
+
+    expect(browserWindow.setTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not schedule a reconnect outside a browser', async () => {
+    // getBrowserWindow returning undefined must not throw inside the close
+    // callback, where nothing would handle it.
+    const { socket } = await subscribedService();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(undefined);
+
+    expect(() => socket.close()).not.toThrow();
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('reconciles through a real reconnect after the socket dropped', async () => {
+    const { service, listener, socket } = await subscribedService();
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    socket.close();
+    browserWindow.flush();
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+
+    listener.mockClear();
+    service.fetchState.mockResolvedValueOnce('changed while down');
+    MockWebSocket.instances[1].open();
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith('changed while down');
+  });
+
+  it('does not reconnect when the socket closes after the last listener left', async () => {
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    unsubscribe();
+
+    // No socket appeared, and no timer was left armed to create one later.
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(browserWindow.setTimeout).not.toHaveBeenCalled();
+  });
+
+  it('closes the socket and clears the cache when the last listener leaves', async () => {
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const closeSpy = vi.spyOn(MockWebSocket.instances[0], 'close');
+
+    unsubscribe();
+    expect(closeSpy).toHaveBeenCalled();
+
+    // The cache is dropped, so the next subscribe must bootstrap rather than
+    // replay a value that may have gone stale while nobody was listening.
+    service.fetchState.mockResolvedValueOnce('fresh');
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(service.fetchState).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith('fresh');
+  });
+
+  it('keeps the socket while other listeners remain', async () => {
+    const { service, socket } = await subscribedService();
+    const closeSpy = vi.spyOn(socket, 'close');
+    const unsubscribeSecond = service.subscribe(vi.fn());
+
+    unsubscribeSecond();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending reconnect timer on teardown', async () => {
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => MockWebSocket.instances.length === 1);
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+
+    // Left unflushed, so the handle is still outstanding when teardown runs.
+    MockWebSocket.instances[0].close();
+    const handle = browserWindow.setTimeout.mock.results[0].value;
+
+    unsubscribe();
+
+    expect(browserWindow.clearTimeout).toHaveBeenCalledWith(handle);
+  });
+
+  it('discards a fetch that resolves after teardown', async () => {
+    const service = new TestService();
+    const unsubscribe = service.subscribe(vi.fn());
+    await vi.waitUntil(() => service.fetchState.mock.calls.length === 1);
+
+    const pending = deferred<string>();
+    service.fetchState.mockReturnValueOnce(pending.promise);
+    const inFlight = service.fetchStatus();
+
+    unsubscribe();
+    pending.resolve('stale');
+    await inFlight;
+
+    // Had the stale result repopulated the cache, this subscribe would replay it
+    // instead of bootstrapping.
+    service.fetchState.mockResolvedValueOnce('fresh');
+    const listener = vi.fn();
+    service.subscribe(listener);
+
+    await vi.waitUntil(() => listener.mock.calls.length > 0);
+    expect(listener).toHaveBeenLastCalledWith('fresh');
+  });
+
+  it('keeps the last known state when a reconnect reconcile fails', async () => {
+    const { service, listener, socket } = await subscribedService();
+    listener.mockClear();
+    service.fetchState.mockRejectedValueOnce(new Error('boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    socket.open();
+
+    await vi.waitUntil(() => errorSpy.mock.calls.length > 0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[test-signal] Failed to reconcile status on connect',
+      expect.any(Error),
+    );
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('logs a failed bootstrap under the configured prefix', async () => {
+    const service = new TestService('custom-prefix');
+    service.fetchState.mockRejectedValueOnce(new Error('boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    service.subscribe(vi.fn());
+
+    await vi.waitUntil(() => errorSpy.mock.calls.length > 0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[custom-prefix] Failed to fetch initial status',
+      expect.any(Error),
+    );
+  });
+
+  it('logs socket errors under the configured prefix and closes the socket', async () => {
+    const { socket } = await subscribedService();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const closeSpy = vi.spyOn(socket, 'close');
+    const wsError = new Error('ws');
+
+    socket.onerror?.(wsError);
+
+    expect(errorSpy).toHaveBeenCalledWith('[test-signal] WebSocket error', wsError);
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('offers the shared handshake protocols on the initial socket and on reconnects', async () => {
+    // Dropping the protocols on a reconnect would fail the handshake once OIDC is
+    // enabled, since a browser cannot set a header here.
+    const { socket } = await subscribedService();
+    expect(socket.url).toBe(resolveWebSocketUrl());
+    expect(socket.protocols).toEqual(webSocketProtocols());
+
+    const browserWindow = recordingWindow();
+    vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
+    socket.close();
+    browserWindow.flush();
+
+    await vi.waitUntil(() => MockWebSocket.instances.length === 2);
+    expect(MockWebSocket.instances[1].protocols).toEqual(webSocketProtocols());
+  });
+});

--- a/web/src/data/wsStatusService.ts
+++ b/web/src/data/wsStatusService.ts
@@ -1,0 +1,193 @@
+import { resolveWebSocketUrl, webSocketProtocols } from './webSocketUrl';
+import { getBrowserWindow } from '../shared/utils';
+
+/** Subscribed listener signature invoked whenever the tracked state changes. */
+export type WsStatusListener<T> = (state: T) => void;
+
+const WS_RETRY_DELAY_MS = 5000;
+
+/**
+ * Base class for a server-owned signal that the UI mirrors: the state is
+ * bootstrapped over REST, then kept current from frames pushed on the shared
+ * `/ws` socket, and broadcast to subscribers. It owns the socket lifecycle
+ * (single connection while listeners exist, reconnect with a fixed delay,
+ * teardown when the last listener leaves) and the ordering guards below.
+ *
+ * Subclasses supply the transport specifics — {@link fetchState} for the REST
+ * bootstrap and {@link parseMessage} for the frames they recognise — and may call
+ * {@link applyAuthoritative} to publish a state this client set itself.
+ *
+ * `T` must be non-nullable: `null` is reserved for "nothing cached yet".
+ */
+export abstract class WsStatusService<T extends NonNullable<unknown>> {
+  private currentStatus: T | null = null;
+  private readonly listeners = new Set<WsStatusListener<T>>();
+  private socket: WebSocket | null = null;
+  private reconnectHandle: number | null = null;
+  // Ordering guards so an out-of-order async result can never revert the state
+  // to a stale value. Both matter because a (re)connect can have a bootstrap and
+  // an onopen fetch in flight at once, alongside live WS pushes and any
+  // imperative action this client takes:
+  //   fetchSeq        - only the most recently issued fetch may apply its result;
+  //                     older concurrent fetches are dropped.
+  //   stateGeneration - bumped on every authoritative update (a recognised WS
+  //                     frame, or an imperative action); a fetch is dropped if
+  //                     one landed while it was in flight, so a slow REST
+  //                     response cannot clobber it.
+  private fetchSeq = 0;
+  private stateGeneration = 0;
+
+  /**
+   * @param logPrefix Tag for this signal's console diagnostics, logged as `[<prefix>] …`.
+   */
+  protected constructor(private readonly logPrefix: string) {}
+
+  /** Reads the authoritative state from the backend. */
+  protected abstract fetchState(): Promise<T>;
+
+  /**
+   * Maps a text frame to a new state, or `undefined` when the frame belongs to
+   * another signal sharing the socket. Returning `undefined` — rather than an
+   * unchanged state — is what keeps unrelated traffic from invalidating a
+   * reconcile that is still in flight.
+   */
+  protected abstract parseMessage(payload: string): T | undefined;
+
+  /**
+   * Retrieves the latest state from the backend and notifies subscribers of the
+   * result. The result is applied only if it is still the newest fetch AND no
+   * authoritative update landed while it was in flight; otherwise it is dropped
+   * and the winning state is returned instead, so REST/WebSocket ordering races
+   * cannot revert subscribers to a stale value.
+   */
+  public async fetchStatus(): Promise<T> {
+    const seq = ++this.fetchSeq;
+    const generation = this.stateGeneration;
+    const state = await this.fetchState();
+    if (seq !== this.fetchSeq || generation !== this.stateGeneration) {
+      return this.currentStatus ?? state;
+    }
+    this.updateStatus(state);
+    return state;
+  }
+
+  /**
+   * Subscribes to state changes, establishing a WebSocket connection when needed.
+   * Returns an unsubscribe function for convenient cleanup.
+   */
+  public subscribe(listener: WsStatusListener<T>): () => void {
+    this.listeners.add(listener);
+
+    if (this.currentStatus === null) {
+      this.fetchStatus().catch(error => {
+        console.error(`[${this.logPrefix}] Failed to fetch initial status`, error);
+      });
+    } else {
+      listener(this.currentStatus);
+    }
+
+    this.ensureSocket();
+
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size > 0) {
+        return;
+      }
+      this.teardownSocket();
+    };
+  }
+
+  /**
+   * Applies a state we know first-hand — a recognised WebSocket frame or an
+   * action this client performed — and invalidates any REST fetch still in
+   * flight, so a slower response carrying the pre-change value cannot overwrite it.
+   */
+  protected applyAuthoritative(state: T) {
+    this.stateGeneration++;
+    this.updateStatus(state);
+  }
+
+  /** Broadcasts the new state to all subscribers. */
+  private updateStatus(state: T) {
+    this.currentStatus = state;
+    for (const listener of this.listeners) {
+      listener(state);
+    }
+  }
+
+  /** Ensures a websocket connection exists whenever there are active listeners. */
+  private ensureSocket() {
+    if (this.socket || this.listeners.size === 0) {
+      return;
+    }
+
+    const url = resolveWebSocketUrl();
+    this.socket = new WebSocket(url, webSocketProtocols());
+
+    // Re-bootstrap against the authoritative state on every (re)connect: the
+    // server only pushes on transitions, and with multiple replicas a transition
+    // can come from another one. A change that happened while this socket was
+    // down — or before a failed bootstrap fetch — would otherwise leave the
+    // client showing a stale state.
+    this.socket.onopen = () => {
+      this.fetchStatus().catch(error => {
+        console.error(`[${this.logPrefix}] Failed to reconcile status on connect`, error);
+      });
+    };
+
+    this.socket.onmessage = event => {
+      const payload = typeof event.data === 'string' ? event.data : '';
+      const next = this.parseMessage(payload);
+      if (next !== undefined) {
+        this.applyAuthoritative(next);
+      }
+    };
+
+    this.socket.onclose = () => {
+      this.socket = null;
+      if (this.listeners.size > 0) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.socket.onerror = error => {
+      console.error(`[${this.logPrefix}] WebSocket error`, error);
+      this.socket?.close();
+    };
+  }
+
+  /** Schedules a websocket reconnect attempt after a fixed delay. */
+  private scheduleReconnect() {
+    if (this.reconnectHandle !== null) {
+      return;
+    }
+
+    const browserWindow = getBrowserWindow();
+    if (!browserWindow) {
+      return;
+    }
+
+    this.reconnectHandle = browserWindow.setTimeout(() => {
+      this.reconnectHandle = null;
+      this.ensureSocket();
+    }, WS_RETRY_DELAY_MS);
+  }
+
+  /** Closes any active websocket and cancels pending reconnect timers. */
+  private teardownSocket() {
+    if (this.reconnectHandle !== null) {
+      const browserWindow = getBrowserWindow();
+      browserWindow?.clearTimeout(this.reconnectHandle);
+      this.reconnectHandle = null;
+    }
+
+    this.socket?.close();
+    this.socket = null;
+    // Forget the cached state so a later re-subscribe bootstraps a fresh fetch
+    // instead of replaying a value that may have gone stale while nobody was
+    // listening. Bumping fetchSeq invalidates any fetch issued before the
+    // teardown, which would otherwise repopulate the cache as it resolves.
+    this.fetchSeq++;
+    this.currentStatus = null;
+  }
+}

--- a/web/src/data/wsStatusService.ts
+++ b/web/src/data/wsStatusService.ts
@@ -122,20 +122,23 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     }
 
     const url = resolveWebSocketUrl();
-    this.socket = new WebSocket(url, webSocketProtocols());
+    // Handlers close over this socket rather than reading `this.socket`, so a
+    // retired connection can never act on behalf of its replacement.
+    const socket = new WebSocket(url, webSocketProtocols());
+    this.socket = socket;
 
     // Re-bootstrap against the authoritative state on every (re)connect: the
     // server only pushes on transitions, and with multiple replicas a transition
     // can come from another one. A change that happened while this socket was
     // down — or before a failed bootstrap fetch — would otherwise leave the
     // client showing a stale state.
-    this.socket.onopen = () => {
+    socket.onopen = () => {
       this.fetchStatus().catch(error => {
         console.error(`[${this.logPrefix}] Failed to reconcile status on connect`, error);
       });
     };
 
-    this.socket.onmessage = event => {
+    socket.onmessage = event => {
       const payload = typeof event.data === 'string' ? event.data : '';
       const next = this.parseMessage(payload);
       if (next !== undefined) {
@@ -143,16 +146,23 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
       }
     };
 
-    this.socket.onclose = () => {
+    socket.onclose = () => {
+      // A closing socket reports back asynchronously, so this can arrive after a
+      // teardown already replaced it (React remounts a subscriber often enough
+      // for that to be routine). Acting on it would abandon the live replacement
+      // and open a third connection.
+      if (this.socket !== socket) {
+        return;
+      }
       this.socket = null;
       if (this.listeners.size > 0) {
         this.scheduleReconnect();
       }
     };
 
-    this.socket.onerror = error => {
+    socket.onerror = error => {
       console.error(`[${this.logPrefix}] WebSocket error`, error);
-      this.socket?.close();
+      socket.close();
     };
   }
 

--- a/web/src/features/argocdStatus/argocdStatusService.test.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.test.ts
@@ -1,36 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ArgocdStatusListener } from './argocdStatusService';
 import { ArgocdStatusService } from './argocdStatusService';
+import { MockWebSocket } from '../../test/mockWebSocket';
 import * as sharedUtils from '../../shared/utils';
-
-class MockWebSocket {
-  public onopen: (() => void) | null = null;
-  public onmessage: ((event: { data: string }) => void) | null = null;
-  public onclose: (() => void) | null = null;
-  public onerror: ((error: unknown) => void) | null = null;
-
-  constructor(public url: string) {
-    MockWebSocket.instances.push(this);
-  }
-
-  public open() {
-    this.onopen?.();
-  }
-
-  public close() {
-    this.onclose?.();
-  }
-
-  public emit(message: string) {
-    this.onmessage?.({ data: message });
-  }
-
-  static readonly instances: MockWebSocket[] = [];
-
-  static reset() {
-    MockWebSocket.instances.length = 0;
-  }
-}
 
 describe('ArgocdStatusService', () => {
   beforeEach(() => {

--- a/web/src/features/argocdStatus/argocdStatusService.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.ts
@@ -1,6 +1,5 @@
 import { httpClient } from '../../data/httpClient';
-import { resolveWebSocketUrl, webSocketProtocols } from '../../data/webSocketUrl';
-import { getBrowserWindow } from '../../shared/utils';
+import { WsStatusService, type WsStatusListener } from '../../data/wsStatusService';
 
 /**
  * Which subsystem argo-watcher cannot reach, when unavailable. Mirrors the
@@ -20,15 +19,13 @@ export interface ArgocdStatus {
 }
 
 /** Subscribed listener signature invoked whenever reachability changes. */
-export type ArgocdStatusListener = (status: ArgocdStatus) => void;
+export type ArgocdStatusListener = WsStatusListener<ArgocdStatus>;
 
 /** Shape of the /api/v1/reachability response body (reason omitted when up). */
 interface ArgocdStatusResponse {
   available?: boolean;
   reason?: string;
 }
-
-const WS_RETRY_DELAY_MS = 5000;
 
 /**
  * WebSocket messages the server pushes on reachability transitions. A down
@@ -61,159 +58,38 @@ const toStatus = (data: ArgocdStatusResponse | null | undefined): ArgocdStatus =
     : { available: false, reason: parseReason(data?.reason) };
 
 /**
- * ArgocdStatusService mirrors the deploy-lock service for a different signal: it
- * bootstraps ArgoCD reachability over REST and then tracks live changes pushed
- * over the shared `/ws` WebSocket, so the frontend can surface an "ArgoCD
- * unreachable" banner (issue #498). It is read-only — there are no imperative
- * actions, unlike the deploy-lock service.
+ * ArgocdStatusService tracks whether argo-watcher can reach ArgoCD and its state
+ * backend, so the frontend can surface an "ArgoCD unreachable" banner (issue
+ * #498). It is read-only — there are no imperative actions, unlike the
+ * deploy-lock service.
  */
-export class ArgocdStatusService {
-  private currentStatus: ArgocdStatus | null = null;
-  private readonly listeners = new Set<ArgocdStatusListener>();
-  private socket: WebSocket | null = null;
-  private reconnectHandle: number | null = null;
-  // Ordering guards so an out-of-order async result can never revert the banner
-  // to a stale value. Both matter because a (re)connect can have a bootstrap and
-  // an onopen fetch in flight at once, alongside live WS pushes:
-  //   fetchSeq     - only the most recently issued fetch may apply its result;
-  //                  older concurrent fetches are dropped.
-  //   wsGeneration - bumped on every WebSocket transition; a fetch is dropped if
-  //                  one landed while it was in flight, so a slow REST response
-  //                  cannot clobber a fresher live update.
-  private fetchSeq = 0;
-  private wsGeneration = 0;
+export class ArgocdStatusService extends WsStatusService<ArgocdStatus> {
+  constructor() {
+    super('argocd-status');
+  }
 
-  /**
-   * Retrieves the latest reachability from the backend and notifies subscribers.
-   * The result is applied only if it is still the newest fetch AND no WebSocket
-   * transition landed while it was in flight; otherwise it is dropped so REST/WS
-   * ordering races cannot revert the banner to a stale value.
-   */
-  public async fetchStatus(): Promise<ArgocdStatus> {
-    const seq = ++this.fetchSeq;
-    const wsGen = this.wsGeneration;
+  /** Reads current reachability from the backend. */
+  protected async fetchState(): Promise<ArgocdStatus> {
     const response = await httpClient<ArgocdStatusResponse>('/api/v1/reachability');
-    const status = toStatus(response.data);
-    if (seq !== this.fetchSeq || wsGen !== this.wsGeneration) {
-      return this.currentStatus ?? status;
-    }
-    this.setStatus(status);
-    return status;
+    return toStatus(response.data);
   }
 
   /**
-   * Subscribes to reachability changes, establishing a WebSocket connection when
-   * needed. Returns an unsubscribe function for convenient cleanup.
+   * Recognises the reachability frames; the other signals on `/ws` are ignored.
+   * A down frame without a suffix, or with a cause this build does not know
+   * (forward-compat), still reports an outage with the reason narrowed to null.
    */
-  public subscribe(listener: ArgocdStatusListener): () => void {
-    this.listeners.add(listener);
-
-    if (this.currentStatus === null) {
-      this.fetchStatus().catch(error => {
-        console.error('[argocd-status] Failed to fetch initial status', error);
-      });
-    } else {
-      listener(this.currentStatus);
+  protected parseMessage(payload: string): ArgocdStatus | undefined {
+    if (payload === ARGOCD_UP_MESSAGE) {
+      return AVAILABLE_STATUS;
     }
-
-    this.ensureSocket();
-
-    return () => {
-      this.listeners.delete(listener);
-      if (this.listeners.size > 0) {
-        return;
-      }
-      this.teardownSocket();
-    };
-  }
-
-  /** Broadcasts the new reachability snapshot to all subscribers. */
-  private setStatus(status: ArgocdStatus) {
-    this.currentStatus = status;
-    for (const listener of this.listeners) {
-      listener(status);
+    if (payload === ARGOCD_DOWN_MESSAGE) {
+      return { available: false, reason: null };
     }
-  }
-
-  /** Ensures a websocket connection exists whenever there are active listeners. */
-  private ensureSocket() {
-    if (this.socket || this.listeners.size === 0) {
-      return;
+    if (payload.startsWith(ARGOCD_DOWN_PREFIX)) {
+      return { available: false, reason: parseReason(payload.slice(ARGOCD_DOWN_PREFIX.length)) };
     }
-
-    const url = resolveWebSocketUrl();
-    this.socket = new WebSocket(url, webSocketProtocols());
-
-    // Re-bootstrap against the authoritative cached state on every (re)connect:
-    // the server only pushes on transitions, so a transition during a socket
-    // drop would otherwise leave the reconnected client with a stale banner —
-    // and a false-negative here hides a real outage (issue #498).
-    this.socket.onopen = () => {
-      this.fetchStatus().catch(error => {
-        console.error('[argocd-status] Failed to reconcile status on connect', error);
-      });
-    };
-
-    this.socket.onmessage = event => {
-      const payload = typeof event.data === 'string' ? event.data : '';
-      if (payload === ARGOCD_UP_MESSAGE) {
-        this.wsGeneration++;
-        this.setStatus(AVAILABLE_STATUS);
-      } else if (payload === ARGOCD_DOWN_MESSAGE || payload.startsWith(ARGOCD_DOWN_PREFIX)) {
-        this.wsGeneration++;
-        const reason = payload.startsWith(ARGOCD_DOWN_PREFIX)
-          ? parseReason(payload.slice(ARGOCD_DOWN_PREFIX.length))
-          : null;
-        this.setStatus({ available: false, reason });
-      }
-    };
-
-    this.socket.onclose = () => {
-      this.socket = null;
-      if (this.listeners.size > 0) {
-        this.scheduleReconnect();
-      }
-    };
-
-    this.socket.onerror = error => {
-      console.error('[argocd-status] WebSocket error', error);
-      this.socket?.close();
-    };
-  }
-
-  /** Schedules a websocket reconnect attempt with basic backoff. */
-  private scheduleReconnect() {
-    if (this.reconnectHandle !== null) {
-      return;
-    }
-
-    const browserWindow = getBrowserWindow();
-    if (!browserWindow) {
-      return;
-    }
-
-    this.reconnectHandle = browserWindow.setTimeout(() => {
-      this.reconnectHandle = null;
-      this.ensureSocket();
-    }, WS_RETRY_DELAY_MS);
-  }
-
-  /** Closes any active websocket and cancels pending reconnect timers. */
-  private teardownSocket() {
-    if (this.reconnectHandle !== null) {
-      const browserWindow = getBrowserWindow();
-      browserWindow?.clearTimeout(this.reconnectHandle);
-      this.reconnectHandle = null;
-    }
-
-    this.socket?.close();
-    this.socket = null;
-    // Forget the cached reachability so a later re-subscribe bootstraps a fresh
-    // fetch instead of replaying a value that may have gone stale while nobody
-    // was listening. Bumping fetchSeq invalidates any fetch issued before the
-    // teardown, which would otherwise repopulate the cache as it resolves.
-    this.fetchSeq++;
-    this.currentStatus = null;
+    return undefined;
   }
 }
 

--- a/web/src/features/deployLock/deployLockService.test.ts
+++ b/web/src/features/deployLock/deployLockService.test.ts
@@ -1,49 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DeployLockListener } from './deployLockService';
-import { DeployLockService, __testing } from './deployLockService';
+import { DeployLockService } from './deployLockService';
+import { MockWebSocket } from '../../test/mockWebSocket';
 import * as sharedUtils from '../../shared/utils';
 import { clearAccessToken, setAccessToken } from '../../auth/tokenStore';
 
-class MockWebSocket {
-  public onopen: (() => void) | null = null;
-  public onmessage: ((event: { data: string }) => void) | null = null;
-  public onclose: (() => void) | null = null;
-  public onerror: ((error: unknown) => void) | null = null;
-
-  constructor(
-    public url: string,
-    public protocols?: string | string[],
-  ) {
-    MockWebSocket.instances.push(this);
-  }
-
-  public open() {
-    this.onopen?.();
-  }
-
-  public close() {
-    this.onclose?.();
-  }
-
-  public emit(message: string) {
-    this.onmessage?.({ data: message });
-  }
-
-  static readonly instances: MockWebSocket[] = [];
-
-  static reset() {
-    MockWebSocket.instances.length = 0;
-  }
-}
-
 describe('DeployLockService', () => {
-  const originalEnv = { ...import.meta.env };
-
   beforeEach(() => {
     vi.restoreAllMocks();
     MockWebSocket.reset();
     vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
-    import.meta.env.VITE_WS_BASE_URL = originalEnv.VITE_WS_BASE_URL;
   });
 
   const mockFetch = (responses: Array<{ body: unknown; status?: number }>) => {
@@ -472,31 +438,5 @@ describe('DeployLockService', () => {
     expect(errorSpy).toHaveBeenCalledWith('[deploy-lock] WebSocket error', wsError);
     expect(closeSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
-  });
-
-  it('builds websocket URLs from env overrides and window location', () => {
-    const customWindow = {
-      location: {
-        protocol: 'https:',
-        host: 'custom.example',
-      },
-    } as unknown as Window;
-    const windowSpy = vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(customWindow);
-
-    import.meta.env.VITE_WS_BASE_URL = 'wss://custom.example';
-    expect(__testing.resolveWebSocketUrl()).toBe('wss://custom.example/ws');
-
-    windowSpy.mockReturnValue({
-      location: {
-        protocol: 'https:',
-        host: 'argo.example',
-      },
-    } as unknown as Window);
-    import.meta.env.VITE_WS_BASE_URL = 'wss://malicious.example';
-    expect(__testing.resolveWebSocketUrl()).toBe('wss://argo.example/ws');
-
-    import.meta.env.VITE_WS_BASE_URL = '';
-    expect(__testing.resolveWebSocketUrl()).toBe('wss://argo.example/ws');
-    windowSpy.mockRestore();
   });
 });

--- a/web/src/features/deployLock/deployLockService.ts
+++ b/web/src/features/deployLock/deployLockService.ts
@@ -1,51 +1,36 @@
 import { httpClient, type HttpResponse } from '../../data/httpClient';
-import { resolveWebSocketUrl, webSocketProtocols } from '../../data/webSocketUrl';
-import { getBrowserWindow } from '../../shared/utils';
+import { WsStatusService, type WsStatusListener } from '../../data/wsStatusService';
 
 /**
  * Subscribed listener signature invoked whenever the deploy-lock status changes.
  */
-export type DeployLockListener = (locked: boolean) => void;
-
-const WS_RETRY_DELAY_MS = 5000;
+export type DeployLockListener = WsStatusListener<boolean>;
 
 /**
- * DeployLockService coordinates REST and WebSocket interactions for the deploy-lock feature,
- * exposing subscription hooks and imperative helpers for lock operations.
+ * DeployLockService mirrors the shared deploy lock: `true` while deployments are
+ * frozen. On top of the REST-bootstrap-plus-WebSocket protocol it inherits, it
+ * adds the imperative operations an operator can trigger from the UI.
  */
-export class DeployLockService {
-  private currentStatus: boolean | null = null;
-  private readonly listeners = new Set<DeployLockListener>();
-  private socket: WebSocket | null = null;
-  private reconnectHandle: number | null = null;
-  // Ordering guards so an out-of-order async result can never revert the banner
-  // to a stale value. Both matter because a (re)connect can have a bootstrap and
-  // an onopen fetch in flight at once, alongside live WS pushes and the operator's
-  // own lock/release calls:
-  //   fetchSeq        - only the most recently issued fetch may apply its result;
-  //                     older concurrent fetches are dropped.
-  //   stateGeneration - bumped on every authoritative update (WS push, lock,
-  //                     release); a fetch is dropped if one landed while it was
-  //                     in flight, so a slow REST response cannot clobber it.
-  private fetchSeq = 0;
-  private stateGeneration = 0;
+export class DeployLockService extends WsStatusService<boolean> {
+  constructor() {
+    super('deploy-lock');
+  }
 
-  /**
-   * Retrieves the latest lock state from the backend and notifies subscribers of
-   * the result. The result is applied only if it is still the newest fetch AND no
-   * authoritative update landed while it was in flight; otherwise it is dropped so
-   * REST/WebSocket ordering races cannot revert the banner to a stale value.
-   */
-  public async fetchStatus(): Promise<boolean> {
-    const seq = ++this.fetchSeq;
-    const generation = this.stateGeneration;
+  /** Reads the current lock state from the backend. */
+  protected async fetchState(): Promise<boolean> {
     const response = await httpClient<boolean>('/api/v1/deploy-lock');
-    const locked = Boolean(response.data);
-    if (seq !== this.fetchSeq || generation !== this.stateGeneration) {
-      return this.currentStatus ?? locked;
+    return Boolean(response.data);
+  }
+
+  /** Recognises the two lock frames; the other signals on `/ws` are ignored. */
+  protected parseMessage(payload: string): boolean | undefined {
+    if (payload === 'locked') {
+      return true;
     }
-    this.updateStatus(locked);
-    return locked;
+    if (payload === 'unlocked') {
+      return false;
+    }
+    return undefined;
   }
 
   /**
@@ -65,138 +50,9 @@ export class DeployLockService {
     this.applyAuthoritative(false);
     return response;
   }
-
-  /**
-   * Subscribes to deploy-lock state changes, automatically establishing a WebSocket connection when needed.
-   * Returns an unsubscribe function for convenient cleanup.
-   */
-  public subscribe(listener: DeployLockListener): () => void {
-    this.listeners.add(listener);
-
-    if (this.currentStatus === null) {
-      this.fetchStatus().catch(error => {
-        console.error('[deploy-lock] Failed to fetch initial status', error);
-      });
-    } else {
-      listener(this.currentStatus);
-    }
-
-    this.ensureSocket();
-
-    return () => {
-      this.listeners.delete(listener);
-      if (this.listeners.size > 0) {
-        return;
-      }
-      this.teardownSocket();
-    };
-  }
-
-  /**
-   * Applies a state we know first-hand — a live WebSocket push or the operator's
-   * own lock/release — and invalidates any REST fetch still in flight, so a slower
-   * response carrying the pre-change value cannot overwrite it.
-   */
-  private applyAuthoritative(locked: boolean) {
-    this.stateGeneration++;
-    this.updateStatus(locked);
-  }
-
-  /** Broadcasts the new lock status to all subscribers. */
-  private updateStatus(locked: boolean) {
-    this.currentStatus = locked;
-    for (const listener of this.listeners) {
-      listener(locked);
-    }
-  }
-
-  /** Ensures a websocket connection exists whenever there are active listeners. */
-  private ensureSocket() {
-    if (this.socket || this.listeners.size === 0) {
-      return;
-    }
-
-    const url = resolveWebSocketUrl();
-    this.socket = new WebSocket(url, webSocketProtocols());
-
-    // Re-bootstrap against the authoritative state on every (re)connect: the
-    // server only pushes on transitions, and with the shared Postgres lock a
-    // transition can come from another replica. A change that happened while this
-    // socket was down — or before a failed bootstrap fetch — would otherwise leave
-    // the client showing a stale state, and a false-negative here hides an active
-    // deployment freeze.
-    this.socket.onopen = () => {
-      this.fetchStatus().catch(error => {
-        console.error('[deploy-lock] Failed to reconcile status on connect', error);
-      });
-    };
-
-    this.socket.onmessage = event => {
-      const payload = typeof event.data === 'string' ? event.data : '';
-      if (payload === 'locked') {
-        this.applyAuthoritative(true);
-      } else if (payload === 'unlocked') {
-        this.applyAuthoritative(false);
-      }
-    };
-
-    this.socket.onclose = () => {
-      this.socket = null;
-      if (this.listeners.size > 0) {
-        this.scheduleReconnect();
-      }
-    };
-
-    this.socket.onerror = error => {
-      console.error('[deploy-lock] WebSocket error', error);
-      this.socket?.close();
-    };
-  }
-
-  /** Schedules a websocket reconnect attempt with basic backoff. */
-  private scheduleReconnect() {
-    if (this.reconnectHandle !== null) {
-      return;
-    }
-
-    const browserWindow = getBrowserWindow();
-    if (!browserWindow) {
-      return;
-    }
-
-    this.reconnectHandle = browserWindow.setTimeout(() => {
-      this.reconnectHandle = null;
-      this.ensureSocket();
-    }, WS_RETRY_DELAY_MS);
-  }
-
-  /** Closes any active websocket and cancels pending reconnect timers. */
-  private teardownSocket() {
-    if (this.reconnectHandle !== null) {
-      const browserWindow = getBrowserWindow();
-      browserWindow?.clearTimeout(this.reconnectHandle);
-      this.reconnectHandle = null;
-    }
-
-    this.socket?.close();
-    this.socket = null;
-    // Forget the cached lock state so a later re-subscribe bootstraps a fresh
-    // fetch instead of replaying a value that may have gone stale while nobody
-    // was listening. Bumping fetchSeq invalidates any fetch issued before the
-    // teardown, which would otherwise repopulate the cache as it resolves.
-    this.fetchSeq++;
-    this.currentStatus = null;
-  }
 }
 
 /**
  * Shared singleton instance consumed by the React-admin UI.
  */
 export const deployLockService = new DeployLockService();
-
-/**
- * Internal testing hooks exposing non-exported helpers.
- */
-export const __testing = {
-  resolveWebSocketUrl,
-};

--- a/web/src/test/mockWebSocket.ts
+++ b/web/src/test/mockWebSocket.ts
@@ -24,8 +24,22 @@ export class MockWebSocket {
     this.onopen?.();
   }
 
-  /** Fires the close handler; also the entry point when production code closes the socket. */
+  /**
+   * When true, `close()` only records the request and the test delivers the close
+   * event itself via {@link fireClose} — matching a real socket, which reports
+   * closed asynchronously. Defaults to false so the common case stays synchronous.
+   */
+  public deferClose = false;
+
+  /** Entry point when production code closes the socket. */
   public close() {
+    if (!this.deferClose) {
+      this.fireClose();
+    }
+  }
+
+  /** Delivers the close event to the handler. */
+  public fireClose() {
     this.onclose?.();
   }
 

--- a/web/src/test/mockWebSocket.ts
+++ b/web/src/test/mockWebSocket.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal WebSocket stand-in for unit tests. Records every constructed instance
+ * and exposes hooks to drive the open/message/close callbacks by hand, so a test
+ * can sequence a handshake, a pushed frame and a drop deterministically.
+ *
+ * Install with `vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)`
+ * and call `MockWebSocket.reset()` in `beforeEach` to clear the instance list.
+ */
+export class MockWebSocket {
+  public onopen: (() => void) | null = null;
+  public onmessage: ((event: { data: string }) => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public onerror: ((error: unknown) => void) | null = null;
+
+  constructor(
+    public url: string,
+    public protocols?: string | string[],
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  /** Fires the open handler, as the browser does once the handshake completes. */
+  public open() {
+    this.onopen?.();
+  }
+
+  /** Fires the close handler; also the entry point when production code closes the socket. */
+  public close() {
+    this.onclose?.();
+  }
+
+  /** Delivers a text frame to the message handler. */
+  public emit(message: string) {
+    this.onmessage?.({ data: message });
+  }
+
+  /**
+   * Delivers a frame whose payload is passed through untouched, for exercising
+   * non-text frames (a real socket hands those over as Blob/ArrayBuffer).
+   */
+  public emitRaw(data: unknown) {
+    this.onmessage?.({ data } as { data: string });
+  }
+
+  /** Every instance constructed since the last reset, in creation order. */
+  static readonly instances: MockWebSocket[] = [];
+
+  static reset() {
+    MockWebSocket.instances.length = 0;
+  }
+}


### PR DESCRIPTION
deployLockService and argocdStatusService each implemented the same protocol independently: bootstrap over REST, track transitions pushed on the shared /ws socket, one socket per signal while listeners exist, reconnect and reconcile after a drop, and two ordering guards so a slow REST response cannot overwrite a fresher push. Roughly a hundred lines, duplicated down to the comments — and the guards are exactly the kind of logic where a fix applied to one copy silently misses the other.

That protocol now lives in WsStatusService<T>. Each service supplies only fetchState() and parseMessage(); deploy-lock keeps its imperative lock/release operations on top. A frame parsing to undefined means it belongs to another signal, which is what stops unrelated traffic on the shared socket from invalidating a reconcile in flight.

Behaviour is unchanged. Both feature suites still assert the whole inherited protocol against the real subclasses -- that overlap with the new base spec is the only evidence the subclasses inherit the guards rather than a test stub doing so.