### PR TITLE
docs: prune comment bloat across the Go packages

### DIFF
--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -37,7 +37,6 @@ func setupRouter() *chi.Mux {
 	return router
 }
 
-// writeJSON renders payload as the response body with the given status code.
 func writeJSON(w http.ResponseWriter, status int, payload any) {
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -32,13 +32,12 @@ const rollbackHistoryWindow = 100
 
 // Unavailability reasons reported by Check and UnavailableReason. They identify
 // which subsystem is unreachable so the frontend banner can name the exact cause
-// (ArgoCD vs the state backend) instead of hedging with "one or the other". An
-// empty reason means everything is reachable.
+// (ArgoCD vs the state backend) instead of hedging with "one or the other".
 const (
 	ReasonNone     = ""         // Everything reachable.
 	ReasonArgoCD   = "argocd"   // ArgoCD API is unreachable or login failed.
 	ReasonDatabase = "database" // The state backend (database) is unreachable.
-	ReasonBoth     = "both"     // ArgoCD and the state backend are both unreachable.
+	ReasonBoth     = "both"
 )
 
 const (
@@ -65,7 +64,8 @@ type Argo struct {
 	reason *atomic.Value
 }
 
-// Init initializes the Argo controller with its dependencies.
+// Init initializes the Argo controller with its dependencies. It allocates the
+// reason cache, so it must run before any read of it.
 func (argo *Argo) Init(state state.TaskRepository, api ArgoApiInterface, metrics prometheus.MetricsInterface) {
 	argo.api = api
 	argo.State = state
@@ -87,8 +87,6 @@ func (argo *Argo) Check() (string, error) {
 	databaseUp := argo.State.Check()
 	userLoggedIn, loginError := argo.api.GetUserInfo()
 
-	// Resolve the ArgoCD side to a specific error (nil when reachable) before
-	// combining it with the database result.
 	var argoErr error
 	switch {
 	case loginError != nil:
@@ -116,11 +114,9 @@ func (argo *Argo) Check() (string, error) {
 	}
 }
 
-// setReason records the latest unavailability cause in one place, keeping the
-// synchronously-readable cache (IsAvailable / UnavailableReason) and the two
-// per-subsystem gauges in lockstep. The gauges are independent: a state-backend
-// outage must NOT raise argocd_unavailable, and vice versa, so a ReasonBoth
-// raises both while a single-cause reason raises only its own.
+// setReason keeps the synchronously-readable cache and the two per-subsystem gauges
+// in lockstep. The gauges are independent: a state-backend outage must NOT raise
+// argocd_unavailable, and vice versa.
 func (argo *Argo) setReason(reason string) {
 	argo.reason.Store(reason)
 	argo.metrics.SetArgoUnavailable(reason == ReasonArgoCD || reason == ReasonBoth)
@@ -135,24 +131,20 @@ func (argo *Argo) IsAvailable() bool {
 }
 
 // UnavailableReason reports which subsystem was unreachable at the most recent
-// Check (ReasonArgoCD or ReasonDatabase), or ReasonNone when everything was
-// reachable. It lets the frontend banner name the exact cause.
+// Check, or ReasonNone when everything was reachable.
 func (argo *Argo) UnavailableReason() string {
 	return argo.reason.Load().(string)
 }
 
 // StartLivenessProbe periodically runs Check() so the argocd_unavailable metric
 // keeps reflecting ArgoCD reachability even during read-only periods (no new
-// deployments). Check() refreshes that gauge as a side effect; the probe's
-// return value is intentionally discarded. This is the single ambient refresher:
-// it lives here, off every request path, so listing tasks never blocks on a
-// live ArgoCD call (see GetTasks). It runs until ctx is cancelled and is meant
-// to be launched in its own goroutine.
+// deployments). This is the single ambient refresher: it lives here, off every
+// request path, so listing tasks never blocks on a live ArgoCD call (see GetTasks).
+// It runs until ctx is cancelled and is meant to be launched in its own goroutine.
 func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration) {
-	// Probe once immediately so the gauge is populated at startup instead of
-	// only after the first interval elapses. Check() updates the metric itself;
-	// log at debug so an outage leaves a correlatable trace without spamming
-	// logs every interval.
+	// Probe once immediately so the gauge is populated at startup instead of only
+	// after the first interval elapses. Log at debug so an outage leaves a
+	// correlatable trace without spamming logs every interval.
 	if _, err := argo.Check(); err != nil {
 		slog.Debug("ArgoCD liveness probe failed", "error", err)
 	}
@@ -197,9 +189,8 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	task.RollbackTargetId = argo.detectRollback(task)
 	task.IsRollback = task.RollbackTargetId != ""
 
-	// Supersede any in-flight deployment for this app that targets one of the same
-	// images before starting a new one, so the watcher stops polling ArgoCD for a
-	// rollout nobody is waiting on anymore (issue #353). Matching on image name
+	// Superseding stops the watcher polling ArgoCD for a rollout nobody is waiting
+	// on anymore (issue #353). Matching on image name
 	// (not just the app) keeps independent per-image deployments of the same app
 	// from cancelling each other. This runs against the shared state, so in an HA
 	// setup it also cancels rollouts being watched by other replicas. Best-effort:
@@ -224,13 +215,11 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	return newTask, nil
 }
 
-// detectRollback reports whether deploying task represents a rollback and, if
-// so, returns the ID of the task it rolls back to. A rollback is a deployment
-// whose image set was successfully deployed at some earlier point for the app
-// AND differs from the current (most recently deployed) version; redeploying
-// the current version is not a rollback. The returned ID is the most recent
-// earlier task carrying that image set. An empty string means "not a rollback".
-// The lookup is bounded by rollbackHistoryWindow.
+// detectRollback returns the ID of the task this deployment rolls back to, or an
+// empty string when it is not a rollback. A rollback is a deployment whose image set
+// was successfully deployed at some earlier point for the app AND differs from the
+// current (most recently deployed) version; redeploying the current version is not a
+// rollback. The returned ID is the most recent earlier task carrying that image set.
 func (argo *Argo) detectRollback(task models.Task) string {
 	deployed, _ := argo.State.GetTasks(0, float64(time.Now().Unix()), task.App, models.StatusDeployedMessage, rollbackHistoryWindow, 0)
 	if len(deployed) == 0 {
@@ -245,8 +234,6 @@ func (argo *Argo) detectRollback(task models.Task) string {
 		return ""
 	}
 
-	// deployed[1:] is scanned newest-first, so the first match is the most
-	// recent earlier deployment of the target image set.
 	for _, previous := range deployed[1:] {
 		if imageSignature(previous) == target {
 			return previous.Id
@@ -256,25 +243,19 @@ func (argo *Argo) detectRollback(task models.Task) string {
 	return ""
 }
 
-// imageSignature returns a stable, order-independent key for a task's image set
-// so two deployments of the same images compare equal regardless of ordering.
+// imageSignature returns a key for a task's image set that is independent of the
+// order the images arrived in.
 func imageSignature(task models.Task) string {
 	return strings.Join(helpers.NormalizeImages(task.ListImages()), ",")
 }
 
-// GetTasks retrieves tasks from the state within a given time range and optional app/status filters and pagination window.
+// GetTasks retrieves tasks from the state.
 //
-// Listing is a pure read from the state store and is deliberately NOT gated on
-// ArgoCD reachability. Stored task history must stay viewable even when ArgoCD
-// is unavailable (e.g. a DNS/network outage): coupling the read to a live
-// ArgoCD `session/userinfo` call would otherwise make the whole list hang on the
-// API retry budget and then hide existing tasks behind an error. Write paths
-// (AddTask) no longer run a live Check() either: they gate on the cached
-// reachability (IsAvailable) so a deploy fails fast during an outage. The
-// background liveness probe (StartLivenessProbe) is therefore the single place
-// the argocd_unavailable metric and the cached state are refreshed. Note the
-// /readyz endpoint probes only the state backend (SimpleHealthCheck), not
-// ArgoCD.
+// Listing is deliberately NOT gated on ArgoCD reachability. Stored task history must
+// stay viewable even when ArgoCD is unavailable (e.g. a DNS/network outage): coupling
+// the read to a live ArgoCD `session/userinfo` call would make the whole list hang on
+// the API retry budget and then hide existing tasks behind an error. Note the /readyz
+// endpoint probes only the state backend (SimpleHealthCheck), not ArgoCD.
 func (argo *Argo) GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) models.TasksResponse {
 	tasks, total := argo.State.GetTasks(startTime, endTime, app, status, limit, offset)
 
@@ -284,7 +265,7 @@ func (argo *Argo) GetTasks(startTime float64, endTime float64, app string, statu
 	}
 }
 
-// SimpleHealthCheck checks only the state backend connection.
+// SimpleHealthCheck checks the state backend only, never ArgoCD.
 func (argo *Argo) SimpleHealthCheck() bool {
 	return argo.State.Check()
 }

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -78,16 +78,15 @@ func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 	return nil
 }
 
-// doGet creates a GET request for the given URL, sets the Accept header for JSON responses,
-// executes it with retry logic for transient transport errors, and returns the response body
-// bytes along with the HTTP status code. Only the HTTP round-trip is retried; request creation
-// and body reading errors are not retried. HTTP error responses (4xx, 5xx) are valid API
-// responses and are returned as-is without retry.
+// doGet executes a GET against reqURL and returns the response body and status code.
+// Only the HTTP round-trip is retried; request creation and body reading errors are
+// not. HTTP error responses (4xx, 5xx) are valid API responses and are returned as-is
+// without retry.
 //
-// The supplied context bounds both the in-flight HTTP round-trip and the retry/backoff loop:
-// once it is cancelled or its deadline is exceeded, any pending request is aborted and no
-// further attempts are made, so a slow ArgoCD cannot stretch a single call past the caller's
-// deadline.
+// The supplied context bounds both the in-flight round-trip and the retry/backoff loop:
+// once it is cancelled or its deadline is exceeded, any pending request is aborted and
+// no further attempts are made, so a slow ArgoCD cannot stretch a single call past the
+// caller's deadline.
 func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, error) {
 	req, err := api.requestFn("GET", reqURL, nil)
 	if err != nil {
@@ -144,8 +143,6 @@ func (e *ArgoAPIError) Error() string {
 	return e.Message
 }
 
-// parseArgoErrorResponse builds an *ArgoAPIError from a non-200 ArgoCD API response.
-// It checks the message field first, then the error field, and falls back to the raw body.
 func parseArgoErrorResponse(statusCode int, body []byte) error {
 	var argoErrorResponse models.ArgoApiErrorResponse
 	if err := json.Unmarshal(body, &argoErrorResponse); err != nil {

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -56,8 +56,6 @@ func (b *stubBody) Close() error {
 	return b.closeErr
 }
 
-// TestArgoApiInit verifies that the ArgoCD API client is properly initialized
-// with URL, token, timeout, and TLS settings.
 func TestArgoApiInit(t *testing.T) {
 	argoURL, err := url.Parse("https://example.com")
 	require.NoError(t, err)
@@ -103,8 +101,6 @@ func TestArgoApiInit(t *testing.T) {
 	})
 }
 
-// TestArgoApiGetUserInfoSuccess verifies that GetUserInfo returns user information
-// when the API call succeeds.
 func TestArgoApiGetUserInfoSuccess(t *testing.T) {
 	expected := models.Userinfo{Username: "tester", LoggedIn: true}
 
@@ -128,8 +124,6 @@ func TestArgoApiGetUserInfoSuccess(t *testing.T) {
 	assert.Equal(t, &expected, userInfo)
 }
 
-// TestArgoApiGetUserInfoErrors verifies error handling for various failure scenarios
-// in GetUserInfo including request errors, body read errors, and JSON parsing errors.
 func TestArgoApiGetUserInfoErrors(t *testing.T) {
 	baseURL, err := url.Parse("https://example.com")
 	require.NoError(t, err)
@@ -332,8 +326,6 @@ func TestArgoApiGetUserInfoErrors(t *testing.T) {
 	}
 }
 
-// TestArgoApiGetApplicationSuccess verifies that GetApplication returns application
-// details when the API call succeeds.
 func TestArgoApiGetApplicationSuccess(t *testing.T) {
 	app := models.Application{}
 	app.Status.Health.Status = "Healthy"
@@ -363,8 +355,8 @@ func TestArgoApiGetApplicationSuccess(t *testing.T) {
 	assert.Equal(t, app.Status.Summary.Images, result.Status.Summary.Images)
 }
 
-// TestArgoApiGetResourceTreeSuccess verifies that GetResourceTree hits the resource-tree
-// endpoint and decodes node health (the only place pod-level failure causes are exposed).
+// TestArgoApiGetResourceTreeSuccess covers the resource-tree endpoint — the only place
+// pod-level failure causes are exposed.
 func TestArgoApiGetResourceTreeSuccess(t *testing.T) {
 	tree := models.ApplicationTree{Nodes: []models.ApplicationTreeNode{
 		{Kind: "Pod", Name: "demo-xyz", Namespace: "demo"},
@@ -394,8 +386,6 @@ func TestArgoApiGetResourceTreeSuccess(t *testing.T) {
 	assert.Equal(t, `Back-off pulling image "demo:v2": ErrImagePull`, result.Nodes[0].Health.Message)
 }
 
-// TestArgoApiGetManagedResourcesSuccess verifies that GetManagedResources hits the
-// managed-resources endpoint and decodes the desired manifests.
 func TestArgoApiGetManagedResourcesSuccess(t *testing.T) {
 	manifest := `{"kind":"Deployment","spec":{"template":{"spec":{"containers":[{"image":"demo:v1"}]}}}}`
 
@@ -421,7 +411,6 @@ func TestArgoApiGetManagedResourcesSuccess(t *testing.T) {
 	assert.Equal(t, []string{"demo"}, result.DesiredImageNames())
 }
 
-// TestArgoApiGetManagedResourcesError verifies a non-200 response surfaces as an error.
 func TestArgoApiGetManagedResourcesError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
@@ -440,7 +429,6 @@ func TestArgoApiGetManagedResourcesError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestArgoApiGetResourceTreeError verifies a non-200 response surfaces as an error.
 func TestArgoApiGetResourceTreeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -461,8 +449,6 @@ func TestArgoApiGetResourceTreeError(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
-// TestArgoApiGetResourceTreeUnmarshalError verifies a 200 with a non-JSON body surfaces a
-// wrapped parse error rather than a nil tree.
 func TestArgoApiGetResourceTreeUnmarshalError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -483,8 +469,8 @@ func TestArgoApiGetResourceTreeUnmarshalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not parse resource-tree response")
 }
 
-// TestArgoApiGetResourceTreeTransportError verifies a transport failure (unreachable server) is
-// returned as an error — the best-effort caller relies on this to fall back to a nil tree.
+// TestArgoApiGetResourceTreeTransportError pins the error the best-effort caller relies
+// on to fall back to a nil tree.
 func TestArgoApiGetResourceTreeTransportError(t *testing.T) {
 	// Port 1 is not listenable, so the request fails to connect.
 	parsedURL, err := url.Parse("http://127.0.0.1:1")
@@ -499,8 +485,8 @@ func TestArgoApiGetResourceTreeTransportError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestArgoApiGetApplicationEscapesAppName verifies that special characters in app names
-// are properly URL-escaped to prevent path traversal and injection attacks.
+// TestArgoApiGetApplicationEscapesAppName covers URL-escaping of app names, which guards
+// against path traversal and injection.
 func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {
 	testCases := []struct {
 		appName     string
@@ -535,8 +521,6 @@ func TestArgoApiGetApplicationEscapesAppName(t *testing.T) {
 	}
 }
 
-// TestArgoApiGetApplicationAddsRefreshQuery verifies that the refresh query parameter
-// is added when refresh is requested, and omitted otherwise.
 func TestArgoApiGetApplicationAddsRefreshQuery(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -569,8 +553,6 @@ func TestArgoApiGetApplicationAddsRefreshQuery(t *testing.T) {
 	}
 }
 
-// TestArgoApiGetApplicationErrors verifies error handling for various failure scenarios
-// in GetApplication including request errors, body read errors, and API error responses.
 func TestArgoApiGetApplicationErrors(t *testing.T) {
 	baseURL, err := url.Parse("https://example.com")
 	require.NoError(t, err)
@@ -802,8 +784,6 @@ func TestArgoApiGetApplicationErrors(t *testing.T) {
 	}
 }
 
-// TestArgoApiDoGetRetriesOnTransientError verifies that transient transport errors
-// trigger retries and succeed if a subsequent attempt works.
 func TestArgoApiDoGetRetriesOnTransientError(t *testing.T) {
 	var callCount atomic.Int32
 	successBody := []byte(`{"loggedIn":true,"username":"ok"}`)
@@ -835,8 +815,6 @@ func TestArgoApiDoGetRetriesOnTransientError(t *testing.T) {
 	assert.Equal(t, int32(3), callCount.Load())
 }
 
-// TestArgoApiDoGetExhaustsRetries verifies that when all retry attempts fail,
-// the final error is returned.
 func TestArgoApiDoGetExhaustsRetries(t *testing.T) {
 	var callCount atomic.Int32
 
@@ -861,8 +839,6 @@ func TestArgoApiDoGetExhaustsRetries(t *testing.T) {
 	assert.Equal(t, int32(3), callCount.Load())
 }
 
-// TestArgoApiDoGetNoRetryOnSuccess verifies that no unnecessary retries happen
-// when the first attempt succeeds.
 func TestArgoApiDoGetNoRetryOnSuccess(t *testing.T) {
 	var callCount atomic.Int32
 	successBody := []byte(`{"status":"ok"}`)
@@ -935,7 +911,7 @@ func TestArgoApiDoGetNoRequestWhenContextAlreadyDone(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already done before doGet runs
+	cancel()
 
 	api := NewArgoApi()
 	api.baseUrl = *baseURL
@@ -953,9 +929,8 @@ func TestArgoApiDoGetNoRequestWhenContextAlreadyDone(t *testing.T) {
 	assert.Equal(t, int32(0), callCount.Load(), "an already-cancelled context must skip the HTTP round-trip entirely")
 }
 
-// TestArgoApiDoGetNoRetryOnNon2xx verifies that HTTP error responses (4xx/5xx)
-// are returned immediately without triggering retries, since they are valid API
-// responses — not transient transport errors.
+// TestArgoApiDoGetNoRetryOnNon2xx pins that 4xx/5xx are returned without retry: they are
+// valid API responses, not transient transport errors.
 func TestArgoApiDoGetNoRetryOnNon2xx(t *testing.T) {
 	var callCount atomic.Int32
 	errorBody := []byte(`{"message":"internal server error"}`)

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -96,21 +96,20 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 
 // Close releases resources held by the updater, draining any in-flight batch
 // write-backs (bounded by ctx) so a graceful shutdown does not abandon queued
-// commits nor overrun its deadline. It is a no-op when batching is disabled.
+// commits nor overrun its deadline.
 func (updater *ArgoStatusUpdater) Close(ctx context.Context) {
 	if updater.gitUpdater != nil {
 		updater.gitUpdater.Close(ctx)
 	}
 }
 
-// WaitForRollout is the main entry point for tracking an application deployment
-// It monitors the application until it reaches a final state (deployed or failed),
-// or stops early if a newer deployment for the same app supersedes it (issue #353).
+// WaitForRollout monitors the application until it reaches a final state (deployed
+// or failed), or stops early if a newer deployment for the same app supersedes it
+// (issue #353).
 func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
 
-	// notify: deployment started
 	sendNotification(task, updater.notifier)
 
 	// start bounds the deployment-duration metric: a monotonic in-process clock over the
@@ -138,28 +137,23 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 		updater.monitor.ProcessDeploymentResult(&task, application)
 	}
 
-	// Record how long a successful deployment took. Only the deployed state is timed:
-	// a failure/abort/supersession is not a completed deployment and its wall-clock is
-	// dominated by the timeout, so it would distort the histogram.
+	// Only the deployed state is timed: a failure/abort/supersession is not a completed
+	// deployment and its wall-clock is dominated by the timeout, so it would distort
+	// the histogram.
 	if task.Status == models.StatusDeployedMessage {
 		updater.monitor.ObserveDeploymentDuration(task.App, time.Since(start).Seconds())
 	}
 
-	// notify: deployment finished
 	sendNotification(task, updater.notifier)
 }
 
-// waitForApplicationDeployment coordinates the deployment monitoring process
-// It checks initial status, updates the git repo if needed, and waits for rollout.
 func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, error) {
-	// Bail out before any ArgoCD call or git update if the task was already
-	// superseded by a newer deployment for the same app.
 	if updater.monitor.taskSuperseded(task.Id) {
 		return nil, errTaskSuperseded
 	}
 
-	// Fetch initial app state. This single call happens before the timed polling loop, so it is
-	// bounded only by the HTTP client's per-request timeout rather than the rollout deadline.
+	// The initial fetch happens before the timed polling loop, so it is bounded only by
+	// the HTTP client's per-request timeout rather than the rollout deadline.
 	app, err := updater.monitor.FetchApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
 	if err != nil {
 		return nil, err
@@ -169,8 +163,8 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 		return nil, err
 	}
 
-	// Handle git repo update if needed. The supersede predicate is re-checked
-	// inside the write-back retry loop so a task that keeps retrying under
+	// The supersede predicate is re-checked inside the write-back retry loop so a
+	// task that keeps retrying under
 	// contention aborts (rather than overwriting a newer deployment) the moment a
 	// newer one supersedes it.
 	if err := updater.gitUpdater.UpdateIfNeeded(app, task, func() bool {
@@ -185,7 +179,6 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 	return updater.monitor.WaitRollout(task)
 }
 
-// sendNotification sends the task update through the configured notifier if available.
 func sendNotification(task models.Task, notifier *notifications.Notifier) {
 	if notifier == nil {
 		return

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -58,8 +58,6 @@ func (s failingStrategy) Send(models.Task) error {
 	return s.err
 }
 
-// capturingStrategy records every task passed to a notifier so tests can assert
-// on the status reported in the outgoing notification.
 type capturingStrategy struct {
 	sent []models.Task
 }
@@ -125,27 +123,21 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// Use a real in-memory locker for testing the updater's logic,
-	// as its behavior is simple and predictable.
 	mockLocker := lock.NewInMemoryLocker()
 
 	t.Run("Status Updater - Application deployed", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
 		cfg.RepoCachePath = "/tmp/"
 		updater := initTestUpdater(t, cfg, argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -158,13 +150,11 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "Healthy"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
@@ -172,27 +162,22 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application deployed with Retry", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
 		cfg.RetryAttempts = 3
 		updater := initTestUpdater(t, cfg, argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -205,19 +190,16 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// unhealthyApp
 		unhealthyApp := models.Application{}
 		unhealthyApp.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
 		unhealthyApp.Status.Sync.Status = "Synced"
 		unhealthyApp.Status.Health.Status = "NotHealthy"
 
-		// healthy app
 		healthyApp := models.Application{}
 		healthyApp.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
 		healthyApp.Status.Sync.Status = "Synced"
 		healthyApp.Status.Health.Status = "Healthy"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
@@ -226,25 +208,20 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application deployed with Registry proxy", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -257,13 +234,11 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"test-registry/ghcr.io/shini4i/argo-watcher:dev"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "Healthy"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
@@ -271,27 +246,22 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application deployed without Registry proxy", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		cfg := newUpdaterTestConfig(mockLocker)
 		cfg.RegistryProxyURL = ""
 		updater := initTestUpdater(t, cfg, argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -304,13 +274,11 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"test-registry/ghcr.io/shini4i/argo-watcher:dev"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "Healthy"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
@@ -322,22 +290,18 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application not found", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
 		// prepare test data. Validated, so the failure is labelled with the app: a
@@ -349,39 +313,32 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			Validated: true,
 		}
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAppNotFoundMessage, "ArgoCD API Error: applications.argoproj.io \"test-app\" not found")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - ArgoCD unavailable", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:        "test-id",
 			App:       "test-app",
 			Validated: true,
 		}
 
-		// mock calls
 		unavailableErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, unavailableErr)
 		metricsMock.EXPECT().AddInProgressTask()
@@ -389,57 +346,46 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application API error", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:        "test-id",
 			App:       "test-app",
 			Validated: true,
 		}
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("unexpected failure"))
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: unexpected failure")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application not available", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -452,11 +398,9 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"test-image:v0.0.1"}
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
@@ -468,25 +412,20 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application out of Sync", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -499,7 +438,6 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
 		application.Status.Sync.Status = "Syncing"
@@ -507,7 +445,6 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		application.Status.OperationState.Phase = "NotWorking"
 		application.Status.OperationState.Message = "Not working test app"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
@@ -519,25 +456,20 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"App status \"NotWorking\"\n"+
 				"App message \"Not working test app\"")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 
 	t.Run("Status Updater - Application not healthy", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		stateMock.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 
-		// argo updater
 		updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-		// prepare test data
 		task := models.Task{
 			Id:      "test-id",
 			App:     "test-app",
@@ -550,13 +482,11 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 			},
 		}
 
-		// application
 		application := models.Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "NotHealthy"
 
-		// mock calls
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
@@ -568,7 +498,6 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"App sync status \"Synced\"\n"+
 				"App health status \"NotHealthy\"")
 
-		// run the rollout
 		updater.WaitForRollout(task)
 	})
 }
@@ -885,7 +814,6 @@ func TestArgoStatusUpdaterAbortsWhenArgoBecomesUnreachableMidPoll(t *testing.T) 
 	application.Status.Sync.Status = "Synced"
 	application.Status.Health.Status = "Progressing"
 
-	// The initial fetch and the first poll succeed; ArgoCD then goes away mid-rollout.
 	gomock.InOrder(
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(2),
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
@@ -1510,7 +1438,6 @@ func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
 
 	updater.WaitForRollout(task)
 
-	// The final outgoing notification must report the cancelled status.
 	require.NotEmpty(t, capture.sent)
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
 }
@@ -1598,9 +1525,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 	notFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
 
 	gomock.InOrder(
-		// Initial check and first poll succeed: the app is present but still progressing.
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&inProgress, nil).Times(2),
-		// The app is then deleted mid-rollout; every subsequent fetch reports not found.
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, notFound).MinTimes(1),
 	)
 
@@ -1647,14 +1572,12 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	application.Status.Sync.Status = "Synced"
 	application.Status.Health.Status = "Healthy"
 
-	// Every supersession check fails to read the status; the rollout must carry on.
 	stateMock.EXPECT().GetTask(task.Id).Return(nil, errors.New("db unavailable")).AnyTimes()
 	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(1)
 	metricsMock.EXPECT().AddInProgressTask()
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
 	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	metricsMock.EXPECT().RemoveInProgressTask()
-	// Proceeds to a normal deployed result rather than stopping as superseded.
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
 	updater.WaitForRollout(task)
@@ -1763,7 +1686,6 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 
 	updater := initTestUpdater(t, newUpdaterTestConfig(mockLocker), argo)
 
-	// success scenario
 	t.Run("processDeploymentResult - success", func(t *testing.T) {
 		task := models.Task{
 			Id:  "test-id",
@@ -1777,7 +1699,6 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		app.Status.Sync.Status = "Synced"
 		app.Status.Health.Status = "Healthy"
 
-		// setup status mocks
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
@@ -1785,7 +1706,6 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		assert.Equal(t, models.StatusDeployedMessage, task.Status)
 	})
 
-	// fire and forget scenario
 	t.Run("processDeploymentResult - fire and forget", func(t *testing.T) {
 		task := models.Task{Id: "test-id", App: "test-app"}
 		app := &models.Application{}
@@ -1819,7 +1739,6 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		assert.Equal(t, models.StatusDeployedMessage, task.Status)
 	})
 
-	// failure scenario
 	t.Run("processDeploymentResult - failure", func(t *testing.T) {
 		task := models.Task{Id: "test-id", App: "test-app"}
 		app := &models.Application{}
@@ -2094,7 +2013,6 @@ func captureDebugLogs(t *testing.T) *logBuffer {
 	return logs
 }
 
-// logBuffer is a concurrency-safe io.Writer holding everything the logger emitted.
 type logBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -2106,7 +2024,6 @@ func (b *logBuffer) Write(p []byte) (int, error) {
 	return b.buf.Write(p)
 }
 
-// String returns everything captured so far.
 func (b *logBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -2145,7 +2062,6 @@ func TestDeploymentMonitorResolveRefresh(t *testing.T) {
 	}
 }
 
-// newFetchTestMonitor builds a monitor wired to mock API + metrics for FetchApplication tests.
 func newFetchTestMonitor(t *testing.T) (*DeploymentMonitor, *mocks.MockArgoApiInterface, *mocks.MockMetricsInterface) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
@@ -2191,8 +2107,6 @@ func TestDeploymentMonitorFetchApplicationRefreshRecordsDuration(t *testing.T) {
 	})
 }
 
-// TestDeploymentMonitorFetchApplicationNoRefresh verifies that when refresh is not requested, the call
-// is forwarded with refresh=false and no refresh duration is recorded.
 func TestDeploymentMonitorFetchApplicationNoRefresh(t *testing.T) {
 	monitor, api, _ := newFetchTestMonitor(t)
 	wantApp := &models.Application{}
@@ -2204,9 +2118,6 @@ func TestDeploymentMonitorFetchApplicationNoRefresh(t *testing.T) {
 	assert.Same(t, wantApp, app)
 }
 
-// TestDetermineFailureStatus verifies that unreachable-ArgoCD errors (transport
-// failures and 5xx responses) are classified as aborted, while genuine
-// application/API errors are classified as failed.
 func TestDetermineFailureStatus(t *testing.T) {
 	task := models.Task{App: "demo"}
 

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -22,12 +22,10 @@ func TestArgoCheck(t *testing.T) {
 	defer ctrl.Finish()
 
 	t.Run("Argo Watcher - Up", func(t *testing.T) {
-		// mocks
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
 		stateMock := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls
 		stateMock.EXPECT().Check().Return(true)
 		testUserInfo := &models.Userinfo{
 			LoggedIn: true,
@@ -37,116 +35,93 @@ func TestArgoCheck(t *testing.T) {
 		metricsMock.EXPECT().SetArgoUnavailable(false)
 		metricsMock.EXPECT().SetStateUnavailable(false)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
 		status, err := argo.Check()
 
-		// assertions
 		assert.Nil(t, err)
 		assert.Equal(t, "up", status)
 	})
 
 	t.Run("Argo Watcher - Down - Cannot connect to State manager", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls
 		state.EXPECT().Check().Return(false)
 		testUserInfo := &models.Userinfo{
 			LoggedIn: true,
 			Username: loggedInUsername,
 		}
 		api.EXPECT().GetUserInfo().Return(testUserInfo, nil)
-		// Only the state backend is down; ArgoCD stays reachable, so the two
-		// gauges must diverge.
 		metrics.EXPECT().SetArgoUnavailable(false)
 		metrics.EXPECT().SetStateUnavailable(true)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		status, err := argo.Check()
 
-		// assertions
 		assert.EqualError(t, err, models.StatusConnectionUnavailable)
 		assert.Equal(t, "down", status)
 		assert.Equal(t, ReasonDatabase, argo.UnavailableReason())
 	})
 
 	t.Run("Argo Watcher - Down - Cannot login", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls
 		state.EXPECT().Check().Return(true)
 		testUserInfo := &models.Userinfo{
 			LoggedIn: false,
 			Username: loggedInUsername,
 		}
 		api.EXPECT().GetUserInfo().Return(testUserInfo, nil)
-		// Only ArgoCD is down (login rejected); the state backend stays reachable.
 		metrics.EXPECT().SetArgoUnavailable(true)
 		metrics.EXPECT().SetStateUnavailable(false)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		status, err := argo.Check()
 
-		// assertions
 		assert.EqualError(t, err, models.StatusArgoCDFailedLogin)
 		assert.Equal(t, "down", status)
 		assert.Equal(t, ReasonArgoCD, argo.UnavailableReason())
 	})
 
 	t.Run("Argo Watcher - Down - Unexpected login failure", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls
 		state.EXPECT().Check().Return(true)
 		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("unexpected login error"))
-		// Only ArgoCD is down (transport error); the state backend stays reachable.
 		metrics.EXPECT().SetArgoUnavailable(true)
 		metrics.EXPECT().SetStateUnavailable(false)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		status, err := argo.Check()
 
-		// assertions
 		assert.EqualError(t, err, models.StatusArgoCDUnavailableMessage)
 		assert.Equal(t, "down", status)
 		assert.Equal(t, ReasonArgoCD, argo.UnavailableReason())
 	})
 
 	t.Run("Argo Watcher - Down - Both ArgoCD and state backend unreachable", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls: state backend down AND ArgoCD login fails at the same time,
-		// so both gauges must be raised.
 		state.EXPECT().Check().Return(false)
 		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("unexpected login error"))
 		metrics.EXPECT().SetArgoUnavailable(true)
 		metrics.EXPECT().SetStateUnavailable(true)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		status, err := argo.Check()
 
-		// assertions: the reason names both, and the error mentions both causes.
 		assert.Equal(t, "down", status)
 		assert.Equal(t, ReasonBoth, argo.UnavailableReason())
 		assert.ErrorContains(t, err, models.StatusConnectionUnavailable)
@@ -154,7 +129,6 @@ func TestArgoCheck(t *testing.T) {
 	})
 
 	t.Run("Argo Watcher - Down - Both, ArgoCD login rejected", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
@@ -167,12 +141,10 @@ func TestArgoCheck(t *testing.T) {
 		metrics.EXPECT().SetArgoUnavailable(true)
 		metrics.EXPECT().SetStateUnavailable(true)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		status, err := argo.Check()
 
-		// assertions
 		assert.Equal(t, "down", status)
 		assert.Equal(t, ReasonBoth, argo.UnavailableReason())
 		assert.ErrorContains(t, err, models.StatusConnectionUnavailable)
@@ -230,50 +202,42 @@ func TestArgoAddTask(t *testing.T) {
 	defer ctrl.Finish()
 
 	t.Run("Argo Unavailable", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		// Simulate a cached outage: AddTask must reject fast, without a live
 		// probe (no Check/GetUserInfo calls) so the client is not held on the
 		// retry budget (issue #498).
 		argo.reason.Store(ReasonArgoCD)
-		task := models.Task{} // empty task
+		task := models.Task{}
 		newTask, err := argo.AddTask(task)
 
-		// assertions
 		assert.Nil(t, newTask)
 		assert.EqualError(t, err, models.StatusArgoCDUnavailableMessage)
 	})
 
 	t.Run("Argo - Image not passed", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
-		task := models.Task{} // empty task
+		task := models.Task{}
 		newTask, err := argo.AddTask(task)
 
-		// assertions
 		assert.Nil(t, newTask)
 		assert.EqualError(t, err, "trying to create task without images")
 	})
 
 	t.Run("Argo - App not passed", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		task := models.Task{
@@ -283,24 +247,20 @@ func TestArgoAddTask(t *testing.T) {
 		}
 		newTask, err := argo.AddTask(task)
 
-		// assertions
 		assert.Nil(t, newTask)
 		assert.EqualError(t, err, "trying to create task without app name")
 	})
 
 	t.Run("Argo - State add failed", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
 
-		// mock calls to add task
 		stateError := fmt.Errorf("database error")
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
 		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).Return(nil, stateError)
 
-		// argo manager
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
 		task := models.Task{
@@ -311,7 +271,6 @@ func TestArgoAddTask(t *testing.T) {
 		}
 		newTask, err := argo.AddTask(task)
 
-		// assertions
 		assert.Nil(t, newTask)
 		assert.EqualError(t, err, stateError.Error())
 	})
@@ -321,7 +280,6 @@ func TestArgoAddTask(t *testing.T) {
 	// vulnerability the authority rule closes.
 	for _, validated := range []bool{true, false} {
 		t.Run(fmt.Sprintf("Argo - Task added (validated=%t)", validated), func(t *testing.T) {
-			// mocks
 			api := newArgoApiMock(ctrl)
 			metrics := mocks.NewMockMetricsInterface(ctrl)
 			state := mocks.NewMockTaskRepository(ctrl)
@@ -335,7 +293,6 @@ func TestArgoAddTask(t *testing.T) {
 			}
 			metrics.EXPECT().AddProcessedDeployment(expectedApp)
 
-			// tasks
 			task := models.Task{
 				App: "test-app",
 				Images: []models.Image{
@@ -364,12 +321,10 @@ func TestArgoAddTask(t *testing.T) {
 				state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil),
 			)
 
-			// argo manager
 			argo := &Argo{}
 			argo.Init(state, api, metrics)
 			newTaskReturned, err := argo.AddTask(task)
 
-			// assertions
 			assert.Nil(t, err)
 			assert.NotNil(t, newTaskReturned)
 			uuidRegexp := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
@@ -378,7 +333,6 @@ func TestArgoAddTask(t *testing.T) {
 	}
 
 	t.Run("Argo - Cancel failure does not block new deployment", func(t *testing.T) {
-		// mocks
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := mocks.NewMockTaskRepository(ctrl)
@@ -388,8 +342,6 @@ func TestArgoAddTask(t *testing.T) {
 		task := models.Task{App: "test-app", Images: []models.Image{{Tag: taskImageTag}}, Validated: true}
 		newTask := models.Task{Id: uuid.NewString(), App: "test-app", Images: []models.Image{{Tag: taskImageTag}}}
 
-		// Cancelling prior in-progress tasks is best-effort: a failure here must not
-		// block the new deployment from being persisted.
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
 		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), supersededTaskReason, gomock.Any()).Return(int64(0), fmt.Errorf("cancel failed"))
 		state.EXPECT().AddTask(gomock.Any()).Return(&newTask, nil)
@@ -416,7 +368,6 @@ func TestArgoAddTask(t *testing.T) {
 		}
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return(deployed, int64(len(deployed)))
 
-		// Capture the task actually handed to the repository.
 		var captured models.Task
 		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(0), nil)
 		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
@@ -441,7 +392,6 @@ func TestArgoAddTask(t *testing.T) {
 
 		metrics.EXPECT().AddProcessedDeployment(models.UnknownApp)
 
-		// Deploying a brand-new version (v3) with no earlier match: not a rollback.
 		deployed := []models.Task{
 			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
 		}
@@ -457,7 +407,6 @@ func TestArgoAddTask(t *testing.T) {
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
-		// Client tries to spoof the rollback flag; the server must overwrite it.
 		_, err := argo.AddTask(models.Task{
 			App:              "test-app",
 			Images:           []models.Image{{Image: "app", Tag: "v3"}},
@@ -479,7 +428,6 @@ func TestArgoDetectRollback(t *testing.T) {
 		return []models.Image{{Image: image, Tag: tag}}
 	}
 
-	// deployedTask is one entry in the app's deployment history.
 	type deployedTask struct {
 		id     string
 		images []models.Image
@@ -488,7 +436,7 @@ func TestArgoDetectRollback(t *testing.T) {
 	tests := []struct {
 		name    string
 		history []deployedTask // successfully deployed tasks, oldest first
-		target  []models.Image // image set being deployed now
+		target  []models.Image
 		// wantTargetID is the expected rollback target task ID ("" = not a rollback).
 		wantTargetID string
 	}{

--- a/internal/argocd/batch_writeback_integration_test.go
+++ b/internal/argocd/batch_writeback_integration_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // testSSHAuth builds go-git SSH auth from a key file with host-key verification
-// disabled (the Gitea instance is ephemeral), matching the other integration helpers.
+// disabled (the Gitea instance is ephemeral).
 func testSSHAuth(t *testing.T, sshKeyPath string) *gogitssh.PublicKeys {
 	t.Helper()
 	auth, err := gogitssh.NewPublicKeysFromFile("git", sshKeyPath, "")
@@ -50,8 +50,6 @@ func newBatchReqFor(name, tag string, superseded func() bool) *batchWriteRequest
 	}
 }
 
-// countArgoCommits clones the remote and counts commits whose message marks an
-// argo-watcher image-tag update, so a test can assert one commit landed per app.
 func countArgoCommits(t *testing.T, repoURL, sshKeyPath, branch string) int {
 	t.Helper()
 	dir := t.TempDir()
@@ -75,9 +73,6 @@ func countArgoCommits(t *testing.T, repoURL, sshKeyPath, branch string) int {
 	return count
 }
 
-// TestIntegration_BatchWriteBack_SingleCloneCommitPerApp verifies the core batch
-// promise: N apps sharing a repo are written with one clone and one commit per
-// app, and all their override files land on the remote after a single flush.
 func TestIntegration_BatchWriteBack_SingleCloneCommitPerApp(t *testing.T) {
 	waitForGitea(t, 60*time.Second)
 	env := setupGitea(t)
@@ -106,11 +101,9 @@ func TestIntegration_BatchWriteBack_SingleCloneCommitPerApp(t *testing.T) {
 	// Clone; a value >1 would mean a retry re-cloned).
 	assert.Equal(t, int32(1), atomic.LoadInt32(&handler.openCount), "the whole batch must share a single clone")
 
-	// One commit per app landed on the remote.
 	assert.Equal(t, 3, countArgoCommits(t, env.DirectRepoURL, env.SSHKeyPath, "master"),
 		"expected one commit per app in the batch")
 
-	// Each app's override file carries its own tag.
 	for _, tc := range []struct{ name, tag string }{{"app-a", "v1"}, {"app-b", "v2"}, {"app-c", "v3"}} {
 		_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master",
 			fmt.Sprintf("apps/.argocd-source-%s.yaml", tc.name))
@@ -118,9 +111,6 @@ func TestIntegration_BatchWriteBack_SingleCloneCommitPerApp(t *testing.T) {
 	}
 }
 
-// TestIntegration_BatchWriteBack_PartialSupersede verifies per-app isolation: a
-// superseded app is dropped from the batch (its file is never written) while the
-// rest are committed and pushed normally.
 func TestIntegration_BatchWriteBack_PartialSupersede(t *testing.T) {
 	waitForGitea(t, 60*time.Second)
 	env := setupGitea(t)
@@ -145,7 +135,6 @@ func TestIntegration_BatchWriteBack_PartialSupersede(t *testing.T) {
 	assert.NoError(t, outcomes[batch[0]])
 	assert.NoError(t, outcomes[batch[2]])
 
-	// The two live apps landed; the superseded one did not.
 	assert.Equal(t, 2, countArgoCommits(t, env.DirectRepoURL, env.SSHKeyPath, "master"))
 	_, superContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master",
 		"apps/.argocd-source-app-super.yaml")
@@ -194,7 +183,6 @@ func TestIntegration_BatchWriteBack_PushRaceRecovery(t *testing.T) {
 			for _, req := range batch {
 				require.NoError(t, outcomes[req], "app %s should succeed after recovery (attempt %d)", req.app.Metadata.Name, attempt)
 			}
-			// The competitor's commit must survive the recovery.
 			_, competitorContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", "competitor.txt")
 			assert.Contains(t, competitorContent, "batch-race",
 				"recovery must preserve the competitor's commit, not force-push over it (attempt %d)", attempt)

--- a/internal/argocd/batcher.go
+++ b/internal/argocd/batcher.go
@@ -22,8 +22,7 @@ var errBatcherClosed = errors.New("git write-back batcher is shutting down")
 // per-app serialized path: an idle repo flushes immediately (no added latency),
 // while requests that arrive while a flush for the same key is in flight — cloning,
 // pushing, or waiting on the per-repo lock — queue into the next batch and flush
-// together the moment the current flush finishes. Batching therefore happens
-// exactly during the window a push occupies, i.e. precisely when contention exists.
+// together the moment the current flush finishes.
 type Batcher struct {
 	locker        lock.Locker
 	repoCachePath string
@@ -42,9 +41,8 @@ type Batcher struct {
 	// active exactly while a flush goroutine is draining its pending queue.
 	pending map[string][]*batchWriteRequest
 	active  map[string]bool
-	// wg tracks in-flight flush goroutines so Close can wait for them to drain.
-	wg     sync.WaitGroup
-	closed bool
+	wg      sync.WaitGroup
+	closed  bool
 	// drainCh is closed by Close to tell in-flight retry loops to stop after their
 	// current attempt. Without it a single flush can retry for
 	// GIT_OP_TIMEOUT * GIT_MAX_ATTEMPTS and outlive the shutdown deadline, leaving
@@ -77,9 +75,8 @@ func batchKey(repo *models.GitopsRepo) string {
 	return repo.RepoUrl + "\x00" + repo.BranchName
 }
 
-// Submit enqueues a write-back request and blocks until the batch it is folded
-// into has been flushed, returning that request's individual outcome. It returns
-// errBatcherClosed if the batcher is shutting down.
+// Submit blocks until the batch its request is folded into has been flushed, and
+// returns that request's individual outcome, or errBatcherClosed when shutting down.
 func (b *Batcher) Submit(req *batchWriteRequest) error {
 	key := batchKey(req.gitopsRepo)
 
@@ -89,9 +86,6 @@ func (b *Batcher) Submit(req *batchWriteRequest) error {
 		return errBatcherClosed
 	}
 	b.pending[key] = append(b.pending[key], req)
-	// Start a flush goroutine only if one is not already draining this key. An
-	// idle key therefore flushes immediately; a busy key coalesces into the next
-	// batch handled by the existing goroutine.
 	if !b.active[key] {
 		b.active[key] = true
 		b.wg.Add(1)
@@ -102,10 +96,9 @@ func (b *Batcher) Submit(req *batchWriteRequest) error {
 	return <-req.resultCh
 }
 
-// flushLoop drains a key's pending queue, flushing in batches of at most
-// maxBatchSize, until the queue is empty. It then clears the key's active flag
-// under the lock so a subsequent Submit starts a fresh loop. Holding the lock
-// across the empty-check and the clear is what makes the hand-off race-free.
+// flushLoop drains a key's pending queue in batches of at most maxBatchSize. Holding
+// the lock across the empty-check and the clear of the active flag is what makes the
+// hand-off to a later Submit race-free.
 func (b *Batcher) flushLoop(key string) {
 	defer b.wg.Done()
 	for {
@@ -131,9 +124,9 @@ func (b *Batcher) flushLoop(key string) {
 	}
 }
 
-// flush runs one batch under the per-repository lock and delivers each request's
-// outcome. All requests in a batch share the same repo URL and branch, so a single
-// GitRepo (one clone) and a single push serve the whole batch.
+// flush runs one batch under the per-repository lock. All requests in a batch share the
+// same repo URL and branch, so a single GitRepo (one clone) and a single push serve the
+// whole batch.
 func (b *Batcher) flush(batch []*batchWriteRequest) {
 	if len(batch) == 0 {
 		return
@@ -175,32 +168,26 @@ func (b *Batcher) flush(batch []*batchWriteRequest) {
 	}
 }
 
-// deliverAll sends the same error to every request in the batch. Used when the
-// whole batch fails before per-request outcomes exist (repo construction or lock
-// acquisition failure).
 func (b *Batcher) deliverAll(batch []*batchWriteRequest, err error) {
 	for _, req := range batch {
 		req.resultCh <- err
 	}
 }
 
-// Close stops accepting new requests and waits — bounded by ctx — for in-flight
-// flush goroutines to drain their pending queues and deliver all results. New
-// Submit calls return errBatcherClosed immediately.
+// Close stops accepting new requests and waits — bounded by ctx — for in-flight flush
+// goroutines to drain. New Submit calls return errBatcherClosed.
 //
 // Closing drainCh tells in-flight retry loops to stop at their next retry boundary,
 // so a flush that would otherwise spend GIT_OP_TIMEOUT × GIT_MAX_ATTEMPTS on an
 // unreachable remote instead resolves its requests with errWritebackDraining after
-// the attempt in flight. That is what makes the bounded wait below usually
-// sufficient rather than a near-certain abandonment.
+// the attempt in flight.
 //
 // It is not a hard bound, in two ways. One attempt is itself capped only by
 // GIT_OP_TIMEOUT (90s by default), which exceeds a typical shutdown budget, so a
 // flush already blocked on a slow remote can outlive ctx. And drainCh is observed
 // only at a retry boundary, never by flushLoop, so batches still queued behind a busy
 // key each get one more full attempt — the drain bounds the retry budget per batch,
-// not the number of queued batches. What the drain reliably removes is the multiplier
-// (attempts per batch), which is what made abandonment near-certain before.
+// not the number of queued batches.
 //
 // Requests abandoned when ctx expires are safe only because Run returns immediately
 // afterwards and the process exits. Do not reuse Close in a context where the process
@@ -210,11 +197,6 @@ func (b *Batcher) deliverAll(batch []*batchWriteRequest, err error) {
 // Deliberately NOT done: having flushLoop resolve every queued batch on sight of the
 // drain. That would discard write-backs that would have succeeded on their first
 // attempt, trading a real commit for a faster shutdown.
-//
-// The wait is still bounded so shutdown cannot exceed the caller's grace period. When
-// ctx expires first, Close returns and the still-running flushes are abandoned (they
-// end when the process does) — the same outcome a hung unbounded drain would force,
-// but without blocking termination.
 //
 // Close is safe to call more than once.
 func (b *Batcher) Close(ctx context.Context) {

--- a/internal/argocd/batcher_test.go
+++ b/internal/argocd/batcher_test.go
@@ -62,7 +62,7 @@ func TestBatcher_IdleKeyFlushesImmediately(t *testing.T) {
 
 	started := make(chan int, 1)
 	release := make(chan struct{})
-	close(release) // never block
+	close(release)
 	b.flushFn = gatedFlush(started, release, nil)
 
 	require.NoError(t, b.Submit(newBatchReq("repo", "main")))
@@ -78,11 +78,9 @@ func TestBatcher_CoalescesRequestsDuringInFlightFlush(t *testing.T) {
 	b.flushFn = gatedFlush(started, release, nil)
 
 	done := make(chan error, 3)
-	// First request: idle key, its flush starts immediately and blocks on release.
 	go func() { done <- b.Submit(newBatchReq("repo", "main")) }()
 	assert.Equal(t, 1, <-started, "req1 flushes alone")
 
-	// Two more arrive while flush #1 is in flight: they coalesce into pending.
 	go func() { done <- b.Submit(newBatchReq("repo", "main")) }()
 	go func() { done <- b.Submit(newBatchReq("repo", "main")) }()
 	waitForPendingLen(t, b, key, 2)
@@ -115,13 +113,11 @@ func TestBatcher_SizeCapBoundsFlush(t *testing.T) {
 		}
 	}
 
-	// First request starts an immediate flush that blocks on release.
 	r0 := newBatchReq("repo", "main")
 	done := make(chan error, 5)
 	go func() { done <- b.Submit(r0) }()
 	assert.Equal(t, 1, <-started)
 
-	// Four more coalesce while flush #1 is in flight.
 	rest := make([]*batchWriteRequest, 4)
 	for i := range rest {
 		rest[i] = newBatchReq("repo", "main")
@@ -131,7 +127,6 @@ func TestBatcher_SizeCapBoundsFlush(t *testing.T) {
 	waitForPendingLen(t, b, key, 4)
 
 	close(release)
-	// The 4 queued are drained in caps of 2: two flushes of size 2.
 	assert.Equal(t, 2, <-started)
 	assert.Equal(t, 2, <-started)
 	for i := 0; i < 5; i++ {
@@ -159,7 +154,6 @@ func TestBatcher_FanOutDeliversPerRequestOutcome(t *testing.T) {
 	b.flushFn = func(batch []*batchWriteRequest) {
 		started <- len(batch)
 		<-release
-		// Deliver a distinct outcome per request by position.
 		for i, req := range batch {
 			if i == 1 {
 				req.resultCh <- errForSecond
@@ -340,7 +334,7 @@ func TestBatcher_CloseSignalsDrain(t *testing.T) {
 	}
 
 	b.Close(context.Background())
-	b.Close(context.Background()) // must not panic on a second close
+	b.Close(context.Background())
 
 	select {
 	case <-b.drainCh:

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -29,8 +29,8 @@ var errForceRetry = errors.New("force retry")
 // Degraded after the task's images landed, which makes the failure terminal. Like errForceRetry it
 // must never reach the user-visible task status: any error escaping WaitRollout is reported through
 // HandleArgoAPIFailure, which blames ArgoCD's API and carries no diagnostics. WaitRollout therefore
-// swallows it so the caller reports the degraded rollout together with its resource-level cause
-// (a failed hook, a crashlooping pod) instead.
+// swallows it so the caller reports the degraded rollout together with its resource-level
+// cause instead.
 var errAppDegraded = errors.New("application has degraded")
 
 // errTaskSuperseded is an internal sentinel returned by the poll loop when the task
@@ -105,9 +105,9 @@ func (monitor *DeploymentMonitor) ObserveDeploymentDuration(app string, seconds 
 	monitor.argo.metrics.ObserveDeploymentDuration(app, seconds)
 }
 
-// resolveRefresh reports whether this task's status check should request an ArgoCD refresh.
-// A per-task Refresh override wins over the instance-wide default; a nil override (field omitted
-// by the client) keeps the default, so old clients behave exactly as before (issue #334).
+// resolveRefresh reports whether this task's status check should request an ArgoCD
+// refresh. A per-task Refresh override wins over the instance-wide default; a nil
+// override (field omitted by the client) keeps the default (issue #334).
 func (monitor *DeploymentMonitor) resolveRefresh(task models.Task) bool {
 	if task.Refresh != nil {
 		return *task.Refresh
@@ -216,11 +216,8 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 		return checkRolloutStatus(task, app, status)
 	}, retryOptions...)
 
-	// Whenever the loop ends with the app's real rollout state already observed, surface the last
-	// successfully-fetched application instead of the internal sentinel or the context error, so the
-	// caller can report that status (e.g. "not synced", "not healthy", "degraded") to the user.
-	// If no fetch ever succeeded (application is nil), the error is returned so the caller can classify
-	// the underlying failure (e.g. connection refused -> aborted).
+	// A nil application means no fetch ever succeeded, so the error is returned as-is for
+	// the caller to classify (e.g. connection refused -> aborted).
 	if application != nil && rolloutStateAlreadyObserved(err) {
 		err = nil
 	}
@@ -240,9 +237,7 @@ func rolloutStateAlreadyObserved(err error) bool {
 		errors.Is(err, context.Canceled)
 }
 
-// configureRetryOptions derives retry attempts by preferring per-task overrides, then monitor defaults, and finally a legacy retry window aligned with the current retry delay.
-//
-// Alongside the retry options it returns the wall-clock deadline for the whole polling loop,
+// configureRetryOptions returns the wall-clock deadline for the whole polling loop,
 // computed as attempts*delay. The attempt count still caps the number of polls, while the
 // deadline caps the elapsed time so that slow API responses cannot stretch the loop past the
 // intended timeout (see WaitRollout).
@@ -260,15 +255,14 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 
 	defaultAttempts := monitor.defaultAttempts
 	if defaultAttempts == 0 {
-		// Legacy fallback: legacyRetryIntervals steps at ArgoSyncRetryDelay pace, scaled to the current delay.
 		fallbackWindow := time.Duration(legacyRetryIntervals) * ArgoSyncRetryDelay
 		defaultAttempts = helpers.SafeIntToUint(helpers.CeilDivDuration(fallbackWindow, delay))
 	}
 
 	if task.Timeout <= 0 {
-		// A zero timeout is the norm: the field is omitted whenever a client leaves TASK_TIMEOUT
-		// unset, so it stays at debug. A negative one can only come from a malformed request and
-		// is worth surfacing.
+		// A zero timeout is the norm: the field is omitted whenever a client leaves
+		// TASK_TIMEOUT unset, so it stays at debug. A negative one can only come from a
+		// malformed request.
 		if task.Timeout < 0 {
 			slog.Warn("Ignoring negative task timeout, falling back to the instance default",
 				"timeout_seconds", task.Timeout, "attempts", defaultAttempts, "id", task.Id)
@@ -388,7 +382,6 @@ func (monitor *DeploymentMonitor) fetchResourceTree(task *models.Task) *models.A
 	return tree
 }
 
-// handleApplicationFetchError ensures we don't retry for not found errors
 func handleApplicationFetchError(task models.Task, err error) error {
 	if task.IsAppNotFoundError(err) {
 		return retry.Unrecoverable(err)
@@ -407,9 +400,8 @@ func shouldValidateDesiredImages(app *models.Application, status string) bool {
 }
 
 // validateDesiredImages returns an *ImageNotPartOfAppError when an expected image is
-// provably absent from the application's desired state. Every uncertainty — the app
-// opted out, the lookup failed, or no images could be read — returns nil so the rollout
-// keeps polling; only positive proof of absence fails the task.
+// provably absent from the application's desired state. Every uncertainty returns nil so
+// the rollout keeps polling; only positive proof of absence fails the task.
 func (monitor *DeploymentMonitor) validateDesiredImages(ctx context.Context, task models.Task, app *models.Application) error {
 	if app.IsImageValidationSkipped() {
 		return nil
@@ -438,7 +430,9 @@ func (monitor *DeploymentMonitor) validateDesiredImages(ctx context.Context, tas
 	return nil
 }
 
-// checkRolloutStatus checks if the application completed rollout successfully
+// checkRolloutStatus returns nil when the rollout succeeded, errForceRetry while it is
+// not yet final, and errAppDegraded when it settled Degraded with the task's images
+// already applied — i.e. the image hash moved off the saved initial one.
 func checkRolloutStatus(task models.Task, application *models.Application, status string) error {
 	switch status {
 	case models.ArgoRolloutAppDegraded:
@@ -457,7 +451,6 @@ func checkRolloutStatus(task models.Task, application *models.Application, statu
 	return errForceRetry
 }
 
-// determineFailureStatus converts API errors into appropriate status messages
 func determineFailureStatus(task models.Task, err error) string {
 	if task.IsAppNotFoundError(err) {
 		return models.StatusAppNotFoundMessage

--- a/internal/argocd/git_updater.go
+++ b/internal/argocd/git_updater.go
@@ -24,9 +24,7 @@ type GitUpdater struct {
 	batcher *Batcher
 }
 
-// NewGitUpdater creates a GitUpdater instance. metrics may be nil, in which case
-// duration observation is skipped. batcher may be nil to use the serialized
-// single-app write-back path; when non-nil, write-backs are routed through it.
+// NewGitUpdater creates a GitUpdater instance.
 func NewGitUpdater(locker lock.Locker, repoCachePath string, metrics prometheus.MetricsInterface, batcher *Batcher) *GitUpdater {
 	return &GitUpdater{
 		locker:        locker,
@@ -37,14 +35,13 @@ func NewGitUpdater(locker lock.Locker, repoCachePath string, metrics prometheus.
 }
 
 // Close releases resources held by the updater, draining any in-flight batch
-// write-backs bounded by ctx. It is a no-op when batching is disabled.
+// write-backs bounded by ctx.
 func (gitUpdater *GitUpdater) Close(ctx context.Context) {
 	if gitUpdater.batcher != nil {
 		gitUpdater.batcher.Close(ctx)
 	}
 }
 
-// observeLockWait records how long a task waited to acquire the per-repo lock.
 func (gitUpdater *GitUpdater) observeLockWait(app string, d time.Duration) {
 	if gitUpdater.metrics != nil {
 		gitUpdater.metrics.ObserveGitLockWaitDuration(app, d.Seconds())
@@ -74,9 +71,8 @@ func (gitUpdater *GitUpdater) UpdateIfNeeded(app *models.Application, task model
 		return err
 	}
 
-	// Batch mode routes the write-back through the coalescing batcher instead of
-	// taking the per-repo lock directly. The batcher owns the lock, clone, commit,
-	// and push for the whole batch.
+	// In batch mode the batcher owns the lock, clone, commit and push for the
+	// whole batch, so the per-repo lock is not taken here.
 	if gitUpdater.batcher != nil {
 		return gitUpdater.updateViaBatcher(app, &task, &gitopsRepo, isSuperseded...)
 	}
@@ -128,9 +124,8 @@ func (gitUpdater *GitUpdater) updateViaBatcher(app *models.Application, task *mo
 }
 
 func (gitUpdater *GitUpdater) updateGitRepo(app *models.Application, task *models.Task, gitopsRepo *models.GitopsRepo, isSuperseded ...func() bool) error {
-	// context.Background() is intentional: the call stack above this point
-	// does not carry a context. Propagating a cancellable context from
-	// WaitForRollout is a future improvement.
+	// context.Background() is intentional: the call stack above this point does
+	// not carry a context.
 	err := UpdateGitImageTag(context.Background(), app, task, gitopsRepo, updater.GitClient{}, isSuperseded...)
 	if err != nil {
 		slog.Error("Failed to update git repo", "error", err, "id", task.Id)

--- a/internal/argocd/git_writeback.go
+++ b/internal/argocd/git_writeback.go
@@ -14,10 +14,9 @@ import (
 )
 
 // ErrDeploymentSuperseded is returned by the git write-back when the task is
-// found to be superseded by a newer deployment for the same app. The retry loop
-// re-checks this before each attempt and aborts rather than committing a stale
-// image tag — so a larger retry budget cannot let an older deployment win over a
-// newer one. Callers treat it as "cancelled", not a failure.
+// superseded by a newer deployment for the same app, so a larger retry budget
+// cannot let an older deployment win over a newer one. Callers treat it as
+// "cancelled", not a failure.
 var ErrDeploymentSuperseded = errors.New("deployment superseded before write-back; aborting to avoid committing a stale image tag")
 
 const (
@@ -25,10 +24,8 @@ const (
 	managedImageTagPattern  = "argo-watcher/%s.helm.image-tag"
 )
 
-// generateOverrideFileContent builds the Helm override file for the task's
-// managed images from the app's annotations. It returns nil (no error) when no
-// managed images are declared, and errors if a managed image is missing its
-// tag-path annotation.
+// generateOverrideFileContent builds the Helm override file for the task's managed
+// images. It returns nil (no error) when no managed images are declared.
 func generateOverrideFileContent(annotations map[string]string, task *models.Task) (*updater.ArgoOverrideFile, error) {
 	overrideFileContent := updater.ArgoOverrideFile{}
 	managedImages, err := extractManagedImages(annotations)
@@ -47,10 +44,9 @@ func generateOverrideFileContent(annotations map[string]string, task *models.Tas
 				tagAnnotation := fmt.Sprintf(managedImageTagPattern, appAlias)
 				tagPath, exists := annotations[tagAnnotation]
 				if !exists {
-					// The image is declared managed but has no tag-path annotation, so
-					// we cannot know which Helm value to override. Silently skipping here
-					// would let the write-back report success while never updating git;
-					// fail loudly so the misconfiguration surfaces on the task instead.
+					// Without the tag-path annotation we cannot know which Helm value to
+					// override. Silently skipping would let the write-back report success
+					// while never updating git, so fail loudly instead.
 					return nil, fmt.Errorf("managed image %q (alias %q) is missing its %s annotation", appImage, appAlias, tagAnnotation)
 				}
 				overrideFileContent.Helm.Parameters = append(overrideFileContent.Helm.Parameters, updater.ArgoParameterOverride{
@@ -68,15 +64,13 @@ func generateOverrideFileContent(annotations map[string]string, task *models.Tas
 // UpdateGitImageTag writes the new image tag for app into the GitOps repository.
 // gitHandler is injected to enable testing; production callers pass updater.GitClient{}.
 //
-// ctx is propagated into the retry loop and each per-attempt context so that
-// a caller can cancel in-flight git operations (e.g. on graceful shutdown).
+// Cancelling ctx cancels in-flight git operations (e.g. on graceful shutdown).
 // Production callers that lack a context chain may pass context.Background()
 // until a proper context is wired through the call stack.
 //
 // isSuperseded is an optional (at most one) predicate re-checked before each
 // write-back attempt; when it returns true the loop aborts with
-// ErrDeploymentSuperseded instead of committing, so a newer deployment for the
-// same app is never overwritten by an older one that keeps retrying.
+// ErrDeploymentSuperseded instead of committing.
 func UpdateGitImageTag(ctx context.Context, app *models.Application, task *models.Task, gitopsRepo *models.GitopsRepo, gitHandler updater.GitHandler, isSuperseded ...func() bool) error {
 	if gitopsRepo.Path == "" {
 		slog.Warn("No path found for app, unsupported Application configuration", "app", app.Metadata.Name, "id", task.Id)
@@ -118,10 +112,7 @@ const (
 )
 
 // gitUpdateBackoff returns the delay before the next retry, given the 1-based
-// number of the attempt that just failed. It computes base*2^(attempt-1),
-// capped at gitUpdateMaxBackoff, then applies full jitter (a uniform random
-// value in [0, ceiling]). Full jitter keeps early retries tight — the key to
-// winning a push race under sustained concurrent-writer contention — and also
+// number of the attempt that just failed. The full jitter it applies also
 // de-synchronises multiple argo-watcher instances contending on one repo.
 func gitUpdateBackoff(attempt uint) time.Duration {
 	ceiling := gitUpdateBaseBackoff << (attempt - 1)
@@ -136,32 +127,23 @@ func gitUpdateBackoff(attempt uint) time.Duration {
 	return time.Duration(rand.Int63n(int64(ceiling) + 1)) // NOSONAR: pseudorandom is safe here (retry jitter, not a security context)
 }
 
-// runGitUpdateWithRetry runs the clone+update sequence with per-attempt
-// bounded contexts and a fixed-backoff retry loop. The final attempt always
-// invalidates the on-disk cache before running so a poisoned cache (partial
-// commit, stale ref, half-written file) is replaced by a fresh clone and
-// self-heals without operator intervention — regardless of the attempt count.
+// runGitUpdateWithRetry runs the clone+update sequence with per-attempt bounded
+// contexts and a retry loop. The final attempt always invalidates the on-disk cache,
+// so a poisoned cache (partial commit, stale ref, half-written file) self-heals.
 //
-// Each attempt derives its context from parentCtx via WithTimeout(opTimeout),
-// so one stuck attempt cannot consume the budget of subsequent attempts. If
-// parentCtx is already cancelled, the loop exits early without sleeping.
-// The total worst-case wall clock is GitOpTimeout * GitMaxAttempts plus the
-// sum of the inter-attempt backoffs, each bounded by gitUpdateMaxBackoff.
+// One stuck attempt cannot consume the budget of subsequent attempts. If parentCtx
+// is already cancelled, the loop exits early without sleeping. The total worst-case
+// wall clock is GitOpTimeout * GitMaxAttempts plus the sum of the inter-attempt
+// backoffs, each bounded by gitUpdateMaxBackoff.
 //
-// Permanent errors (see updater.IsPermanent) short-circuit the loop — for
-// example, a bad SSH key or auth failure will fail the same way on every
-// attempt and retrying just wastes the budget.
+// Permanent errors (see updater.IsPermanent) short-circuit the loop — a bad SSH key
+// or auth failure fails the same way on every attempt.
 func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, appName string, releaseOverrides *updater.ArgoOverrideFile, task *models.Task, isSuperseded func() bool) error {
 	maxAttempts := repo.GitMaxAttempts()
 	opTimeout := repo.GitOpTimeout()
 
 	var lastErr error
 	for attempt := uint(1); attempt <= maxAttempts; attempt++ {
-		// Abort before touching git if a newer deployment for the same app has
-		// superseded this task. Re-checked every attempt (not just once up front)
-		// so a task that keeps retrying under contention cannot commit a stale tag
-		// on top of a newer one — the correctness guard that makes a larger retry
-		// budget safe.
 		if isSuperseded != nil && isSuperseded() {
 			slog.Info("Git update aborted: task superseded by a newer deployment", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
 			return ErrDeploymentSuperseded
@@ -191,9 +173,6 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 	return fmt.Errorf("git update failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
-// invalidateCacheOnFinalAttempt clears the on-disk cache before the final
-// attempt so a poisoned cache (partial commit, stale ref, half-written file) is
-// replaced by a fresh clone and self-heals without operator intervention.
 func invalidateCacheOnFinalAttempt(repo *updater.GitRepo, task *models.Task, attempt, maxAttempts uint) {
 	if attempt != maxAttempts {
 		return
@@ -204,9 +183,6 @@ func invalidateCacheOnFinalAttempt(repo *updater.GitRepo, task *models.Task, att
 	}
 }
 
-// backoffBeforeRetry waits (jittered) before the next attempt, unless this was
-// the final one. It returns a non-nil error only if parentCtx is cancelled
-// during the wait, signalling the caller to stop retrying.
 func backoffBeforeRetry(parentCtx context.Context, task *models.Task, attemptErr error, attempt, maxAttempts uint) error {
 	if attempt >= maxAttempts {
 		return nil
@@ -221,11 +197,7 @@ func backoffBeforeRetry(parentCtx context.Context, task *models.Task, attemptErr
 	}
 }
 
-// runGitUpdateAttempt performs one clone+update cycle. It derives a per-attempt
-// context from parentCtx bounded by opTimeout, so a hung network call is
-// capped at opTimeout while still honouring cancellation from the parent.
-// Errors are returned wrapped with the failed phase so the retry loop's logs
-// indicate where the attempt failed.
+// runGitUpdateAttempt performs one clone+update cycle, bounded by opTimeout.
 func runGitUpdateAttempt(parentCtx context.Context, repo *updater.GitRepo, opTimeout time.Duration, appName string, releaseOverrides *updater.ArgoOverrideFile, task *models.Task) error {
 	ctx, cancel := context.WithTimeout(parentCtx, opTimeout)
 	defer cancel()
@@ -241,8 +213,7 @@ func runGitUpdateAttempt(parentCtx context.Context, repo *updater.GitRepo, opTim
 	return nil
 }
 
-// extractManagedImages extracts the managed images from the application's annotations.
-// It returns a map of the managed images, where the key is the application alias and the value is the image name.
+// extractManagedImages maps each application alias from the annotations to its image name.
 func extractManagedImages(annotations map[string]string) (map[string]string, error) {
 	managedImages := map[string]string{}
 

--- a/internal/argocd/git_writeback_backoff_test.go
+++ b/internal/argocd/git_writeback_backoff_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/shini4i/argo-watcher/internal/updater"
 )
 
-// retryingGitHandler returns a MockGitHandler that drives runGitUpdateWithRetry
-// without a real remote: PlainOpen reports no cache so Clone takes the
-// fresh-clone path, AddSSHKey succeeds, and PlainClone returns cloneErr exactly
-// wantClones times. The Times(wantClones) expectation verifies how many attempts
-// actually reached the clone, replacing a manual counter.
+// retryingGitHandler returns a MockGitHandler whose PlainClone always fails with
+// cloneErr. The Times(wantClones) expectation fails the test at controller finish
+// unless exactly that many attempts reached the clone.
 func retryingGitHandler(ctrl *gomock.Controller, cloneErr error, wantClones int) *mocks.MockGitHandler {
 	h := mocks.NewMockGitHandler(ctrl)
 	h.EXPECT().PlainOpen(gomock.Any()).Return(nil, git.ErrRepositoryNotExists).AnyTimes()
@@ -30,7 +28,6 @@ func retryingGitHandler(ctrl *gomock.Controller, cloneErr error, wantClones int)
 	return h
 }
 
-// gitTestRepo builds a GitopsRepo pointing at a throwaway cache dir.
 func gitTestRepo(t *testing.T) *models.GitopsRepo {
 	return &models.GitopsRepo{
 		RepoUrl:       "git@example.com:test/repo.git",
@@ -41,19 +38,15 @@ func gitTestRepo(t *testing.T) *models.GitopsRepo {
 }
 
 // TestGitUpdateSupersededOnLaterAttempt proves the supersession guard is
-// re-checked on a LATER attempt, not just once up front: attempt 1 proceeds
-// (reaches the clone) and fails transiently; the predicate flips to true before
-// attempt 2, which must abort with ErrDeploymentSuperseded before cloning again.
+// re-checked on a LATER attempt, not just once up front.
 func TestGitUpdateSupersededOnLaterAttempt(t *testing.T) {
 	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
 	t.Setenv("GIT_OP_TIMEOUT", "5s")
 	t.Setenv("GIT_MAX_ATTEMPTS", "5")
 
-	// attempt 1 reaches the clone (Times(1)); the guard fires on attempt 2 before
-	// any second clone, which gomock verifies at controller finish.
 	h := retryingGitHandler(gomock.NewController(t), errors.New("transient clone failure"), 1)
 	checks := 0
-	supersede := func() bool { checks++; return checks >= 2 } // false on attempt 1, true on attempt 2
+	supersede := func() bool { checks++; return checks >= 2 }
 
 	err := UpdateGitImageTag(
 		context.Background(), newAppWithImages("test-app"), newImageTask(), gitTestRepo(t), h, supersede,
@@ -62,16 +55,11 @@ func TestGitUpdateSupersededOnLaterAttempt(t *testing.T) {
 	require.ErrorIs(t, err, ErrDeploymentSuperseded)
 }
 
-// TestGitUpdateExhaustsRetries covers the multi-attempt retry mechanics on the
-// changed loop: a transient error on every attempt exhausts the budget and the
-// error wraps with the attempt count.
 func TestGitUpdateExhaustsRetries(t *testing.T) {
 	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
 	t.Setenv("GIT_OP_TIMEOUT", "5s")
 	t.Setenv("GIT_MAX_ATTEMPTS", "3")
 
-	// all 3 attempts must reach the clone when every one fails transiently;
-	// Times(3) enforces that at controller finish.
 	h := retryingGitHandler(gomock.NewController(t), errors.New("transient clone failure"), 3)
 
 	err := UpdateGitImageTag(
@@ -82,11 +70,8 @@ func TestGitUpdateExhaustsRetries(t *testing.T) {
 	assert.Contains(t, err.Error(), "git update failed after 3 attempts")
 }
 
-// TestUpdateGitImageTagSupersededGuard verifies the write-back aborts with
-// ErrDeploymentSuperseded — before touching git — when the supersede predicate
-// returns true, and does NOT abort with that error when it returns false. This
-// is what keeps a larger retry budget from letting an older deployment overwrite
-// a newer one.
+// TestUpdateGitImageTagSupersededGuard covers the guard that keeps a larger retry
+// budget from letting an older deployment overwrite a newer one.
 func TestUpdateGitImageTagSupersededGuard(t *testing.T) {
 	// SSH_KEY_PATH need only be set (not exist) for config load; the guard fires
 	// before the key is ever read, so a nonexistent path is fine here.
@@ -114,18 +99,15 @@ func TestUpdateGitImageTagSupersededGuard(t *testing.T) {
 			context.Background(), newAppWithImages("test-app"), newImageTask(), repo(t), updater.GitClient{},
 			func() bool { return false },
 		)
-		require.Error(t, err) // fails on the missing SSH key, having passed the guard
+		require.Error(t, err)
 		assert.NotErrorIs(t, err, ErrDeploymentSuperseded)
 	})
 }
 
-// TestGitUpdateBackoff verifies the retry backoff is capped-exponential with
-// full jitter: every sample stays within [0, ceiling] where the ceiling grows
-// with the attempt number until it saturates at gitUpdateMaxBackoff. Fast early
-// retries are what let the write-back win a git push race against a competing
-// writer before it advances the branch again.
+// TestGitUpdateBackoff verifies the retry backoff is capped-exponential with full
+// jitter. Fast early retries are what let the write-back win a git push race
+// against a competing writer before it advances the branch again.
 func TestGitUpdateBackoff(t *testing.T) {
-	// ceiling(attempt) = min(gitUpdateMaxBackoff, base * 2^(attempt-1))
 	ceiling := func(attempt uint) time.Duration {
 		c := gitUpdateBaseBackoff << (attempt - 1)
 		if c <= 0 || c > gitUpdateMaxBackoff {
@@ -153,11 +135,9 @@ func TestGitUpdateBackoff(t *testing.T) {
 		}
 	}
 
-	// The ceiling must actually grow early on (fast first retry, slower later).
 	if ceiling(1) >= ceiling(4) {
 		t.Fatalf("ceiling should increase: ceiling(1)=%s ceiling(4)=%s", ceiling(1), ceiling(4))
 	}
-	// And saturate at the cap.
 	if ceiling(12) != gitUpdateMaxBackoff {
 		t.Fatalf("ceiling(12)=%s, want cap %s", ceiling(12), gitUpdateMaxBackoff)
 	}

--- a/internal/argocd/git_writeback_batch.go
+++ b/internal/argocd/git_writeback_batch.go
@@ -80,7 +80,7 @@ func runBatchWriteBack(parentCtx context.Context, repo *updater.GitRepo, batch [
 			lastErr = err
 		}
 		if recordAttempt(batch, committed, outcomes, err, attempt, maxAttempts) {
-			break // permanent failure — retrying cannot help
+			break
 		}
 
 		// Keep retrying while anything is unresolved — a failed/pending push or a
@@ -106,9 +106,7 @@ func runBatchWriteBack(parentCtx context.Context, repo *updater.GitRepo, batch [
 	return outcomes
 }
 
-// recordAttempt applies one attempt's result to outcomes: on success it marks the
-// committed apps resolved; on a permanent error it fails every still-unresolved
-// app (retrying cannot help). It returns true when the retry loop must stop.
+// recordAttempt returns true when the retry loop must stop.
 func recordAttempt(batch, committed []*batchWriteRequest, outcomes map[*batchWriteRequest]error, err error, attempt, maxAttempts uint) bool {
 	if err == nil {
 		for _, req := range committed {
@@ -125,13 +123,10 @@ func recordAttempt(batch, committed []*batchWriteRequest, outcomes map[*batchWri
 	return false
 }
 
-// runBatchAttempt performs one clone + per-app commit + single push cycle. It
-// resolves outcomes[req] for terminally-resolved apps and records retriable per-app
-// commit errors in commitErrs (leaving those requests unresolved), returning the
-// requests that produced a local commit this attempt — whose fate depends on the
-// push. The returned error is non-nil when the clone or push failed; the caller
-// decides whether it is permanent or retriable. On a nil error every returned
-// committed request pushed successfully.
+// runBatchAttempt performs one clone + per-app commit + single push cycle. The
+// requests it returns produced a local commit this attempt — their fate still depends
+// on the push. Whether a returned error is permanent or retriable is the caller's
+// decision.
 func runBatchAttempt(parentCtx context.Context, repo *updater.GitRepo, opTimeout time.Duration, active []*batchWriteRequest, outcomes, commitErrs map[*batchWriteRequest]error) ([]*batchWriteRequest, error) {
 	ctx, cancel := context.WithTimeout(parentCtx, opTimeout)
 	defer cancel()
@@ -158,12 +153,10 @@ func runBatchAttempt(parentCtx context.Context, repo *updater.GitRepo, opTimeout
 	return committed, nil
 }
 
-// applyRequest resolves one request within a single attempt. It returns true when
-// the request produced a local commit (its fate then rides on the shared push).
-// Terminal outcomes are set for superseded / unsupported / generation cases; a
-// per-app commit error is recorded in commitErrs and the request is left
-// unresolved so the next attempt retries it — mirroring the single-app path, where
-// a commit failure is also retriable rather than fatal.
+// applyRequest returns true when the request produced a local commit (its fate then
+// rides on the shared push). A per-app commit error is recorded in commitErrs and the
+// request is left unresolved so the next attempt retries it — mirroring the single-app
+// path, where a commit failure is also retriable rather than fatal.
 func applyRequest(repo *updater.GitRepo, req *batchWriteRequest, outcomes, commitErrs map[*batchWriteRequest]error) bool {
 	// Re-check supersede every attempt so a task that keeps retrying under
 	// contention aborts the moment a newer deployment for the same app wins.
@@ -211,17 +204,14 @@ func applyRequest(repo *updater.GitRepo, req *batchWriteRequest, outcomes, commi
 	return true
 }
 
-// failUnresolved assigns err as the terminal outcome of every request without one.
 func failUnresolved(batch []*batchWriteRequest, outcomes map[*batchWriteRequest]error, err error) {
 	for _, req := range unresolvedRequests(batch, outcomes) {
 		outcomes[req] = err
 	}
 }
 
-// resolveRemaining assigns a final error to every request still unresolved after
-// the retry loop ends (exhausted attempts, a cancelled backoff, or a drain). A
-// per-app commit error takes precedence over the batch-level error so a persistently
-// misconfigured app reports its own cause.
+// resolveRemaining assigns a final error to every request still unresolved after the
+// retry loop ends (exhausted attempts, a cancelled backoff, or a drain).
 //
 // These errors become the task's stored failure reason, so two properties matter.
 // The attempt count is asserted only when the budget was actually spent — claiming
@@ -250,7 +240,7 @@ func resolveRemaining(batch []*batchWriteRequest, outcomes, commitErrs map[*batc
 
 // unresolvedRequests returns the requests in batch that do not yet have an outcome.
 // A nil value is a valid (successful) outcome, so resolution is tracked by key
-// presence, not by the value.
+// presence, not by value.
 func unresolvedRequests(batch []*batchWriteRequest, outcomes map[*batchWriteRequest]error) []*batchWriteRequest {
 	var active []*batchWriteRequest
 	for _, req := range batch {
@@ -261,9 +251,8 @@ func unresolvedRequests(batch []*batchWriteRequest, outcomes map[*batchWriteRequ
 	return active
 }
 
-// invalidateBatchCacheOnFinalAttempt clears the on-disk cache before the final
-// attempt so a poisoned cache self-heals with a fresh clone, mirroring the
-// single-app invalidateCacheOnFinalAttempt.
+// invalidateBatchCacheOnFinalAttempt mirrors the single-app
+// invalidateCacheOnFinalAttempt: a poisoned cache self-heals with a fresh clone.
 func invalidateBatchCacheOnFinalAttempt(repo *updater.GitRepo, batchSize int, attempt, maxAttempts uint) {
 	if attempt != maxAttempts {
 		return
@@ -275,11 +264,10 @@ func invalidateBatchCacheOnFinalAttempt(repo *updater.GitRepo, batchSize int, at
 	}
 }
 
-// backoffBeforeBatchRetry waits (jittered) before the next batch attempt, unless
-// this was the final one. It returns a non-nil error if parentCtx is cancelled or
-// the batcher starts draining during the wait, signalling the caller to stop
-// retrying. It reuses gitUpdateBackoff so batch and single-app retries share the
-// same anti-thundering-herd behaviour.
+// backoffBeforeBatchRetry waits (jittered) before the next batch attempt, unless this
+// was the final one. It returns a non-nil error if parentCtx is cancelled or the
+// batcher starts draining during the wait. It reuses gitUpdateBackoff so batch and
+// single-app retries share the same anti-thundering-herd behaviour.
 //
 // The drain is observed here — between attempts — rather than by cancelling the
 // per-attempt context, and that placement is the point. Cancelling mid-push would
@@ -288,8 +276,7 @@ func invalidateBatchCacheOnFinalAttempt(repo *updater.GitRepo, batchSize int, at
 // every reported outcome truthful, at the cost of one more in-flight attempt
 // (bounded by GIT_OP_TIMEOUT) before the drain completes.
 //
-// A nil drainCh (tests that pass no signal) blocks forever in the select, so the
-// backoff behaves exactly as it did before.
+// A nil drainCh (tests that pass no signal) blocks forever in the select.
 func backoffBeforeBatchRetry(parentCtx context.Context, attempt, maxAttempts uint, drainCh <-chan struct{}) error {
 	if attempt >= maxAttempts {
 		return nil

--- a/internal/argocd/git_writeback_batch_test.go
+++ b/internal/argocd/git_writeback_batch_test.go
@@ -27,9 +27,6 @@ func batchReqFor(app *models.Application, path string, superseded func() bool) *
 	}
 }
 
-// newBatchTestRepo builds a real *updater.GitRepo backed by the given mock handler,
-// so the batch retry loop runs against controllable Clone/Push behaviour without a
-// live remote.
 func newBatchTestRepo(t *testing.T, handler updater.GitHandler) *updater.GitRepo {
 	t.Helper()
 	repo, err := updater.NewGitRepo("git@example.com:test/repo.git", "main", "", "", t.TempDir(), handler)
@@ -66,8 +63,6 @@ func TestRunBatchWriteBack_ExhaustsRetriesResolvesEveryRequest(t *testing.T) {
 	}
 }
 
-// TestRunBatchWriteBack_PermanentErrorFailsAllImmediately verifies a permanent
-// error (auth failure) is not retried and fails every request in the batch at once.
 func TestRunBatchWriteBack_PermanentErrorFailsAllImmediately(t *testing.T) {
 	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
 	t.Setenv("GIT_OP_TIMEOUT", "5s")
@@ -91,10 +86,6 @@ func TestRunBatchWriteBack_PermanentErrorFailsAllImmediately(t *testing.T) {
 	}
 }
 
-// TestRunBatchWriteBack_MixedPerAppOutcomes proves per-app isolation and the
-// one-outcome-per-request invariant in a single successful clone attempt: a
-// superseded app aborts, an unmanaged (no path) app is a no-op success, and a
-// misconfigured app fails only itself — none poisons the others.
 func TestRunBatchWriteBack_MixedPerAppOutcomes(t *testing.T) {
 	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
 	t.Setenv("GIT_OP_TIMEOUT", "5s")
@@ -157,9 +148,6 @@ func TestRunBatchWriteBack_CommitErrorIsRetried(t *testing.T) {
 	assert.Contains(t, outcomes[req].Error(), "after 2 attempts", "the commit error must be retried, not terminal on attempt 1")
 }
 
-// TestRunBatchWriteBack_CancelledDuringBackoffResolvesEveryRequest verifies that a
-// context cancelled during the inter-attempt backoff stops the loop early and still
-// resolves every request with the cancellation error (never leaving one hanging).
 func TestRunBatchWriteBack_CancelledDuringBackoffResolvesEveryRequest(t *testing.T) {
 	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
 	t.Setenv("GIT_OP_TIMEOUT", "5s")

--- a/internal/argocd/git_writeback_test.go
+++ b/internal/argocd/git_writeback_test.go
@@ -124,7 +124,6 @@ func TestExtractManagedImages(t *testing.T) {
 	}
 }
 
-// newAppWithImages builds an Application with managed-image annotations for testing.
 func newAppWithImages(name string) *models.Application {
 	return &models.Application{
 		Metadata: models.ApplicationMetadata{
@@ -137,7 +136,6 @@ func newAppWithImages(name string) *models.Application {
 	}
 }
 
-// newImageTask builds a Task with a single image for testing.
 func newImageTask() *models.Task {
 	return &models.Task{
 		Id: "test-id",
@@ -357,7 +355,6 @@ func TestUpdateGitImageTag(t *testing.T) {
 		const branchName = "master"
 		const repoURL = "git@example.com:test/recovery-race.git"
 
-		// 1. Create a bare remote with an initial empty commit.
 		remotePath := t.TempDir()
 		sourcePath := t.TempDir()
 		sourceRepo, err := gogit.PlainInit(sourcePath, false)
@@ -465,7 +462,6 @@ func TestUpdateGitImageTag(t *testing.T) {
 		mockHandler := mocks.NewMockGitHandler(ctrl)
 		mockHandler.EXPECT().AddSSHKey(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, nil).AnyTimes()
-		// Both attempts fail at the clone step. Default cache-miss path on each.
 		mockHandler.EXPECT().PlainOpen(gomock.Any()).
 			Return(nil, gogit.ErrRepositoryNotExists).Times(2)
 		mockHandler.EXPECT().PlainClone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -485,7 +481,6 @@ func TestUpdateGitImageTag(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "git update failed after 2 attempts")
-		// Verify the original error is preserved through the wrap chain.
 		assert.Contains(t, err.Error(), "upstream unreachable")
 	})
 

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-// settledApp returns an application that finished rolling out without the expected image.
 func settledApp() *models.Application {
 	app := &models.Application{}
 	app.Status.Sync.Status = "Synced"
@@ -23,7 +22,6 @@ func settledApp() *models.Application {
 	return app
 }
 
-// managedResources wraps target-state manifests in a managed-resources response.
 func managedResources(manifests ...string) *models.ManagedResources {
 	resources := &models.ManagedResources{}
 	for _, manifest := range manifests {
@@ -32,7 +30,6 @@ func managedResources(manifests ...string) *models.ManagedResources {
 	return resources
 }
 
-// refreshMetrics returns a metrics mock tolerating the refresh timing a refreshed poll records.
 func refreshMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
 	metrics := mocks.NewMockMetricsInterface(ctrl)
 	metrics.EXPECT().ObserveRefreshDuration(gomock.Any(), gomock.Any()).AnyTimes()
@@ -112,7 +109,6 @@ func TestValidateDesiredImages(t *testing.T) {
 		assert.NoError(t, newMonitor(api, "").validateDesiredImages(context.Background(), cronTask, settledApp()))
 	})
 
-	// The task's Image may already carry a tag; only the repository name is compared.
 	t.Run("ignoresTagOnTheRequestedImage", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -230,8 +226,6 @@ func TestWaitRolloutFailsFastOnImageNotPartOfApp(t *testing.T) {
 	require.ErrorAs(t, err, &imageErr)
 }
 
-// TestWaitRolloutValidatesDesiredImagesOnce verifies an inconclusive lookup does not repeat
-// on every poll, and that the rollout keeps waiting.
 func TestWaitRolloutValidatesDesiredImagesOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -295,8 +289,6 @@ func TestWaitRolloutSkipsValidationWithoutRefresh(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestHandleImageNotPartOfApp pins the terminal wiring: the task is marked failed with the
-// actionable reason and the failure is counted.
 func TestHandleImageNotPartOfApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/argocd/integration_helpers_test.go
+++ b/internal/argocd/integration_helpers_test.go
@@ -38,8 +38,6 @@ const (
 	toxiproxyUpstrm  = "gitea:22" // resolved on the docker network shared by both services
 )
 
-// giteaEnv captures everything a test needs to push to an isolated Gitea repo
-// over SSH, with both direct (port 2222) and toxiproxy-fronted (port 12222) URLs.
 type giteaEnv struct {
 	User          string
 	Password      string
@@ -75,7 +73,6 @@ func setupGitea(t *testing.T) *giteaEnv {
 	stamp := time.Now().UnixNano()
 	user := fmt.Sprintf("u%d", stamp)
 	repoName := fmt.Sprintf("repo-%d", stamp)
-	// Generate a random password: 16 random bytes encoded as hex.
 	randBytes := make([]byte, 16)
 	_, _ = rand.Read(randBytes)
 	password := fmt.Sprintf("pass_%x", randBytes)
@@ -124,7 +121,6 @@ func setupGitea(t *testing.T) *giteaEnv {
 	}
 }
 
-// giteaAPIPost sends a JSON POST to Gitea with basic auth and asserts a 2xx response.
 func giteaAPIPost(t *testing.T, user, pass, path string, body map[string]any) {
 	t.Helper()
 	buf, err := json.Marshal(body)
@@ -141,8 +137,6 @@ func giteaAPIPost(t *testing.T, user, pass, path string, body map[string]any) {
 	require.Less(t, resp.StatusCode, 300, "gitea %s returned %d", path, resp.StatusCode)
 }
 
-// setupToxiproxy creates an SSH proxy listening on 12222 and forwarding to
-// gitea:22. Returns the proxy handle so tests can add/remove toxins.
 func setupToxiproxy(t *testing.T) *toxiclient.Proxy {
 	t.Helper()
 	waitForToxiproxy(t, 30*time.Second)

--- a/internal/argocd/push_race_integration_test.go
+++ b/internal/argocd/push_race_integration_test.go
@@ -106,10 +106,6 @@ func TestIntegration_PushRaceRecovery_WithLatencyInjection(t *testing.T) {
 		toxiclient.Attributes{"latency": 300})
 	require.NoError(t, err)
 
-	// The race window is timing-sensitive: on a slow runner the competitor may
-	// push before A's fetch completes, leaving the retry path unexercised.
-	// Retry the race-injection sequence up to maxAttempts times until PlainOpen
-	// is called >= 2 times (proving the retry loop re-entered Clone()).
 	const maxAttempts = 3
 	var lastOpens int32
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -171,8 +167,7 @@ func TestIntegration_PushRaceRecovery_WithLatencyInjection(t *testing.T) {
 // entirely on UpdateGitImageTag's retry loop to succeed.
 //
 // N=2 with GIT_MAX_ATTEMPTS pinned to 3 gives the slower writer two chances to
-// retry after losing the race — comfortably more than the single retry the
-// previous architecture afforded.
+// retry after losing the race.
 func TestIntegration_PushRaceRecovery_Concurrent(t *testing.T) {
 	waitForGitea(t, 60*time.Second)
 	env := setupGitea(t)
@@ -197,7 +192,7 @@ func TestIntegration_PushRaceRecovery_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			<-startCh // wait for the barrier release
+			<-startCh
 			start := time.Now()
 			errs[idx] = UpdateGitImageTag(
 				context.Background(),
@@ -217,7 +212,7 @@ func TestIntegration_PushRaceRecovery_Concurrent(t *testing.T) {
 			durations[idx] = time.Since(start)
 		}(i)
 	}
-	close(startCh) // release all writers at once
+	close(startCh)
 	wg.Wait()
 	totalWall := time.Since(started)
 
@@ -232,7 +227,6 @@ func TestIntegration_PushRaceRecovery_Concurrent(t *testing.T) {
 		assert.Less(t, d, 90*time.Second,
 			"goroutine %d took %s — retry loop or network call exceeded budget", i, d)
 	}
-	// Both writers + worst-case retries should complete within 90s wall clock.
 	assert.Less(t, totalWall, 90*time.Second,
 		"total wall clock %s exceeds 90s", totalWall)
 }
@@ -342,9 +336,6 @@ func TestIntegration_GitTimeoutEnforcement_ReturnsWithinBudget(t *testing.T) {
 	require.Error(t, a.err, "A should fail under the latency toxin")
 	require.Error(t, b.err, "B should fail once it acquires the lock")
 
-	// A is bounded by either the GIT_OP_TIMEOUT context (if the stall hits
-	// post-handshake) or the SSH library's handshake timeout. Either is
-	// acceptable; the only failure mode is unbounded hang.
 	assert.Less(t, a.dur, perTaskCeiling,
 		"A took %s — operation hung beyond SSH handshake timeout (%s)",
 		a.dur, perTaskCeiling)

--- a/internal/argocd/shallow_clone_integration_test.go
+++ b/internal/argocd/shallow_clone_integration_test.go
@@ -69,9 +69,6 @@ func localPresentCommitCount(t *testing.T, localRepoPath string) int {
 		count++
 		return nil
 	})
-	// The ONLY tolerated terminal error is running off the shallow boundary
-	// (the parent commit is absent locally). Any other error is a real failure
-	// that must not be silently swallowed into a falsely-low count.
 	if walkErr != nil {
 		require.ErrorIs(t, walkErr, plumbing.ErrObjectNotFound,
 			"commit walk failed for a reason other than the shallow boundary")
@@ -197,10 +194,8 @@ func TestIntegration_ShallowClone_UpgradeFromFullCache(t *testing.T) {
 		testGitHandler{},
 	)
 
-	// Invariant 1: the write-back succeeds against a pre-existing full cache.
 	require.NoError(t, err, "write-back must succeed against a pre-upgrade full-history cache")
 
-	// Invariant 2: the commit lands correctly on the remote.
 	_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
 	assert.Contains(t, content, "v1", "the upgrade write-back must commit the tag")
 
@@ -263,9 +258,6 @@ func TestIntegration_ShallowClone_WarmFetchOfExternallyAdvancedTip(t *testing.T)
 	require.NoError(t, writeBack("v2"),
 		"warm write-back must succeed against an externally-advanced tip")
 
-	// The pushed HEAD's tree must contain BOTH our v2 override AND the
-	// competitor's file — proving we committed on top of their tip rather than
-	// force-pushing over it.
 	_, overrideContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", overrideRel)
 	_, competitorContent := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master", "competitor.txt")
 	assert.Contains(t, overrideContent, "v2", "our v2 tag must be committed")
@@ -316,8 +308,6 @@ func TestIntegration_ShallowClone_SelfHealFreshClone(t *testing.T) {
 	require.NoError(t, writeBack("v1"), "first self-heal write-back should succeed")
 	require.NoError(t, writeBack("v2"), "second self-heal write-back should succeed")
 
-	// Two commits landed, stacked linearly on top of the base — the fresh
-	// re-clone between them neither lost v1 nor rewrote history.
 	assert.Equal(t, base+2, remoteCommitCount(t, env.DirectRepoURL, env.SSHKeyPath, "master"),
 		"each self-heal write-back must add exactly one commit, preserving prior history")
 
@@ -334,16 +324,9 @@ func TestIntegration_ShallowClone_SelfHealFreshClone(t *testing.T) {
 // a cold clone followed by repeated warm write-backs (fetch + hard reset +
 // commit + push) against the SAME cache directory.
 //
-// It asserts two independent things:
-//   - correctness: every write-back's commit lands on the remote, and an
-//     unchanged write-back is skipped — the warm path must work on a shallow repo;
-//   - shallowness: the cache is shallow after the cold clone AND stays shallow
-//     across warm fetches (go-git must not silently deepen to full history,
-//     which would defeat the whole point on a 100k-commit repo).
-//
-// Before Depth:1 is implemented this fails on the shallowness assertion (a full
-// clone has no shallow boundary); after, all assertions must hold, or shallow
-// clone does not fit our flow and must not ship.
+// It asserts both correctness (every write-back's commit lands, an unchanged one is
+// skipped) and shallowness: go-git must not silently deepen to full history across
+// warm fetches, which would defeat the whole point on a 100k-commit repo.
 func TestIntegration_ShallowClone_WarmCacheWriteBacks(t *testing.T) {
 	waitForGitea(t, 60*time.Second)
 	env := setupGitea(t)
@@ -385,10 +368,8 @@ func TestIntegration_ShallowClone_WarmCacheWriteBacks(t *testing.T) {
 		)
 	}
 
-	// The deterministic on-disk cache path the code will actually use.
 	localRepoPath := computeRepoCachePath(cachePath, env.DirectRepoURL, "master")
 
-	// (1) Cold clone + commit v1.
 	require.NoError(t, writeBack("v1"), "cold write-back should succeed")
 
 	shallowMarker := filepath.Join(localRepoPath, ".git", "shallow")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -158,8 +158,7 @@ func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, str
 	return false, rejectedErr
 }
 
-// ValidateStrategy restricts validation to a single allowed strategy header.
-// Only the strategy registered under allowedHeader is considered; all other headers are skipped.
+// ValidateStrategy restricts validation to the strategy registered under allowedHeader.
 func (a *Authenticator) ValidateStrategy(request *http.Request, allowedHeader string) (bool, error) {
 	if a == nil || request == nil {
 		return false, nil
@@ -188,8 +187,7 @@ func (a *Authenticator) Strategy(header string) (AuthStrategy, bool) {
 	return strategy, ok
 }
 
-// NewOIDCAuthService initializes a new OIDC authentication service using the given server config.
-// It validates the issuer URL and returns an error if the config is nil or the URL is malformed.
+// NewOIDCAuthService initializes an OIDC authentication service from the given server config.
 func NewOIDCAuthService(config *config.ServerConfig) (*OIDCAuthService, error) {
 	if config == nil {
 		return nil, fmt.Errorf("server config must not be nil")
@@ -207,16 +205,14 @@ func NewOIDCAuthService(config *config.ServerConfig) (*OIDCAuthService, error) {
 	return oidcAuthService, nil
 }
 
-// NewDeployTokenAuthService initializes a new deploy token authentication service.
-// Accepts a token string and returns a pointer to a DeployTokenAuthService.
+// NewDeployTokenAuthService initializes a deploy token authentication service.
 func NewDeployTokenAuthService(token string) *DeployTokenAuthService {
 	return &DeployTokenAuthService{
 		token: token,
 	}
 }
 
-// NewJWTAuthService initializes a new JWT authentication service.
-// It takes a secret key string and returns a pointer to a JWTAuthService.
+// NewJWTAuthService initializes a JWT authentication service.
 func NewJWTAuthService(secret string) *JWTAuthService {
 	return &JWTAuthService{
 		secretKey: []byte(secret),

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -93,7 +93,6 @@ func TestAuthenticatorValidateWithBearerPrefix(t *testing.T) {
 
 	request.Header.Set("Authorization", "Bearer trimmed-token")
 
-	// The "Bearer " prefix must be stripped before the strategy sees the token.
 	strategy := mocks.NewMockAuthStrategy(gomock.NewController(t))
 	strategy.EXPECT().Validate("trimmed-token").Return(true, nil).AnyTimes()
 
@@ -403,7 +402,6 @@ func TestAuthenticatorValidateStrategy(t *testing.T) {
 
 		request, err := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 		assert.NoError(t, err)
-		// Do not set the Authorization header
 
 		valid, validateErr := authenticator.ValidateStrategy(request, "Authorization")
 		assert.False(t, valid)
@@ -496,7 +494,6 @@ func TestAuthenticatorValidateStrategy(t *testing.T) {
 
 		request, err := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 		assert.NoError(t, err)
-		// Set both headers, but only ARGO_WATCHER_DEPLOY_TOKEN should be evaluated
 		request.Header.Set("Authorization", "jwt-token")
 		request.Header.Set("ARGO_WATCHER_DEPLOY_TOKEN", "deploy-token")
 
@@ -558,11 +555,9 @@ func TestNewAuthenticatorSkipsNilStrategies(t *testing.T) {
 		"ARGO_WATCHER_DEPLOY_TOKEN": NewDeployTokenAuthService("token"),
 	})
 
-	// The nil strategy should have been filtered out
 	_, found := authenticator.Strategy("Authorization")
 	assert.False(t, found)
 
-	// The non-nil strategy should be present
 	_, found = authenticator.Strategy("ARGO_WATCHER_DEPLOY_TOKEN")
 	assert.True(t, found)
 }

--- a/internal/auth/deployToken.go
+++ b/internal/auth/deployToken.go
@@ -2,17 +2,14 @@ package auth
 
 import "fmt"
 
-// DeployTokenAuthService is a struct that maintains and validates deploy tokens.
+// DeployTokenAuthService validates deploy tokens.
 type DeployTokenAuthService struct {
-	// token is the deploy token string used for validation.
 	token string
 }
 
-// Validate checks if the provided token matches the stored deploy token.
-// Returns a boolean indicating whether the token is valid, and an error
-// describing why when it is not. Note: this method is only invoked by the
-// authenticator with a non-empty token, so the failure mode is always
-// "wrong value", never "missing" — the wording reflects that.
+// Validate checks the provided token against the stored deploy token. The
+// authenticator only invokes it with a non-empty token, so the failure mode is
+// always "wrong value", never "missing" — the error wording reflects that.
 func (s *DeployTokenAuthService) Validate(token string) (bool, error) {
 	if s.token != token {
 		return false, fmt.Errorf("deploy token is invalid")

--- a/internal/auth/deployToken_test.go
+++ b/internal/auth/deployToken_test.go
@@ -20,9 +20,8 @@ func TestValidateDeployToken(t *testing.T) {
 		_, err := service.Validate("invalid_token")
 
 		assert.Error(t, err)
-		// The wording must reflect what actually happened: the strategy is
-		// only ever invoked with a non-empty token, so "missing or invalid"
-		// is misleading. Should clearly say the token is invalid.
+		// The strategy is only ever invoked with a non-empty token, so
+		// "missing or invalid" would be misleading wording.
 		assert.Contains(t, err.Error(), "invalid")
 		assert.NotContains(t, err.Error(), "missing")
 	})

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -30,7 +30,6 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 		return false, err
 	}
 
-	// Explicitly verify token validity after parsing
 	if !token.Valid {
 		return false, errors.New("invalid token")
 	}
@@ -44,7 +43,6 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 		return false, errors.New("missing exp claim")
 	}
 
-	// Validate "iat" (issued at) claim
 	if iatVal, ok := claims["iat"].(float64); ok {
 		if time.Now().Unix() < int64(iatVal) {
 			return false, errors.New("token used before issued")

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -12,7 +12,6 @@ func TestJWTAuthService(t *testing.T) {
 	secretKey := "test_secret_key"
 	service := &JWTAuthService{secretKey: []byte(secretKey)}
 
-	// Valid JWT
 	t.Run("valid JWT", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -23,7 +22,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.True(t, isValid)
 	})
 
-	// Empty token
 	t.Run("empty token", func(t *testing.T) {
 		isValid, err := service.Validate("")
 		assert.Error(t, err)
@@ -31,7 +29,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Malformed token
 	t.Run("malformed token", func(t *testing.T) {
 		isValid, err := service.Validate("invalid.token.format")
 		assert.Error(t, err)
@@ -39,14 +36,12 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Completely invalid token
 	t.Run("completely invalid token", func(t *testing.T) {
 		isValid, err := service.Validate("randomgarbage123")
 		assert.Error(t, err)
 		assert.False(t, isValid)
 	})
 
-	// Missing exp claim
 	t.Run("missing exp claim", func(t *testing.T) {
 		claims := jwt.MapClaims{}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -58,7 +53,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Expired JWT
 	t.Run("expired JWT", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(-time.Hour).Unix())}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -70,7 +64,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Invalid signing method
 	t.Run("invalid signing method", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}
 		token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
@@ -82,7 +75,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Token with invalid signature
 	t.Run("token with invalid signature", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -94,7 +86,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Token used before issued (iat in future)
 	t.Run("token used before issued", func(t *testing.T) {
 		claims := jwt.MapClaims{
 			"exp": float64(time.Now().Add(time.Hour).Unix()),
@@ -109,7 +100,6 @@ func TestJWTAuthService(t *testing.T) {
 		assert.False(t, isValid)
 	})
 
-	// Token used before allowed time (nbf in future)
 	t.Run("token used before allowed time", func(t *testing.T) {
 		claims := jwt.MapClaims{
 			"exp": float64(time.Now().Add(time.Hour).Unix()),

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -23,7 +23,6 @@ type userInfoResponse struct {
 	Groups   []string `json:"groups"`
 }
 
-// discoveryDocument is the subset of the OIDC discovery metadata we consume.
 type discoveryDocument struct {
 	UserinfoEndpoint string `json:"userinfo_endpoint"`
 }
@@ -294,8 +293,6 @@ func (o *OIDCAuthService) allowedToRollback(username string, groups []string) bo
 	return false
 }
 
-// closeBody closes an HTTP response body and logs any error, keeping the call
-// sites free of repeated deferred-close boilerplate.
 func closeBody(body io.ReadCloser) {
 	if err := body.Close(); err != nil {
 		slog.Error("error closing response body", "error", err)

--- a/internal/auth/oidc_cache.go
+++ b/internal/auth/oidc_cache.go
@@ -40,8 +40,6 @@ type validationCache struct {
 	entries map[string]cachedValidation
 }
 
-// newValidationCache builds a cache whose entries live for at most ttl. A
-// non-positive ttl yields a cache that stores nothing.
 func newValidationCache(ttl time.Duration) *validationCache {
 	return &validationCache{
 		ttl:     ttl,
@@ -49,14 +47,12 @@ func newValidationCache(ttl time.Duration) *validationCache {
 	}
 }
 
-// cacheKey derives the storage key for a token.
 func cacheKey(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])
 }
 
-// get returns the remembered decision for a token, or ok=false when there is
-// none or it has expired.
+// get returns ok=false when there is no remembered decision or it has expired.
 func (c *validationCache) get(token string) (cachedValidation, bool) {
 	if c == nil || c.ttl <= 0 {
 		return cachedValidation{}, false

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newOIDCTestServer spins up an httptest server that serves both the OIDC
-// discovery document and a userinfo endpoint. The discovery document advertises
-// this same server's /userinfo path, so the service resolves it via discovery
-// exactly as it would against a real provider. discoveryHits (optional) counts
-// discovery requests so tests can assert caching / retry behaviour.
+// The discovery document advertises this same server's /userinfo path, so the service
+// resolves it via discovery exactly as it would against a real provider. discoveryHits
+// (optional) counts discovery requests so tests can assert caching / retry behaviour.
 func newOIDCTestServer(t *testing.T, userinfoStatus int, userinfoBody string, discoveryHits *int32, failFirstDiscovery bool) *httptest.Server {
 	t.Helper()
 
@@ -65,7 +63,6 @@ func TestOIDCAuthService_Init(t *testing.T) {
 		assert.Equal(t, issuer, service.IssuerURL)
 		assert.Equal(t, "test", service.ClientId)
 		assert.IsType(t, &http.Client{}, service.client)
-		// Discovery is lazy: no userinfo URL is resolved during Init.
 		assert.Empty(t, service.userinfoURL)
 	})
 
@@ -115,9 +112,6 @@ func TestOIDCAuthService_Init(t *testing.T) {
 	})
 }
 
-// TestOIDCAuthService_Validate covers token validation through discovery-resolved
-// userinfo: privileged-group membership, invalid tokens, malformed responses, and
-// unreachable providers.
 func TestOIDCAuthService_Validate(t *testing.T) {
 	newService := func(t *testing.T, server *httptest.Server, groups []string) *OIDCAuthService {
 		t.Helper()
@@ -211,21 +205,17 @@ func TestOIDCAuthService_Validate(t *testing.T) {
 
 		service := newService(t, server, []string{"group1"})
 
-		// First attempt: discovery returns 500, so validation fails but nothing is cached.
 		ok, err := service.Validate("test")
 		assert.Error(t, err)
 		assert.False(t, ok)
 
-		// Second attempt: discovery succeeds and the token validates.
 		ok, err = service.Validate("test")
 		assert.NoError(t, err)
 		assert.True(t, ok)
 	})
 }
 
-// newCountingOIDCServer serves a working discovery document and a userinfo
-// endpoint that reports the given groups, counting userinfo requests so tests can
-// assert how often the provider is actually consulted.
+// Counts userinfo requests so tests can assert how often the provider is actually consulted.
 func newCountingOIDCServer(t *testing.T, groups string) (*httptest.Server, *int32) {
 	t.Helper()
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -28,8 +28,7 @@ const (
 	// transient failure (network error or 5xx) before giving up. Deployments
 	// can poll for many minutes, so a single blip must not abort the process.
 	maxTransientRetries = 3
-	// defaultRetryDelay is the fixed backoff between transient retries.
-	defaultRetryDelay = 2 * time.Second
+	defaultRetryDelay   = 2 * time.Second
 )
 
 type Watcher struct {
@@ -75,8 +74,6 @@ func credentialFrom(config *Config) credential {
 	}
 }
 
-// apply sets the credential on a request, leaving it untouched when no credential is
-// configured or the configured value is empty.
 func (c credential) apply(request *http.Request) {
 	if c.header == "" || c.value == "" {
 		return
@@ -118,8 +115,7 @@ func dropCredentialOnHostChange(request *http.Request, via []*http.Request) erro
 	return nil
 }
 
-// addTask adds a given task to the watcher, presenting the watcher's credential.
-// It returns the task ID or an error.
+// addTask presents the watcher's credential and returns the new task ID.
 func (watcher *Watcher) addTask(task models.Task) (string, error) {
 	requestBody, err := json.Marshal(task)
 	if err != nil {
@@ -174,8 +170,6 @@ func (watcher *Watcher) addTask(task models.Task) (string, error) {
 	return accepted.Id, nil
 }
 
-// getTaskStatus retrieves the status of the task identified by the given ID,
-// returning a TaskStatus or an error.
 func (watcher *Watcher) getTaskStatus(id string) (*models.TaskStatus, error) {
 	url := fmt.Sprintf("%s/api/v1/tasks/%s", watcher.baseUrl, id)
 	var taskStatus models.TaskStatus
@@ -185,8 +179,6 @@ func (watcher *Watcher) getTaskStatus(id string) (*models.TaskStatus, error) {
 	return &taskStatus, nil
 }
 
-// getWatcherConfig retrieves the watcher's server configuration,
-// returning a ServerConfig or an error.
 func (watcher *Watcher) getWatcherConfig() (*config.ServerConfig, error) {
 	url := fmt.Sprintf("%s/api/v1/config", watcher.baseUrl)
 	var serverConfig config.ServerConfig
@@ -196,8 +188,6 @@ func (watcher *Watcher) getWatcherConfig() (*config.ServerConfig, error) {
 	return &serverConfig, nil
 }
 
-// waitForDeployment waits for the deployment identified by the given ID,
-// performing retries if necessary, and returns an error if deployment fails.
 func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 	retryCount := 0
 
@@ -238,9 +228,6 @@ func (watcher *Watcher) waitForDeployment(id, appName, version string) error {
 	}
 }
 
-// handleDeploymentError logs the given error,
-// generates an application URL in case of deployment failure
-// and exits the program with code 1.
 func handleDeploymentError(watcher *Watcher, task models.Task, err error) {
 	log.Println(err)
 	if strings.Contains(err.Error(), "The deployment has failed") {
@@ -253,20 +240,15 @@ func handleDeploymentError(watcher *Watcher, task models.Task, err error) {
 	os.Exit(1)
 }
 
-// handleFatalError logs a provided error message and terminates the program with status 1.
 func handleFatalError(err error, message string) {
 	log.Fatalf("%s Got the following error: %s", message, err)
 }
 
-// isDeploymentOverTime checks if the deployment has exceeded the expected deployment time,
-// returning a boolean value.
 func isDeploymentOverTime(retryCount int, retryInterval time.Duration, expectedDeploymentTime time.Duration) bool {
 	return time.Duration(retryCount)*retryInterval > expectedDeploymentTime
 }
 
-// Run initializes the client configuration, sets up the watcher,
-// creates the task, adds the task to the watcher,
-// waits for deployment and handles any errors in the process.
+// Run is the client entrypoint: it builds the task, submits it, and waits for the deployment.
 func Run() {
 	var err error
 
@@ -288,7 +270,6 @@ func Run() {
 		handleFatalError(err, "Couldn't add task.")
 	}
 
-	// Giving Argo-Watcher some time to process the task
 	time.Sleep(5 * time.Second)
 
 	if err = watcher.waitForDeployment(id, task.App, clientConfig.Tag); err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -106,13 +106,11 @@ func statusReason(status string) string {
 }
 
 func TestAddTaskServerError(t *testing.T) {
-	// Create a test server that always returns a 500 status code
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
-	// Create a new Watcher instance
 	watcher := NewWatcher(server.URL, false, 30*time.Second)
 
 	task := models.Task{
@@ -131,10 +129,6 @@ func TestAddTaskServerError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestAddTask_AuthFailureSurfacesServerReason verifies that when the server
-// rejects the task (e.g. 401 with `{"error":"deploy token is invalid"}`),
-// the client surfaces the server's reason and a hint about which env vars
-// govern auth, instead of the old opaque "response code 401".
 func TestAddTask_AuthFailureSurfacesServerReason(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
@@ -155,12 +149,9 @@ func TestAddTask_AuthFailureSurfacesServerReason(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "401")
 	assert.Contains(t, err.Error(), "deploy token is invalid")
-	// The client should hint at which env vars to check on auth failures.
 	assert.Contains(t, err.Error(), "ARGO_WATCHER_DEPLOY_TOKEN")
 }
 
-// TestAddTask_NonAuthFailureSurfacesServerReason verifies the same body-
-// surfacing behaviour for non-auth errors (e.g. 503 with a reason).
 func TestAddTask_NonAuthFailureSurfacesServerReason(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusServiceUnavailable)
@@ -367,32 +358,24 @@ func TestGetTaskStatus(t *testing.T) {
 		assert.Equal(t, models.StatusFailedMessage, task.Status)
 	})
 
-	// Test case: server returns invalid JSON
 	t.Run("server returns invalid JSON", func(t *testing.T) {
-		// Create a test server that always returns an invalid JSON response
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			_, _ = rw.Write([]byte(`invalid JSON`))
 		}))
 		defer server.Close()
 
-		// Create a new Watcher instance
 		watcher := NewWatcher(server.URL, false, 30*time.Second)
 
-		// Call the function
 		_, err := watcher.getTaskStatus("test-id")
 
-		// We expect an error
 		assert.Error(t, err)
 	})
 }
 
 func TestGetWatcherConfig(t *testing.T) {
-	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Test request parameters
 		assert.Equal(t, req.URL.String(), "/api/v1/config")
 
-		// Create the response data
 		configResponse := struct {
 			ArgoCDURL      url.URL `json:"argo_cd_url"`
 			ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
@@ -401,31 +384,24 @@ func TestGetWatcherConfig(t *testing.T) {
 			ArgoCDURLAlias: "https://argo-cd.example.com",
 		}
 
-		// Marshal the response data to JSON
 		jsonData, err := json.Marshal(configResponse)
 		if err != nil {
 			t.Error(err)
 			return
 		}
 
-		// Write the JSON data to the response writer
 		if _, err := rw.Write(jsonData); err != nil {
 			t.Error(err)
 		}
 	}))
-	// Close the server when test finishes
 	defer server.Close()
 
-	// Create a new Watcher instance
 	watcher := NewWatcher(server.URL, false, 30*time.Second)
 
-	// Call getWatcherConfig method
 	serverConfig, err := watcher.getWatcherConfig()
 
-	// Assert there was no error
 	assert.NoError(t, err)
 
-	// Assert the response was as expected
 	expectedUrl, _ := url.Parse("http://localhost:8080")
 	assert.Equal(t, expectedUrl, &serverConfig.ArgoUrl)
 	assert.Equal(t, "https://argo-cd.example.com", serverConfig.ArgoUrlAlias)
@@ -481,7 +457,6 @@ func TestWaitForDeployment(t *testing.T) {
 		},
 	}
 
-	// Run test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := client.waitForDeployment(tc.taskId, "test", testVersion)

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -28,10 +28,8 @@ type Config struct {
 	Debug                  bool          `env:"DEBUG"`
 }
 
-// NewClientConfig parses environment variables into a Config and returns the
-// new instance or an error. When parsing fails the returned error groups
-// missing required variables and invalid values under separate headers, so
-// the user can fix everything in one pass.
+// NewClientConfig parses environment variables into a Config. A parse failure groups
+// missing required variables and invalid values under separate headers.
 func NewClientConfig() (*Config, error) {
 	config, err := envConfig.ParseAs[Config]()
 	if err != nil {

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// setValidClientEnv populates every required client env var with a valid value.
-// Tests can override individual vars to exercise specific failure modes.
 func setValidClientEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("ARGO_WATCHER_URL", "http://localhost:8080")
@@ -60,7 +58,7 @@ func TestNewClientConfig_InvalidDuration(t *testing.T) {
 // tag), not silently accepted.
 func TestNewClientConfig_EmptyRequiredRejected(t *testing.T) {
 	setValidClientEnv(t)
-	t.Setenv("ARGO_APP", "") // set, but empty
+	t.Setenv("ARGO_APP", "")
 
 	_, err := NewClientConfig()
 

--- a/internal/client/credential_test.go
+++ b/internal/client/credential_test.go
@@ -15,9 +15,8 @@ import (
 
 const testJWT = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjF9.signature"
 
-// TestCredentialFrom pins how the client picks the credential it presents. A JWT
-// wins over a deploy token when both are configured, and the "Bearer " prefix is
-// normalized away so the wire format never depends on how BEARER_TOKEN was set.
+// The "Bearer " prefix is normalized away so the wire format never depends on how
+// BEARER_TOKEN was set.
 func TestCredentialFrom(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -155,9 +154,6 @@ func TestCredentialDroppedOnCrossHostRedirect(t *testing.T) {
 	})
 }
 
-// TestReadsWithoutCredentialStayBare guards backward compatibility from the other
-// side: a client configured with no token must keep talking to a server that
-// requires none, sending no auth header at all.
 func TestReadsWithoutCredentialStayBare(t *testing.T) {
 	var headers http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/utility.go
+++ b/internal/client/utility.go
@@ -24,8 +24,7 @@ type transientError struct {
 func (e transientError) Error() string { return e.err.Error() }
 func (e transientError) Unwrap() error { return e.err }
 
-// doRequest creates a new HTTP request, presents the configured credential on it
-// and sends it using the watcher's client, returning the response or an error.
+// doRequest presents the configured credential on every request it sends.
 func (watcher *Watcher) doRequest(method, url string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -59,9 +58,7 @@ func (watcher *Watcher) getJSON(url string, v interface{}) error {
 	}
 }
 
-// getJSONOnce performs a single GET request and decodes the JSON response into
-// v. It classifies failures as transient (retryable) or terminal by wrapping
-// the former in transientError.
+// getJSONOnce wraps retryable failures in transientError; terminal ones are returned as-is.
 func (watcher *Watcher) getJSONOnce(url string, v interface{}) error {
 	resp, err := watcher.doRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -106,10 +103,8 @@ func serverErrorFromResponse(statusCode int, body []byte) error {
 	return fmt.Errorf("argo-watcher returned status %d: %s", statusCode, reason)
 }
 
-// serverReason extracts a useful message from the response body. Argo-watcher
-// returns errors as JSON with `error` and `status` fields (models.TaskStatus);
-// if neither is present we fall back to the raw body, which still beats the
-// status-code-only message we used to surface.
+// serverReason extracts a message from the response body, falling back to the raw body
+// when neither the `error` nor the `status` field of models.TaskStatus is present.
 func serverReason(body []byte) string {
 	body = []byte(strings.TrimSpace(string(body)))
 	if len(body) == 0 {
@@ -127,8 +122,6 @@ func serverReason(body []byte) string {
 	return string(body)
 }
 
-// getImagesList takes a list of image names and a tag,
-// then returns a list of Image structs with these properties.
 func getImagesList(list []string, tag string) []models.Image {
 	var images []models.Image
 	for _, image := range list {
@@ -140,8 +133,6 @@ func getImagesList(list []string, tag string) []models.Image {
 	return images
 }
 
-// createTask takes a config struct, generates the images list and returns a Task object
-// filled with the respective properties from the config.
 func createTask(config *Config) models.Task {
 	images := getImagesList(config.Images, config.Tag)
 	return models.Task{
@@ -154,8 +145,7 @@ func createTask(config *Config) models.Task {
 	}
 }
 
-// printClientConfiguration logs the current configuration of the client including the assigned images and tokens.
-// It also warns if auth tokens are missing.
+// printClientConfiguration logs the client configuration and warns when no auth token is set.
 func printClientConfiguration(watcher *Watcher, task models.Task) {
 	fmt.Printf("Got the following configuration:\n"+
 		"ARGO_WATCHER_URL: %s\n"+
@@ -170,8 +160,6 @@ func printClientConfiguration(watcher *Watcher, task models.Task) {
 	}
 }
 
-// generateAppUrl fetches the watcher config and uses it to construct
-// and return the URL for the Argo application.
 func generateAppUrl(watcher *Watcher, task models.Task) (string, error) {
 	cfg, err := watcher.getWatcherConfig()
 	if err != nil {

--- a/internal/client/utility_test.go
+++ b/internal/client/utility_test.go
@@ -27,9 +27,6 @@ func newTestWatcher(url string) *Watcher {
 	return watcher
 }
 
-// flakyTransport fails the first `failures` round-trips with a network error,
-// then delegates to fallback. It counts every attempt so tests can assert how
-// many requests actually left the client.
 type flakyTransport struct {
 	failures int32
 	calls    int32
@@ -44,8 +41,6 @@ func (f *flakyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f.fallback.RoundTrip(req)
 }
 
-// TestGetJSON_RetriesOn5xxThenSucceeds verifies a transient 5xx is retried and
-// the eventual 200 is decoded, rather than aborting the whole process.
 func TestGetJSON_RetriesOn5xxThenSucceeds(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -69,8 +64,7 @@ func TestGetJSON_RetriesOn5xxThenSucceeds(t *testing.T) {
 	assert.Equal(t, int32(3), calls.Load(), "two 503s then a 200 should be three requests")
 }
 
-// TestGetJSON_RetriesNetworkErrorThenSucceeds verifies a transport-level failure
-// (connection refused/reset, DNS, timeout) is retried.
+// Stands in for the whole transport-failure class: connection refused/reset, DNS, timeout.
 func TestGetJSON_RetriesNetworkErrorThenSucceeds(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		_, _ = rw.Write([]byte(`{"message":"OK"}`))
@@ -91,8 +85,6 @@ func TestGetJSON_RetriesNetworkErrorThenSucceeds(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(&transport.calls), "two dial failures then success should be three attempts")
 }
 
-// TestGetJSON_ExhaustsRetriesOnPersistent5xx verifies retries are bounded and
-// the final error surfaces the server status.
 func TestGetJSON_ExhaustsRetriesOnPersistent5xx(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -130,15 +122,12 @@ func TestGetJSON_DoesNotRetryMalformedBody(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load(), "a malformed 200 body must not be retried")
 }
 
-// TestGetJSON_ExhaustsRetriesOnNetworkError verifies a persistent transport-level
-// failure is retried up to the bound and then surfaces the underlying error.
 func TestGetJSON_ExhaustsRetriesOnNetworkError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		_, _ = rw.Write([]byte(`{"message":"OK"}`))
 	}))
 	defer server.Close()
 
-	// Fail every attempt so the retry budget is exhausted.
 	transport := &flakyTransport{failures: maxTransientRetries + 1, fallback: server.Client().Transport}
 	watcher := newTestWatcher(server.URL)
 	watcher.client.Transport = transport
@@ -172,7 +161,6 @@ func TestGetJSON_DoesNotRetryTerminalError(t *testing.T) {
 }
 
 func TestDoRequest(t *testing.T) {
-	// Test case 1: The server returns a 200 OK status code
 	t.Run("200 status code", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -192,7 +180,6 @@ func TestDoRequest(t *testing.T) {
 		assert.Equal(t, "OK", string(body))
 	})
 
-	// Test case 2: An error occurs while creating the request
 	t.Run("invalid URL", func(t *testing.T) {
 		watcher := NewWatcher("http://invalid-url", false, 30*time.Second)
 		_, err := watcher.doRequest(http.MethodGet, "http://invalid-url", nil)
@@ -202,42 +189,30 @@ func TestDoRequest(t *testing.T) {
 }
 
 func TestGetJSON(t *testing.T) {
-	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Test request parameters
 		assert.Equal(t, req.URL.String(), "/test")
-		// Send response to be tested
 		if _, err := rw.Write([]byte(`{"message": "OK"}`)); err != nil {
 			t.Error(err)
 		}
 	}))
-	// Close the server when test finishes
 	defer server.Close()
 
-	// Create a new Watcher instance
 	watcher := NewWatcher(server.URL, false, 30*time.Second)
 
-	// Define a struct to hold the response
 	type response struct {
 		Message string `json:"message"`
 	}
 	var resp response
 
-	// Call getJSON method
 	err := watcher.getJSON(server.URL+"/test", &resp)
 
-	// Assert there was no error
 	assert.NoError(t, err)
 
-	// Assert the response was as expected
 	assert.Equal(t, "OK", resp.Message)
 }
 
-// TestGetJSON_NonOKResponseSurfacesBody verifies that when the server returns
-// a non-200 status, the client error includes whatever the server sent in the
-// response body — not just the status code. This is the difference between
-// "received non-200 status code: 401" (useless) and "received status 401:
-// deploy token is invalid" (actionable).
+// The error must carry the server's response body, not just the status code: "received
+// status 401: deploy token is invalid" beats "received non-200 status code: 401".
 func TestGetJSON_NonOKResponseSurfacesBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
@@ -254,9 +229,6 @@ func TestGetJSON_NonOKResponseSurfacesBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "deploy token is invalid")
 }
 
-// TestServerErrorFromResponse exercises the branches of serverErrorFromResponse
-// directly: the empty-body fallback (status code only), the 401/403 auth hint,
-// and the raw-body fallback when the body is not TaskStatus JSON.
 func TestServerErrorFromResponse(t *testing.T) {
 	const authHint = "check ARGO_WATCHER_DEPLOY_TOKEN or BEARER_TOKEN"
 
@@ -410,7 +382,6 @@ func TestCreateTask(t *testing.T) {
 }
 
 func TestPrintClientConfiguration(t *testing.T) {
-	// Initialize clientConfig
 	clientConfig = &Config{
 		Url:     "http://localhost:8080",
 		Images:  []string{"image1", "image2"},
@@ -423,7 +394,6 @@ func TestPrintClientConfiguration(t *testing.T) {
 		Debug:   true,
 	}
 
-	// Create a Watcher and Task for testing
 	watcher := NewWatcher("http://localhost:8080", true, 30*time.Second)
 	task := models.Task{
 		App:     "test-app",
@@ -441,7 +411,6 @@ func TestPrintClientConfiguration(t *testing.T) {
 		},
 	}
 
-	// Expected output
 	expectedOutput := "Got the following configuration:\n" +
 		"ARGO_WATCHER_URL: http://localhost:8080\n" +
 		"ARGO_APP: test-app\n" +
@@ -451,36 +420,28 @@ func TestPrintClientConfiguration(t *testing.T) {
 		"IMAGES: [{image1 test-tag} {image2 test-tag}]\n\n" +
 		"Neither deploy token nor JSON Web token found, git commit will not be performed\n"
 
-	// Redirect standard output to a buffer
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// Call the function
 	printClientConfiguration(watcher, task)
 
-	// Restore standard output
 	err := w.Close()
 	assert.NoError(t, err)
 
 	os.Stdout = oldStdout
 
-	// Read the buffer
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 
-	// Compare the buffer's content with the expected output
 	assert.Equal(t, expectedOutput, buf.String())
 }
 
 func TestGenerateAppUrl(t *testing.T) {
 	t.Run("SuccessScenarioAlias", func(t *testing.T) {
-		// Create a test server
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			// Test request parameters
 			assert.Equal(t, req.URL.String(), "/api/v1/config")
 
-			// Create and send the response data
 			configResponse := struct {
 				ArgoCDURL      url.URL `json:"argo_cd_url"`
 				ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
@@ -497,34 +458,25 @@ func TestGenerateAppUrl(t *testing.T) {
 		}))
 		defer server.Close()
 
-		// Create a new Watcher instance
 		watcher := NewWatcher(server.URL, false, 30*time.Second)
 
-		// Create a Task for testing
 		task := models.Task{
 			App: "test-app",
 		}
 
-		// Call the function
 		appUrl, err := generateAppUrl(watcher, task)
 
-		// Assert no error
 		assert.Nil(t, err)
 
-		// Expected output
 		expectedOutput := "https://argo-cd.example.com/applications/test-app"
 
-		// Compare the function's output with the expected output
 		assert.Equal(t, expectedOutput, appUrl)
 	})
 
 	t.Run("SuccessScenarioNoAlias", func(t *testing.T) {
-		// Create a test server
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			// Test request parameters
 			assert.Equal(t, req.URL.String(), "/api/v1/config")
 
-			// Create and send the response data
 			configResponse := struct {
 				ArgoCDURL url.URL `json:"argo_cd_url"`
 			}{
@@ -539,25 +491,18 @@ func TestGenerateAppUrl(t *testing.T) {
 		}))
 		defer server.Close()
 
-		// Create a new Watcher instance
 		watcher := NewWatcher(server.URL, false, 30*time.Second)
 
-		// Create a Task for testing
 		task := models.Task{
 			App: "test-app",
-			// other task fields...
 		}
 
-		// Call the function
 		appUrl, err := generateAppUrl(watcher, task)
 
-		// Assert no error
 		assert.Nil(t, err)
 
-		// Expected output
 		expectedOutput := "http://localhost:8080/applications/test-app"
 
-		// Compare the function's output with the expected output
 		assert.Equal(t, expectedOutput, appUrl)
 	})
 
@@ -567,33 +512,26 @@ func TestGenerateAppUrl(t *testing.T) {
 		invalidURL := "http://invalid-url"
 		watcher := newTestWatcher(invalidURL)
 
-		// Create a Task for testing
 		task := models.Task{
 			App: "test-app",
 		}
 
-		// Call the function
 		appUrl, err := generateAppUrl(watcher, task)
 
-		// Assert that an error is returned
 		assert.NotNil(t, err)
 
-		// Assert that the returned URL is empty
 		assert.Equal(t, "", appUrl)
 	})
 }
 
 func TestSetupWatcher(t *testing.T) {
-	// Define the input
 	config := &Config{
 		Url:   "http://localhost:8080",
 		Debug: true,
 	}
 
-	// Call the function
 	watcher := setupWatcher(config)
 
-	// Assert the watcher's properties
 	assert.Equal(t, config.Url, watcher.baseUrl)
 	assert.Equal(t, config.Debug, watcher.debugMode)
 	assert.Equal(t, credential{}, watcher.auth, "a client with no token configured carries no credential")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,7 +83,7 @@ type ServerConfig struct {
 	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
 	ArgoToken          string           `env:"ARGO_TOKEN,required,notEmpty" json:"-"`
 	ArgoApiTimeout     int64            `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`
-	AcceptSuspendedApp bool             `env:"ACCEPT_SUSPENDED_APP" envDefault:"false" json:"accept_suspended_app"` // If true, we will accept "Suspended" health status as valid
+	AcceptSuspendedApp bool             `env:"ACCEPT_SUSPENDED_APP" envDefault:"false" json:"accept_suspended_app"`
 	DeploymentTimeout  uint             `env:"DEPLOYMENT_TIMEOUT" envDefault:"900" json:"deployment_timeout"`
 	ArgoRefreshApp     bool             `env:"ARGO_REFRESH_APP" envDefault:"true" json:"argo_refresh_app"`
 	RegistryProxyUrl   string           `env:"DOCKER_IMAGES_PROXY" json:"registry_proxy_url,omitempty"`
@@ -174,7 +174,6 @@ func applyKeycloakCompat(cfg *ServerConfig) error {
 	return nil
 }
 
-// anyKeycloakVarSet reports whether any deprecated KEYCLOAK_* variable is present.
 func anyKeycloakVarSet() bool {
 	for _, v := range []string{
 		"KEYCLOAK_ENABLED", "KEYCLOAK_URL", "KEYCLOAK_REALM", "KEYCLOAK_CLIENT_ID",
@@ -188,8 +187,7 @@ func anyKeycloakVarSet() bool {
 }
 
 // legacyValue returns the deprecated legacyKey's value, but only when the
-// canonical primaryKey is unset (the OIDC_* variable always wins). It returns
-// ("", false) when the primary is set or the legacy variable is absent.
+// canonical primaryKey is unset — the OIDC_* variable always wins.
 func legacyValue(primaryKey, legacyKey string) (string, bool) {
 	if _, ok := os.LookupEnv(primaryKey); ok {
 		return "", false
@@ -197,8 +195,8 @@ func legacyValue(primaryKey, legacyKey string) (string, bool) {
 	return os.LookupEnv(legacyKey)
 }
 
-// keycloakIssuer synthesizes the OIDC issuer a Keycloak realm advertises from the
-// deprecated KEYCLOAK_URL + KEYCLOAK_REALM pair, or "" if either is missing.
+// keycloakIssuer synthesizes the issuer a Keycloak realm advertises from the deprecated
+// KEYCLOAK_URL + KEYCLOAK_REALM pair, or "" if either is missing.
 func keycloakIssuer() string {
 	url := strings.TrimSpace(os.Getenv("KEYCLOAK_URL"))
 	realm := strings.TrimSpace(os.Getenv("KEYCLOAK_REALM"))
@@ -208,7 +206,6 @@ func keycloakIssuer() string {
 	return strings.TrimRight(url, "/") + "/realms/" + realm
 }
 
-// splitGroups parses a comma-separated privileged-groups list, trimming blanks.
 func splitGroups(val string) []string {
 	var groups []string
 	for _, g := range strings.Split(val, ",") {
@@ -257,10 +254,8 @@ func NewServerConfig() (*ServerConfig, error) {
 	return &config, nil
 }
 
-// ensureConnectTimeout appends a connect_timeout parameter (in seconds) to a
-// PostgreSQL DSN when it does not already specify one. An operator-provided
-// connect_timeout is left untouched. Both the URI form (postgres://...) and the
-// keyword/value form (host=... port=...) are supported.
+// ensureConnectTimeout appends a connect_timeout parameter (in seconds) to a PostgreSQL
+// DSN, in either the URI or keyword/value form, when it does not already specify one.
 func ensureConnectTimeout(dsn string, timeout int) string {
 	if strings.Contains(dsn, "connect_timeout=") {
 		return dsn

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,19 +11,15 @@ import (
 
 func TestNewServerConfig(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Set up the required environment variables
 		t.Setenv("ARGO_URL", "https://example.com")
 		t.Setenv("ARGO_TOKEN", "secret-token")
 		t.Setenv("STATE_TYPE", "postgres")
 
-		// Call the NewServerConfig function
 		cfg, err := NewServerConfig()
 
-		// Assert that the configuration was parsed successfully
 		assert.NoError(t, err)
 		assert.NotNil(t, cfg)
 
-		// Assert specific field values
 		expectedUrl, _ := url.Parse("https://example.com")
 		assert.Equal(t, *expectedUrl, cfg.ArgoUrl)
 		assert.Equal(t, "secret-token", cfg.ArgoToken)
@@ -55,10 +51,8 @@ func TestNewServerConfig(t *testing.T) {
 	})
 }
 
-// TestNewServerConfig_DatabaseConnectTimeout verifies that the database DSN
-// carries a connect_timeout so an unreachable Postgres fails fast at startup
-// instead of blocking on the OS TCP timeout, and that DB_CONNECT_TIMEOUT
-// overrides the default.
+// The database DSN carries a connect_timeout so an unreachable Postgres fails fast at
+// startup instead of blocking on the OS TCP timeout.
 func TestNewServerConfig_DatabaseConnectTimeout(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		t.Setenv("ARGO_URL", "https://example.com")
@@ -86,13 +80,8 @@ func TestNewServerConfig_DatabaseConnectTimeout(t *testing.T) {
 	})
 }
 
-// TestNewServerConfig_ConnectTimeoutValidation verifies that a non-positive
-// DB_CONNECT_TIMEOUT is rejected with a readable error, since 0 (and negatives on
-// libpq) mean "wait indefinitely" and would silently defeat the fail-fast guard.
-// TestNewServerConfig_ConnectTimeoutInjectedIntoCustomDSN verifies that an
-// explicitly supplied DB_DSN (which bypasses the default template) still gets a
-// connect_timeout so the fail-fast guard cannot be silently defeated, while an
-// operator-provided connect_timeout is left untouched.
+// An explicitly supplied DB_DSN bypasses the default template, so it still gets a
+// connect_timeout — while an operator-provided one is left untouched.
 func TestNewServerConfig_ConnectTimeoutInjectedIntoCustomDSN(t *testing.T) {
 	base := func(t *testing.T) {
 		t.Setenv("ARGO_URL", "https://example.com")
@@ -132,6 +121,8 @@ func TestNewServerConfig_ConnectTimeoutInjectedIntoCustomDSN(t *testing.T) {
 	})
 }
 
+// A non-positive DB_CONNECT_TIMEOUT is rejected: 0 (and negatives on libpq) mean
+// "wait indefinitely" and would silently defeat the fail-fast guard.
 func TestNewServerConfig_ConnectTimeoutValidation(t *testing.T) {
 	for _, value := range []string{"0", "-1"} {
 		t.Run(value, func(t *testing.T) {
@@ -157,19 +148,12 @@ func TestNewServerConfig_RequiredFieldsMissing(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
-	// Assert the formatter is wired in: the message must use the grouped
-	// header, and ARGO_TOKEN (which this test never sets) must appear under
-	// it. STATE_TYPE is intentionally not asserted because the project's
-	// Taskfile sets STATE_TYPE=in-memory for `task test` runs.
+	// STATE_TYPE is intentionally not asserted: the project's Taskfile sets
+	// STATE_TYPE=in-memory for `task test` runs.
 	assert.Contains(t, err.Error(), "missing required environment variables:")
 	assert.Contains(t, err.Error(), "ARGO_TOKEN")
 }
 
-// TestNewServerConfig_InvalidStateType_IsReadable verifies that the
-// validator error names the field, the constraint, and the offending value
-// — replacing the unreadable
-// "Key: 'ServerConfig.StateType' Error:Field validation for ... 'oneof' tag"
-// blob with something an operator can act on directly.
 func TestNewServerConfig_InvalidStateType_IsReadable(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -180,12 +164,9 @@ func TestNewServerConfig_InvalidStateType_IsReadable(t *testing.T) {
 	assert.Contains(t, err.Error(), "StateType")
 	assert.Contains(t, err.Error(), "must be one of [postgres in-memory]")
 	assert.Contains(t, err.Error(), `"invalid"`)
-	// We no longer leak go-playground/validator's blob format.
 	assert.NotContains(t, err.Error(), "Key: 'ServerConfig.StateType'")
 }
 
-// TestNewServerConfig_InvalidArgoApiRetries_IsReadable verifies the same for
-// numeric range validation.
 func TestNewServerConfig_InvalidArgoApiRetries_IsReadable(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -199,10 +180,8 @@ func TestNewServerConfig_InvalidArgoApiRetries_IsReadable(t *testing.T) {
 	assert.Contains(t, err.Error(), "got 11")
 }
 
-// TestNewServerConfig_EmptyRequiredRejected verifies that a required variable
-// that is present but empty is rejected at parse time (the `,notEmpty` tag),
-// not silently accepted and left to fail later. This guards the empty-value
-// rejection that replaced go-playground/validator.
+// A required variable that is present but empty is rejected at parse time (the
+// `,notEmpty` tag), not silently accepted and left to fail later.
 func TestNewServerConfig_EmptyRequiredRejected(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("STATE_TYPE", "in-memory")
@@ -215,20 +194,15 @@ func TestNewServerConfig_EmptyRequiredRejected(t *testing.T) {
 }
 
 func TestServerConfig_GetRetryAttempts(t *testing.T) {
-	// Create a ServerConfig instance with a specific DeploymentTimeout value
 	config := &ServerConfig{
 		DeploymentTimeout: 60,
 	}
 
-	// Call the GetRetryAttempts function
 	retryAttempts := config.GetRetryAttempts()
 
-	// Assert that the retryAttempts value matches the expected result
 	assert.Equal(t, uint(5), retryAttempts)
 }
 
-// TestNewServerConfig_ArgoApiRetriesDefault verifies that the ArgoApiRetries field
-// defaults to 3 when not explicitly set via environment variable.
 func TestNewServerConfig_ArgoApiRetriesDefault(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -239,8 +213,6 @@ func TestNewServerConfig_ArgoApiRetriesDefault(t *testing.T) {
 	assert.Equal(t, uint(3), cfg.ArgoApiRetries)
 }
 
-// TestNewServerConfig_ArgoApiRetriesCustom verifies that the ArgoApiRetries field
-// can be overridden via the ARGO_API_RETRIES environment variable.
 func TestNewServerConfig_ArgoApiRetriesCustom(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -252,8 +224,7 @@ func TestNewServerConfig_ArgoApiRetriesCustom(t *testing.T) {
 	assert.Equal(t, uint(5), cfg.ArgoApiRetries)
 }
 
-// TestNewServerConfig_ArgoApiRetriesZeroRejected verifies that setting ARGO_API_RETRIES=0
-// fails validation, since zero attempts would cause infinite retries with retry-go.
+// Zero attempts would cause infinite retries with retry-go.
 func TestNewServerConfig_ArgoApiRetriesZeroRejected(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -264,8 +235,7 @@ func TestNewServerConfig_ArgoApiRetriesZeroRejected(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNewServerConfig_ArgoApiRetriesTooHighRejected verifies that setting ARGO_API_RETRIES
-// above the maximum (10) fails validation.
+// 10 is the maximum.
 func TestNewServerConfig_ArgoApiRetriesTooHighRejected(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -276,10 +246,9 @@ func TestNewServerConfig_ArgoApiRetriesTooHighRejected(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNewServerConfig_OIDCKeycloakFallback verifies that the deprecated
-// KEYCLOAK_* variables are mapped onto the generic OIDC config, with the issuer
-// synthesized from KEYCLOAK_URL + KEYCLOAK_REALM, so existing Keycloak
-// deployments keep working after the rename without any config change.
+// The deprecated KEYCLOAK_* variables map onto the generic OIDC config, with the issuer
+// synthesized from KEYCLOAK_URL + KEYCLOAK_REALM, so existing Keycloak deployments keep
+// working after the rename without any config change.
 func TestNewServerConfig_OIDCKeycloakFallback(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -301,18 +270,15 @@ func TestNewServerConfig_OIDCKeycloakFallback(t *testing.T) {
 	assert.Equal(t, []string{"admins", "operators"}, cfg.OIDC.PrivilegedGroups)
 }
 
-// TestNewServerConfig_OIDCMixedFallback verifies the per-field fallback that a
-// real upgrade hits: an operator sets the new OIDC_ISSUER_URL but still relies on
-// the deprecated KEYCLOAK_CLIENT_ID / KEYCLOAK_PRIVILEGED_GROUPS. Each field must
-// resolve independently — the OIDC issuer plus the Keycloak-sourced client id and
-// groups.
+// The per-field fallback a real upgrade hits: an operator sets the new OIDC_ISSUER_URL
+// but still relies on the deprecated KEYCLOAK_CLIENT_ID / KEYCLOAK_PRIVILEGED_GROUPS.
+// Each field must resolve independently.
 func TestNewServerConfig_OIDCMixedFallback(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
 	t.Setenv("STATE_TYPE", "in-memory")
 	t.Setenv("OIDC_ENABLED", "true")
 	t.Setenv("OIDC_ISSUER_URL", "https://authentik.example.com/application/o/aw/")
-	// Deprecated aliases still supply the fields OIDC_* leaves unset.
 	t.Setenv("KEYCLOAK_CLIENT_ID", "legacy-client")
 	t.Setenv("KEYCLOAK_PRIVILEGED_GROUPS", "admins,operators")
 
@@ -324,9 +290,8 @@ func TestNewServerConfig_OIDCMixedFallback(t *testing.T) {
 	assert.Equal(t, []string{"admins", "operators"}, cfg.OIDC.PrivilegedGroups)
 }
 
-// TestNewServerConfig_KeycloakPartialIssuer verifies that a half-configured legacy
-// Keycloak (URL without realm) does not synthesize a malformed issuer; with auth
-// enabled it must surface as the OIDC.IssuerURL validation error.
+// A half-configured legacy Keycloak (URL without realm) must not synthesize a
+// malformed issuer.
 func TestNewServerConfig_KeycloakPartialIssuer(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -342,8 +307,7 @@ func TestNewServerConfig_KeycloakPartialIssuer(t *testing.T) {
 	assert.Contains(t, err.Error(), "OIDC.IssuerURL")
 }
 
-// TestNewServerConfig_KeycloakMalformedValuesRejected verifies that a malformed
-// deprecated value fails startup rather than silently disabling auth: a typo like
+// A malformed deprecated value must fail startup rather than silently disable auth: a typo like
 // KEYCLOAK_ENABLED=yes must never quietly drop the protected OIDC routes from an
 // otherwise healthy deployment (fail closed, not open).
 func TestNewServerConfig_KeycloakMalformedValuesRejected(t *testing.T) {
@@ -376,8 +340,6 @@ func TestNewServerConfig_KeycloakMalformedValuesRejected(t *testing.T) {
 	})
 }
 
-// TestNewServerConfig_OIDCPrecedence verifies that OIDC_* takes precedence over
-// the deprecated KEYCLOAK_* aliases when both are set.
 func TestNewServerConfig_OIDCPrecedence(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -385,7 +347,6 @@ func TestNewServerConfig_OIDCPrecedence(t *testing.T) {
 	t.Setenv("OIDC_ENABLED", "true")
 	t.Setenv("OIDC_ISSUER_URL", "https://authentik.example.com/application/o/argo-watcher/")
 	t.Setenv("OIDC_CLIENT_ID", "aw-oidc")
-	// Legacy values that must be ignored because OIDC_* is set.
 	t.Setenv("KEYCLOAK_URL", "https://kc.example.com")
 	t.Setenv("KEYCLOAK_REALM", "legacy")
 	t.Setenv("KEYCLOAK_CLIENT_ID", "legacy-client")
@@ -397,8 +358,6 @@ func TestNewServerConfig_OIDCPrecedence(t *testing.T) {
 	assert.Equal(t, "aw-oidc", cfg.OIDC.ClientId)
 }
 
-// TestNewServerConfig_OIDCValidation verifies that enabling OIDC without an
-// issuer or client id is rejected with a readable, field-named error.
 func TestNewServerConfig_OIDCValidation(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
@@ -412,8 +371,7 @@ func TestNewServerConfig_OIDCValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "OIDC.ClientId")
 }
 
-// TestNewServerConfig_RequireTaskReadAuth covers the switch that closes
-// GET /api/v1/tasks/{id}. It only has meaning while the reads are protected at all,
+// The switch that closes GET /api/v1/tasks/{id} only has meaning while reads are protected at all,
 // so setting it with OIDC disabled is a misconfiguration the operator must see: it
 // would otherwise leave the endpoint open while reading as if it were closed.
 func TestNewServerConfig_RequireTaskReadAuth(t *testing.T) {
@@ -475,9 +433,8 @@ func TestNewServerConfig_RequireTaskReadAuth(t *testing.T) {
 	})
 }
 
-// TestServerConfig_JSONDualKey verifies that /api/v1/config exposes the OIDC
-// block under both the canonical "oidc" key and the legacy "keycloak" mirror
-// with identical content, preserving backward compatibility for old consumers.
+// /api/v1/config exposes the OIDC block under both the canonical "oidc" key and the
+// legacy "keycloak" mirror, preserving backward compatibility for old consumers.
 func TestServerConfig_JSONDualKey(t *testing.T) {
 	cfg := &ServerConfig{
 		OIDC: OIDCConfig{
@@ -510,31 +467,25 @@ func TestServerConfig_JSONDualKey(t *testing.T) {
 
 func TestServerConfig_JSONExcludesSensitiveFields(t *testing.T) {
 	databaseConfig := DatabaseConfig{}
-	// Create a ServerConfig instance with some dummy data
 	config := &ServerConfig{
 		ArgoToken:   "secret-token",
 		DeployToken: "deploy-token",
 		Db:          databaseConfig,
 	}
 
-	// Marshal the ServerConfig instance to JSON
 	jsonBytes, err := json.Marshal(config)
 	assert.NoError(t, err)
 
-	// Convert the JSON bytes to a string
 	jsonString := string(jsonBytes)
 
-	// Check that the sensitive fields are not present in the JSON string
 	assert.NotContains(t, jsonString, "secret-token")
 	assert.NotContains(t, jsonString, "db-password")
 	assert.NotContains(t, jsonString, "deploy-token")
 }
 
-// TestServerConfig_JSONOmitsNotificationTargets pins the payload of the
-// unauthenticated GET /api/v1/config: how to reach a notification receiver must not be
-// readable by anyone who can reach the server, since a webhook URL is itself the
-// credential. The `enabled` flags stay — they name no target, and downstream consumers
-// (argo-watcher-mcp) forward them.
+// GET /api/v1/config is unauthenticated: how to reach a notification receiver must not be
+// readable by anyone who can reach the server, since a webhook URL is itself the credential.
+// The `enabled` flags stay — they name no target, and argo-watcher-mcp forwards them.
 func TestServerConfig_JSONOmitsNotificationTargets(t *testing.T) {
 	config := &ServerConfig{
 		SkipTlsVerify:    true,
@@ -562,8 +513,6 @@ func TestServerConfig_JSONOmitsNotificationTargets(t *testing.T) {
 	assert.NotContains(t, jsonString, "mattermost-token")
 	assert.NotContains(t, jsonString, "channel-id")
 
-	// What other consumers read must survive: the enabled flags, the schedule and the
-	// TLS posture are all allowlisted downstream.
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(jsonBytes, &decoded))
 	assert.Equal(t, true, decoded["webhook"].(map[string]any)["enabled"])
@@ -574,9 +523,7 @@ func TestServerConfig_JSONOmitsNotificationTargets(t *testing.T) {
 	assert.Contains(t, jsonString, "oidc")
 }
 
-// TestServerConfig_DefaultValidationIntervalMatchesTokenLifetime guards the
-// caching default: revalidating every 10s (the previously documented but never
-// implemented value) would turn every UI refresh into provider traffic.
+// Revalidating every 10s would turn every UI refresh into provider traffic.
 func TestServerConfig_DefaultValidationInterval(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")

--- a/internal/helpers/configerr_test.go
+++ b/internal/helpers/configerr_test.go
@@ -50,9 +50,6 @@ func TestPrettifyEnvError_GroupsMissingAndInvalid(t *testing.T) {
 }
 
 func TestPrettifyEnvError_InvalidOnlyOmitsMissingHeader(t *testing.T) {
-	// All required vars are present, but one value fails to parse. The output
-	// must report the invalid value without emitting an empty "missing
-	// required environment variables:" header.
 	t.Setenv("SAMPLE_PRETTIFY_URL", "http://example.com")
 	t.Setenv("SAMPLE_PRETTIFY_NAME", "sample")
 	t.Setenv("SAMPLE_PRETTIFY_TIMEOUT", "nope")

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -60,7 +60,6 @@ func CurlCommandFromRequest(request *http.Request, redactHeaders ...string) (str
 	}
 
 	if len(clonedRequest) > 0 {
-		// Skip past the request line and headers to the body.
 		headerEndIndex := strings.Index(string(clonedRequest), "\r\n\r\n")
 		if headerEndIndex != -1 && headerEndIndex+4 <= len(clonedRequest) {
 			body := string(clonedRequest[headerEndIndex+4:])
@@ -103,7 +102,7 @@ func GenerateHash(s string) []byte {
 	return hash.Sum(nil)
 }
 
-// NormalizeImages returns a sorted copy of the provided image slice to guarantee stable ordering without mutating the original.
+// NormalizeImages returns a sorted copy, leaving the original untouched.
 func NormalizeImages(images []string) []string {
 	copied := append([]string(nil), images...)
 	slices.Sort(copied)

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -33,8 +33,6 @@ var imageContainsTest = []imagesContainsTest{
 	{[]string{image1, image2, image3}, "v0.0.2", registryProxy, false},
 }
 
-// TestImageContains verifies that ImagesContains correctly detects images in a list,
-// including scenarios with and without a registry proxy.
 func TestImageContains(t *testing.T) {
 	for _, test := range imageContainsTest {
 		testErrorMsg := fmt.Sprintf("ImageContains(%s, %s, %s) should be %t", test.images, test.image, test.registryProxy, test.expected)
@@ -42,8 +40,6 @@ func TestImageContains(t *testing.T) {
 	}
 }
 
-// TestImageName verifies that ImageName strips tags and digests while leaving a
-// registry host's port intact.
 func TestImageName(t *testing.T) {
 	tests := []struct {
 		reference string
@@ -64,42 +60,30 @@ func TestImageName(t *testing.T) {
 	}
 }
 
-// TestCurlCommandFromRequest verifies that CurlCommandFromRequest generates
-// a valid cURL command from an HTTP request with headers and body.
 func TestCurlCommandFromRequest(t *testing.T) {
-	// Create a sample HTTP request with a non-empty request body
 	requestBody := `{"key": "value"}`
 	request, _ := http.NewRequest("POST", "https://example.com/api", strings.NewReader(requestBody))
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Authorization", "Bearer Token123")
 	request.Header.Add("X-Custom-Header", "CustomValue")
 
-	// Create the expected cURL command
 	expectedCurl := `curl -X POST -H 'Authorization: Bearer Token123' -H 'Content-Type: application/json' -H 'X-Custom-Header: CustomValue' -d '{"key": "value"}' 'https://example.com/api'`
 
-	// Call the function to get the actual cURL command
 	actualCurl, err := CurlCommandFromRequest(request)
 	assert.NoError(t, err)
 
-	// Split the cURL commands by space
 	expectedParts := strings.Fields(expectedCurl)
 	actualParts := strings.Fields(actualCurl)
 
-	// Sort the headers alphabetically, excluding the first part (curl command and method)
 	sort.Strings(expectedParts[3:])
 	sort.Strings(actualParts[3:])
 
-	// Reconstruct the cURL commands with sorted headers
 	sortedExpectedCurl := strings.Join(expectedParts, " ")
 	sortedActualCurl := strings.Join(actualParts, " ")
 
-	// Compare the expected and actual cURL commands
 	assert.Equal(t, sortedExpectedCurl, sortedActualCurl)
 }
 
-// TestCurlCommandFromRequest_RedactsHeaders verifies that the values of the
-// named sensitive headers are replaced with a placeholder while non-sensitive
-// headers are emitted verbatim, and that matching is case-insensitive.
 func TestCurlCommandFromRequest_RedactsHeaders(t *testing.T) {
 	request, _ := http.NewRequest("POST", "https://example.com/api", strings.NewReader(""))
 	request.Header.Add("Authorization", "super-secret-jwt")
@@ -109,21 +93,15 @@ func TestCurlCommandFromRequest_RedactsHeaders(t *testing.T) {
 	actualCurl, err := CurlCommandFromRequest(request, "authorization", "ARGO_WATCHER_DEPLOY_TOKEN")
 	assert.NoError(t, err)
 
-	// Secret values must not appear anywhere in the command.
 	assert.NotContains(t, actualCurl, "super-secret-jwt", "JWT value must be redacted")
 	assert.NotContains(t, actualCurl, "super-secret-token", "deploy token value must be redacted")
 
-	// Header names stay visible with a redacted placeholder value.
 	assert.Contains(t, actualCurl, "-H 'Authorization: <redacted>'")
 	assert.Contains(t, actualCurl, "-H 'Argo_watcher_deploy_token: <redacted>'")
 
-	// Non-sensitive headers are unchanged.
 	assert.Contains(t, actualCurl, "-H 'Content-Type: application/json'")
 }
 
-// TestCurlCommandFromRequest_RedactsMultiValueHeader verifies that a sensitive
-// header carrying multiple values collapses to a single redacted entry and never
-// emits any of the raw values.
 func TestCurlCommandFromRequest_RedactsMultiValueHeader(t *testing.T) {
 	request, _ := http.NewRequest("POST", "https://example.com/api", strings.NewReader(""))
 	request.Header.Add("Authorization", "secret-a")
@@ -138,28 +116,20 @@ func TestCurlCommandFromRequest_RedactsMultiValueHeader(t *testing.T) {
 		"multi-value sensitive header must collapse to exactly one redacted entry")
 }
 
-// TestCurlCommandFromRequest_ShellEscaping verifies that single quotes in headers,
-// body, and URL are properly escaped to prevent shell injection.
+// Unescaped single quotes in a header, body or URL would be a shell-injection vector.
 func TestCurlCommandFromRequest_ShellEscaping(t *testing.T) {
-	// Create a sample HTTP request with single quotes in various places
 	requestBody := `{"name": "O'Brien"}`
 	request, _ := http.NewRequest("POST", "https://example.com/api?name=O'Connor", strings.NewReader(requestBody))
 	request.Header.Add("X-Author", "O'Reilly")
 
-	// Call the function to get the actual cURL command
 	actualCurl, err := CurlCommandFromRequest(request)
 	assert.NoError(t, err)
 
-	// Verify single quotes are escaped with '\'' pattern
 	assert.Contains(t, actualCurl, `O'\''Reilly`, "header value should have escaped single quote")
 	assert.Contains(t, actualCurl, `O'\''Brien`, "body should have escaped single quote")
 	assert.Contains(t, actualCurl, `O'\''Connor`, "URL should have escaped single quote")
 }
 
-// TestShellEscapeSingleQuote verifies that shellEscapeSingleQuote correctly escapes
-// single quotes for safe shell string interpolation, using the sequence:
-//
-//	'\''
 func TestShellEscapeSingleQuote(t *testing.T) {
 	testCases := []struct {
 		input    string
@@ -180,8 +150,6 @@ func TestShellEscapeSingleQuote(t *testing.T) {
 	}
 }
 
-// TestGenerateHash verifies that GenerateHash produces correct SHA256 hashes
-// for known input strings.
 func TestGenerateHash(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/internal/lock/deploy_lock_postgres.go
+++ b/internal/lock/deploy_lock_postgres.go
@@ -19,8 +19,6 @@ type PostgresDeployLockStore struct {
 	db *gorm.DB
 }
 
-// NewPostgresDeployLockStore creates a DeployLockStore backed by the deploy_lock
-// table of the given database.
 func NewPostgresDeployLockStore(db *gorm.DB) DeployLockStore {
 	return &PostgresDeployLockStore{db: db}
 }
@@ -48,7 +46,6 @@ func (s *PostgresDeployLockStore) State() (DeployLockState, error) {
 	}, nil
 }
 
-// Lock engages the manual lockdown and drops any pending override.
 func (s *PostgresDeployLockStore) Lock() error {
 	return s.write(true, time.Time{})
 }

--- a/internal/lock/deploy_lock_postgres_test.go
+++ b/internal/lock/deploy_lock_postgres_test.go
@@ -79,8 +79,6 @@ func TestPostgresDeployLockStore_MissingRowIsUnlocked(t *testing.T) {
 func TestPostgresDeployLockStore_StateSurfacesReadErrors(t *testing.T) {
 	db := newDeployLockTestDB(t)
 
-	// A dedicated connection, closed underneath the store: no other test shares
-	// this handle, so nothing else is affected.
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 	require.NoError(t, sqlDB.Close())

--- a/internal/lock/in_memory.go
+++ b/internal/lock/in_memory.go
@@ -2,20 +2,17 @@ package lock
 
 import "sync"
 
-// mutexMap is a thread-safe map to hold mutexes for different keys.
 type mutexMap struct {
 	mu sync.Mutex
 	m  map[string]*sync.Mutex
 }
 
-// newMutexMap creates a new, initialized mutexMap.
 func newMutexMap() *mutexMap {
 	return &mutexMap{
 		m: make(map[string]*sync.Mutex),
 	}
 }
 
-// get returns the mutex for a given key, creating it if it doesn't exist.
 func (m *mutexMap) get(key string) *sync.Mutex {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -27,8 +24,7 @@ func (m *mutexMap) get(key string) *sync.Mutex {
 	return mu
 }
 
-// InMemoryLocker is an implementation of the Locker interface that uses
-// an in-memory mutex map.
+// InMemoryLocker is a Locker backed by an in-memory mutex map.
 type InMemoryLocker struct {
 	mutexMap *mutexMap
 }

--- a/internal/lock/in_memory_test.go
+++ b/internal/lock/in_memory_test.go
@@ -15,7 +15,6 @@ func TestInMemoryLocker(t *testing.T) {
 	// The buffer must be large enough to hold all sent values before they are read.
 	executionOrder := make(chan int, 4)
 
-	// Goroutine 1
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -32,7 +31,6 @@ func TestInMemoryLocker(t *testing.T) {
 	// Give the first goroutine a moment to acquire the lock
 	time.Sleep(1 * time.Millisecond)
 
-	// Goroutine 2
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -47,7 +45,6 @@ func TestInMemoryLocker(t *testing.T) {
 	wg.Wait()
 	close(executionOrder)
 
-	// Verify execution order
 	// Expected: 1 (start), 1 (end), 2 (start), 2 (end)
 	var order []int
 	for i := range executionOrder {

--- a/internal/lock/postgres.go
+++ b/internal/lock/postgres.go
@@ -7,8 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// PostgresLocker is an implementation of the Locker interface that uses
-// PostgreSQL advisory locks.
+// PostgresLocker is a Locker backed by PostgreSQL advisory locks.
 type PostgresLocker struct {
 	db *gorm.DB
 }

--- a/internal/lock/postgres_test.go
+++ b/internal/lock/postgres_test.go
@@ -12,8 +12,7 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-// This test requires a running PostgreSQL database.
-// Run with: go test -v -tags integration ./...
+// Requires a running PostgreSQL database; gated on POSTGRES_DSN and skipped in short mode.
 func TestPostgresLocker(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode.")
@@ -35,7 +34,6 @@ func TestPostgresLocker(t *testing.T) {
 	// The buffer must be large enough to hold all sent values before they are read.
 	executionOrder := make(chan int, 4)
 
-	// Goroutine 1
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -52,7 +50,6 @@ func TestPostgresLocker(t *testing.T) {
 	// Give the first goroutine a moment to acquire the lock
 	time.Sleep(10 * time.Millisecond)
 
-	// Goroutine 2
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -67,7 +64,6 @@ func TestPostgresLocker(t *testing.T) {
 	wg.Wait()
 	close(executionOrder)
 
-	// Verify execution order
 	var order []int
 	for i := range executionOrder {
 		order = append(order, i)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -12,9 +12,9 @@ import (
 
 var levelVar = new(slog.LevelVar)
 
-// Init configures the global slog logger to emit JSON to stderr at the level
-// parsed from level. An unparseable level is logged as a warning and leaves the
-// logger at its default (info) level.
+// Init configures the global slog logger to emit JSON to stderr at the level parsed
+// from level. An unparseable level is logged as a warning and leaves the level
+// unchanged -- info on the first call, otherwise whatever a prior call set.
 func Init(level string) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: levelVar})))
 	if lvl, err := parseLevel(level); err != nil {

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	// A valid level is parsed and applied to the shared levelVar.
 	Init("debug")
 	assert.Equal(t, slog.LevelDebug, levelVar.Level())
 

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -1,5 +1,3 @@
-// Package migrate handles database migrations. This file defines the
-// configuration loading specific to the migration process.
 package migrate
 
 import (
@@ -11,7 +9,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/helpers"
 )
 
-// dbConfig holds the database connection components required to build a migration-compatible DSN.
 type dbConfig struct {
 	User           string `env:"DB_USER,required,notEmpty"`
 	Password       string `env:"DB_PASSWORD,required,notEmpty"`
@@ -29,8 +26,7 @@ type MigrationConfig struct {
 	MigrationsPath string
 }
 
-// NewMigrationConfig creates a new configuration by parsing environment variables
-// and constructing a URI-based DSN suitable for golang-migrate.
+// NewMigrationConfig parses environment variables into a URI-based DSN for golang-migrate.
 func NewMigrationConfig() (*MigrationConfig, error) {
 	dbCfg, err := envConfig.ParseAs[dbConfig]()
 	if err != nil {

--- a/internal/migrate/config_test.go
+++ b/internal/migrate/config_test.go
@@ -1,4 +1,3 @@
-// internal/migrate/config_test.go
 package migrate
 
 import (
@@ -11,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewMigrationConfig_Success tests that the default configuration is loaded correctly.
 func TestNewMigrationConfig_Success(t *testing.T) {
-	// Arrange
 	t.Setenv("DB_HOST", "localhost")
 	t.Setenv("DB_PORT", "5432")
 	t.Setenv("DB_USER", "testuser")
@@ -23,21 +20,14 @@ func TestNewMigrationConfig_Success(t *testing.T) {
 	// Unset the custom path to ensure the default is used.
 	t.Setenv("DB_MIGRATIONS_PATH", "")
 
-	// Act
 	cfg, err := NewMigrationConfig()
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "/app/db/migrations", cfg.MigrationsPath)
-	// Verify the DSN is assembled correctly: DB_SSL_MODE flows into the sslmode
-	// segment, the password's special characters are URL-escaped, and the default
-	// connect_timeout (10s) is appended so an unreachable database fails fast.
 	assert.Equal(t, "pgx5://testuser:testpassword%21%40%23@localhost:5432/testdb?sslmode=require&connect_timeout=10", cfg.DSN)
 }
 
-// TestNewMigrationConfig_ConnectTimeoutOverride verifies DB_CONNECT_TIMEOUT flows
-// into the connect_timeout segment of the migration DSN.
 func TestNewMigrationConfig_ConnectTimeoutOverride(t *testing.T) {
 	t.Setenv("DB_HOST", "localhost")
 	t.Setenv("DB_PORT", "5432")
@@ -72,9 +62,7 @@ func TestNewMigrationConfig_SchemeIsRegisteredDriver(t *testing.T) {
 	assert.Contains(t, database.List(), parsed.Scheme)
 }
 
-// TestNewMigrationConfig_CustomPath tests that a custom migration path from env vars is used.
 func TestNewMigrationConfig_CustomPath(t *testing.T) {
-	// Arrange
 	t.Setenv("DB_HOST", "localhost")
 	t.Setenv("DB_PORT", "5432")
 	t.Setenv("DB_USER", "testuser")
@@ -82,10 +70,8 @@ func TestNewMigrationConfig_CustomPath(t *testing.T) {
 	t.Setenv("DB_NAME", "testdb")
 	t.Setenv("DB_MIGRATIONS_PATH", "/my/custom/path")
 
-	// Act
 	cfg, err := NewMigrationConfig()
 
-	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, "/my/custom/path", cfg.MigrationsPath)
 }
@@ -114,16 +100,11 @@ func TestNewMigrationConfig_ConnectTimeoutRejectsNonPositive(t *testing.T) {
 	}
 }
 
-// TestNewMigrationConfig_ValidationError tests the failure case where a required
-// environment variable is missing. This test covers the validation error path.
 func TestNewMigrationConfig_ValidationError(t *testing.T) {
-	// Arrange
 	os.Clearenv() // Ensure no conflicting variables are set.
 
-	// Act
 	cfg, err := NewMigrationConfig()
 
-	// Assert
 	require.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "missing required environment variables")

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -11,11 +11,9 @@ import (
 	// the "postgres" driver because it reuses the pgx stack the state layer already
 	// links, instead of pulling a second PostgreSQL driver (lib/pq) into the binary.
 	_ "github.com/golang-migrate/migrate/v4/database/pgx/v5"
-	// Registers the "file" migration source driver with golang-migrate.
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-// migrator is an interface that wraps the Up method for testing.
 type migrator interface {
 	Up() error
 }
@@ -37,7 +35,7 @@ func NewMigrator(cfg *MigrationConfig) (*Migrator, error) {
 	return NewMigratorWithDriver(m), nil
 }
 
-// NewMigratorWithDriver initializes a new Migrator with a provided driver for testing.
+// NewMigratorWithDriver wraps an already-constructed migrate driver.
 func NewMigratorWithDriver(driver migrator) *Migrator {
 	return &Migrator{
 		migrator: driver,

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -15,54 +15,39 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 )
 
-// TestMigrator_Run_Success tests the successful execution of migrations.
 func TestMigrator_Run_Success(t *testing.T) {
-	// Arrange
 	mock := mocks.NewMockmigrator(gomock.NewController(t))
 	mock.EXPECT().Up().Return(nil)
 	m := NewMigratorWithDriver(mock)
 
-	// Act
 	err := m.Run()
 
-	// Assert
 	assert.NoError(t, err)
 }
 
-// TestMigrator_Run_NoChange tests the case where there are no new migrations.
 func TestMigrator_Run_NoChange(t *testing.T) {
-	// Arrange
 	mock := mocks.NewMockmigrator(gomock.NewController(t))
 	mock.EXPECT().Up().Return(migrate.ErrNoChange)
 	m := NewMigratorWithDriver(mock)
 
-	// Act
 	err := m.Run()
 
-	// Assert
 	assert.NoError(t, err, "migrate.ErrNoChange should be treated as a success")
 }
 
-// TestMigrator_Run_Failure tests the case where the migration returns an error.
 func TestMigrator_Run_Failure(t *testing.T) {
-	// Arrange
 	expectedErr := errors.New("a serious migration error")
 	mock := mocks.NewMockmigrator(gomock.NewController(t))
 	mock.EXPECT().Up().Return(expectedErr)
 	m := NewMigratorWithDriver(mock)
 
-	// Act
 	err := m.Run()
 
-	// Assert
 	require.Error(t, err)
-	// Check that our specific error was wrapped and returned.
 	assert.ErrorIs(t, err, expectedErr)
 }
 
-// TestNewMigrator_Success tests that the real constructor succeeds with a valid config.
 func TestNewMigrator_Success(t *testing.T) {
-	// Arrange
 	migrationsDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(migrationsDir, "1_init.up.sql"), []byte("CREATE TABLE users (id int);"), 0600))
 
@@ -71,25 +56,19 @@ func TestNewMigrator_Success(t *testing.T) {
 		MigrationsPath: migrationsDir,
 	}
 
-	// Act
 	migrator, err := NewMigrator(cfg)
 
-	// Assert
 	require.NoError(t, err)
 	assert.NotNil(t, migrator)
 }
 
-// TestNewMigrator_Failure tests that the real constructor fails with an invalid DSN.
 func TestNewMigrator_Failure(t *testing.T) {
-	// Arrange
 	cfg := &MigrationConfig{
 		DSN: "this-is-not-a-valid-uri",
 	}
 
-	// Act
 	migrator, err := NewMigrator(cfg)
 
-	// Assert
 	require.Error(t, err)
 	assert.Nil(t, migrator)
 }

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -40,15 +40,15 @@ type ApplicationOperationResource struct {
 }
 
 type ApplicationResource struct {
-	Kind      string `json:"kind"`      // example: Pod | Job
-	Name      string `json:"name"`      // example: app-migrations
-	Namespace string `json:"namespace"` // example: app
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 	// Status is the resource's current sync state (example: OutOfSync). ArgoCD omits it for
 	// resources it does not compare, so an empty value means "not assessed", not "in sync".
 	Status string `json:"status"`
 	Health struct {
-		Message string `json:"message"` // example: Job has reached the specified backoff limit
-		Status  string `json:"status"`  // example: Synced
+		Message string `json:"message"`
+		Status  string `json:"status"`
 	} `json:"health"`
 }
 
@@ -68,12 +68,12 @@ type ApplicationTree struct {
 }
 
 type ApplicationTreeNode struct {
-	Kind      string `json:"kind"`      // example: Pod | Job
-	Name      string `json:"name"`      // example: app-6b7f-abcde
-	Namespace string `json:"namespace"` // example: app
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 	Health    struct {
-		Status  string `json:"status"`  // example: Degraded
-		Message string `json:"message"` // example: Back-off pulling image "app:v2": ErrImagePull
+		Status  string `json:"status"`
+		Message string `json:"message"`
 	} `json:"health"`
 }
 
@@ -81,8 +81,8 @@ type ApplicationTreeNode struct {
 // type) or an advisory warning (a "*Warning" type). A manifest-generation failure surfaces here
 // and nowhere in the sync status itself, which merely reports "Unknown".
 type ApplicationCondition struct {
-	Type    string `json:"type"`    // example: ComparisonError
-	Message string `json:"message"` // example: Failed to load target state
+	Type    string `json:"type"`
+	Message string `json:"message"`
 }
 
 type ApplicationStatus struct {
@@ -169,9 +169,7 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 // describe (see buildSyncFailureDiagnostics).
 func (app *Application) GetRolloutMessage(status string, rolloutImages []string, tree *ApplicationTree) string {
 	switch status {
-	// not all expected images were deployed
 	case ArgoRolloutAppNotAvailable:
-		// Image-mismatch is the bare minimum we always show, then append any diagnostics.
 		base := fmt.Sprintf(
 			"List of current images (last app check):\n"+
 				"\t%s\n\n"+
@@ -182,7 +180,6 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 		)
 		// Base message has no resource listing, so fall back to Status.Resources when no tree.
 		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, true))
-	// sync status was not "Synced"
 	case ArgoRolloutAppNotSynced:
 		base := fmt.Sprintf(
 			"App status \"%s\"\n"+
@@ -194,11 +191,9 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 			appendResourceListing(base, app.ListSyncResultResources()),
 			app.buildSyncFailureDiagnostics(tree),
 		)
-	// app is unhealthy or degraded
 	case ArgoRolloutAppNotHealthy, ArgoRolloutAppDegraded:
-		// display current health of the top-level resources, then append the same
-		// diagnostics as the "not available" path — a stalled rollout caused by a
-		// failing pod surfaces here just as often, and its cause lives in the tree.
+		// Appends the same diagnostics as the "not available" path — a stalled rollout
+		// caused by a failing pod surfaces here just as often, and its cause lives in the tree.
 		base := fmt.Sprintf(
 			"App sync status \"%s\"\n"+
 				"App health status \"%s\"",
@@ -246,8 +241,7 @@ func formatSyncResultResource(r ApplicationOperationResource) string {
 	return fmt.Sprintf("%s(%s) %s %s with message %s", r.Kind, r.Name, r.HookType, r.HookPhase, r.Message)
 }
 
-// ListSyncResultResources returns one formatted line per sync-result resource
-// (see formatSyncResultResource for the format).
+// ListSyncResultResources returns one formatted line per sync-result resource.
 func (app *Application) ListSyncResultResources() []string {
 	list := make([]string, len(app.Status.OperationState.SyncResult.Resources))
 	for index := range app.Status.OperationState.SyncResult.Resources {
@@ -266,8 +260,7 @@ func formatHealthResource(r ApplicationResource) string {
 	return line
 }
 
-// ListUnhealthyResources returns one formatted line per resource with a non-empty
-// health status (see formatHealthResource for the format).
+// ListUnhealthyResources returns one formatted line per resource with a non-empty health status.
 func (app *Application) ListUnhealthyResources() []string {
 	var list []string
 
@@ -366,7 +359,6 @@ func isProblemHealthStatus(status string) bool {
 }
 
 // listFailedSyncResultResources returns formatted lines for sync-result resources whose hook phase indicates failure.
-// Reuses the same one-line format as ListSyncResultResources via formatSyncResultResource.
 func (app *Application) listFailedSyncResultResources() []string {
 	var list []string
 	for index := range app.Status.OperationState.SyncResult.Resources {
@@ -380,7 +372,6 @@ func (app *Application) listFailedSyncResultResources() []string {
 }
 
 // listProblemResources returns formatted lines for resources whose health status indicates a problem.
-// Reuses formatHealthResource for output formatting; applies the stricter problem-only filter via isProblemHealthStatus.
 func (app *Application) listProblemResources() []string {
 	var list []string
 	for index := range app.Status.Resources {
@@ -502,8 +493,7 @@ func (app *Application) IsFireAndForgetModeActive() bool {
 	return app.Metadata.Annotations[fireAndForgetAnnotation] == "true"
 }
 
-// IsImageValidationSkipped reports whether the app opted out of the desired-state
-// image check via the "argo-watcher/skip-image-validation=true" annotation.
+// IsImageValidationSkipped reports whether the app carries "argo-watcher/skip-image-validation=true".
 func (app *Application) IsImageValidationSkipped() bool {
 	if app.Metadata.Annotations == nil {
 		return false

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -9,56 +9,46 @@ import (
 )
 
 func TestListSyncResultResources(t *testing.T) {
-	// Read the JSON data file
 	jsonData, err := os.ReadFile("testdata/failed-deployment.json")
 	if err != nil {
 		t.Fatalf("Failed to read JSON data file: %s", err)
 	}
 
-	// Unmarshal JSON into the Application struct
 	var app Application
 	err = json.Unmarshal(jsonData, &app)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal JSON data: %s", err)
 	}
 
-	// Invoke the method being tested
 	resultResources := app.ListSyncResultResources()
 
-	// Define the expected resource strings based on the JSON data
 	expectedResources := []string{
 		"Pod(app-migrations) PreSync Succeeded with message ",
 		"Job(app-job) PostSync Failed with message Job has reached the specified backoff limit",
 	}
 
-	// Assert that the result matches the expected resources
 	assert.Equal(t, expectedResources, resultResources)
 }
 
 func TestListUnhealthyResources(t *testing.T) {
-	// Read the JSON data file
 	jsonData, err := os.ReadFile("testdata/failed-deployment.json")
 	if err != nil {
 		t.Fatalf("Failed to read JSON data file: %s", err)
 	}
 
-	// Unmarshal JSON into the Application struct
 	var app Application
 	err = json.Unmarshal(jsonData, &app)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal JSON data: %s", err)
 	}
 
-	// Invoke the method being tested
 	unhealthyResources := app.ListUnhealthyResources()
 
-	// Define the expected resource strings based on the JSON data
 	expectedResources := []string{
 		"Pod(app-pod) Synced",
 		"Job(app-job) Unhealthy with message Job has reached the specified backoff limit",
 	}
 
-	// Assert that the result matches the expected unhealthy resources
 	assert.Equal(t, expectedResources, unhealthyResources)
 }
 
@@ -93,64 +83,49 @@ func TestNotSyncedDiagnosticsFromPayload(t *testing.T) {
 
 func TestArgoRolloutStatus(t *testing.T) {
 	t.Run("Rollout status - ArgoRolloutAppNotAvailable", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version2"}
 		registryProxyUrl := ""
-		// test status
 		assert.Equal(t, ArgoRolloutAppNotAvailable, application.GetRolloutStatus(images, registryProxyUrl, false))
 	})
 
 	t.Run("Rollout status - ArgoRolloutAppNotSynced", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		application.Status.Sync.Status = "Syncing"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		registryProxyUrl := ""
-		// test status
 		assert.Equal(t, ArgoRolloutAppNotSynced, application.GetRolloutStatus(images, registryProxyUrl, false))
 	})
 
 	t.Run("Rollout status - ArgoRolloutAppNotHealthy", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "NotHealthy"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		registryProxyUrl := ""
-		// test status
 		assert.Equal(t, ArgoRolloutAppNotHealthy, application.GetRolloutStatus(images, registryProxyUrl, false))
 	})
 
 	t.Run("Rollout status - ArgoRolloutAppSuccess", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "Healthy"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		registryProxyUrl := ""
-		// test status
 		assert.Equal(t, ArgoRolloutAppSuccess, application.GetRolloutStatus(images, registryProxyUrl, false))
 	})
 
 	t.Run("Rollout status - ArgoRolloutAppDegraded", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
-		application.Status.Sync.Status = "Synced" // Not "OutOfSync"
+		application.Status.Sync.Status = "Synced"
 		application.Status.Health.Status = "Degraded"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		registryProxyUrl := ""
-		// test status
 		assert.Equal(t, ArgoRolloutAppDegraded, application.GetRolloutStatus(images, registryProxyUrl, false))
 	})
 
@@ -191,10 +166,8 @@ func TestArgoRolloutStatus(t *testing.T) {
 func TestArgoRolloutMessage(t *testing.T) {
 
 	t.Run("Rollout message - ArgoRolloutAppNotAvailable", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version2"}
 		assert.Equal(t,
 			"List of current images (last app check):\n\tghcr.io/shini4i/argo-watcher:version1\n\nList of expected images:\n\tghcr.io/shini4i/argo-watcher:version2",
@@ -365,7 +338,6 @@ func TestArgoRolloutMessage(t *testing.T) {
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotSynced", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		application.Status.Sync.Status = "Syncing"
@@ -373,7 +345,6 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.OperationState.Phase = "NotWorking"
 		application.Status.OperationState.Message = "Not working test app"
 		application.Status.OperationState.SyncResult.Resources = make([]ApplicationOperationResource, 2)
-		// first resource
 		application.Status.OperationState.SyncResult.Resources[0].HookPhase = "Succeeded"
 		application.Status.OperationState.SyncResult.Resources[0].HookType = "PreSync"
 		application.Status.OperationState.SyncResult.Resources[0].Kind = "Pod"
@@ -382,7 +353,6 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.OperationState.SyncResult.Resources[0].SyncPhase = "PreSync"
 		application.Status.OperationState.SyncResult.Resources[0].Name = "app-migrations"
 		application.Status.OperationState.SyncResult.Resources[0].Namespace = "app"
-		// second resource
 		application.Status.OperationState.SyncResult.Resources[1].HookPhase = "Failed"
 		application.Status.OperationState.SyncResult.Resources[1].HookType = "PostSync"
 		application.Status.OperationState.SyncResult.Resources[1].Kind = "Job"
@@ -391,7 +361,6 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.OperationState.SyncResult.Resources[1].SyncPhase = "PostSync"
 		application.Status.OperationState.SyncResult.Resources[1].Name = "app-job"
 		application.Status.OperationState.SyncResult.Resources[1].Namespace = "app"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		assert.Equal(t,
 			"App status \"NotWorking\"\nApp message \"Not working test app\"\nResources:\n\tPod(app-migrations) PreSync Succeeded with message \n\tJob(app-job) PostSync Failed with message Job has reached the specified backoff limit",
@@ -399,7 +368,6 @@ func TestArgoRolloutMessage(t *testing.T) {
 	})
 
 	t.Run("Rollout message - ArgoRolloutAppNotHealthy", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		application.Status.Sync.Status = "Syncing"
@@ -407,19 +375,16 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.OperationState.Phase = "NotWorking"
 		application.Status.OperationState.Message = "Not working test app"
 		application.Status.Resources = make([]ApplicationResource, 2)
-		// first resource
 		application.Status.Resources[0].Kind = "Pod"
 		application.Status.Resources[0].Name = "app-pod"
 		application.Status.Resources[0].Namespace = "app"
 		application.Status.Resources[0].Health.Message = ""
 		application.Status.Resources[0].Health.Status = "Synced"
-		// second resource
 		application.Status.Resources[1].Kind = "Job"
 		application.Status.Resources[1].Name = "app-job"
 		application.Status.Resources[1].Namespace = "app"
 		application.Status.Resources[1].Health.Message = "Job has reached the specified backoff limit"
 		application.Status.Resources[1].Health.Status = "Unhealthy"
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		assert.Equal(t,
 			"App sync status \"Syncing\"\nApp health status \"NotHealthy\"\nResources:\n\tPod(app-pod) Synced\n\tJob(app-job) Unhealthy with message Job has reached the specified backoff limit",
@@ -427,10 +392,8 @@ func TestArgoRolloutMessage(t *testing.T) {
 	})
 
 	t.Run("Rollout message - default", func(t *testing.T) {
-		// define application
 		application := Application{}
 		application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:version1"}
-		// define expected images
 		images := []string{"ghcr.io/shini4i/argo-watcher:version2"}
 		assert.Equal(t, "received unexpected rollout status \"unexpected status\"", application.GetRolloutMessage("unexpected status", images, nil))
 	})
@@ -893,8 +856,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 	})
 }
 
-// treeNode builds an ApplicationTreeNode with the given health, sparing tests the anonymous
-// struct literal for the Health field.
+// treeNode spares call sites the anonymous struct literal for the Health field.
 func treeNode(kind, name, status, message string) ApplicationTreeNode {
 	n := ApplicationTreeNode{Kind: kind, Name: name, Namespace: "app"}
 	n.Health.Status = status
@@ -915,8 +877,6 @@ func TestApplicationTreeListProblemNodes(t *testing.T) {
 
 	got := tree.ListProblemNodes()
 
-	// Every status isProblemHealthStatus whitelists survives (Degraded, Missing, Unknown,
-	// Suspended); Healthy/Progressing/empty are filtered out.
 	assert.Equal(t, []string{
 		`Pod(pull-fail) Degraded with message Back-off pulling image "app:v2": ErrImagePull`,
 		"Job(missing-hook) Missing",

--- a/internal/models/gitops.go
+++ b/internal/models/gitops.go
@@ -32,10 +32,8 @@ func extractGitOverrides(annotations map[string]string, app *Application, isSour
 	fields := make(map[string]*string)
 
 	if isSourceNil {
-		// when app.Spec.Sources is nil, just include the managedGitFile
 		fields[managedGitFile] = &gr.Filename
 	} else {
-		// when app.Spec.Sources is not nil, include all fields
 		fields = map[string]*string{
 			managedGitRepo:   &gr.RepoUrl,
 			managedGitBranch: &gr.BranchName,

--- a/internal/models/managed_resources_test.go
+++ b/internal/models/managed_resources_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// resource builds a ManagedResource around a raw target-state manifest.
 func resource(targetState string) ManagedResource {
 	return ManagedResource{TargetState: targetState}
 }
@@ -44,15 +43,11 @@ const cronJobManifest = `{
 
 const serviceManifest = `{"apiVersion": "v1", "kind": "Service", "spec": {"ports": [{"port": 80}]}}`
 
-// TestDesiredImageNamesCollectsWorkloadKinds verifies that images are extracted from
-// arbitrarily nested pod templates, that tags are stripped, and that duplicates are
-// collapsed into a single sorted list.
 func TestDesiredImageNamesCollectsWorkloadKinds(t *testing.T) {
 	resources := ManagedResources{Items: []ManagedResource{
 		resource(deploymentManifest),
 		resource(cronJobManifest),
 		resource(serviceManifest),
-		// A second workload repeating an image already seen must not duplicate it.
 		resource(deploymentManifest),
 	}}
 
@@ -63,9 +58,7 @@ func TestDesiredImageNamesCollectsWorkloadKinds(t *testing.T) {
 	}, resources.DesiredImageNames())
 }
 
-// TestDesiredImageNamesSkipsUnusableItems verifies that an unparsable or empty
-// target state is ignored rather than aborting the whole extraction — a single bad
-// manifest must not blind the check to the images it can read.
+// A single unparsable manifest must not blind the check to the images it can read.
 func TestDesiredImageNamesSkipsUnusableItems(t *testing.T) {
 	resources := ManagedResources{Items: []ManagedResource{
 		resource(""),
@@ -78,8 +71,8 @@ func TestDesiredImageNamesSkipsUnusableItems(t *testing.T) {
 	assert.Equal(t, []string{"busybox", "ghcr.io/shini4i/app"}, resources.DesiredImageNames())
 }
 
-// TestDesiredImageNamesCollectsNonTemplateImages verifies that an image declared outside a
-// pod template — an operator CR is the common case — still counts as part of the application.
+// An image declared outside a pod template — an operator CR is the common case — still
+// counts as part of the application.
 func TestDesiredImageNamesCollectsNonTemplateImages(t *testing.T) {
 	resources := ManagedResources{Items: []ManagedResource{
 		resource(`{"kind":"Workflow","spec":{"templates":[{"container":{"image":"ghcr.io/shini4i/step:v1"}}]}}`),
@@ -90,8 +83,7 @@ func TestDesiredImageNamesCollectsNonTemplateImages(t *testing.T) {
 	assert.Equal(t, []string{"ghcr.io/shini4i/step"}, resources.DesiredImageNames())
 }
 
-// TestDesiredImageNamesEmpty verifies that an application whose manifests declare no
-// images yields an empty list, which callers treat as "cannot conclude".
+// An empty list is what callers treat as "cannot conclude".
 func TestDesiredImageNamesEmpty(t *testing.T) {
 	resources := ManagedResources{Items: []ManagedResource{resource(serviceManifest)}}
 	assert.Empty(t, resources.DesiredImageNames())

--- a/internal/notifications/mattermost.go
+++ b/internal/notifications/mattermost.go
@@ -84,8 +84,6 @@ func NewMattermostStrategy(cfg *config.MattermostConfig, client HTTPClient) (*Ma
 }
 
 // Send delivers the Mattermost notification for the provided task.
-// A task with the "in progress" status creates a root post whose id is
-// remembered; any other status replies in that post's thread and forgets it.
 func (s *MattermostStrategy) Send(task models.Task) error {
 	var message bytes.Buffer
 	if err := s.template.Execute(&message, task); err != nil {
@@ -128,7 +126,6 @@ func (s *MattermostStrategy) Send(task models.Task) error {
 	return err
 }
 
-// createPost sends POST /api/v4/posts and returns the created post id.
 func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/notifications/mattermost_test.go
+++ b/internal/notifications/mattermost_test.go
@@ -37,7 +37,6 @@ func unusedHTTPClient(t *testing.T) *mocks.MockHTTPClient {
 	return mocks.NewMockHTTPClient(gomock.NewController(t))
 }
 
-// TestNewMattermostStrategy tests the constructor for MattermostStrategy.
 func TestNewMattermostStrategy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		cfg := validMattermostConfig()
@@ -150,7 +149,6 @@ func decodePostBody(t *testing.T, req *http.Request) map[string]any {
 	return decoded
 }
 
-// TestMattermostSend tests the Send method of the MattermostStrategy.
 func TestMattermostSend(t *testing.T) {
 	t.Run("Start Creates Root Post And Stores Post Id", func(t *testing.T) {
 		mockClient := mocks.NewMockHTTPClient(gomock.NewController(t))

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -27,7 +27,6 @@ type NotificationStrategy interface {
 }
 
 // HTTPClient defines the interface for a client that can perform HTTP requests.
-// This allows for mocking in unit tests.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -77,8 +76,7 @@ type WebhookStrategy struct {
 	template             *template.Template
 }
 
-// NewWebhookStrategy creates and initializes the webhook strategy.
-// It requires an HTTPClient and a non-empty format template, keeping the strategy testable and predictable.
+// NewWebhookStrategy requires an HTTPClient and a non-empty format template.
 func NewWebhookStrategy(cfg *config.WebhookConfig, client HTTPClient) (*WebhookStrategy, error) {
 	if cfg == nil {
 		return nil, errors.New("webhook configuration cannot be nil")

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -17,10 +17,8 @@ import (
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-// TestNewWebhookStrategy tests the constructor for WebhookStrategy.
 func TestNewWebhookStrategy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// arrange
 		ctrl := gomock.NewController(t)
 		cfg := &config.WebhookConfig{
 			Enabled:              true,
@@ -33,10 +31,8 @@ func TestNewWebhookStrategy(t *testing.T) {
 		}
 		client := mocks.NewMockHTTPClient(ctrl)
 
-		// act
 		service, err := NewWebhookStrategy(cfg, client)
 
-		// assert
 		require.NoError(t, err)
 		assert.NotNil(t, service)
 		assert.Equal(t, cfg.Url, service.url)
@@ -49,16 +45,13 @@ func TestNewWebhookStrategy(t *testing.T) {
 	})
 
 	t.Run("Nil HTTPClient", func(t *testing.T) {
-		// arrange
 		cfg := &config.WebhookConfig{
 			Enabled: true,
 			Format:  `{"id":"{{.Id}}"}`,
 		}
 
-		// act
 		service, err := NewWebhookStrategy(cfg, nil)
 
-		// assert
 		require.Error(t, err)
 		assert.Nil(t, service)
 		assert.Equal(t, "HTTPClient cannot be nil", err.Error())
@@ -103,20 +96,16 @@ func TestNewWebhookStrategy(t *testing.T) {
 	})
 }
 
-// TestSend tests the Send method of the WebhookStrategy.
 func TestSend(t *testing.T) {
 	task := models.Task{Id: "test-task-123"}
 
-	// Pre-compile a valid template for reuse in tests
 	tmpl, err := template.New("webhook").Parse(`{"id":"{{.Id}}"}`)
 	require.NoError(t, err)
 
 	t.Run("Successful Webhook", func(t *testing.T) {
-		// arrange
 		ctrl := gomock.NewController(t)
 		mockClient := mocks.NewMockHTTPClient(ctrl)
 		mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			// Assert request details
 			assert.Equal(t, http.MethodPost, req.Method)
 			assert.Equal(t, "http://testhost/hook", req.URL.String())
 			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
@@ -141,48 +130,38 @@ func TestSend(t *testing.T) {
 			template:             tmpl,
 		}
 
-		// act
 		err := service.Send(task)
 
-		// assert
 		assert.NoError(t, err)
 	})
 
 	t.Run("Failed Template Execution", func(t *testing.T) {
-		// arrange
-		// Use a template that requires a field not present in the task model
 		invalidTmpl, err := template.New("webhook").Parse(`{"missing_field":"{{.Missing}}>"}`)
 		require.NoError(t, err)
 
 		service := &WebhookStrategy{
-			template: invalidTmpl, // a template that will fail
+			template: invalidTmpl,
 		}
 
-		// act
 		err = service.Send(task)
 
-		// assert
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to execute webhook template")
 	})
 
 	t.Run("Failed Request Creation", func(t *testing.T) {
-		// arrange
 		service := &WebhookStrategy{
 			url:      ":invalid-url:", // This will cause http.NewRequestWithContext to fail
 			template: tmpl,
 		}
 
-		// act
 		err := service.Send(task)
 
-		// assert
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create webhook request")
 	})
 
 	t.Run("Client Throws Error", func(t *testing.T) {
-		// arrange
 		ctrl := gomock.NewController(t)
 		mockClient := mocks.NewMockHTTPClient(ctrl)
 		mockClient.EXPECT().Do(gomock.Any()).Return(nil, errors.New("network error"))
@@ -193,16 +172,13 @@ func TestSend(t *testing.T) {
 			template: tmpl,
 		}
 
-		// act
 		err := service.Send(task)
 
-		// assert
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to send webhook: network error")
 	})
 
 	t.Run("Non-Allowed Status Code", func(t *testing.T) {
-		// arrange
 		ctrl := gomock.NewController(t)
 		mockClient := mocks.NewMockHTTPClient(ctrl)
 		mockClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
@@ -217,18 +193,14 @@ func TestSend(t *testing.T) {
 			template:             tmpl,
 		}
 
-		// act
 		err := service.Send(task)
 
-		// assert
 		require.Error(t, err)
 		assert.Equal(t, "received non-allowed status code 500: {\"error\":\"internal server error\"}", err.Error())
 	})
 
 	t.Run("Non-Allowed Status Code with Body Read Error", func(t *testing.T) {
-		// arrange
 		ctrl := gomock.NewController(t)
-		// Custom reader that returns an error on Read
 		errorReader := &errorReader{err: errors.New("read error")}
 
 		mockClient := mocks.NewMockHTTPClient(ctrl)
@@ -244,10 +216,8 @@ func TestSend(t *testing.T) {
 			template:             tmpl,
 		}
 
-		// act
 		err := service.Send(task)
 
-		// assert
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "received non-allowed status code 403, and failed to read response body: read error")
 	})
@@ -280,15 +250,12 @@ func TestNotifierSend(t *testing.T) {
 	})
 }
 
-// NotificationStrategyFunc allows defining inline notification strategies for tests.
 type NotificationStrategyFunc func(models.Task) error
 
-// Send executes the wrapped function.
 func (f NotificationStrategyFunc) Send(task models.Task) error {
 	return f(task)
 }
 
-// errorReader is a helper struct that implements io.Reader and always returns an error.
 type errorReader struct {
 	err error
 }

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -22,7 +22,6 @@ type MetricsInterface interface {
 	AddUnauthenticatedRead(path, app string)
 }
 
-// Metrics contains all the prometheus collectors.
 type Metrics struct {
 	FailedDeployment     *prometheus.GaugeVec
 	ProcessedDeployments *prometheus.CounterVec
@@ -37,7 +36,7 @@ type Metrics struct {
 	UnauthenticatedReads *prometheus.CounterVec
 }
 
-// NewMetrics creates and registers the metrics with the provided Registerer.
+// NewMetrics registers the collectors with the provided Registerer.
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	m := &Metrics{
 		FailedDeployment: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -121,22 +120,18 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	return m
 }
 
-// AddProcessedDeployment increments the ProcessedDeployments counter.
 func (m *Metrics) AddProcessedDeployment(app string) {
 	m.ProcessedDeployments.WithLabelValues(app).Inc()
 }
 
-// AddFailedDeployment increments the FailedDeployment gauge for the given app.
 func (m *Metrics) AddFailedDeployment(app string) {
 	m.FailedDeployment.WithLabelValues(app).Inc()
 }
 
-// ResetFailedDeployment resets the FailedDeployment gauge for the given app.
 func (m *Metrics) ResetFailedDeployment(app string) {
 	m.FailedDeployment.WithLabelValues(app).Set(0)
 }
 
-// SetArgoUnavailable sets the ArgocdUnavailable gauge.
 func (m *Metrics) SetArgoUnavailable(unavailable bool) {
 	if unavailable {
 		m.ArgocdUnavailable.Set(1)
@@ -145,7 +140,7 @@ func (m *Metrics) SetArgoUnavailable(unavailable bool) {
 	}
 }
 
-// SetStateUnavailable sets the StateUnavailable gauge (state backend reachability).
+// SetStateUnavailable sets the StateUnavailable gauge.
 func (m *Metrics) SetStateUnavailable(unavailable bool) {
 	if unavailable {
 		m.StateUnavailable.Set(1)
@@ -154,17 +149,14 @@ func (m *Metrics) SetStateUnavailable(unavailable bool) {
 	}
 }
 
-// AddInProgressTask increments the InProgressTasks gauge.
 func (m *Metrics) AddInProgressTask() {
 	m.InProgressTasks.Inc()
 }
 
-// RemoveInProgressTask decrements the InProgressTasks gauge.
 func (m *Metrics) RemoveInProgressTask() {
 	m.InProgressTasks.Dec()
 }
 
-// ObserveRefreshDuration records how long an ArgoCD refresh request took for the given app.
 func (m *Metrics) ObserveRefreshDuration(app string, seconds float64) {
 	m.RefreshDuration.WithLabelValues(app).Observe(seconds)
 }
@@ -187,8 +179,7 @@ func (m *Metrics) ObserveDeploymentDuration(app string, seconds float64) {
 	m.DeploymentDuration.WithLabelValues(app).Observe(seconds)
 }
 
-// ObserveGitBatchSize records how many applications were coalesced into a single
-// batch write-back flush.
+// ObserveGitBatchSize records how many applications were coalesced into one flush.
 func (m *Metrics) ObserveGitBatchSize(size int) {
 	m.GitBatchSize.Observe(float64(size))
 }

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestMetrics_AddProcessedDeployment(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 	expectedMetric := `
@@ -21,16 +20,13 @@ func TestMetrics_AddProcessedDeployment(t *testing.T) {
 		processed_deployments{app="test-app"} 1
 	`
 
-	// Act
 	m.AddProcessedDeployment("test-app")
 
-	// Assert
 	err := testutil.CollectAndCompare(m.ProcessedDeployments, strings.NewReader(expectedMetric))
 	assert.NoError(t, err)
 }
 
 func TestMetrics_AddFailedDeployment(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 	appName := "test-app"
@@ -40,16 +36,13 @@ func TestMetrics_AddFailedDeployment(t *testing.T) {
 		failed_deployment{app="test-app"} 1
 	`
 
-	// Act
 	m.AddFailedDeployment(appName)
 
-	// Assert
 	err := testutil.CollectAndCompare(m.FailedDeployment, strings.NewReader(expectedMetric))
 	assert.NoError(t, err)
 }
 
 func TestMetrics_ResetFailedDeployment(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 	appName := "test-app"
@@ -61,10 +54,8 @@ func TestMetrics_ResetFailedDeployment(t *testing.T) {
 		failed_deployment{app="test-app"} 0
 	`
 
-	// Act
 	m.ResetFailedDeployment(appName)
 
-	// Assert
 	err := testutil.CollectAndCompare(m.FailedDeployment, strings.NewReader(expectedMetric))
 	assert.NoError(t, err)
 }
@@ -81,14 +72,11 @@ func TestMetrics_SetArgoUnavailable(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Arrange
 			reg := prometheus.NewRegistry()
 			m := NewMetrics(reg)
 
-			// Act
 			m.SetArgoUnavailable(tc.unavailable)
 
-			// Assert
 			assert.Equal(t, tc.expectedValue, testutil.ToFloat64(m.ArgocdUnavailable))
 		})
 	}
@@ -106,21 +94,16 @@ func TestMetrics_SetStateUnavailable(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Arrange
 			reg := prometheus.NewRegistry()
 			m := NewMetrics(reg)
 
-			// Act
 			m.SetStateUnavailable(tc.unavailable)
 
-			// Assert
 			assert.Equal(t, tc.expectedValue, testutil.ToFloat64(m.StateUnavailable))
 		})
 	}
 }
 
-// histogramSampleForApp reads the sample count and sum recorded for a given app label
-// on a HistogramVec, so tests can assert the exact value that was observed.
 func histogramSampleForApp(t *testing.T, vec *prometheus.HistogramVec, app string) (count uint64, sum float64) {
 	t.Helper()
 	obs, err := vec.GetMetricWithLabelValues(app)
@@ -131,43 +114,34 @@ func histogramSampleForApp(t *testing.T, vec *prometheus.HistogramVec, app strin
 }
 
 func TestMetrics_ObserveGitWritebackDuration(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 
-	// Act
 	m.ObserveGitWritebackDuration("test-app", 3.5)
 
-	// Assert: exactly one observation of the passed value for the app.
 	count, sum := histogramSampleForApp(t, m.GitWritebackDuration, "test-app")
 	assert.Equal(t, uint64(1), count)
 	assert.Equal(t, 3.5, sum)
 }
 
 func TestMetrics_ObserveGitLockWaitDuration(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 
-	// Act
 	m.ObserveGitLockWaitDuration("test-app", 12)
 
-	// Assert: exactly one observation of the passed value for the app.
 	count, sum := histogramSampleForApp(t, m.GitLockWaitDuration, "test-app")
 	assert.Equal(t, uint64(1), count)
 	assert.Equal(t, float64(12), sum)
 }
 
 func TestMetrics_ObserveGitBatchSize(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 
-	// Act
 	m.ObserveGitBatchSize(3)
 
-	// Assert: exactly one observation of value 3. GitBatchSize is a plain
-	// Histogram (no per-app label), so read it directly rather than via a Vec.
+	// GitBatchSize is a plain Histogram (no per-app label), so read it directly.
 	var metric dto.Metric
 	require.NoError(t, m.GitBatchSize.Write(&metric))
 	assert.Equal(t, uint64(1), metric.GetHistogram().GetSampleCount())
@@ -175,32 +149,25 @@ func TestMetrics_ObserveGitBatchSize(t *testing.T) {
 }
 
 func TestMetrics_ObserveDeploymentDuration(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 
-	// Act
 	m.ObserveDeploymentDuration("test-app", 42)
 
-	// Assert: exactly one observation of the passed value for the app.
 	count, sum := histogramSampleForApp(t, m.DeploymentDuration, "test-app")
 	assert.Equal(t, uint64(1), count)
 	assert.Equal(t, float64(42), sum)
 }
 
 func TestMetrics_InProgressTasks(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 
-	// Assert initial state
 	assert.Equal(t, float64(0), testutil.ToFloat64(m.InProgressTasks))
 
-	// Act: Add a task
 	m.AddInProgressTask()
 	assert.Equal(t, float64(1), testutil.ToFloat64(m.InProgressTasks))
 
-	// Act: Remove a task
 	m.RemoveInProgressTask()
 	assert.Equal(t, float64(0), testutil.ToFloat64(m.InProgressTasks))
 }

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -30,8 +30,7 @@ type Env struct {
 	// report the pod out of service while it is still able to serve. It is separate
 	// from shutdownCh, which is closed later in the sequence (after the listener),
 	// and deliberately never reset: shutdown is terminal.
-	draining atomic.Bool
-	// shutdownOnce ensures Shutdown() can be called multiple times safely.
+	draining     atomic.Bool
 	shutdownOnce sync.Once
 	// connWg tracks active WebSocket connection goroutines for graceful shutdown.
 	connWg sync.WaitGroup
@@ -80,9 +79,6 @@ const (
 	argoDownMessage = "argocd_down"
 )
 
-// argoStatusMessage builds the WebSocket payload for a reachability reason:
-// argoUpMessage when everything is reachable, otherwise "argocd_down:<reason>"
-// so clients learn which subsystem is down (see argocd.Reason* constants).
 func argoStatusMessage(reason string) string {
 	if reason == argocd.ReasonNone {
 		return argoUpMessage
@@ -152,7 +148,6 @@ func (env *Env) beginDraining() {
 	env.draining.Store(true)
 }
 
-// isDraining reports whether graceful shutdown has begun.
 func (env *Env) isDraining() bool {
 	return env.draining.Load()
 }
@@ -174,7 +169,6 @@ func (env *Env) Shutdown(ctx context.Context) {
 		})
 	}
 
-	// Wait for all WebSocket connection goroutines to finish with timeout
 	done := make(chan struct{})
 	go func() {
 		env.connWg.Wait()
@@ -189,10 +183,8 @@ func (env *Env) Shutdown(ctx context.Context) {
 	}
 }
 
-// NewEnv wires up an Env from the server config: lockdown schedules backed by
-// the given deploy lock store and the enabled auth strategies (deploy token,
-// optional OIDC — registered under both the canonical and legacy Keycloak
-// headers — and optional JWT).
+// NewEnv wires up an Env from the server config: lockdown schedules backed by the
+// given deploy lock store, and the enabled auth strategies.
 func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater, deployLockStore lock.DeployLockStore) (*Env, error) {
 	var env *Env
 	var err error

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -293,7 +293,6 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 			return false
 		}
 		if err != nil {
-			// A header was present and the strategy rejected the token. Surface the reason.
 			slog.Warn("rejected request with invalid token",
 				"method", r.Method, "url", r.URL, "error", err)
 			writeJSON(w, http.StatusUnauthorized, models.TaskStatus{

--- a/internal/server/handlers_argocd_test.go
+++ b/internal/server/handlers_argocd_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 )
 
-// TestArgoStatus verifies the read-only reachability endpoint reflects the
-// cached availability and names the unreachable subsystem in its JSON body.
 func TestArgoStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -65,8 +63,6 @@ func TestArgoStatus(t *testing.T) {
 	t.Run("reports unavailable and names ArgoCD after a failed login", func(t *testing.T) {
 		repo := mocks.NewMockTaskRepository(ctrl)
 		repo.EXPECT().Check().Return(true)
-		// State backend is up but ArgoCD login fails, so only ArgoCD is down and
-		// the reason must serialize as "argocd" at the HTTP layer.
 		api := mocks.NewMockArgoApiInterface(ctrl)
 		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("login boom"))
 		argo := &argocd.Argo{}
@@ -132,14 +128,11 @@ func TestStartArgoWatcher(t *testing.T) {
 
 	select {
 	case <-done:
-		// goroutine exited and released its connWg slot
 	case <-time.After(2 * time.Second):
 		t.Fatal("StartArgoWatcher goroutine did not exit after shutdown")
 	}
 }
 
-// TestWatchArgoTransitions verifies the watcher pushes a message only when the
-// observed reachability actually changes, and that it stops on request.
 func TestWatchArgoTransitions(t *testing.T) {
 	recv := func(t *testing.T, msgs <-chan string) string {
 		t.Helper()
@@ -169,7 +162,6 @@ func TestWatchArgoTransitions(t *testing.T) {
 		go watchArgoTransitions(stop, 5*time.Millisecond, load, func(m string) { msgs <- m })
 		time.Sleep(20 * time.Millisecond) // allow the watcher to capture its baseline
 
-		// Reachable -> database down: down message carries the cause.
 		reason.Store(argocd.ReasonDatabase)
 		assert.Equal(t, argoDownMessage+":"+argocd.ReasonDatabase, recv(t, msgs))
 
@@ -178,7 +170,6 @@ func TestWatchArgoTransitions(t *testing.T) {
 		reason.Store(argocd.ReasonBoth)
 		assert.Equal(t, argoDownMessage+":"+argocd.ReasonBoth, recv(t, msgs))
 
-		// Recovery clears the banner with the plain up message.
 		reason.Store(argocd.ReasonNone)
 		assert.Equal(t, argoUpMessage, recv(t, msgs))
 	})
@@ -195,7 +186,6 @@ func TestWatchArgoTransitions(t *testing.T) {
 		case m := <-msgs:
 			t.Fatalf("unexpected notification: %q", m)
 		case <-time.After(50 * time.Millisecond):
-			// no transition occurred, so no notification is expected
 		}
 	})
 
@@ -213,7 +203,6 @@ func TestWatchArgoTransitions(t *testing.T) {
 
 		select {
 		case <-done:
-			// returned as expected
 		case <-time.After(time.Second):
 			t.Fatal("watchArgoTransitions did not return after stop was closed")
 		}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -45,7 +45,6 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 	}
 }
 
-// writeString renders a plain-text response body with the given status code.
 func writeString(w http.ResponseWriter, status int, body string) {
 	w.Header().Set("Content-Type", textContentType)
 	w.WriteHeader(status)
@@ -84,8 +83,6 @@ type taskAppLabel struct {
 	app string
 }
 
-// withTaskAppLabel returns a request carrying a holder for the resolved app name,
-// along with the holder itself.
 func withTaskAppLabel(r *http.Request) (*http.Request, *taskAppLabel) {
 	holder := &taskAppLabel{}
 	return r.WithContext(context.WithValue(r.Context(), taskAppContextKey, holder)), holder
@@ -100,7 +97,6 @@ func setTaskApp(r *http.Request, app string) {
 	}
 }
 
-// routeParam matches a chi path parameter, which routePattern rewrites.
 var routeParam = regexp.MustCompile(`\{([^}]+)\}`)
 
 // routePattern returns the matched route in the `/api/v1/tasks/:id` form.

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 // TestWriteJSONUnmarshalableBody covers why writeJSON marshals before it touches the
-// writer: a value that cannot be encoded must produce an error status rather than a
-// 200 with a truncated body.
+// writer: an unencodable value must produce an error status, not a truncated 200.
 func TestWriteJSONUnmarshalableBody(t *testing.T) {
 	w := httptest.NewRecorder()
 

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -204,8 +204,6 @@ func protectedReadServer(t *testing.T, env *Env) *httptest.Server {
 	return srv
 }
 
-// callProtectedRead issues an authenticated read, carrying the token in the
-// canonical OIDC header when one is given, and returns the HTTP status code.
 func callProtectedRead(t *testing.T, srv *httptest.Server, token string) int {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/version", nil)

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -39,7 +39,6 @@ type LockdownSchedule struct {
 	EndMin    int
 }
 
-// parseSchedule parses a single schedule from a string and returns a LockdownSchedule struct.
 func parseSchedule(schedule string) (LockdownSchedule, error) {
 	times := strings.Split(strings.TrimSpace(schedule), "-")
 	if len(times) != 2 {
@@ -83,7 +82,6 @@ func parseSchedule(schedule string) (LockdownSchedule, error) {
 	}, nil
 }
 
-// parseTime parses a time from a string and returns the hour and minute as integers.
 func parseTime(timeStr string) (int, int, error) {
 	timeParts := strings.Split(timeStr, ":")
 	hour, err := strconv.Atoi(timeParts[0])
@@ -158,7 +156,6 @@ func (l *Lockdown) isLockedWith(state lock.DeployLockState, now time.Time) bool 
 	return l.scheduleActive(now)
 }
 
-// scheduleActive reports whether now falls within any configured lockdown window.
 func (l *Lockdown) scheduleActive(now time.Time) bool {
 	for _, s := range l.Schedules {
 		if timeWithinSchedule(now, s.StartDay, s.EndDay, s.StartHour, s.StartMin, s.EndHour, s.EndMin) {
@@ -233,9 +230,7 @@ func (l *Lockdown) WatchTransitions(stop <-chan struct{}, interval time.Duration
 	}
 }
 
-// NewLockdown initializes a new Lockdown structure backed by the given store and
-// parses the lockdown schedules if provided. If the schedule parsing is
-// successful, it returns the new Lockdown. Otherwise, it returns an error.
+// NewLockdown parses the schedule string and binds the lockdown to the given store.
 func NewLockdown(schedules string, store lock.DeployLockStore) (*Lockdown, error) {
 	lockdown := &Lockdown{
 		store:            store,
@@ -257,19 +252,16 @@ func timeWithinSchedule(now time.Time, startDay, endDay time.Weekday, startHour,
 	currHour := now.Hour()
 	currMin := now.Minute()
 
-	// If it's the same day
 	if startDay == endDay {
 		return currDay == startDay &&
 			timeAtOrAfter(currHour, currMin, startHour, startMin) &&
 			timeBefore(currHour, currMin, endHour, endMin)
 	}
 
-	// For different days
 	if !dayInRange(currDay, startDay, endDay) {
 		return false
 	}
 
-	// Check times for start and end day
 	switch currDay {
 	case startDay:
 		return timeAtOrAfter(currHour, currMin, startHour, startMin)
@@ -280,12 +272,10 @@ func timeWithinSchedule(now time.Time, startDay, endDay time.Weekday, startHour,
 	}
 }
 
-// timeAtOrAfter reports whether hour:min is at or after ref hour:min on the same day.
 func timeAtOrAfter(hour, min, refHour, refMin int) bool {
 	return hour > refHour || (hour == refHour && min >= refMin)
 }
 
-// timeBefore reports whether hour:min is strictly before ref hour:min on the same day.
 func timeBefore(hour, min, refHour, refMin int) bool {
 	return hour < refHour || (hour == refHour && min < refMin)
 }
@@ -299,8 +289,6 @@ func dayInRange(day, start, end time.Weekday) bool {
 	return day >= start || day <= end
 }
 
-// dayToWeekday converts a three-letter abbreviation of a weekday (e.g., "Mon") to its corresponding time.Weekday enum value.
-// If the input doesn't match a valid weekday abbreviation, it returns an error.
 func dayToWeekday(day string) (time.Weekday, error) {
 	switch day {
 	case "Sun":

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -117,8 +117,6 @@ func TestLockdown_SetLock_ReleaseLock(t *testing.T) {
 	}
 }
 
-// TestLockdown_ReleaseLockOverride covers the temporary override that releasing
-// the lock creates while a scheduled lockdown is active, and its expiry.
 func TestLockdown_ReleaseLockOverride(t *testing.T) {
 	t.Run("release overrides an active scheduled lockdown", func(t *testing.T) {
 		l := newTestLockdown(t, "")
@@ -310,7 +308,7 @@ func TestTimeWithinSchedule(t *testing.T) {
 			endDay:    time.Monday,
 			startHour: 10,
 			startMin:  0,
-			endHour:   10, // end time is earlier than current time in hours
+			endHour:   10,
 			endMin:    30,
 			expected:  false, // because 11:00 on Monday is after the end time on Monday
 		},
@@ -375,12 +373,10 @@ func TestNewLockdown(t *testing.T) {
 	}
 }
 
-// TestLockdown_ConcurrentAccess verifies that the lockdown struct is thread-safe.
 func TestLockdown_ConcurrentAccess(t *testing.T) {
 	l := newTestLockdown(t, "")
 	var wg sync.WaitGroup
 
-	// Multiple goroutines setting and releasing locks
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
@@ -396,17 +392,13 @@ func TestLockdown_ConcurrentAccess(t *testing.T) {
 		}()
 	}
 
-	// Wait for all goroutines to complete
 	wg.Wait()
 
 	// No race conditions should have occurred (test passes if no data race detected with -race flag)
 	assert.False(t, l.IsLocked())
 }
 
-// TestLockdown_WatchTransitions verifies that the watcher notifies clients only
-// when the computed lock state actually changes, and that it stops on request.
 func TestLockdown_WatchTransitions(t *testing.T) {
-	// recv waits for a single message or fails the test on timeout.
 	recv := func(t *testing.T, msgs <-chan string) string {
 		t.Helper()
 		select {
@@ -460,8 +452,6 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 	})
 
 	t.Run("notifies on a schedule-derived transition", func(t *testing.T) {
-		// A schedule window spanning four minutes around now locks the system
-		// without a manual lock, so the transition below is schedule-derived.
 		l := newTestLockdown(t, "")
 		l.Schedules = []LockdownSchedule{scheduleAround(-2*time.Minute, 2*time.Minute)}
 		assert.True(t, l.IsLocked(), "schedule should lock the system at baseline")
@@ -491,7 +481,6 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 		case m := <-msgs:
 			t.Fatalf("unexpected notification: %q", m)
 		case <-time.After(50 * time.Millisecond):
-			// no transition occurred, so no notification is expected
 		}
 	})
 
@@ -510,7 +499,6 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 		case m := <-msgs:
 			t.Fatalf("unexpected notification while the store was failing: %q", m)
 		case <-time.After(50 * time.Millisecond):
-			// staying silent is the expected outcome
 		}
 	})
 
@@ -528,15 +516,12 @@ func TestLockdown_WatchTransitions(t *testing.T) {
 
 		select {
 		case <-done:
-			// returned as expected
 		case <-time.After(time.Second):
 			t.Fatal("WatchTransitions did not return after stop was closed")
 		}
 	})
 }
 
-// TestLockdown_IsLockedWith covers how the shared state and the local schedules
-// combine into the resolved lock state.
 func TestLockdown_IsLockedWith(t *testing.T) {
 	now := time.Now()
 	openWindow := scheduleAround(-2*time.Minute, 2*time.Minute)

--- a/internal/server/probes_test.go
+++ b/internal/server/probes_test.go
@@ -101,8 +101,6 @@ func TestReadinessFailsWhileDraining(t *testing.T) {
 		"an operator curling the endpoint mid-incident must be able to tell a drain from an outage")
 }
 
-// TestProbeRoutesAreRegistered guards the wiring: the handlers above are useless if
-// CreateRouter never exposes them.
 func TestProbeRoutesAreRegistered(t *testing.T) {
 	env, _ := readAuthEnv(t, false, nil)
 

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -60,8 +60,6 @@ func readAuthEnv(t *testing.T, oidcEnabled bool, strategies map[string]auth.Auth
 	return readAuthEnvWithTask(t, oidcEnabled, strategies, nil)
 }
 
-// readAuthEnvWithTask is readAuthEnv with a task the state backend knows, so a lookup
-// resolves to an application instead of answering 404.
 func readAuthEnvWithTask(t *testing.T, oidcEnabled bool, strategies map[string]auth.AuthStrategy, task *models.Task) (*Env, *prometheus.Metrics) {
 	t.Helper()
 
@@ -97,13 +95,10 @@ func readAuthEnvWithTask(t *testing.T, oidcEnabled bool, strategies map[string]a
 	return env, metrics
 }
 
-// unauthenticatedReads reads the counter value the server would export for one
-// path/app series.
 func unauthenticatedReads(metrics *prometheus.Metrics, path, app string) float64 {
 	return promtestutil.ToFloat64(metrics.UnauthenticatedReads.WithLabelValues(path, app))
 }
 
-// getWith issues a GET through the full router, optionally carrying a credential.
 func getWith(t *testing.T, env *Env, path, header, value string) *httptest.ResponseRecorder {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, path, http.NoBody)
@@ -117,7 +112,6 @@ func getWith(t *testing.T, env *Env, path, header, value string) *httptest.Respo
 	return recorder
 }
 
-// protectedReads are the endpoints that require a credential once OIDC is enabled.
 var protectedReads = []string{
 	"/api/v1/tasks?from_timestamp=0",
 	"/api/v1/version",
@@ -253,8 +247,6 @@ func TestDeployLockProviderUnavailable(t *testing.T) {
 	assert.False(t, env.lockdown.IsLocked(), "a failed authorization must not set the lock")
 }
 
-// TestReadAuthOpenEndpoints covers what stays reachable without a credential when
-// OIDC is enabled, and why each one has to.
 func TestReadAuthOpenEndpoints(t *testing.T) {
 	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
 		oidcHeader: oidcLikeStrategy{authenticated: true},
@@ -301,7 +293,6 @@ func TestReadAuthOpenEndpoints(t *testing.T) {
 // route table rather than a hand-kept list, so a read added later to the wrong group
 // fails here without anyone remembering to extend a test.
 func TestReadAuthCoversEveryRegisteredRead(t *testing.T) {
-	// Exemptions, each justified in CreateRouter.
 	openByDesign := map[string]bool{
 		"/api/v1/config":     true,
 		"/api/v1/tasks/{id}": true,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -17,7 +17,6 @@ import (
 
 const deployLockEndpoint = "/deploy-lock"
 
-// swaggerPrefix is where the generated API specification is mounted.
 const swaggerPrefix = "/swagger"
 
 // CreateRouter initialize router.

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -32,9 +32,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/state"
 )
 
-// repoCapture records the arguments of the most recent GetTasks call so
-// handler-level tests can assert that query params are forwarded to the
-// repository.
 type repoCapture struct {
 	lastApp    string
 	lastStatus string
@@ -43,10 +40,8 @@ type repoCapture struct {
 }
 
 // newRepo returns a permissive TaskRepository mock plus the capture struct its
-// GetTasks stub writes to. GetTasks always returns an empty result (its return
-// value is never customized in these tests); Connect, SetTaskStatus,
-// CancelInProgressTasks and ProcessObsoleteTasks are permissive no-ops. Tests
-// that exercise Check, GetTask or AddTask add those expectations themselves.
+// GetTasks stub writes to. Tests that exercise Check, GetTask or AddTask add those
+// expectations themselves.
 func newRepo(ctrl *gomock.Controller) (*mocks.MockTaskRepository, *repoCapture) {
 	repo := mocks.NewMockTaskRepository(ctrl)
 	capture := &repoCapture{}
@@ -65,9 +60,6 @@ func newRepo(ctrl *gomock.Controller) (*mocks.MockTaskRepository, *repoCapture) 
 	return repo, capture
 }
 
-// newArgoAPI returns an ArgoApiInterface mock whose calls all succeed with
-// empty/logged-in values, so it can stand in as a passive dependency for
-// handlers that never touch ArgoCD.
 func newArgoAPI(ctrl *gomock.Controller) *mocks.MockArgoApiInterface {
 	api := mocks.NewMockArgoApiInterface(ctrl)
 	api.EXPECT().Init(gomock.Any()).Return(nil).AnyTimes()
@@ -77,9 +69,6 @@ func newArgoAPI(ctrl *gomock.Controller) *mocks.MockArgoApiInterface {
 	return api
 }
 
-// newMetrics returns a MetricsInterface mock with permissive no-op expectations
-// for every metric, so it can be passed to argo.Init without each test having
-// to anticipate which counters a handler touches.
 func newMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
 	metrics := mocks.NewMockMetricsInterface(ctrl)
 	metrics.EXPECT().AddProcessedDeployment(gomock.Any()).AnyTimes()
@@ -97,9 +86,9 @@ func newMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
 	return metrics
 }
 
-// newAuthStrategy returns an AuthStrategy mock whose Validate always yields the
-// given result, callable any number of times (some strategies are skipped when
-// their header does not match the request).
+// newAuthStrategy returns an AuthStrategy mock whose Validate always yields the given
+// result, callable any number of times (some strategies are skipped when their header
+// does not match the request).
 func newAuthStrategy(t testing.TB, valid bool, err error) *mocks.MockAuthStrategy {
 	t.Helper()
 	strategy := mocks.NewMockAuthStrategy(gomock.NewController(t))
@@ -200,8 +189,8 @@ func routeExists(t *testing.T, router *chi.Mux, method, pattern string) bool {
 	return found
 }
 
-// TestDeployLockEndpointRegistration verifies that the state-changing deploy-lock
-// endpoints only exist when OIDC auth is enabled. Without an auth backend they cannot
+// TestDeployLockEndpointRegistration covers why the state-changing deploy-lock
+// endpoints only exist when OIDC auth is enabled: without an auth backend they cannot
 // be protected, so they must not be exposed; the read-only GET stays available so the
 // banner and scheduled lockdown keep working.
 func TestDeployLockEndpointRegistration(t *testing.T) {
@@ -251,12 +240,10 @@ func TestRemoveWebSocketConnection(t *testing.T) {
 }
 
 func TestWebSocketConnectionsConcurrentAccess(t *testing.T) {
-	// Reset connections slice
 	connectionsMutex.Lock()
 	connections = nil
 	connectionsMutex.Unlock()
 
-	// Test concurrent add and remove operations don't cause race conditions
 	var wg sync.WaitGroup
 	numGoroutines := 10
 
@@ -274,7 +261,6 @@ func TestWebSocketConnectionsConcurrentAccess(t *testing.T) {
 
 	wg.Wait()
 
-	// All connections should have been removed
 	connectionsMutex.Lock()
 	assert.Empty(t, connections)
 	connectionsMutex.Unlock()
@@ -321,8 +307,6 @@ func TestNewEnv(t *testing.T) {
 	assert.NotNil(t, env.authenticator)
 }
 
-// TestNewEnvInvalidOIDCURL verifies that NewEnv returns an error when OIDC is
-// enabled but the issuer URL is invalid.
 func TestNewEnvInvalidOIDCURL(t *testing.T) {
 	serverConfig := &config.ServerConfig{
 		Host:        "localhost",
@@ -341,11 +325,10 @@ func TestNewEnvInvalidOIDCURL(t *testing.T) {
 	assert.Nil(t, env)
 }
 
-// TestGetStateInvalidQueryParams verifies that the getState handler gracefully handles
-// invalid query parameters by logging debug messages and using default values.
+// TestGetStateInvalidQueryParams pins that bad query params fall back to defaults and
+// are logged at debug rather than rejected.
 func TestGetStateInvalidQueryParams(t *testing.T) {
 
-	// Set up Argo with mock dependencies
 	ctrl := gomock.NewController(t)
 	repo, _ := newRepo(ctrl)
 	argo := &argocd.Argo{}
@@ -403,15 +386,11 @@ func TestGetStateInvalidQueryParams(t *testing.T) {
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 
-			// The handler should return 200 OK even with invalid params
-			// (it falls back to defaults and logs debug messages)
 			assert.Equal(t, http.StatusOK, w.Code)
 		})
 	}
 }
 
-// TestGetStateForwardsFilters verifies that getState forwards `app` and `status`
-// query parameters to the underlying TaskRepository.
 func TestGetStateForwardsFilters(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
@@ -439,8 +418,8 @@ func TestGetStateForwardsFilters(t *testing.T) {
 	assert.Equal(t, "in progress", capture.lastStatus)
 }
 
-// TestGetStateRejectsUnknownStatus verifies that getState returns 400 when
-// the `status` query param is not accepted by models.IsAllowedTaskStatus.
+// TestGetStateRejectsUnknownStatus covers the 400 returned when the `status` query
+// param is not accepted by models.IsAllowedTaskStatus.
 func TestGetStateRejectsUnknownStatus(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
@@ -480,10 +459,9 @@ func TestGetStateRejectsUnknownStatus(t *testing.T) {
 	}
 }
 
-// TestGetStateClampsLimit verifies that getState bounds the limit query
-// param to maxTaskListLimit so callers cannot drain the entire task table
-// in a single request (the underlying repositories treat limit <= 0 as
-// "no LIMIT clause").
+// TestGetStateClampsLimit covers the bound on the limit query param, so callers cannot
+// drain the entire task table in a single request (the underlying repositories treat
+// limit <= 0 as "no LIMIT clause").
 func TestGetStateClampsLimit(t *testing.T) {
 
 	cases := []struct {
@@ -527,10 +505,8 @@ func TestGetStateClampsLimit(t *testing.T) {
 
 func TestStaticFileServing(t *testing.T) {
 
-	// Create a temporary directory for static files
 	tmpDir := t.TempDir()
 
-	// Create test files
 	indexContent := []byte("<html><body>Index</body></html>")
 	jsContent := []byte("console.log('test');")
 
@@ -574,26 +550,20 @@ func TestStaticFileServing(t *testing.T) {
 	})
 
 	t.Run("prevents path traversal attack", func(t *testing.T) {
-		// Try to access /etc/passwd via path traversal
 		// Note: Go's net/http rejects malformed URLs with 400, which is also protection
 		req, _ := http.NewRequest(http.MethodGet, "/../../../etc/passwd", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
 		// Should either return 400 (Go's built-in protection) or index.html (our protection)
-		// Either way, /etc/passwd should NOT be served
 		assert.NotContains(t, w.Body.String(), "root:")
 	})
 
 	t.Run("prevents encoded path traversal", func(t *testing.T) {
-		// URL-encoded path traversal attempt
-		// Note: Go's net/http rejects malformed URLs with 400, which is also protection
 		req, _ := http.NewRequest(http.MethodGet, "/..%2F..%2F..%2Fetc%2Fpasswd", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// Should either return 400 (Go's built-in protection) or index.html (our protection)
-		// Either way, /etc/passwd should NOT be served
 		assert.NotContains(t, w.Body.String(), "root:")
 	})
 
@@ -603,7 +573,6 @@ func TestStaticFileServing(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// Should not serve /etc/passwd
 		assert.NotContains(t, w.Body.String(), "root:")
 	})
 
@@ -650,7 +619,6 @@ func (b *logBuffer) Write(p []byte) (int, error) {
 	return b.buf.Write(p)
 }
 
-// String returns everything captured so far.
 func (b *logBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -663,10 +631,10 @@ func (b *logBuffer) reset() {
 	b.buf.Reset()
 }
 
-// captureDebugLogs redirects the global slog logger into a buffer at debug level
-// for the duration of the test and returns that buffer. It proves the capture is
-// live before handing the buffer back, so a test whose only assertion is
-// NotContains or Empty cannot pass because logging was silently broken.
+// captureDebugLogs redirects the global slog logger into a buffer at debug level for
+// the duration of the test and returns it. It proves the capture is live before handing
+// the buffer back, so a test whose only assertion is NotContains or Empty cannot pass
+// because logging was silently broken.
 //
 // Not safe under t.Parallel: it swaps the process-global default logger.
 //
@@ -690,7 +658,6 @@ func captureDebugLogs(t *testing.T) *logBuffer {
 
 func TestWebSocketInterceptor(t *testing.T) {
 
-	// Create a minimal test environment
 	tmpDir := t.TempDir()
 	err := os.WriteFile(tmpDir+"/index.html", []byte("<html></html>"), 0644)
 	assert.NoError(t, err)
@@ -792,12 +759,10 @@ func TestWebSocketInterceptor(t *testing.T) {
 // it. Keep the -race CI step if you touch this test.
 func TestWebSocketConnectionIntegration(t *testing.T) {
 
-	// Reset connections at start to ensure clean state
 	connectionsMutex.Lock()
 	connections = nil
 	connectionsMutex.Unlock()
 
-	// Create a temporary directory for static files
 	tmpDir := t.TempDir()
 	err := os.WriteFile(tmpDir+"/index.html", []byte("<html></html>"), 0644)
 	assert.NoError(t, err)
@@ -829,7 +794,6 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	// floods debug output again.
 	logs := captureDebugLogs(t)
 
-	// Convert http:// to ws://
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
 
 	// Use a generous timeout — the WebSocket handshake through httptest can take several
@@ -837,14 +801,12 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	// Attempt WebSocket connection
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("WebSocket connection failed: %v", err)
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "test complete")
 
-	// Connection succeeded - the pre-hijack wrapper works
 	t.Log("WebSocket connection established successfully")
 
 	// Empty, not just "no diagnostic": the upgrade path must emit no per-request
@@ -1020,18 +982,12 @@ func TestValidatePath(t *testing.T) {
 	})
 
 	t.Run("leading dotdot at root level is normalized and joined safely", func(t *testing.T) {
-		// Input: /../etc/passwd → Cleaned: /etc/passwd → Joined: /tmp/etc/passwd
-		// This is SAFE because the joined path /tmp/etc/passwd IS within basePath /tmp/
-		// The file that would be served is /tmp/etc/passwd, NOT /etc/passwd
 		cleanPath, err := fs.validatePath("/../etc/passwd")
 		assert.NoError(t, err)
 		assert.Equal(t, "/etc/passwd", cleanPath)
 	})
 
 	t.Run("dotdot in path is normalized and joined safely", func(t *testing.T) {
-		// Input: /subdir/../../etc/passwd → Cleaned: /etc/passwd → Joined: /tmp/etc/passwd
-		// This is SAFE because the joined path /tmp/etc/passwd IS within basePath /tmp/
-		// The file that would be served is /tmp/etc/passwd, NOT /etc/passwd
 		cleanPath, err := fs.validatePath("/subdir/../../etc/passwd")
 		assert.NoError(t, err)
 		assert.Equal(t, "/etc/passwd", cleanPath)
@@ -1044,11 +1000,9 @@ func TestValidatePath(t *testing.T) {
 	})
 }
 
-// TestSafeFileSystem tests the safe file system implementation.
 func TestSafeFileSystem(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create test files
 	err := os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("content"), 0644)
 	require.NoError(t, err)
 
@@ -1114,16 +1068,13 @@ func TestSafeFileSystem(t *testing.T) {
 	})
 }
 
-// TestSafeFileSystemSymlinkProtection tests symlink escape prevention.
 func TestSafeFileSystemSymlinkProtection(t *testing.T) {
 	tmpDir := t.TempDir()
 	outsideDir := t.TempDir()
 
-	// Create a file outside the static directory
 	err := os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("secret data"), 0644)
 	require.NoError(t, err)
 
-	// Create a symlink inside tmpDir that points outside
 	symlinkPath := filepath.Join(tmpDir, "escape")
 	err = os.Symlink(outsideDir, symlinkPath)
 	require.NoError(t, err)
@@ -1153,7 +1104,6 @@ func shutdownEnv(env *Env) {
 	env.Shutdown(ctx)
 }
 
-// TestEnvShutdown tests the graceful shutdown functionality.
 func TestEnvShutdown(t *testing.T) {
 	t.Run("shutdown closes channel", func(t *testing.T) {
 		shutdownCh := make(chan struct{})
@@ -1161,21 +1111,16 @@ func TestEnvShutdown(t *testing.T) {
 			shutdownCh: shutdownCh,
 		}
 
-		// Verify channel is not closed
 		select {
 		case <-env.shutdownCh:
 			t.Fatal("channel should not be closed yet")
 		default:
-			// expected
 		}
 
-		// Call shutdown
 		env.Shutdown(context.Background())
 
-		// Verify channel is now closed
 		select {
 		case <-env.shutdownCh:
-			// expected - channel is closed
 		default:
 			t.Fatal("channel should be closed after Shutdown()")
 		}
@@ -1186,7 +1131,6 @@ func TestEnvShutdown(t *testing.T) {
 			shutdownCh: nil,
 		}
 
-		// Should not panic
 		env.Shutdown(context.Background())
 	})
 
@@ -1196,15 +1140,12 @@ func TestEnvShutdown(t *testing.T) {
 			shutdownCh: shutdownCh,
 		}
 
-		// Should not panic when called multiple times
 		env.Shutdown(context.Background())
 		env.Shutdown(context.Background())
 		env.Shutdown(context.Background())
 
-		// Verify channel is closed
 		select {
 		case <-env.shutdownCh:
-			// expected - channel is closed
 		default:
 			t.Fatal("channel should be closed")
 		}
@@ -1236,31 +1177,24 @@ func TestEnvShutdown(t *testing.T) {
 			shutdownCh: shutdownCh,
 		}
 
-		// Simulate an active connection by incrementing the WaitGroup
 		env.connWg.Add(1)
 
-		// Start Shutdown in a goroutine and track when it completes
 		shutdownDone := make(chan struct{})
 		go func() {
 			env.Shutdown(context.Background())
 			close(shutdownDone)
 		}()
 
-		// Verify Shutdown is blocked waiting for connWg
 		select {
 		case <-shutdownDone:
 			t.Fatal("Shutdown should be blocked waiting for connWg")
 		case <-time.After(300 * time.Millisecond):
-			// Expected - Shutdown is still waiting
 		}
 
-		// Now release the WaitGroup
 		env.connWg.Done()
 
-		// Shutdown should now complete
 		select {
 		case <-shutdownDone:
-			// Expected - Shutdown completed after connWg.Done()
 		case <-time.After(time.Second):
 			t.Fatal("Shutdown should have completed after connWg.Done()")
 		}
@@ -1272,7 +1206,6 @@ func TestEnvShutdown(t *testing.T) {
 // store it is how clients learn about a lock another replica set — and it is
 // tracked by connWg so it stops when the shutdown channel is closed.
 func TestStartLockdownWatcher(t *testing.T) {
-	// waitTracked reports whether connWg reaches zero within the timeout.
 	waitTracked := func(env *Env, timeout time.Duration) bool {
 		done := make(chan struct{})
 		go func() {
@@ -1310,7 +1243,6 @@ func TestStartLockdownWatcher(t *testing.T) {
 
 		env.StartLockdownWatcher()
 
-		// The watcher is running; connWg must not drain until shutdown.
 		assert.False(t, waitTracked(env, 100*time.Millisecond), "watcher should keep connWg non-zero before shutdown")
 
 		close(env.shutdownCh)
@@ -1318,7 +1250,6 @@ func TestStartLockdownWatcher(t *testing.T) {
 	})
 }
 
-// TestStartRouter tests the StartRouter method.
 func TestStartRouter(t *testing.T) {
 
 	tmpDir := t.TempDir()
@@ -1343,16 +1274,13 @@ func TestStartRouter(t *testing.T) {
 	assert.Equal(t, 10*time.Second, srv.ReadHeaderTimeout)
 }
 
-// TestNotifyWebSocketClients tests the WebSocket notification functionality.
 func TestNotifyWebSocketClients(t *testing.T) {
 	t.Run("notifies with no connections", func(t *testing.T) {
-		// Reset connections
 		connectionsMutex.Lock()
 		connections = nil
 		closedConns = make(map[*websocket.Conn]bool)
 		connectionsMutex.Unlock()
 
-		// Cleanup to prevent test pollution
 		t.Cleanup(func() {
 			connectionsMutex.Lock()
 			connections = nil
@@ -1360,21 +1288,17 @@ func TestNotifyWebSocketClients(t *testing.T) {
 			connectionsMutex.Unlock()
 		})
 
-		// Should not panic with empty connections
 		notifyWebSocketClients("test message")
 	})
 }
 
-// TestRemoveWebSocketConnectionCleanup tests the connection removal cleanup functionality.
 func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
 	t.Run("removes connection and cleans up closedConns", func(t *testing.T) {
-		// Reset state
 		connectionsMutex.Lock()
 		connections = nil
 		closedConns = make(map[*websocket.Conn]bool)
 		connectionsMutex.Unlock()
 
-		// Cleanup to prevent test pollution
 		t.Cleanup(func() {
 			connectionsMutex.Lock()
 			connections = nil
@@ -1382,24 +1306,20 @@ func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
 			connectionsMutex.Unlock()
 		})
 
-		// This test verifies the function doesn't panic with nil
 		removeWebSocketConnection(nil)
 
 		connectionsMutex.RLock()
 		assert.Len(t, connections, 0)
-		// closedConns should be empty after cleanup
 		assert.Len(t, closedConns, 0)
 		connectionsMutex.RUnlock()
 	})
 
 	t.Run("removes actual connection from slice", func(t *testing.T) {
-		// Reset state
 		connectionsMutex.Lock()
 		connections = nil
 		closedConns = make(map[*websocket.Conn]bool)
 		connectionsMutex.Unlock()
 
-		// Cleanup to prevent test pollution
 		t.Cleanup(func() {
 			connectionsMutex.Lock()
 			connections = nil
@@ -1416,13 +1336,11 @@ func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
 
 		connectionsMutex.RLock()
 		assert.NotContains(t, connections, conn)
-		// Entry should be deleted after removal
 		assert.Len(t, closedConns, 0)
 		connectionsMutex.RUnlock()
 	})
 
 	t.Run("removes connection from middle of slice", func(t *testing.T) {
-		// Reset state
 		connectionsMutex.Lock()
 		connections = nil
 		closedConns = make(map[*websocket.Conn]bool)
@@ -1442,7 +1360,6 @@ func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
 		connections = append(connections, conn1, conn2, conn3)
 		connectionsMutex.Unlock()
 
-		// Remove middle connection
 		removeWebSocketConnection(conn2)
 
 		connectionsMutex.RLock()
@@ -1470,9 +1387,7 @@ func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
 	})
 }
 
-// TestNotifyWebSocketClientsFiltersClosedConnections tests that closed connections are filtered.
 func TestNotifyWebSocketClientsFiltersClosedConnections(t *testing.T) {
-	// Reset state
 	connectionsMutex.Lock()
 	connections = nil
 	closedConns = make(map[*websocket.Conn]bool)
@@ -1485,18 +1400,15 @@ func TestNotifyWebSocketClientsFiltersClosedConnections(t *testing.T) {
 		connectionsMutex.Unlock()
 	})
 
-	// Add a connection and mark it as closed
 	conn := &websocket.Conn{}
 	connectionsMutex.Lock()
 	connections = append(connections, conn)
 	closedConns[conn] = true
 	connectionsMutex.Unlock()
 
-	// Should not panic and should skip the closed connection
 	notifyWebSocketClients("test message")
 }
 
-// TestConnWgTracking tests that connWg is properly incremented and decremented.
 func TestConnWgTracking(t *testing.T) {
 	env := &Env{
 		shutdownCh: make(chan struct{}),
@@ -1509,44 +1421,35 @@ func TestConnWgTracking(t *testing.T) {
 	checkDone := make(chan struct{})
 	go func() {
 		defer env.connWg.Done()
-		// Simulate waiting for shutdown signal
 		<-env.shutdownCh
 		close(checkDone)
 	}()
 
-	// Verify the goroutine is running (WaitGroup has 1)
 	select {
 	case <-checkDone:
 		t.Fatal("goroutine should not have exited yet")
 	case <-time.After(50 * time.Millisecond):
-		// Expected - goroutine is waiting
 	}
 
-	// Trigger shutdown
 	shutdownComplete := make(chan struct{})
 	go func() {
 		shutdownEnv(env)
 		close(shutdownComplete)
 	}()
 
-	// The checkDone should close first (simulating goroutine exit)
 	select {
 	case <-checkDone:
-		// Expected
 	case <-time.After(time.Second):
 		t.Fatal("goroutine should have received shutdown signal")
 	}
 
-	// Then shutdown should complete
 	select {
 	case <-shutdownComplete:
-		// Expected
 	case <-time.After(time.Second):
 		t.Fatal("Shutdown should have completed")
 	}
 }
 
-// TestCreateRouterInitializesShutdownChannel tests that CreateRouter initializes the shutdown channel.
 func TestCreateRouterInitializesShutdownChannel(t *testing.T) {
 
 	tmpDir := t.TempDir()
@@ -1557,22 +1460,18 @@ func TestCreateRouterInitializesShutdownChannel(t *testing.T) {
 		StaticFilePath: tmpDir,
 	}
 
-	// Create env without shutdown channel
 	env := &Env{
 		config:     serverConfig,
 		shutdownCh: nil,
 	}
 	env.lockdown, _ = NewLockdown("", lock.NewInMemoryDeployLockStore())
 
-	// CreateRouter should initialize the shutdown channel
 	_ = env.CreateRouter()
 
 	assert.NotNil(t, env.shutdownCh, "CreateRouter should initialize shutdownCh")
 }
 
-// TestValidatePathEdgeCases tests edge cases in path validation.
 func TestValidatePathEdgeCases(t *testing.T) {
-	// Create a temp directory with a specific structure
 	tmpDir := t.TempDir()
 
 	fs := safeFileSystem{
@@ -1599,7 +1498,6 @@ func TestValidatePathEdgeCases(t *testing.T) {
 	})
 }
 
-// TestGetConfigEndpoint tests the getConfig endpoint.
 func TestGetConfigEndpoint(t *testing.T) {
 
 	serverConfig := &config.ServerConfig{
@@ -1623,7 +1521,6 @@ func TestGetConfigEndpoint(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "devEnvironment")
 }
 
-// TestGetTaskStatusEndpoint tests the getTaskStatus endpoint.
 func TestGetTaskStatusEndpoint(t *testing.T) {
 
 	t.Run("returns task when found", func(t *testing.T) {
@@ -1701,7 +1598,6 @@ func TestGetTaskStatusEndpoint(t *testing.T) {
 	})
 }
 
-// TestValidateTokenWithStrategies tests the validateToken method.
 func TestValidateTokenWithStrategies(t *testing.T) {
 
 	t.Run("returns result from authenticator when no allowed strategy", func(t *testing.T) {
@@ -1715,7 +1611,6 @@ func TestValidateTokenWithStrategies(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodPost, "/test", nil)
 
-		// With empty authenticator and no strategies, validation returns false
 		valid, err := env.validateToken(req, "")
 		assert.False(t, valid)
 		assert.NoError(t, err)
@@ -1731,14 +1626,12 @@ func TestValidateTokenWithStrategies(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, "/test", nil)
 		req.Header.Set("Authorization", "Bearer test-token")
 
-		// With no matching strategy, returns false
 		valid, err := env.validateToken(req, "Keycloak-Authorization")
 		assert.False(t, valid)
 		assert.NoError(t, err)
 	})
 }
 
-// TestAddTaskEndpoint tests the addTask endpoint.
 func TestAddTaskEndpoint(t *testing.T) {
 
 	t.Run("returns error for invalid JSON payload", func(t *testing.T) {
@@ -1953,7 +1846,6 @@ func TestAddTaskEndpoint(t *testing.T) {
 	})
 }
 
-// TestSetDeployLockWithKeycloak tests SetDeployLock with Keycloak authentication.
 func TestSetDeployLockWithKeycloak(t *testing.T) {
 
 	t.Run("returns 401 with reason when token is invalid", func(t *testing.T) {
@@ -2006,7 +1898,6 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 		router.Post("/api/v1/deploy-lock", env.SetDeployLock)
 
 		req, _ := http.NewRequest(http.MethodPost, "/api/v1/deploy-lock", nil)
-		// no auth header
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
@@ -2048,7 +1939,6 @@ func TestSetDeployLockWithKeycloak(t *testing.T) {
 // error itself stays in the log.
 func TestDeployLockStoreFailure(t *testing.T) {
 
-	// newEnv builds an authenticated Env whose deploy lock store always fails.
 	newEnv := func(t *testing.T) *Env {
 		t.Helper()
 
@@ -2165,7 +2055,7 @@ func TestRequireOIDCAuthHeaderPrecedence(t *testing.T) {
 	t.Run("a rejected canonical header does not fall through to the legacy header", func(t *testing.T) {
 		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
 		legacy := mocks.NewMockAuthStrategy(gomock.NewController(t))
-		legacy.EXPECT().Validate(gomock.Any()).Times(0) // must never be consulted
+		legacy.EXPECT().Validate(gomock.Any()).Times(0)
 		strategies := map[string]auth.AuthStrategy{
 			oidcHeader:           newAuthStrategy(t, false, fmt.Errorf("canonical rejected")),
 			legacyKeycloakHeader: legacy,
@@ -2190,7 +2080,6 @@ func TestRequireOIDCAuthHeaderPrecedence(t *testing.T) {
 	})
 }
 
-// TestReleaseDeployLockWithKeycloak tests ReleaseDeployLock with Keycloak authentication.
 func TestReleaseDeployLockWithKeycloak(t *testing.T) {
 
 	t.Run("returns 401 with reason when token is invalid", func(t *testing.T) {
@@ -2251,7 +2140,6 @@ func TestReleaseDeployLockWithKeycloak(t *testing.T) {
 	})
 }
 
-// TestValidateTokenWithAllowedStrategy tests validateToken with an allowed strategy header.
 func TestValidateTokenWithAllowedStrategy(t *testing.T) {
 
 	t.Run("validates successfully with matching strategy", func(t *testing.T) {
@@ -2319,7 +2207,6 @@ func TestValidateTokenWithAllowedStrategy(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, "/test", nil)
 		req.Header.Set("Authorization", "Bearer token")
 
-		// Only oidcHeader is allowed, so Authorization should be skipped
 		valid, err := env.validateToken(req, oidcHeader)
 		assert.False(t, valid)
 		assert.NoError(t, err)
@@ -2455,8 +2342,6 @@ func TestCORSPolicy(t *testing.T) {
 	})
 
 	t.Run("the origin gate runs before the trailing-slash redirect", func(t *testing.T) {
-		// Deliberately stricter than the framework this replaced, which redirected
-		// without consulting the origin at all.
 		router := newRouter(t, true)
 
 		w := do(router, http.MethodGet, "/api/v1/config/", map[string]string{"Origin": "http://evil.test"})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,7 +68,6 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	if err != nil {
 		return nil, err
 	}
-	// Background cleanup of obsolete tasks.
 	go s.ProcessObsoleteTasks(0)
 
 	argo := &argocd.Argo{}
@@ -172,14 +171,12 @@ func (s *Server) Run() {
 		}
 	}()
 
-	// Wait for interrupt signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
 	slog.Info("shutting down server...")
 
-	// Stop the background ArgoCD liveness probe.
 	if s.probeCancel != nil {
 		s.probeCancel()
 	}
@@ -215,11 +212,10 @@ type httpShutdowner interface {
 // returns with that handler outstanding. Hijacked WebSocket connections are not
 // waited on by srv.Shutdown; they are drained by env.Shutdown.
 //
-// The phases run in sequence and share one deadline, so their total cannot
-// exceed shutdownBudget. Previously each carried its own independent timeout, letting
-// the sequence run far longer than any realistic terminationGracePeriodSeconds — the
-// kubelet then SIGKILLed the process partway through, which defeats the phase that
-// matters most (draining queued git write-backs, last in line).
+// The phases run in sequence and share one deadline, so their total cannot exceed
+// shutdownBudget. It must stay inside terminationGracePeriodSeconds: a SIGKILL partway
+// through defeats the phase that matters most (draining queued git write-backs, last
+// in line).
 //
 // No phase failure short-circuits the sequence: a forced HTTP shutdown is logged and
 // the later phases still get their share, because dropping a queued commit over an
@@ -240,9 +236,6 @@ func (s *Server) shutdown(srv httpShutdowner) {
 		}
 	}
 
-	// Phase 1: let outstanding HTTP requests finish. Capped well below the total
-	// because argo-watcher's handlers are short-lived; hijacked WebSocket
-	// connections are not waited on here at all (they are phase 2).
 	httpCtx, cancelHTTP := context.WithTimeout(shutdownCtx, httpDrainBudget)
 	err := srv.Shutdown(httpCtx)
 	cancelHTTP()
@@ -250,8 +243,6 @@ func (s *Server) shutdown(srv httpShutdowner) {
 		slog.Error("server forced to shutdown", "error", err)
 	}
 
-	// Phase 2: now that the listener is closed, signal the WebSocket connection
-	// goroutines to stop and wait for them to finish.
 	wsCtx, cancelWS := context.WithTimeout(shutdownCtx, shutdownTimeout)
 	s.env.Shutdown(wsCtx)
 	cancelWS()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestNewServer_Success(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	argoURL, err := url.Parse("https://argo.example.com")
 	require.NoError(t, err)
@@ -27,10 +26,8 @@ func TestNewServer_Success(t *testing.T) {
 		StateType: "in-memory",
 	}
 
-	// Act
 	s, err := NewServer(cfg, reg)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	assert.Equal(t, cfg, s.config)
@@ -41,7 +38,6 @@ func TestNewServer_Success(t *testing.T) {
 }
 
 func TestNewServer_StateInitFailure(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	argoURL, err := url.Parse("https://argo.example.com")
 	require.NoError(t, err)
@@ -52,16 +48,13 @@ func TestNewServer_StateInitFailure(t *testing.T) {
 		StateType: "invalid-state-type",
 	}
 
-	// Act
 	_, err = NewServer(cfg, reg)
 
-	// Assert
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected state type received: invalid-state-type")
 }
 
 func TestNewServer_PostgresConnectionFailure(t *testing.T) {
-	// Arrange
 	reg := prometheus.NewRegistry()
 	argoURL, err := url.Parse("https://argo.example.com")
 	require.NoError(t, err)
@@ -74,12 +67,9 @@ func TestNewServer_PostgresConnectionFailure(t *testing.T) {
 		StateType: "postgres",
 	}
 
-	// Act
 	_, err = NewServer(cfg, reg)
 
-	// Assert
 	assert.Error(t, err)
-	// This is the corrected, more robust assertion.
 	assert.Contains(t, err.Error(), "failed to connect to")
 }
 

--- a/internal/server/staticfs.go
+++ b/internal/server/staticfs.go
@@ -16,18 +16,11 @@ type safeFileSystem struct {
 	basePath string
 }
 
-// validatePath checks if a path is safe before any I/O operations.
-// Returns the cleaned path if valid, or an error if the path would escape the base directory.
-// This performs validation without any I/O operations by checking the cleaned path.
 func (fs safeFileSystem) validatePath(name string) (string, error) {
-	// Clean the path to remove any .. or . components
 	cleanName := filepath.Clean("/" + name)
 
-	// Construct the would-be full path and verify it stays within bounds
-	// filepath.Join handles path separators and cleaning
 	fullPath := filepath.Join(fs.basePath, cleanName)
 
-	// Clean the full path to resolve any remaining . or .. components
 	cleanedFull := filepath.Clean(fullPath)
 
 	// Verify the cleaned path is still within the base directory
@@ -43,9 +36,8 @@ func (fs safeFileSystem) validatePath(name string) (string, error) {
 	return cleanName, nil
 }
 
-// Open implements http.FileSystem interface with path validation and symlink protection.
+// Open rejects any name that escapes the root, including via a symlink.
 func (fs safeFileSystem) Open(name string) (http.File, error) {
-	// Validate path before any I/O operation
 	cleanName, err := fs.validatePath(name)
 	if err != nil {
 		return nil, err
@@ -58,7 +50,6 @@ func (fs safeFileSystem) Open(name string) (http.File, error) {
 		return nil, err
 	}
 
-	// Additional symlink protection: verify the real path is within bounds
 	osFile, ok := f.(*os.File)
 	if !ok {
 		return f, nil
@@ -82,19 +73,15 @@ func (fs safeFileSystem) Open(name string) (http.File, error) {
 	return f, nil
 }
 
-// createStaticFileHandler returns a handler for serving static files with SPA fallback.
-// It attempts to serve the requested file, falling back to index.html for SPA routing.
 func (env *Env) createStaticFileHandler(fs safeFileSystem, staticPath string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if tryServeStaticFile(w, r, fs) {
 			return
 		}
-		// Fall back to index.html for SPA routing
 		http.ServeFile(w, r, filepath.Join(staticPath, "index.html"))
 	}
 }
 
-// tryServeStaticFile attempts to serve a static file and returns true if successful.
 func tryServeStaticFile(w http.ResponseWriter, r *http.Request, fs safeFileSystem) bool {
 	f, err := fs.Open(r.URL.Path)
 	if err != nil {

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -79,7 +79,6 @@ func (env *Env) authorizeWebSocket(w http.ResponseWriter, r *http.Request) bool 
 	return false
 }
 
-// wsSubprotocolToken returns the credential offered in Sec-WebSocket-Protocol, or "".
 func wsSubprotocolToken(request *http.Request) string {
 	for _, offered := range strings.Split(request.Header.Get("Sec-WebSocket-Protocol"), ",") {
 		if token, found := strings.CutPrefix(strings.TrimSpace(offered), wsTokenSubprotocolPrefix); found {
@@ -90,10 +89,6 @@ func wsSubprotocolToken(request *http.Request) string {
 	return ""
 }
 
-// handleWebSocketConnection accepts a WebSocket connection, adds it to a slice,
-// and initiates a goroutine to ping the connection regularly. If WebSocket
-// acceptance fails, an error is logged. The goroutine serves to monitor
-// the connection's activity and removes it from the slice if it's inactive.
 func (env *Env) handleWebSocketConnection(w http.ResponseWriter, r *http.Request) {
 	// Before the upgrade, so a rejection is an ordinary HTTP response.
 	if !env.authorizeWebSocket(w, r) {
@@ -120,7 +115,7 @@ func (env *Env) handleWebSocketConnection(w http.ResponseWriter, r *http.Request
 	defer env.connWg.Done()
 
 	options := &websocket.AcceptOptions{
-		InsecureSkipVerify: env.config.DevEnvironment, // It will disable websocket host validation if set to true
+		InsecureSkipVerify: env.config.DevEnvironment, // dev only: skips the WebSocket origin/host check
 		Subprotocols:       []string{wsSubprotocol},
 	}
 
@@ -130,18 +125,14 @@ func (env *Env) handleWebSocketConnection(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Append the connection before starting the goroutine
 	connectionsMutex.Lock()
 	connections = append(connections, conn)
 	connectionsMutex.Unlock()
 
-	// Track the goroutine for graceful shutdown
 	env.connWg.Add(1)
 	go env.checkConnection(conn)
 }
 
-// checkConnection is a method for the Env struct that continuously checks the
-// health of a WebSocket connection by sending periodic "heartbeat" messages.
 func (env *Env) checkConnection(c *websocket.Conn) {
 	defer env.connWg.Done()
 
@@ -170,13 +161,9 @@ func (env *Env) checkConnection(c *websocket.Conn) {
 	}
 }
 
-// notifyWebSocketClients sends message to every active WebSocket connection.
-// A connection that fails the write is closed and removed from the slice.
 func notifyWebSocketClients(message string) {
 	var wg sync.WaitGroup
 
-	// Copy connections slice under mutex to avoid race condition during iteration
-	// Also filter out closed connections
 	connectionsMutex.RLock()
 	connsCopy := make([]*websocket.Conn, 0, len(connections))
 	for _, c := range connections {

--- a/internal/server/ws_auth_test.go
+++ b/internal/server/ws_auth_test.go
@@ -39,8 +39,6 @@ func wsAuthServer(t *testing.T, oidcEnabled bool, strategies map[string]auth.Aut
 	return env, "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
 }
 
-// dialWS attempts a handshake and returns the HTTP response status, closing any
-// connection it establishes. A status of 0 means the dial failed before a response.
 func dialWS(t *testing.T, url string, opts *websocket.DialOptions) (int, string) {
 	t.Helper()
 
@@ -65,14 +63,12 @@ func dialWS(t *testing.T, url string, opts *websocket.DialOptions) (int, string)
 	return status, subprotocol
 }
 
-// activeConnections reports how many sockets the server currently tracks.
 func activeConnections() int {
 	connectionsMutex.RLock()
 	defer connectionsMutex.RUnlock()
 	return len(connections)
 }
 
-// TestWebSocketAuthDisabled pins that an OIDC-less deployment keeps its open socket.
 func TestWebSocketAuthDisabled(t *testing.T) {
 	_, url := wsAuthServer(t, false, nil)
 
@@ -98,9 +94,8 @@ func TestWebSocketAuthRejectsUncredentialed(t *testing.T) {
 	shutdownEnv(env)
 }
 
-// TestWebSocketAuthAcceptsHeaderCredential covers non-browser clients, which can set
-// headers: the CLI, wsprobe, and anything else driving the socket directly.
-// TestAuthorizeWebSocket covers the credential matrix without opening sockets: closing
+// TestAuthorizeWebSocket covers the credential matrix — including the header path used by
+// non-browser clients such as the CLI and wsprobe — without opening sockets: closing
 // an established connection waits out a close-handshake timeout, so a real handshake per
 // case would dominate the package's runtime. The two tests around this one prove the
 // decision is actually wired into the handshake.
@@ -181,8 +176,6 @@ func TestWebSocketAuthAcceptsSubprotocolCredential(t *testing.T) {
 	assert.Equal(t, wsSubprotocol, negotiated)
 }
 
-// TestWebSocketAuthRejectsBadSubprotocolCredential pins that the subprotocol is a
-// transport for the credential, not a way around checking it.
 func TestWebSocketAuthRejectsBadSubprotocolCredential(t *testing.T) {
 	_, url := wsAuthServer(t, true, map[string]auth.AuthStrategy{
 		oidcHeader: oidcLikeStrategy{authenticated: false},

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -15,17 +15,14 @@ import (
 )
 
 const (
-	// TaskStaleThresholdSeconds is the time in seconds after which an in-progress task is considered stale and aborted.
 	TaskStaleThresholdSeconds = 3600
-	// ObsoleteTaskCheckInterval is the interval between checks for obsolete tasks.
 	ObsoleteTaskCheckInterval = 60 * time.Minute
 	// StaleTaskAbortReason is the status reason set when an in-progress task is
 	// aborted for exceeding the staleness window (distinct from an ArgoCD outage).
 	StaleTaskAbortReason = "Deployment did not complete within the staleness window; marked aborted by argo-watcher."
 )
 
-// InMemoryState provides a thread-safe in-memory implementation of task storage.
-// It uses a read-write mutex to protect concurrent access to the tasks slice.
+// InMemoryState is a thread-safe in-memory implementation of task storage.
 type InMemoryState struct {
 	mu    sync.RWMutex
 	tasks []models.Task
@@ -83,8 +80,6 @@ func paginate(tasks []models.Task, limit, offset int) []models.Task {
 	return tasks[offset:end]
 }
 
-// GetTasks retrieves tasks from the in-memory state based on the provided time range, app, and status filters.
-// Empty filter values (app == "" or status == "") are treated as wildcards.
 func (state *InMemoryState) GetTasks(startTime float64, endTime float64, app string, status string, limit int, offset int) ([]models.Task, int64) {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
@@ -118,7 +113,7 @@ func (state *InMemoryState) GetTasks(startTime float64, endTime float64, app str
 	return paginate(tasks, limit, offset), int64(len(tasks))
 }
 
-// GetTask returns the task with the given id, or ErrTaskNotFound if none matches.
+// GetTask returns ErrTaskNotFound when no task matches.
 func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
@@ -131,8 +126,7 @@ func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	return nil, ErrTaskNotFound
 }
 
-// SetTaskStatus updates the status and status reason of the task with the given
-// id, or returns an error if no task matches.
+// SetTaskStatus errors when no task matches the given id.
 func (state *InMemoryState) SetTaskStatus(id, status, reason string) error {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -199,8 +193,6 @@ func (state *InMemoryState) ProcessObsoleteTasks(retryTimes uint) {
 	}
 }
 
-// processInMemoryObsoleteTasks returns tasks with "app not found" entries dropped
-// and "in progress" entries older than TaskStaleThresholdSeconds marked "aborted".
 func processInMemoryObsoleteTasks(tasks []models.Task) []models.Task {
 	var updatedTasks []models.Task
 	for _, task := range tasks {

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-// createTestTask creates a task with default test values.
 func createTestTask(app string) models.Task {
 	return models.Task{
 		App:     app,
@@ -28,17 +27,13 @@ func createTestTask(app string) models.Task {
 	}
 }
 
-// taskWithImage returns an in-progress task for the given app deploying a single
-// named image, used to exercise image-aware cancellation.
 func taskWithImage(app, image string) models.Task {
 	task := createTestTask(app)
 	task.Images = []models.Image{{Image: image, Tag: "v0.0.1"}}
 	return task
 }
 
-// TestImageNamesOverlap locks the boundary contract of the overlap helper:
-// empty/nil inputs never match, tags are ignored, and a single shared image
-// name (even within larger disjoint sets) counts as an overlap.
+// Tags are ignored, and a single shared image name counts as an overlap.
 func TestImageNamesOverlap(t *testing.T) {
 	tests := []struct {
 		name string
@@ -60,8 +55,6 @@ func TestImageNamesOverlap(t *testing.T) {
 	}
 }
 
-// TestInMemoryState_AddTask verifies that tasks can be added to the in-memory state
-// and receive unique IDs.
 func TestInMemoryState_AddTask(t *testing.T) {
 	state := InMemoryState{}
 
@@ -76,7 +69,6 @@ func TestInMemoryState_AddTask(t *testing.T) {
 	assert.NotEqual(t, firstTask.Id, secondTask.Id, "Each task should have a unique ID")
 }
 
-// TestInMemoryState_GetTask verifies that a task can be retrieved by its ID.
 func TestInMemoryState_GetTask(t *testing.T) {
 	state := InMemoryState{}
 
@@ -90,8 +82,6 @@ func TestInMemoryState_GetTask(t *testing.T) {
 	assert.Equal(t, models.StatusInProgressMessage, retrievedTask.Status)
 }
 
-// TestInMemoryState_GetTask_NotFound verifies that GetTask returns an error
-// when the task ID does not exist.
 func TestInMemoryState_GetTask_NotFound(t *testing.T) {
 	state := InMemoryState{}
 	task, err := state.GetTask("non-existent-id")
@@ -99,8 +89,6 @@ func TestInMemoryState_GetTask_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
-// TestInMemoryState_GetTasks verifies that tasks can be retrieved within a time range
-// and optionally filtered by app name.
 func TestInMemoryState_GetTasks(t *testing.T) {
 	state := InMemoryState{}
 
@@ -148,8 +136,6 @@ func TestInMemoryState_GetTasks(t *testing.T) {
 	})
 }
 
-// TestInMemoryState_GetTasks_EdgeCases verifies edge cases in GetTasks including
-// empty state, pagination, and negative parameters.
 func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 	t.Run("empty state returns empty slice", func(t *testing.T) {
 		state := InMemoryState{}
@@ -213,7 +199,6 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 	})
 }
 
-// TestInMemoryState_SetTaskStatus verifies that a task's status can be updated.
 func TestInMemoryState_SetTaskStatus(t *testing.T) {
 	state := InMemoryState{}
 
@@ -229,8 +214,6 @@ func TestInMemoryState_SetTaskStatus(t *testing.T) {
 	assert.Equal(t, "deployed successfully", updatedTask.StatusReason)
 }
 
-// TestInMemoryState_SetTaskStatus_NotFound verifies that SetTaskStatus returns an error
-// when the task ID does not exist.
 func TestInMemoryState_SetTaskStatus_NotFound(t *testing.T) {
 	state := InMemoryState{}
 	err := state.SetTaskStatus("non-existent-id", models.StatusDeployedMessage, "")
@@ -238,17 +221,12 @@ func TestInMemoryState_SetTaskStatus_NotFound(t *testing.T) {
 	assert.Equal(t, "task not found", err.Error())
 }
 
-// TestInMemoryState_CancelInProgressTasks verifies that only in-progress tasks
-// for the target app that share an image name with the new deployment are
-// switched to cancelled, and that same-app-different-image tasks, already-
-// finished tasks, and tasks for other apps are left untouched.
 func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
 	state := InMemoryState{}
 
 	inProgress, err := state.AddTask(taskWithImage("app-a", "image-a"))
 	require.NoError(t, err)
 
-	// Same app, but a different image deployed independently.
 	sameAppOtherImage, err := state.AddTask(taskWithImage("app-a", "image-b"))
 	require.NoError(t, err)
 
@@ -259,8 +237,6 @@ func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
 
-	// A new deployment of image-a for app-a supersedes only the in-progress
-	// image-a task.
 	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded", false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count, "only the in-progress app-a task sharing image-a should be cancelled")
@@ -270,17 +246,14 @@ func TestInMemoryState_CancelInProgressTasks(t *testing.T) {
 	assert.Equal(t, models.StatusCancelledMessage, got.Status)
 	assert.Equal(t, "superseded", got.StatusReason)
 
-	// Same app but a different image is untouched.
 	gotSameApp, err := state.GetTask(sameAppOtherImage.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusInProgressMessage, gotSameApp.Status)
 
-	// A different app is untouched.
 	gotOther, err := state.GetTask(otherApp.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusInProgressMessage, gotOther.Status)
 
-	// An already-deployed task is untouched.
 	gotFinished, err := state.GetTask(finished.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusDeployedMessage, gotFinished.Status)
@@ -303,7 +276,6 @@ func TestInMemoryState_CancelInProgressTasks_MultiImageOverlap(t *testing.T) {
 	disjointTask, err := state.AddTask(disjoint)
 	require.NoError(t, err)
 
-	// New deployment shares only image-b with the first task and nothing with the second.
 	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-b", Tag: "v2"}, {Image: "image-e", Tag: "v1"}}, "superseded", false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count, "only the task sharing an image name should be cancelled")
@@ -317,9 +289,6 @@ func TestInMemoryState_CancelInProgressTasks_MultiImageOverlap(t *testing.T) {
 	assert.Equal(t, models.StatusInProgressMessage, gotDisjoint.Status)
 }
 
-// TestInMemoryState_CancelInProgressTasks_Count verifies the returned count:
-// every matching in-progress task is cancelled (aggregation), and a deployment
-// that overlaps nothing in flight cancels nothing.
 func TestInMemoryState_CancelInProgressTasks_Count(t *testing.T) {
 	state := InMemoryState{}
 
@@ -328,12 +297,10 @@ func TestInMemoryState_CancelInProgressTasks_Count(t *testing.T) {
 	second, err := state.AddTask(taskWithImage("app-a", "image-a"))
 	require.NoError(t, err)
 
-	// No overlap: nothing is cancelled and both tasks stay in progress.
 	count, err := state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-z", Tag: "v1"}}, "superseded", false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count, "a deployment sharing no image should cancel nothing")
 
-	// Overlap: both in-progress tasks sharing image-a are cancelled.
 	count, err = state.CancelInProgressTasks("app-a", []models.Image{{Image: "image-a", Tag: "v2"}}, "superseded", false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count, "every matching in-progress task must be cancelled")
@@ -420,20 +387,15 @@ func TestInMemoryState_CancelInProgressTasks_AuthorityMixedFleet(t *testing.T) {
 	assert.Equal(t, models.StatusCancelledMessage, gotAnonymous.Status)
 }
 
-// TestInMemoryState_ProcessObsoleteTasks verifies that stale in-progress tasks
-// are marked as aborted after the threshold period.
 func TestInMemoryState_ProcessObsoleteTasks(t *testing.T) {
 	state := InMemoryState{}
 
-	// Add a fresh task
 	freshTask, err := state.AddTask(createTestTask("Fresh"))
 	require.NoError(t, err)
 
-	// Add a stale task by directly manipulating internal state
 	staleTask, err := state.AddTask(createTestTask("Stale"))
 	require.NoError(t, err)
 
-	// Make the stale task appear old by adjusting its Updated timestamp
 	state.mu.Lock()
 	for idx := range state.tasks {
 		if state.tasks[idx].Id == staleTask.Id {
@@ -445,67 +407,53 @@ func TestInMemoryState_ProcessObsoleteTasks(t *testing.T) {
 	// Run processing with 1 attempt (will complete immediately)
 	state.ProcessObsoleteTasks(1)
 
-	// Verify the fresh task is unchanged
 	retrievedFresh, err := state.GetTask(freshTask.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusInProgressMessage, retrievedFresh.Status)
 
-	// Verify the stale task was marked as aborted with the stale-task reason
 	retrievedStale, err := state.GetTask(staleTask.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusAborted, retrievedStale.Status)
 	assert.Equal(t, StaleTaskAbortReason, retrievedStale.StatusReason)
 }
 
-// TestInMemoryState_ProcessObsoleteTasks_RemovesAppNotFound verifies that tasks with
-// "app not found" status are removed during obsolete task processing.
 func TestInMemoryState_ProcessObsoleteTasks_RemovesAppNotFound(t *testing.T) {
 	state := InMemoryState{}
 
-	// Add a normal task
 	normalTask, err := state.AddTask(createTestTask("Normal"))
 	require.NoError(t, err)
 
-	// Add a task and set it to "app not found"
 	appNotFoundTask, err := state.AddTask(createTestTask("AppNotFound"))
 	require.NoError(t, err)
 	err = state.SetTaskStatus(appNotFoundTask.Id, models.StatusAppNotFoundMessage, "")
 	require.NoError(t, err)
 
-	// Run processing
 	state.ProcessObsoleteTasks(1)
 
-	// Verify normal task still exists
 	_, err = state.GetTask(normalTask.Id)
 	assert.NoError(t, err)
 
-	// Verify "app not found" task was removed
 	_, err = state.GetTask(appNotFoundTask.Id)
 	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
-// TestInMemoryState_Check verifies that the Check method returns true for in-memory state.
 func TestInMemoryState_Check(t *testing.T) {
 	state := InMemoryState{}
 	assert.True(t, state.Check())
 }
 
-// TestInMemoryState_Connect verifies that Connect method returns nil error.
 func TestInMemoryState_Connect(t *testing.T) {
 	state := InMemoryState{}
 	err := state.Connect(nil)
 	assert.NoError(t, err)
 }
 
-// TestInMemoryState_ConcurrentAccess verifies thread safety of the in-memory state
-// by exercising concurrent reads and writes.
 func TestInMemoryState_ConcurrentAccess(t *testing.T) {
 	state := InMemoryState{}
 	var wg sync.WaitGroup
 	taskCount := 50
 	errCh := make(chan error, taskCount)
 
-	// Spawn goroutines to add tasks concurrently
 	for i := 0; i < taskCount; i++ {
 		wg.Add(1)
 		go func(i int) {
@@ -517,7 +465,6 @@ func TestInMemoryState_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	// Spawn goroutines to read tasks concurrently
 	for i := 0; i < taskCount; i++ {
 		wg.Add(1)
 		go func() {
@@ -529,12 +476,10 @@ func TestInMemoryState_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 	close(errCh)
 
-	// Check for any errors from goroutines
 	for err := range errCh {
 		t.Errorf("AddTask failed: %v", err)
 	}
 
-	// Verify all tasks were added
 	tasks, total := state.GetTasks(0, float64(time.Now().Unix())+10, "", "", 0, 0)
 	assert.Equal(t, int64(taskCount), total)
 	assert.Len(t, tasks, taskCount)

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -19,7 +19,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/state/state_models"
 )
 
-// whereStatusEquals is the GORM condition matching a task by its status column.
 const whereStatusEquals = "status = ?"
 
 type PostgresState struct {
@@ -42,7 +41,7 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 	return nil
 }
 
-// AddTask inserts a new in-progress task and returns it with the DB-generated id and creation time.
+// AddTask returns the task with the DB-generated id and creation time.
 func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 	ormTask := state_models.TaskModel{
 		Images:           datatypes.NewJSONSlice(task.Images),
@@ -132,8 +131,7 @@ func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 	return ormTask.ConvertToExternalTask(), nil
 }
 
-// SetTaskStatus updates a task's status and status_reason. It returns an error
-// if the id is malformed or no matching task exists.
+// SetTaskStatus errors if the id is malformed or no matching task exists.
 func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	uuidv4, err := uuid.Parse(id)
 	if err != nil {
@@ -191,7 +189,7 @@ func (state *PostgresState) CancelInProgressTasks(app string, images []models.Im
 	return result.RowsAffected, nil
 }
 
-// Check reports whether the database connection is alive by pinging it.
+// Check reports whether the database connection is alive.
 func (state *PostgresState) Check() bool {
 	connection, err := state.orm.DB()
 	if err != nil {
@@ -230,8 +228,6 @@ func (state *PostgresState) ProcessObsoleteTasks(retryTimes uint) {
 	}
 }
 
-// doProcessPostgresObsoleteTasks deletes "app not found" tasks older than 1 hour
-// and marks "in progress" tasks older than 1 hour as "aborted".
 func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 	slog.Debug("Removing obsolete tasks...")
 
@@ -251,8 +247,7 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 	return nil
 }
 
-// GetDB returns the underlying GORM database instance.
-// This allows sharing the database connection pool with other components.
+// GetDB exposes the connection pool so other components can share it.
 func (state *PostgresState) GetDB() *gorm.DB {
 	return state.orm
 }

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -18,8 +18,7 @@ type postgresTestEnv struct {
 	state *PostgresState
 }
 
-// newPostgresTestEnv prepares an isolated Postgres-backed repository for integration testing.
-// Tests are skipped automatically when no Postgres configuration is present in the environment.
+// Skips the test automatically when no Postgres configuration is present.
 func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
 	t.Helper()
 
@@ -47,7 +46,6 @@ func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
 	return env
 }
 
-// addTask persists a task fixture and returns the stored record.
 func (env *postgresTestEnv) addTask(t *testing.T, task models.Task) *models.Task {
 	t.Helper()
 	result, err := env.state.AddTask(task)
@@ -65,7 +63,6 @@ func (env *postgresTestEnv) storedModel(t *testing.T, id string) state_models.Ta
 	return stored
 }
 
-// sampleTask builds a reusable task definition for integration tests.
 func sampleTask(app string) models.Task {
 	return models.Task{
 		App:     app,
@@ -224,7 +221,6 @@ func TestPostgresState_CancelInProgressTasks(t *testing.T) {
 	assert.Equal(t, models.StatusCancelledMessage, got.Status)
 	assert.Equal(t, "superseded", got.StatusReason)
 
-	// Same app but a different image is untouched.
 	gotSameApp, err := env.state.GetTask(sameAppOtherImage.Id)
 	require.NoError(t, err)
 	assert.Equal(t, models.StatusInProgressMessage, gotSameApp.Status)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,8 +41,6 @@ func imageNamesOverlap(a, b []models.Image) bool {
 }
 
 // TaskRepository defines the contract for task persistence.
-// Implementations are responsible for connecting to the underlying storage and
-// offering CRUD-like operations for deployment tasks.
 type TaskRepository interface {
 	Connect(serverConfig *config.ServerConfig) error
 	AddTask(task models.Task) (*models.Task, error)
@@ -66,9 +64,7 @@ type TaskRepository interface {
 	ProcessObsoleteTasks(retryTimes uint)
 }
 
-// NewState creates a new task repository based on the provided server configuration.
-// It initializes the appropriate repository according to the StateType field and
-// ensures that the returned implementation is already connected to the storage backend.
+// NewState returns a task repository for the configured StateType, already connected.
 func NewState(serverConfig *config.ServerConfig) (TaskRepository, error) {
 	slog.Debug("Initializing argo-watcher state...")
 	var state TaskRepository

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -9,33 +9,25 @@ import (
 )
 
 func TestNewState_success(t *testing.T) {
-	// Create a ServerConfig instance with a specific StateType value
 	cfg := &config.ServerConfig{
 		StateType: "in-memory",
 	}
 
-	// Call the NewState function
 	state, err := NewState(cfg)
 
-	// Assert that the state is not nil
 	assert.NotNil(t, state)
 
-	// Assert that the error is nil
 	assert.Nil(t, err)
 }
 
 func TestNewState_fail(t *testing.T) {
-	// Create a ServerConfig instance with a specific StateType value
 	cfg := &config.ServerConfig{
 		StateType: "non-existing-state",
 	}
 
-	// Call the NewState function
 	state, err := NewState(cfg)
 
-	// Assert that the state is nil
 	assert.Nil(t, state)
 
-	// Assert that the error is not nil
 	assert.NotNil(t, err)
 }

--- a/internal/updater/config.go
+++ b/internal/updater/config.go
@@ -34,9 +34,8 @@ type GitConfig struct {
 	// competing writer (another argo-watcher instance, other CI, or a human)
 	// advances the branch, each write-back attempt re-fetches, re-applies, and
 	// re-pushes. Combined with tight early backoff, 5 attempts clear typical
-	// contention; the old default of 3 gave up too soon. A superseded task aborts
-	// the loop early, so a larger budget does not let an older deployment
-	// overwrite a newer one.
+	// contention. A superseded task aborts the loop early, so raising this budget
+	// cannot let an older deployment overwrite a newer one.
 	GitMaxAttempts uint `env:"GIT_MAX_ATTEMPTS" envDefault:"5"`
 }
 
@@ -98,11 +97,9 @@ func NewGitConfig() (*GitConfig, error) {
 	return &config, nil
 }
 
-// applyLegacyGitTimeout maps the deprecated GIT_TIMEOUT env var to GIT_OP_TIMEOUT
-// when the latter was not set explicitly. The mapping is 1:1 — GIT_TIMEOUT is used
-// directly as GIT_OP_TIMEOUT — to preserve the original per-call budget unchanged.
-// Retries are opt-in via GIT_MAX_ATTEMPTS; the old single-attempt wall clock is
-// preserved per attempt rather than divided across retries.
+// applyLegacyGitTimeout maps the deprecated GIT_TIMEOUT to GIT_OP_TIMEOUT when the
+// latter was not set explicitly. Retries are opt-in via GIT_MAX_ATTEMPTS; the old
+// single-attempt wall clock is preserved per attempt, not divided across retries.
 func applyLegacyGitTimeout(config *GitConfig) error {
 	legacyRaw, legacySet := os.LookupEnv("GIT_TIMEOUT")
 	if !legacySet {

--- a/internal/updater/config_test.go
+++ b/internal/updater/config_test.go
@@ -150,9 +150,6 @@ func TestNewBatchConfig(t *testing.T) {
 	})
 }
 
-// TestLegacyGitTimeoutMapping covers the backward-compat shim that maps the
-// deprecated GIT_TIMEOUT directly to GIT_OP_TIMEOUT (1:1, no division), so
-// the per-attempt budget is unchanged for operators that have not migrated.
 func TestLegacyGitTimeoutMapping(t *testing.T) {
 	t.Run("GIT_TIMEOUT alone is used directly as GIT_OP_TIMEOUT", func(t *testing.T) {
 		t.Setenv("SSH_KEY_PATH", "/test/key")
@@ -171,8 +168,6 @@ func TestLegacyGitTimeoutMapping(t *testing.T) {
 		t.Setenv("SSH_KEY_PATH", "/test/key")
 		t.Setenv("GIT_TIMEOUT", "2m")
 		t.Setenv("GIT_MAX_ATTEMPTS", "4")
-		// Still a 1:1 map: GIT_OP_TIMEOUT = 2m.
-		// GIT_MAX_ATTEMPTS only affects total wall-clock ceiling, not the per-attempt budget.
 
 		config, err := NewGitConfig()
 

--- a/internal/updater/interfaces.go
+++ b/internal/updater/interfaces.go
@@ -75,8 +75,6 @@ func (GitClient) AddSSHKey(user, path, passphrase string) (*ssh.PublicKeys, erro
 	return ssh.NewPublicKeysFromFile(user, path, passphrase)
 }
 
-// validateSSHKeyFile validates that the SSH key file exists, is readable,
-// is not empty, and contains a valid SSH private key format.
 func validateSSHKeyFile(path string) error {
 	if path == "" {
 		return ErrSSHKeyNotProvided

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,7 +1,6 @@
-// Package updater provides the core logic for interacting with Git repositories.
-// This includes cloning, caching, updating, and pushing changes to application manifests.
-// It is designed to be safe for concurrent use, with locking mechanisms handled upstream
-// and a robust caching strategy to ensure efficiency and resilience.
+// Package updater clones, caches, updates and pushes application manifests in Git.
+// Concurrent write-back to one repository must be serialised by the caller; that
+// locking lives upstream, not in this package.
 package updater
 
 import (
@@ -41,35 +40,27 @@ type ArgoParameterOverride struct {
 	ForceString bool   `yaml:"forceString"`
 }
 
-// GitRepo encapsulates all the necessary information and state for performing
-// operations on a single Git repository branch.
+// GitRepo holds the state for operations on a single Git repository branch.
 type GitRepo struct {
 	// RepoURL is the SSH URL of the repository to be cloned.
-	RepoURL string
-	// BranchName is the target branch for all operations.
+	RepoURL    string
 	BranchName string
 	// Path is the directory within the repository where the manifest file is located.
-	Path string
-	// FileName is the name of the override file to be updated.
-	FileName string
-	// repoCachePath is the base directory on the local filesystem for storing cached repositories.
+	Path          string
+	FileName      string
 	repoCachePath string
 	// localRepoPath is the full path to the cached clone of this specific repository and branch.
 	localRepoPath string
-	// localRepo is the go-git object representing the repository on disk.
-	localRepo *git.Repository
-	// sshAuth holds the SSH authentication method.
-	sshAuth *ssh.PublicKeys
+	localRepo     *git.Repository
+	sshAuth       *ssh.PublicKeys
 	// gitConfig contains user-configurable git settings like commit author and email.
-	gitConfig *GitConfig
-	// GitHandler is an interface for git operations, allowing for easier testing and mocking.
+	gitConfig  *GitConfig
 	GitHandler GitHandler
 }
 
 // getRepoCachePath generates a unique, deterministic local path for the repository cache.
-// It uses an FNV-1a hash of the combined repository URL and branch name to ensure that
-// concurrent operations on different branches of the same repository do not conflict.
-// This approach provides filesystem-level isolation.
+// Hashing URL+branch gives filesystem-level isolation, so concurrent operations on
+// different branches of the same repository do not conflict.
 func (repo *GitRepo) getRepoCachePath() string {
 	hasher := fnv.New64a()
 	// The Write method on hash.Hash is documented to never return an error.
@@ -78,16 +69,13 @@ func (repo *GitRepo) getRepoCachePath() string {
 	return filepath.Join(repo.repoCachePath, strconv.FormatUint(hashUint64, 16))
 }
 
-// Clone handles the initial setup of the local repository cache.
+// Clone handles the initial setup of the local repository cache. A cache that opens
+// cleanly and has an "origin" remote is fetched and hard-reset to the remote branch
+// HEAD, so the worktree is always clean and at origin on return; anything else
+// (missing, corrupt, no "origin") is re-cloned from scratch rather than repaired.
 //
-// The logic is designed to be resilient against incomplete or corrupt clones. It first attempts
-// to open an existing repository at the expected cache path.
-//   - If opening succeeds, it means a valid cache exists. The function then proceeds to fetch the
-//     latest changes from the remote and performs a hard reset to ensure the working directory
-//     is clean and up-to-date with the remote branch's HEAD.
-//   - If opening fails (for any reason, including the directory not existing or being corrupt),
-//     the function assumes the cache is invalid. It safely removes the directory and then
-//     performs a fresh, single-branch clone from the remote.
+// commitLocal's byte-compare skip depends on that reset: it treats equal bytes as
+// "no change", which only holds because this function leaves the worktree at origin.
 //
 // Both the fresh clone and the warm-cache fetch are shallow (Depth:1, no tags):
 // argo-watcher only reads the branch tip and commits one file on top of it, so
@@ -113,13 +101,10 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 
 	repo.localRepo, err = repo.GitHandler.PlainOpen(repo.localRepoPath)
 	if err == nil {
-		// If open succeeded, ensure the 'origin' remote exists.
 		_, err = repo.localRepo.Remote("origin")
 	}
 
-	// Handle the case where the cache is invalid or does not exist.
 	if err != nil {
-		// Differentiate between a simple "not found" and a real corruption issue for logging.
 		if errors.Is(err, git.ErrRepositoryNotExists) {
 			slog.Debug("No cache found for repo, cloning fresh", "repo", repo.RepoURL, "path", repo.localRepoPath)
 		} else {
@@ -129,7 +114,6 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 			}
 		}
 
-		// Shallow, single-branch, no tags — see the Clone doc comment for why.
 		repo.localRepo, err = repo.GitHandler.PlainClone(ctx, repo.localRepoPath, false, &git.CloneOptions{
 			URL:           repo.RepoURL,
 			ReferenceName: plumbing.ReferenceName("refs/heads/" + repo.BranchName),
@@ -141,7 +125,6 @@ func (repo *GitRepo) Clone(ctx context.Context) error {
 		return err
 	}
 
-	// If we get here, the cache is valid and has an 'origin' remote.
 	slog.Debug("Successfully opened cached repository", "path", repo.localRepoPath)
 	// Keep the fetch shallow too; otherwise go-git deepens the clone toward full
 	// history on the first fetch, undoing the shallow clone's win.
@@ -276,9 +259,6 @@ func assertInsideRoot(root, path string) error {
 	return nil
 }
 
-// mergeOverrideFileContent reads an existing override file (if one exists) and
-// merges the new parameter overrides into it. If no file exists, it returns the
-// new content directly.
 func (repo *GitRepo) mergeOverrideFileContent(fullPath string, overrideContent *ArgoOverrideFile) (*ArgoOverrideFile, error) {
 	existingContent, err := os.ReadFile(fullPath) // #nosec G304 -- path already validated by assertInsideRoot in UpdateApp
 	if err != nil {
@@ -298,9 +278,6 @@ func (repo *GitRepo) mergeOverrideFileContent(fullPath string, overrideContent *
 	return &existingOverrideFile, nil
 }
 
-// commitLocal writes the override file, stages it, and creates a local commit.
-// It reports whether a commit was actually created: if the file already contains
-// exactly the content to be written, it skips the commit and returns (false, nil).
 func (repo *GitRepo) commitLocal(fullPath, commitMsg string, overrideContent *ArgoOverrideFile) (bool, error) {
 	worktree, err := repo.localRepo.Worktree()
 	if err != nil {
@@ -331,7 +308,6 @@ func (repo *GitRepo) commitLocal(fullPath, commitMsg string, overrideContent *Ar
 	// go-git hashes and stages only that file (new or modified).
 	relativePath, err := filepath.Rel(repo.localRepoPath, fullPath)
 	if err != nil {
-		// This is a programmatic error, should not happen in practice.
 		return false, fmt.Errorf("could not determine relative path: %w", err)
 	}
 	if err := worktree.AddWithOptions(&git.AddOptions{Path: relativePath, SkipStatus: true}); err != nil {
@@ -376,9 +352,6 @@ func (repo *GitRepo) push(ctx context.Context) error {
 	return repo.localRepo.PushContext(ctx, pushOpts)
 }
 
-// mergeParameters updates the `existing` parameters with values from `newContent`.
-// If a parameter from `newContent` already exists by name in `existing`, it is overwritten.
-// If it does not exist, it is appended.
 func mergeParameters(existing, newContent *ArgoOverrideFile) {
 	for _, newParam := range newContent.Helm.Parameters {
 		found := false
@@ -395,8 +368,7 @@ func mergeParameters(existing, newContent *ArgoOverrideFile) {
 	}
 }
 
-// NewGitRepo is the constructor for the GitRepo struct. It initializes the struct
-// with all necessary information for git operations, including loading the git configuration.
+// NewGitRepo constructs a GitRepo, loading the git configuration from the environment.
 func NewGitRepo(repoURL, branchName, path, fileName, repoCachePath string, gitHandler GitHandler) (*GitRepo, error) {
 	gitConfig, err := NewGitConfig()
 	if err != nil {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 )
 
-// newTestRepo creates a valid GitRepo instance for testing purposes.
 func newTestRepo(t *testing.T, handler GitHandler) *GitRepo {
 	t.Helper()
 	t.Setenv("SSH_KEY_PATH", "/dev/null")
@@ -77,7 +76,6 @@ func TestInvalidateCache(t *testing.T) {
 		repo, err := NewGitRepo("url", "branch", "path", "file", cacheBase, &GitClient{})
 		require.NoError(t, err)
 
-		// Pre-create the cache path so InvalidateCache has something to remove.
 		repo.localRepoPath = filepath.Join(cacheBase, "cached-repo")
 		require.NoError(t, os.MkdirAll(repo.localRepoPath, 0755))
 		marker := filepath.Join(repo.localRepoPath, "marker")
@@ -97,7 +95,6 @@ func TestInvalidateCache(t *testing.T) {
 		repo, err := NewGitRepo("url", "branch", "path", "file", cacheBase, &GitClient{})
 		require.NoError(t, err)
 
-		// Path inside cacheBase but does not exist on disk — RemoveAll should succeed silently.
 		repo.localRepoPath = filepath.Join(cacheBase, "does-not-exist")
 		assert.NoError(t, repo.InvalidateCache())
 	})
@@ -171,9 +168,7 @@ func TestGetRepoCachePath(t *testing.T) {
 }
 
 func TestGenerateOverrideFileName(t *testing.T) {
-	// Custom filename is used verbatim under the path.
 	assert.Equal(t, "apps/custom.yaml", generateOverrideFileNameForApp("apps", "custom.yaml", "my-app"))
-	// Empty filename falls back to the per-app default name.
 	assert.Equal(t, "apps/.argocd-source-my-app.yaml", generateOverrideFileNameForApp("apps", "", "my-app"))
 }
 
@@ -281,20 +276,17 @@ func TestClone(t *testing.T) {
 		// No AddSSHKey expectation — strict controller fails the test if it is called.
 
 		assert.NoError(t, repo.Clone(context.Background()))
-		repo.sshAuth = nil // reset for any future subtests
+		repo.sshAuth = nil
 	})
 }
 
-// setupGitForTest is a helper to create a clean git environment for each sub-test.
 func setupGitForTest(t *testing.T) (sourceRepo, remoteRepo, localRepo *git.Repository, remotePath, localPath string) {
 	t.Helper()
 
-	// 1. Create a NON-BARE repository first, which will be the source.
 	sourcePath := t.TempDir()
 	sourceRepo, err := git.PlainInit(sourcePath, false)
 	require.NoError(t, err)
 
-	// 2. Create an initial commit in the source repository so it's not empty.
 	sourceWorktree, err := sourceRepo.Worktree()
 	require.NoError(t, err)
 	_, err = sourceWorktree.Commit("initial commit", &git.CommitOptions{
@@ -303,14 +295,12 @@ func setupGitForTest(t *testing.T) (sourceRepo, remoteRepo, localRepo *git.Repos
 	})
 	require.NoError(t, err)
 
-	// 3. Create a BARE repository to act as the "origin" remote, by cloning the source.
 	remotePath = t.TempDir()
 	remoteRepo, err = git.PlainClone(remotePath, true, &git.CloneOptions{
 		URL: sourcePath,
 	})
 	require.NoError(t, err)
 
-	// 4. Create the final "local" clone that our code will operate on.
 	localPath = t.TempDir()
 	localRepo, err = git.PlainClone(localPath, false, &git.CloneOptions{
 		URL: remotePath,
@@ -357,13 +347,11 @@ func TestFullUpdateAppCycle(t *testing.T) {
 		appDir := filepath.Join(localPath, "apps")
 		require.NoError(t, os.Mkdir(appDir, 0755))
 
-		// First, perform a successful change.
 		initialParams := &ArgoOverrideFile{}
 		initialParams.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
 		err := repo.UpdateApp(context.Background(), "my-app", initialParams, nil)
 		require.NoError(t, err)
 
-		// Now, try again with the same content.
 		headBefore, err := localRepo.Head()
 		require.NoError(t, err)
 
@@ -385,7 +373,7 @@ func TestFullUpdateAppCycle(t *testing.T) {
 		require.NoError(t, os.Mkdir(appDir, 0755))
 
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // already expired before UpdateApp runs
+		cancel()
 
 		newParams := &ArgoOverrideFile{}
 		newParams.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
@@ -404,29 +392,24 @@ func TestFullUpdateAppCycle(t *testing.T) {
 		appDir := filepath.Join(localPath, "apps")
 		require.NoError(t, os.Mkdir(appDir, 0755))
 
-		// Get the worktree from the non-bare source repo.
 		sourceWorktree, err := sourceRepo.Worktree()
 		require.NoError(t, err)
 
-		// Add the bare repository as a remote to the source repo.
 		_, err = sourceRepo.CreateRemote(&config.RemoteConfig{
 			Name: "origin",
 			URLs: []string{remotePath},
 		})
 		require.NoError(t, err)
 
-		// Commit a conflicting change to the source repo.
 		_, err = sourceWorktree.Commit("a conflicting commit", &git.CommitOptions{
 			Author:            &object.Signature{Name: "Other", Email: "other@test.com", When: time.Now()},
 			AllowEmptyCommits: true,
 		})
 		require.NoError(t, err)
 
-		// Push the conflicting commit from source to the bare remote.
 		err = sourceRepo.Push(&git.PushOptions{})
 		require.NoError(t, err)
 
-		// Now, try to update our local repo, which will fail on push.
 		newParams := &ArgoOverrideFile{}
 		newParams.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v3.0.0"}}
 
@@ -473,10 +456,8 @@ func TestCommitAppLocalAndPush_MultipleAppsSinglePush(t *testing.T) {
 	}
 	assert.Equal(t, 2, commitCount)
 
-	// Nothing pushed yet: the remote must still be at its initial commit.
 	require.NoError(t, repo.Push(context.Background()))
 
-	// Both files landed on the remote after the single push.
 	head, err := remoteRepo.Head()
 	require.NoError(t, err)
 	commit, err := remoteRepo.CommitObject(head.Hash())
@@ -510,7 +491,6 @@ func TestCommitAppLocal_NoChangeReportsNotCommitted(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, committed)
 
-	// Byte-identical content on the second call: no new commit.
 	committed, err = repo.CommitAppLocal("app-a", "apps", "", params, nil)
 	require.NoError(t, err)
 	assert.False(t, committed, "unchanged content must report not committed so the push is skipped")
@@ -577,13 +557,11 @@ func TestCommitLocal_SkipsWhenContentUnchanged(t *testing.T) {
 	params := &ArgoOverrideFile{}
 	params.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v2.0.0"}}
 
-	// First write creates the commit.
 	commitLocalAndPush(t, repo, fullPath, "msg", params)
 
 	headBefore, err := localRepo.Head()
 	require.NoError(t, err)
 
-	// Second call with byte-identical content must skip: no new commit, no error.
 	committed, err := repo.commitLocal(fullPath, "msg", params)
 	require.NoError(t, err)
 	assert.False(t, committed, "unchanged content must report not committed")
@@ -603,7 +581,6 @@ func TestCommitLocalAndPush_RestagesModifiedTrackedFile(t *testing.T) {
 	require.NoError(t, os.Mkdir(appDir, 0755))
 	fullPath := filepath.Join(appDir, "values.yaml")
 
-	// First commit tracks the file at v1.
 	v1 := &ArgoOverrideFile{}
 	v1.Helm.Parameters = []ArgoParameterOverride{{Name: "image.tag", Value: "v1.0.0"}}
 	commitLocalAndPush(t, repo, fullPath, "v1", v1)
@@ -679,7 +656,6 @@ func TestCommitLocal_WriteFileError(t *testing.T) {
 }
 
 func TestGitClient_Coverage(t *testing.T) {
-	// 1. Create a source repository with a commit, so it's not empty.
 	sourcePath := t.TempDir()
 	sourceRepo, err := git.PlainInit(sourcePath, false)
 	require.NoError(t, err)
@@ -691,20 +667,15 @@ func TestGitClient_Coverage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// 2. Create an instance of the concrete client.
 	client := GitClient{}
 
-	// 3. Execute and cover PlainClone.
 	clonePath := t.TempDir()
 	_, err = client.PlainClone(context.Background(), clonePath, false, &git.CloneOptions{URL: sourcePath})
 	require.NoError(t, err, "PlainClone method failed")
 
-	// 4. Execute and cover PlainOpen on the new clone.
 	_, err = client.PlainOpen(clonePath)
 	require.NoError(t, err, "PlainOpen method failed")
 
-	// 5. Execute and cover AddSSHKey.
-	// We expect an error because it's not a real key, but the call will cover the line.
 	keyFile := filepath.Join(t.TempDir(), "dummy_key")
 	err = os.WriteFile(keyFile, []byte("not-a-real-key"), 0600)
 	require.NoError(t, err)
@@ -724,8 +695,6 @@ func TestUpdateApp_ErrorHandling(t *testing.T) {
 		appDir := filepath.Join(localPath, "apps")
 		require.NoError(t, os.Mkdir(appDir, 0755))
 
-		// A bad template must NOT abort the update — it falls back to the default
-		// commit message and the write succeeds.
 		err := repo.UpdateApp(context.Background(), "my-app", newParams, nil)
 		assert.NoError(t, err)
 	})
@@ -753,7 +722,6 @@ func TestAssertInsideRoot(t *testing.T) {
 	})
 
 	t.Run("Root itself is rejected (not strictly inside)", func(t *testing.T) {
-		// The override file must be inside the root, not the root itself.
 		err := assertInsideRoot(root, root)
 		require.Error(t, err)
 	})
@@ -780,7 +748,6 @@ func TestInvalidateCache_PathEscapeGuard(t *testing.T) {
 	repo, err := NewGitRepo("url", "branch", "path", "file", cacheBase, &GitClient{})
 	require.NoError(t, err)
 
-	// Simulate misuse: localRepoPath set to a path outside repoCachePath.
 	repo.localRepoPath = "/tmp/dangerous-removal-target"
 
 	err = repo.InvalidateCache()
@@ -788,7 +755,6 @@ func TestInvalidateCache_PathEscapeGuard(t *testing.T) {
 	assert.Contains(t, err.Error(), "refusing to remove")
 }
 
-// TestCorruptedGitRepo_ErrorPaths covers failures on an invalid git repo.
 func TestCorruptedGitRepo_ErrorPaths(t *testing.T) {
 	corruptRepoPath := t.TempDir()
 	gitDir := filepath.Join(corruptRepoPath, ".git")
@@ -811,7 +777,6 @@ func TestCorruptedGitRepo_ErrorPaths(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestValidateSSHKeyFile tests the SSH key validation function.
 func TestValidateSSHKeyFile(t *testing.T) {
 	t.Run("Empty path returns error", func(t *testing.T) {
 		err := validateSSHKeyFile("")


### PR DESCRIPTION
A pass over the Go side of the repo to cut comments that do not earn their place — diary entries, prose restating the line below it, AAA banners, docstrings that spell the signature back out. Docstrings on exported symbols were shrunk to their contract line rather than removed, and comments carrying a fact the code cannot state were left alone. A handful of comments that had drifted out of sync with the code are corrected.

No behaviour changes. 92 files, -1556/+333; `go vet`, `go build` and the full test suite are green.

Covers the Go packages and `cmd/`. `web/` and `test/e2e/` are untouched and will follow separately.