### PR TITLE
docs(web): prune comment bloat from the frontend

### DIFF
--- a/web/e2e/auth/deploy-lock.spec.ts
+++ b/web/e2e/auth/deploy-lock.spec.ts
@@ -4,7 +4,6 @@ import { expectAppLoaded, KEYCLOAK_ORIGIN, mintToken, signIn } from '../helpers'
 const BANNER = /Deploy lock is active/;
 const LOCK_SWITCH = 'Toggle deploy lock';
 
-/** Signs in as the privileged user and waits for the app shell. */
 const signInPrivileged = async (page: Page): Promise<void> => {
   await page.goto('/');
   await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));

--- a/web/e2e/auth/login-redirect.spec.ts
+++ b/web/e2e/auth/login-redirect.spec.ts
@@ -2,9 +2,8 @@ import { expect, test } from '@playwright/test';
 import { expectAppLoaded, expectOnApp, KEYCLOAK_ORIGIN, signIn } from '../helpers';
 
 /**
- * The top-level OIDC redirect: leaving the document for the provider and coming
- * back with an authorization code. jsdom implements no cross-document
- * navigation, so this whole flow is invisible to the unit suite.
+ * jsdom implements no cross-document navigation, so the top-level OIDC redirect
+ * is invisible to the unit suite.
  */
 test('an unauthenticated visit signs in through the provider and returns to the app', async ({ page }) => {
   await page.goto('/');

--- a/web/e2e/auth/privileged-gating.spec.ts
+++ b/web/e2e/auth/privileged-gating.spec.ts
@@ -13,7 +13,6 @@ import {
 const ROLLBACK_BUTTON = 'Rollback to this version';
 const LOCK_SWITCH = 'Toggle deploy lock';
 
-/** Opens the configuration drawer, which holds the deploy-lock toggle. */
 const openConfigDrawer = async (page: Page): Promise<void> => {
   await page.getByRole('button', { name: 'Open configuration drawer' }).click();
   // MUI's temporary Drawer is a presentation modal, not a dialog, so wait on its
@@ -39,11 +38,9 @@ const openTaskAs = async (
 };
 
 /**
- * Privilege gating for the two destructive controls: the task rollback button
- * and the deploy-lock toggle.
- *
- * Both gate on `permissions.groups`, which the app resolves from the provider's
- * userinfo endpoint — the same source the backend enforces on. Component tests
+ * The rollback button and the deploy-lock toggle both gate on
+ * `permissions.groups`, which the app resolves from the provider's userinfo
+ * endpoint — the same source the backend enforces on. Component tests
  * inject that permission object directly, so only a browser signed in against a
  * real provider proves the full chain: token, userinfo call, `groups` claim, and
  * the rendered control. The last assertion in each test pins the documented

--- a/web/e2e/auth/rollback.spec.ts
+++ b/web/e2e/auth/rollback.spec.ts
@@ -2,11 +2,9 @@ import { expect, test } from '@playwright/test';
 import { expectAppLoaded, KEYCLOAK_ORIGIN, mintToken, seedTask, signIn, waitForDeployed } from '../helpers';
 
 /**
- * The rollback write path, driven from the UI as a privileged user.
- *
- * It is the only flow that proves the browser's in-memory access token reaches a
- * write request, and that the author on the resulting task comes from the real
- * OIDC identity — component tests stub both the HTTP client and the identity.
+ * The only flow that proves the author on the resulting task comes from the
+ * real OIDC identity — component tests stub both the HTTP client and the
+ * identity, so neither the token nor the author is real there.
  */
 test('a privileged user can roll a task back, and the new task carries their identity', async ({ page, request }) => {
   const id = await seedTask(request, 'rollback-source');
@@ -27,7 +25,6 @@ test('a privileged user can roll a task back, and the new task carries their ide
   const since = Math.floor(Date.now() / 1000) - 1;
   await page.getByRole('button', { name: 'Yes' }).click();
 
-  // A confirmed rollback returns to the list.
   await expectAppLoaded(page);
   await expect(page).toHaveURL(/\/tasks(\?|$)/);
 

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -96,6 +96,7 @@ export const awaitPermissionsResolved = (page: Page): Promise<unknown> =>
       response.status() === 200,
   );
 
+/** Asserts the browser is no longer parked on the identity provider. */
 export const expectOnApp = (page: Page): void => {
   expect(page.url(), 'expected to be on the application origin').not.toContain(KEYCLOAK_ORIGIN);
 };

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -16,14 +16,10 @@ export const MOCK_APP = 'app';
 export const MOCK_TAG = 'v0.0.1';
 
 /**
- * Creates a task through the public API.
- *
  * `POST /api/v1/tasks` is exempt from OIDC read protection, so this seeds both
  * the authenticated and unauthenticated servers without a credential.
  *
- * @param request - Playwright request context bound to the project's baseURL.
- * @param author - author recorded on the task, used by specs to identify their own seed.
- * @returns the new task's id.
+ * @param author - recorded on the task, used by specs to identify their own seed.
  */
 export const seedTask = async (request: APIRequestContext, author: string): Promise<string> => {
   const response = await request.post('/api/v1/tasks', {
@@ -43,9 +39,6 @@ export const seedTask = async (request: APIRequestContext, author: string): Prom
 /**
  * Polls a task until it reaches `deployed`, so specs assert against a settled
  * row rather than one still transitioning under them.
- *
- * @param request - Playwright request context bound to the project's baseURL.
- * @param id - task id returned by {@link seedTask}.
  */
 export const waitForDeployed = async (request: APIRequestContext, id: string): Promise<void> => {
   await expect
@@ -64,15 +57,13 @@ export const waitForDeployed = async (request: APIRequestContext, id: string): P
 };
 
 /**
- * Signs in through the Keycloak login form and waits until the browser is back
- * on the application origin.
+ * Resolves once the browser has left the provider's origin — NOT once the app
+ * has loaded. Callers must still assert their own render or URL condition.
  *
  * Selectors are Keycloak's stable form element ids rather than visible labels,
  * which change with the login theme and locale.
  *
  * @param page - page currently showing the Keycloak login form.
- * @param username - realm user to sign in as.
- * @param password - that user's password.
  */
 export const signIn = async (
   page: Page,
@@ -90,15 +81,12 @@ export const signIn = async (
 };
 
 /**
- * Waits for group membership to be resolved from the provider's userinfo
- * endpoint.
- *
  * Every privilege-gated control renders its UNPRIVILEGED form while permissions
  * are still resolving, so a negative assertion made before this settles passes
  * whether the gating works or not. Arm this before signing in, await it after.
  *
- * @param page - page about to complete a sign-in.
- * @returns a promise resolving once userinfo has answered.
+ * Keys on the provider's `/protocol/openid-connect/userinfo` response, so a
+ * change to how groups are resolved has to update this helper too.
  */
 export const awaitPermissionsResolved = (page: Page): Promise<unknown> =>
   page.waitForResponse(
@@ -108,19 +96,14 @@ export const awaitPermissionsResolved = (page: Page): Promise<unknown> =>
       response.status() === 200,
   );
 
-/** Asserts the browser is on the application, not parked on the identity provider. */
 export const expectOnApp = (page: Page): void => {
   expect(page.url(), 'expected to be on the application origin').not.toContain(KEYCLOAK_ORIGIN);
 };
 
 /**
- * Waits for the application shell to be up.
- *
  * Deliberately keys on the top bar rather than the task table: an empty task
  * list renders an empty state with no column headers, so a table-based wait
  * would silently depend on another spec having seeded data first.
- *
- * @param page - page expected to have mounted the app.
  */
 export const expectAppLoaded = async (page: Page): Promise<void> => {
   await expect(page.getByRole('link', { name: 'Recent' })).toBeVisible();
@@ -129,10 +112,6 @@ export const expectAppLoaded = async (page: Page): Promise<void> => {
 /**
  * Mints an access token via the direct access grant, for API calls a spec makes
  * outside the browser session.
- *
- * @param request - any Playwright request context; the provider is addressed absolutely.
- * @param user - realm credentials to authenticate with.
- * @returns a bearer token for that user.
  */
 export const mintToken = async (
   request: APIRequestContext,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,8 +10,6 @@ import { TaskShow } from './features/tasks/show/TaskShow';
 import { useThemeMode } from './theme';
 
 /**
- * Root React-admin application wiring data/auth providers, resources, and custom routes.
- *
  * `loginPage={false}` disables React-admin's built-in username/password login form.
  * This app authenticates exclusively via a top-level OIDC redirect (see
  * authProvider), so the stock form is never a valid entry point; leaving it enabled

--- a/web/src/auth/authFailure.test.ts
+++ b/web/src/auth/authFailure.test.ts
@@ -31,9 +31,6 @@ describe('describeCallbackError', () => {
     expect(failure.uri).toBe('https://idp/docs/err');
   });
 
-  // Only a real, followable address is worth offering. Everything else — a
-  // relative path, a bare phrase, or a script payload arriving through the
-  // callback query — is dropped rather than rendered as a link.
   it.each([
     { label: 'a relative path', uri: '/docs/errors' },
     { label: 'plain text', uri: 'see the manual' },
@@ -107,7 +104,6 @@ describe('describeCallbackError', () => {
 
     expect(failure.kind).toBe('provider_error');
     expect(failure.code).toBe('access_denied');
-    // Unusable values are dropped, never coerced onto the screen.
     if ('error_description' in overrides) {
       expect(failure.detail).toBeUndefined();
     }

--- a/web/src/auth/authFailure.ts
+++ b/web/src/auth/authFailure.ts
@@ -1,14 +1,11 @@
 /**
- * User-facing descriptions of the ways an OIDC sign-in can fail.
- *
- * A misconfigured provider is otherwise invisible: the browser leaves for the
+ * Nothing else surfaces a misconfigured provider: the browser leaves for the
  * provider, comes back with an error it cannot act on, and the app renders
- * without a session. These descriptions turn what the provider (or the library)
- * reported into something an operator can act on, so the failure is shown once
- * instead of being retried silently.
+ * without a session. The descriptions here turn what the provider (or the
+ * library) reported into something an operator can act on, so the failure is
+ * shown once instead of being retried silently.
  */
 
-/** Longest run of provider-supplied text rendered verbatim. */
 const MAX_DETAIL_LENGTH = 300;
 
 /**
@@ -34,7 +31,7 @@ export interface AuthFailure {
   readonly code?: string;
   /** Provider- or library-supplied explanation, truncated for display. */
   readonly detail?: string;
-  /** What to check to fix it. */
+  /** Argo Watcher's own suggested remedy — never provider-supplied. */
   readonly hint?: string;
   /**
    * Provider-supplied documentation link (`error_uri`), present only when the
@@ -49,8 +46,7 @@ export interface AuthFailure {
  * The optional fields are `unknown` because they are not guaranteed to be strings:
  * on the token-exchange path the library builds `ErrorResponse` from the provider's
  * parsed JSON body without coercing it, so a non-conformant provider can put any
- * value here (RFC 6749 §5.2 asks for strings). Only `error` is checked, by
- * {@link asProviderError}.
+ * value here (RFC 6749 §5.2 asks for strings).
  */
 interface ProviderErrorShape {
   error: string;
@@ -63,9 +59,7 @@ const clamp = (text: string): string =>
   text.length > MAX_DETAIL_LENGTH ? `${text.slice(0, MAX_DETAIL_LENGTH)}…` : text;
 
 /**
- * Normalizes optional provider text, dropping anything that is not usable text.
- *
- * Total by design: these descriptions are produced while handling a sign-in
+ * Never throws, by design: these descriptions are produced while handling a sign-in
  * failure, so a throw in here would reject the bootstrap, mount the app on a
  * failed callback, and start the redirect loop this screen exists to end.
  */
@@ -79,11 +73,10 @@ const optionalText = (value: unknown): string | undefined => {
 
 /**
  * Keeps `error_uri` only when it is an absolute http(s) address short enough to
- * show in full, so the error box offers a link exclusively when the provider sent
- * something followable. Over-length values are dropped rather than truncated: a
- * clamped URL keeps its host and still resolves, to a path the provider does not
- * have. It also keeps a `javascript:` or `data:` payload — the value arrives in
- * the callback query — from ever becoming a link target.
+ * show in full. Over-length values are dropped rather than truncated: a clamped
+ * URL keeps its host and still resolves, to a path the provider does not have.
+ * It also keeps a `javascript:` or `data:` payload — the value arrives in the
+ * callback query — from ever becoming a link target.
  */
 const optionalUrl = (value: unknown): string | undefined => {
   const text = typeof value === 'string' ? value.trim() : '';
@@ -99,8 +92,6 @@ const optionalUrl = (value: unknown): string | undefined => {
 };
 
 /**
- * Drops trailing slashes so an issuer keeps exactly one before the discovery path.
- *
  * Written as a scan rather than a `/\/+$/` replace, whose backtracking is
  * super-linear in the number of trailing slashes.
  */
@@ -112,7 +103,6 @@ const trimTrailingSlashes = (value: string): string => {
   return value.slice(0, end);
 };
 
-/** Best-effort message for anything thrown, including non-Error values. */
 const messageOf = (error: unknown): string | undefined => {
   if (error instanceof Error) {
     return optionalText(error.message);
@@ -139,9 +129,8 @@ const asProviderError = (error: unknown): ProviderErrorShape | null => {
 };
 
 /**
- * Maps an OAuth error code to the setting that produces it. Only the codes with
- * a specific, checkable cause are called out; anything else gets the general
- * pointer at the client registration.
+ * Only the codes with a specific, checkable cause are called out; anything else
+ * gets the general pointer at the client registration.
  */
 const hintForCode = (code: string): string => {
   switch (code) {
@@ -158,8 +147,6 @@ const hintForCode = (code: string): string => {
 };
 
 /**
- * Describes a failure to complete a sign-in callback.
- *
  * A provider error response is reported with its own code and description; any
  * other throw means the response arrived but could not be exchanged locally,
  * which is a different problem and is labelled as one.
@@ -189,14 +176,9 @@ export const describeCallbackError = (error: unknown): AuthFailure => {
 };
 
 /**
- * Describes a failure to start the sign-in redirect. Unreadable OIDC discovery is
- * the usual cause, but the same call also fails when the PKCE state cannot be
- * stored, so the title claims only that the sign-in did not start and the hint
- * carries the likely cause.
- *
- * That hint names the discovery URL and insists on the browser as the vantage
- * point: an issuer reachable from the Argo Watcher pod but not from the user's
- * browser is the misconfiguration this screen exists to make visible.
+ * Unreadable OIDC discovery is the usual reason the redirect never starts, but
+ * the same call also fails when the PKCE state cannot be stored, so the title
+ * claims only that the sign-in did not start and the hint carries the likely cause.
  */
 export const describeRedirectError = (error: unknown, issuerUrl?: string): AuthFailure => {
   // Type-checked, not just truthiness-checked: the issuer comes from parsed but
@@ -216,11 +198,7 @@ export const describeRedirectError = (error: unknown, issuerUrl?: string): AuthF
   };
 };
 
-/**
- * Describes an OIDC block that is enabled but missing required settings.
- *
- * @param missing - configuration field names the server did not supply.
- */
+/** @param missing - configuration field names the server did not supply. */
 export const describeIncompleteConfig = (missing: readonly string[]): AuthFailure => ({
   kind: 'config_incomplete',
   title: 'Argo Watcher is misconfigured for OIDC',

--- a/web/src/auth/authProvider.test.ts
+++ b/web/src/auth/authProvider.test.ts
@@ -152,8 +152,6 @@ describe('authProvider', () => {
 
     await provider.checkAuth({});
 
-    // Surrounding whitespace in a deployment value must not become part of the
-    // authority or the client id on the wire.
     expect(MockUserManager).toHaveBeenCalledWith(
       expect.objectContaining({
         authority: 'https://idp.example.com/realms/demo',
@@ -203,7 +201,6 @@ describe('authProvider', () => {
   });
 
   it('reads groups from userinfo (the source the backend enforces on), not the ID token', async () => {
-    // ID token carries stale/no groups; userinfo is authoritative.
     mockConfig(enabledConfig(), ['admins']);
     userManagerMock.getUser.mockResolvedValue(signedInUser({ groups: [] }));
     const provider = await loadAuthProvider();
@@ -216,7 +213,6 @@ describe('authProvider', () => {
   it('falls back to ID-token groups when the userinfo request fails', async () => {
     mockConfig(enabledConfig());
     userManagerMock.getUser.mockResolvedValue(signedInUser({ groups: ['token-only'] }));
-    // Make only the userinfo fetch fail; config fetch still succeeds.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
@@ -359,7 +355,6 @@ describe('authProvider', () => {
       mockConfig(enabledConfig());
       window.history.replaceState({}, '', '/?code=abc&state=xyz');
       userManagerMock.signinRedirectCallback.mockResolvedValue(signedInUser());
-      // Recorded rather than asserted inside the callback, as above.
       let exchangeCallsWhenNotified = -1;
       const onOidcEnabled = vi.fn(() => {
         exchangeCallsWhenNotified = userManagerMock.signinRedirectCallback.mock.calls.length;
@@ -387,7 +382,6 @@ describe('authProvider', () => {
       await module.bootstrapAuth({ onOidcEnabled });
 
       expect(onOidcEnabled).toHaveBeenCalledTimes(1);
-      // A broken loading screen must not cost the user their sign-in.
       expect(userManagerMock.signinRedirect).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('onOidcEnabled callback threw'),
@@ -430,9 +424,6 @@ describe('authProvider', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const module = await import('./authProvider');
 
-      // The error response is recognized as a callback and consumed — not turned
-      // into a fresh sign-in. It is reported rather than retried, which is what
-      // keeps the caller from mounting an app that would redirect straight back.
       await expect(module.bootstrapAuth()).resolves.not.toBeNull();
       expect(userManagerMock.signinRedirect).not.toHaveBeenCalled();
 
@@ -478,8 +469,6 @@ describe('authProvider', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const module = await import('./authProvider');
 
-      // The whole point: what the provider said reaches the UI instead of the
-      // console, so the user is not left on a silent, session-less app.
       await expect(module.bootstrapAuth()).resolves.toMatchObject({
         kind: 'provider_error',
         code: 'invalid_scope',

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -31,7 +31,7 @@ let serverConfig: ServerConfig | null = null;
 let userManager: UserManager | null = null;
 let cachedUserGroups: string[] | null = null;
 
-/** Reads the `groups` claim from a signed-in user's ID-token profile, defaulting to []. */
+/** Reads the `groups` claim from the ID-token profile, not from userinfo. */
 const extractProfileGroups = (user: User): string[] => {
   const groups = (user.profile as { groups?: unknown }).groups;
   return Array.isArray(groups) ? [...(groups as string[])] : [];
@@ -43,12 +43,11 @@ const clearUserGroupsCache = () => {
 };
 
 /**
- * Resolves the user's group membership from the provider's userinfo endpoint —
- * the SAME source the backend uses for its privileged-group check — so the UI's
- * button gating always agrees with server-side enforcement. This does not depend
- * on a requested scope or on groups being present in the ID token. Falls back to
- * the ID-token `groups` claim if the userinfo call fails (mirrors the previous
- * keycloak-js loadUserInfo() behaviour and its fallback).
+ * Resolves group membership from the provider's userinfo endpoint — the SAME
+ * source the backend uses for its privileged-group check — so the UI's button
+ * gating always agrees with server-side enforcement. This does not depend on a
+ * requested scope or on groups being present in the ID token. Falls back to the
+ * ID-token `groups` claim when the userinfo call fails.
  */
 const loadGroups = async (manager: UserManager, user: User): Promise<string[]> => {
   try {
@@ -71,7 +70,6 @@ const loadGroups = async (manager: UserManager, user: User): Promise<string[]> =
   return extractProfileGroups(user);
 };
 
-/** Returns cached groups or resolves them once from userinfo and caches the result. */
 const ensureGroups = async (manager: UserManager, user: User): Promise<string[]> => {
   if (cachedUserGroups) {
     return cachedUserGroups;
@@ -81,9 +79,8 @@ const ensureGroups = async (manager: UserManager, user: User): Promise<string[]>
 };
 
 /**
- * Resolves the app's base URL (origin + Vite BASE_URL), used as the OIDC
- * redirect and post-logout URIs. When no browser window is available (SSR/tests)
- * it returns the normalized base path alone.
+ * The app's base URL, used as the OIDC redirect and post-logout URIs. With no
+ * browser window (SSR/tests) it returns the normalized base path alone.
  */
 const appBaseUrl = (): string => {
   const base = import.meta.env.BASE_URL ?? '/';
@@ -103,9 +100,6 @@ const currentPath = (): string | undefined => {
   return `${browserWindow.location.pathname}${browserWindow.location.search}`;
 };
 
-/**
- * Fetches the backend configuration once and caches the promise for subsequent calls.
- */
 const fetchServerConfig = async (): Promise<ServerConfig> => {
   serverConfigPromise ??= fetch('/api/v1/config', {
     headers: {
@@ -132,8 +126,6 @@ const fetchServerConfig = async (): Promise<ServerConfig> => {
 };
 
 /**
- * Reads a required OIDC setting, treating a blank or non-string value as absent.
- *
  * Blank counts as missing because the server applies the same rule (it refuses to
  * start when the issuer or client id trims to empty), and because a whitespace
  * issuer would otherwise reach discovery and be reported as an unreachable
@@ -144,20 +136,13 @@ const requiredOidcField = (value: unknown): string | undefined => {
   return trimmed || undefined;
 };
 
-/**
- * Lists the OIDC fields required to build a UserManager that the server did not
- * supply, in configuration-key form so the message can name them.
- */
+/** Names the missing fields in configuration-key form, for a user-facing message. */
 const missingOidcFields = (config: OidcConfig): string[] =>
   [
     !requiredOidcField(config.issuer_url) && 'issuer_url',
     !requiredOidcField(config.client_id) && 'client_id',
   ].filter((field): field is string => typeof field === 'string');
 
-/**
- * Verifies that the OIDC config contains the minimum fields required to build a
- * UserManager (issuer and client id).
- */
 const assertOidcFields = (config: OidcConfig) => {
   if (missingOidcFields(config).length > 0) {
     throw new HttpError('OIDC configuration is incomplete', 500, config);
@@ -165,7 +150,7 @@ const assertOidcFields = (config: OidcConfig) => {
 };
 
 /**
- * Lazily constructs the singleton UserManager when OIDC is enabled server-side.
+ * Returns null when OIDC is disabled server-side.
  *
  * Tokens are held in an in-memory store (never localStorage) to preserve the
  * original security posture: on a full page reload the in-memory user is gone and
@@ -226,11 +211,9 @@ const ensureUserManager = async (): Promise<UserManager | null> => {
 };
 
 /**
- * True when the current URL carries an OIDC redirect callback — either a
- * successful authorization code (`code`) or a provider error (`error`), both
- * paired with `state`. Recognizing the error form is essential: otherwise an
- * error response (denied consent, `login_required`, …) is not consumed and
- * bootstrap starts a fresh sign-in, bouncing between the app and the provider.
+ * Recognizing the `error` form matters as much as `code`: otherwise an error
+ * response (denied consent, `login_required`, …) is not consumed and bootstrap
+ * starts a fresh sign-in, bouncing between the app and the provider.
  */
 const isRedirectCallback = (): boolean => {
   const browserWindow = getBrowserWindow();
@@ -241,7 +224,6 @@ const isRedirectCallback = (): boolean => {
   return params.has('state') && (params.has('code') || params.has('error'));
 };
 
-/** Rewrites the URL to `target`, dropping the callback query params. */
 const replaceUrl = (target: string) => {
   const browserWindow = getBrowserWindow();
   if (browserWindow) {
@@ -250,10 +232,10 @@ const replaceUrl = (target: string) => {
 };
 
 /**
- * Completes an OIDC redirect callback: on success it exchanges the code for
- * tokens and returns to the pre-login path encoded in `url_state`; on failure it
- * consumes the response (stripping the query so a reload cannot re-trigger it)
- * and reports the reason, which the caller shows instead of retrying.
+ * On success the browser returns to the pre-login path carried in `url_state`.
+ * On failure the response is still consumed — the query is stripped so a reload
+ * cannot re-trigger it — and the reason is reported for the caller to show
+ * instead of retrying.
  *
  * @returns the failure to show the user, or null once a session exists.
  */
@@ -272,10 +254,7 @@ const completeSignin = async (manager: UserManager): Promise<AuthFailure | null>
 };
 
 /**
- * Ensures the user is authenticated, redirecting to the provider's login page
- * when no valid session exists.
- *
- * It deliberately NEVER rejects for an unauthenticated user: a rejected checkAuth
+ * Deliberately NEVER rejects for an unauthenticated user: a rejected checkAuth
  * makes React-admin call authProvider.logout(), which would terminate a still-valid
  * SSO session and bounce the browser between the app and the login page. An
  * unauthenticated user is redirected instead, and the call still resolves.
@@ -303,10 +282,9 @@ const ensureAuthenticated = async (manager: UserManager): Promise<AuthFailure | 
 };
 
 /**
- * Turns a failed UserManager construction into a displayable failure, but only for
- * the one cause the operator can act on: OIDC enabled without the fields it needs.
- * Anything else (a configuration request that did not answer) reports null so the
- * app still renders.
+ * Only the one cause an operator can act on becomes a displayable failure: OIDC
+ * enabled without the fields it needs. Anything else (a configuration request
+ * that did not answer) reports null so the app still renders.
  */
 const incompleteConfigFailure = (): AuthFailure | null => {
   const oidc = serverConfig?.oidc;
@@ -328,7 +306,7 @@ interface BootstrapOptions {
 }
 
 /**
- * Eagerly processes authentication before the React tree is mounted.
+ * Must run before the React tree is mounted.
  *
  * The authorization-code callback (`?code=...&state=...`) must be consumed while
  * it is still on the URL: the SPA router performs its default index redirect
@@ -377,10 +355,6 @@ export const bootstrapAuth = async ({
   return ensureAuthenticated(manager);
 };
 
-/**
- * React-admin AuthProvider implementation backed by a generic OIDC provider for
- * login, logout, permissions, and identity.
- */
 export const authProvider: AuthProvider = {
   async login(params) {
     const manager = await ensureUserManager();
@@ -411,9 +385,8 @@ export const authProvider: AuthProvider = {
   },
 
   async checkAuth() {
-    // Resolves for a valid or redirecting session; throws only for genuine
-    // failures (config errors, unreachable backend). An unauthenticated user is
-    // redirected rather than rejected — see ensureAuthenticated.
+    // Throws only for genuine failures (config errors, unreachable backend). An
+    // unauthenticated user is redirected rather than rejected — see ensureAuthenticated.
     const manager = await ensureUserManager();
     if (!manager) {
       setAccessToken(null);
@@ -450,7 +423,6 @@ export const authProvider: AuthProvider = {
     const privilegedGroups = config.oidc.privileged_groups ?? [];
     const user = await manager.getUser();
     if (!user || user.expired) {
-      // No usable session — kick off the login redirect and report empty groups.
       await ensureAuthenticated(manager);
       return { groups: [], privilegedGroups } satisfies Permissions;
     }
@@ -476,7 +448,6 @@ export const authProvider: AuthProvider = {
 };
 
 export const __testing = {
-  /** Resets cached OIDC state for unit tests so each test starts fresh. */
   reset() {
     serverConfigPromise = null;
     serverConfig = null;
@@ -484,6 +455,5 @@ export const __testing = {
     clearAccessToken();
     clearUserGroupsCache();
   },
-  /** Exposes base-URL resolution for direct verification in tests. */
   appBaseUrl,
 };

--- a/web/src/auth/tokenStore.ts
+++ b/web/src/auth/tokenStore.ts
@@ -1,17 +1,14 @@
 let accessToken: string | null = null;
 
-/** Stores the current OIDC access token in memory for API calls. */
 export const setAccessToken = (token: string | null) => {
   accessToken = token ?? null;
 };
 
-/** Returns the in-memory access token, if any. */
 export const getAccessToken = () => accessToken;
 
-/** Clears the cached token, effectively logging the user out locally. */
+/** Ends the session locally only: the token is not revoked at the provider. */
 export const clearAccessToken = () => {
   accessToken = null;
 };
 
-/** Indicates whether a token is currently cached for authenticated requests. */
 export const isAuthenticated = () => accessToken !== null;

--- a/web/src/data/dataProvider.test.ts
+++ b/web/src/data/dataProvider.test.ts
@@ -19,7 +19,6 @@ const createListParams = () => ({
 });
 
 const getQueryParams = (call: string) => new URL(call, 'https://example.test').searchParams;
-/** Exercises the custom dataProvider against pagination, auth, and error-handling scenarios. */
 describe('dataProvider', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/web/src/data/dataProvider.ts
+++ b/web/src/data/dataProvider.ts
@@ -42,7 +42,6 @@ const ALLOWED_TASK_STATUSES: ReadonlySet<string> = new Set([
   'cancelled',
 ]);
 
-/** Normalizes various date/timestamp inputs to seconds since epoch. */
 const toUnixSeconds = (value: Date | string | number | undefined, fallback: number): number => {
   if (value === undefined || value === null) {
     return fallback;
@@ -60,7 +59,6 @@ const toUnixSeconds = (value: Date | string | number | undefined, fallback: numb
   return Math.floor(parsed / 1000);
 };
 
-/** Builds the time window and filters for list queries based on React-admin params. */
 const selectListWindow = (params: GetListParams) => {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const defaultFrom = nowSeconds - 24 * 60 * 60;
@@ -78,24 +76,18 @@ const selectListWindow = (params: GetListParams) => {
   };
 };
 
-/**
- * Converts backend task list responses into React-admin's list structure.
- * The backend always returns `total` for non-empty pages; when the result
- * set is empty Go's `omitempty` drops the field, so we coalesce to 0.
- */
+/** Go's `omitempty` drops `total` on an empty result set, hence the coalesce to 0. */
 const toRaListResult = (response: TasksResponse): GetListResult<Task> => ({
   data: response.tasks ?? [],
   total: response.total ?? 0,
 });
 
-/** Guards against consumers requesting unsupported resources via the data provider. */
 const ensureSupportedResource = (resource: string) => {
   if (resource !== RESOURCE_TASKS) {
     throw new HttpError(`Unsupported resource: ${resource}`, 404);
   }
 };
 
-/** Fetches a page of tasks applying time range filters, pagination, and app filters. */
 const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
   const timeframe = selectListWindow(params);
   const { perPage, page } = params.pagination;
@@ -115,8 +107,8 @@ const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
   const response = data ?? { tasks: [], total: 0 };
 
   // Backend returns HTTP 200 with a non-empty `error` field when ArgoCD is unreachable.
-  // Treat it as an empty result rather than rejecting, so the empty-state placeholder
-  // can render instead of leaving the Datagrid in its loading skeleton forever.
+  // Not rejecting lets the empty-state placeholder render instead of leaving the
+  // Datagrid in its loading skeleton forever.
   if (response.error) {
     console.warn(`Tasks endpoint reported a soft error: ${String(response.error).slice(0, 200)}`);
   }
@@ -124,7 +116,6 @@ const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
   return toRaListResult(response);
 };
 
-/** Retrieves a single task detail, throwing when the backend reports an error. */
 const getOne = async (params: GetOneParams): Promise<GetOneResult<TaskStatus>> => {
   const { data } = await httpClient<TaskStatus>(`/api/v1/${RESOURCE_TASKS}/${params.id}`);
   if (!data) {
@@ -139,7 +130,6 @@ const getOne = async (params: GetOneParams): Promise<GetOneResult<TaskStatus>> =
   };
 };
 
-/** Posts a task to the backend and returns the accepted record with its identifier. */
 const createTask = async (params: CreateParams): Promise<CreateResult<TaskStatus & RaRecord>> => {
   const { data: payload } = params;
 
@@ -155,11 +145,9 @@ const createTask = async (params: CreateParams): Promise<CreateResult<TaskStatus
   return { data: data as TaskStatus & RaRecord };
 };
 
-/** Utility helper for methods that the data provider intentionally does not implement. */
 const unsupported = (method: string): Promise<never> =>
   Promise.reject(new HttpError(`${method} is not supported by this resource`, 405));
 
-/** React-admin DataProvider backed by the Go API used to list/create tasks. */
 export const dataProvider: DataProvider = {
   getList: async (resource, params: GetListParams) => {
     ensureSupportedResource(resource);

--- a/web/src/data/httpClient.test.ts
+++ b/web/src/data/httpClient.test.ts
@@ -148,7 +148,6 @@ describe('httpClient', () => {
       const response = await httpClient<{ status: string }>('/status');
       expect(response.data).toEqual({ status: 'ok' });
 
-      // Advancing past the timeout must not abort the already-completed request.
       const init = mockFetch.mock.calls[0][1] as RequestInit;
       await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS * 2);
       expect((init.signal as AbortSignal).aborted).toBe(false);

--- a/web/src/data/httpClient.ts
+++ b/web/src/data/httpClient.ts
@@ -9,10 +9,9 @@ const DEFAULT_HEADERS: Record<string, string> = {
 
 /**
  * Hard ceiling on how long a single request may stay in flight before it is
- * aborted. Without it a degraded backend (e.g. a task list blocked behind an
- * upstream dependency that is retrying against a dead resolver) leaves the UI
- * stuck in its loading skeleton indefinitely. Aborting surfaces the failure to
- * react-admin so the caller can render an honest error state instead.
+ * aborted. Without it a degraded backend leaves the UI stuck in its loading
+ * skeleton; aborting surfaces the failure to react-admin so the caller can
+ * render an honest error state instead.
  */
 export const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -31,14 +30,12 @@ export interface HttpResponse<T> {
   headers: Headers;
 }
 
-/** Combines the API base URL with a relative path while cleaning duplicate slashes. */
 const joinUrl = (base: string, path: string): string => {
   const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
   return `${normalizedBase}${normalizedPath}`;
 };
 
-/** Converts various header shapes (Headers, arrays, objects) into a plain object. */
 const normalizeHeaders = (headers?: HeadersInit): Record<string, string> => {
   if (!headers) {
     return {};
@@ -55,7 +52,6 @@ const normalizeHeaders = (headers?: HeadersInit): Record<string, string> => {
   return { ...headers };
 };
 
-/** Builds a fetch RequestInit including auth headers and serialized bodies. */
 const buildRequestInit = (options: HttpClientOptions): RequestInit => {
   const method = options.method ?? 'GET';
   const headers = { ...DEFAULT_HEADERS, ...normalizeHeaders(options.headers) };
@@ -79,7 +75,7 @@ const buildRequestInit = (options: HttpClientOptions): RequestInit => {
   return init;
 };
 
-/** Parses JSON bodies defensively, returning undefined for non-json responses. */
+/** Returns undefined for a non-JSON or empty body; throws HttpError on malformed JSON. */
 const parseJson = async <T>(response: Response): Promise<T | undefined> => {
   const contentType = response.headers.get('Content-Type') ?? '';
   if (!contentType.includes('application/json')) {
@@ -98,7 +94,6 @@ const parseJson = async <T>(response: Response): Promise<T | undefined> => {
   }
 };
 
-/** Creates a HttpError with the most descriptive message available from the payload. */
 const buildHttpError = (status: number, body: unknown, fallbackMessage: string): HttpError => {
   if (body && typeof body === 'object' && 'status' in body && typeof body.status === 'string') {
     return new HttpError(body.status, status, body);
@@ -120,7 +115,6 @@ export const httpClient = async <T>(path: string, options: HttpClientOptions = {
   const url = joinUrl(API_BASE_URL, path);
   const requestInit = buildRequestInit(options);
 
-  // Bound the request so a hung backend cannot pin the UI in its loading state.
   const controller = new AbortController();
   requestInit.signal = controller.signal;
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);

--- a/web/src/data/wsStatusService.test.ts
+++ b/web/src/data/wsStatusService.test.ts
@@ -56,10 +56,9 @@ class BooleanService extends WsStatusService<boolean> {
 }
 
 /**
- * Window stub that records armed timers and lets the test fire them with
- * `flush()`. A browser never runs the callback before `setTimeout` returns, so
- * firing it synchronously would leave the service's timer handle assigned after
- * the timer had already run — hiding whether a second reconnect can be armed.
+ * A browser never runs the callback before `setTimeout` returns, so firing it
+ * synchronously would leave the service's timer handle assigned after the timer
+ * had already run — hiding whether a second reconnect can be armed.
  */
 const recordingWindow = () => {
   const pendingTimers: Array<() => void> = [];
@@ -70,7 +69,6 @@ const recordingWindow = () => {
       return nextHandle++ as unknown as number;
     }),
     clearTimeout: vi.fn(),
-    /** Runs every timer armed since the last flush, as the event loop would. */
     flush: () => {
       pendingTimers.splice(0, pendingTimers.length).forEach(cb => cb());
     },
@@ -272,7 +270,6 @@ describe('WsStatusService', () => {
   });
 
   it('arms only one reconnect timer while one is already pending', async () => {
-    // Repeated close events must not fan out into parallel sockets to /ws.
     const { socket } = await subscribedService();
     const browserWindow = recordingWindow();
     vi.spyOn(sharedUtils, 'getBrowserWindow').mockReturnValue(browserWindow as unknown as Window);
@@ -367,7 +364,6 @@ describe('WsStatusService', () => {
 
     retired.fireClose();
 
-    // No third socket, and no reconnect armed to open one later.
     expect(MockWebSocket.instances).toHaveLength(2);
     expect(browserWindow.setTimeout).not.toHaveBeenCalled();
 
@@ -387,7 +383,6 @@ describe('WsStatusService', () => {
 
     unsubscribe();
 
-    // No socket appeared, and no timer was left armed to create one later.
     expect(MockWebSocket.instances).toHaveLength(1);
     expect(browserWindow.setTimeout).not.toHaveBeenCalled();
   });

--- a/web/src/data/wsStatusService.ts
+++ b/web/src/data/wsStatusService.ts
@@ -13,10 +13,6 @@ const WS_RETRY_DELAY_MS = 5000;
  * (single connection while listeners exist, reconnect with a fixed delay,
  * teardown when the last listener leaves) and the ordering guards below.
  *
- * Subclasses supply the transport specifics — {@link fetchState} for the REST
- * bootstrap and {@link parseMessage} for the frames they recognise — and may call
- * {@link applyAuthoritative} to publish a state this client set itself.
- *
  * `T` must be non-nullable: `null` is reserved for "nothing cached yet".
  */
 export abstract class WsStatusService<T extends NonNullable<unknown>> {
@@ -37,9 +33,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
   private fetchSeq = 0;
   private stateGeneration = 0;
 
-  /**
-   * @param logPrefix Tag for this signal's console diagnostics, logged as `[<prefix>] …`.
-   */
   protected constructor(private readonly logPrefix: string) {}
 
   /** Reads the authoritative state from the backend. */
@@ -54,11 +47,10 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
   protected abstract parseMessage(payload: string): T | undefined;
 
   /**
-   * Retrieves the latest state from the backend and notifies subscribers of the
-   * result. The result is applied only if it is still the newest fetch AND no
-   * authoritative update landed while it was in flight; otherwise it is dropped
-   * and the winning state is returned instead, so REST/WebSocket ordering races
-   * cannot revert subscribers to a stale value.
+   * Fetches the authoritative state and broadcasts it, but only if it is still
+   * the newest fetch AND no authoritative update landed while it was in flight;
+   * otherwise it is dropped and the winning state is returned instead, so
+   * REST/WebSocket ordering races cannot revert subscribers to a stale value.
    */
   public async fetchStatus(): Promise<T> {
     const seq = ++this.fetchSeq;
@@ -71,10 +63,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     return state;
   }
 
-  /**
-   * Subscribes to state changes, establishing a WebSocket connection when needed.
-   * Returns an unsubscribe function for convenient cleanup.
-   */
   public subscribe(listener: WsStatusListener<T>): () => void {
     this.listeners.add(listener);
 
@@ -107,7 +95,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     this.updateStatus(state);
   }
 
-  /** Broadcasts the new state to all subscribers. */
   private updateStatus(state: T) {
     this.currentStatus = state;
     for (const listener of this.listeners) {
@@ -115,7 +102,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     }
   }
 
-  /** Ensures a websocket connection exists whenever there are active listeners. */
   private ensureSocket() {
     if (this.socket || this.listeners.size === 0) {
       return;
@@ -166,7 +152,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     };
   }
 
-  /** Schedules a websocket reconnect attempt after a fixed delay. */
   private scheduleReconnect() {
     if (this.reconnectHandle !== null) {
       return;
@@ -183,7 +168,6 @@ export abstract class WsStatusService<T extends NonNullable<unknown>> {
     }, WS_RETRY_DELAY_MS);
   }
 
-  /** Closes any active websocket and cancels pending reconnect timers. */
   private teardownSocket() {
     if (this.reconnectHandle !== null) {
       const browserWindow = getBrowserWindow();

--- a/web/src/features/argocdStatus/ArgocdStatusProvider.test.tsx
+++ b/web/src/features/argocdStatus/ArgocdStatusProvider.test.tsx
@@ -26,7 +26,6 @@ describe('ArgocdStatusProvider', () => {
       wrapper: ArgocdStatusProvider,
     });
 
-    // Optimistic default before the first update arrives.
     expect(result.current.available).toBe(true);
     expect(result.current.reason).toBeNull();
 

--- a/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
+++ b/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
@@ -30,6 +30,7 @@ export const ArgocdStatusProvider = ({ children }: { children: ReactNode }) => {
   return <ArgocdStatusContext.Provider value={value}>{children}</ArgocdStatusContext.Provider>;
 };
 
+/** Throws outside an ArgocdStatusProvider. */
 export const useArgocdStatus = (): ArgocdStatusContextValue => {
   const context = useContext(ArgocdStatusContext);
   if (!context) {

--- a/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
+++ b/web/src/features/argocdStatus/ArgocdStatusProvider.tsx
@@ -10,7 +10,6 @@ export interface ArgocdStatusContextValue {
 
 const ArgocdStatusContext = createContext<ArgocdStatusContextValue | undefined>(undefined);
 
-/** Provides ArgoCD reachability state backed by the shared WebSocket service. */
 export const ArgocdStatusProvider = ({ children }: { children: ReactNode }) => {
   // Default to available so the banner never flashes before the initial fetch
   // resolves; the service corrects this within one round-trip.
@@ -31,7 +30,6 @@ export const ArgocdStatusProvider = ({ children }: { children: ReactNode }) => {
   return <ArgocdStatusContext.Provider value={value}>{children}</ArgocdStatusContext.Provider>;
 };
 
-/** Hook exposing ArgoCD reachability context. */
 export const useArgocdStatus = (): ArgocdStatusContextValue => {
   const context = useContext(ArgocdStatusContext);
   if (!context) {

--- a/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
+++ b/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
@@ -29,7 +29,6 @@ const messageForReason = (reason: ArgocdUnavailableReason): string => {
   }
 };
 
-/** Displays an error banner at the bottom of the viewport when ArgoCD or its state backend is unreachable. */
 export const ArgocdUnreachableBanner = () => {
   const { available, reason } = useArgocdStatus();
 

--- a/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
+++ b/web/src/features/argocdStatus/ArgocdUnreachableBanner.tsx
@@ -29,6 +29,7 @@ const messageForReason = (reason: ArgocdUnavailableReason): string => {
   }
 };
 
+/** Renders nothing while ArgoCD and its state backend are reachable. */
 export const ArgocdUnreachableBanner = () => {
   const { available, reason } = useArgocdStatus();
 

--- a/web/src/features/argocdStatus/argocdStatusService.test.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.test.ts
@@ -74,7 +74,6 @@ describe('ArgocdStatusService', () => {
     await vi.waitUntil(() => MockWebSocket.instances.length === 1);
     const socket = MockWebSocket.instances[0];
 
-    // A down message carries the cause as a suffix.
     socket.emit('argocd_down:argocd');
     expect(listener).toHaveBeenLastCalledWith({ available: false, reason: 'argocd' });
 
@@ -121,7 +120,6 @@ describe('ArgocdStatusService', () => {
     await vi.waitUntil(() => MockWebSocket.instances.length === 1);
     listener.mockClear();
 
-    // Server now reports unreachable; the reconnect handshake must pick it up.
     MockWebSocket.instances[0].open();
 
     await vi.waitUntil(() => listener.mock.calls.length > 0);
@@ -143,7 +141,6 @@ describe('ArgocdStatusService', () => {
     MockWebSocket.instances[0].emit('argocd_down:argocd');
     expect(listener).toHaveBeenLastCalledWith({ available: false, reason: 'argocd' });
 
-    // The stale bootstrap now resolves "reachable" — it must be discarded.
     resolveFetch(new Response(JSON.stringify({ available: true }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -193,7 +190,7 @@ describe('ArgocdStatusService', () => {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     }));
-    await pending; // the stale result has now been fully processed (or dropped)
+    await pending;
 
     mockFetch([{ body: { available: false, reason: 'database' } }]);
     const listener = vi.fn();

--- a/web/src/features/argocdStatus/argocdStatusService.ts
+++ b/web/src/features/argocdStatus/argocdStatusService.ts
@@ -18,7 +18,6 @@ export interface ArgocdStatus {
   reason: ArgocdUnavailableReason;
 }
 
-/** Subscribed listener signature invoked whenever reachability changes. */
 export type ArgocdStatusListener = WsStatusListener<ArgocdStatus>;
 
 /** Shape of the /api/v1/reachability response body (reason omitted when up). */
@@ -39,7 +38,6 @@ const ARGOCD_DOWN_PREFIX = `${ARGOCD_DOWN_MESSAGE}:`;
 /** Canonical "everything reachable" snapshot, reused to avoid re-allocation. */
 const AVAILABLE_STATUS: ArgocdStatus = { available: true, reason: null };
 
-/** Narrows an arbitrary reason string to a known ArgocdUnavailableReason. */
 const parseReason = (raw: string | undefined | null): ArgocdUnavailableReason => {
   switch (raw) {
     case 'argocd':
@@ -51,7 +49,6 @@ const parseReason = (raw: string | undefined | null): ArgocdUnavailableReason =>
   }
 };
 
-/** Builds a status snapshot from the reachability endpoint response body. */
 const toStatus = (data: ArgocdStatusResponse | null | undefined): ArgocdStatus =>
   data?.available
     ? AVAILABLE_STATUS
@@ -68,7 +65,6 @@ export class ArgocdStatusService extends WsStatusService<ArgocdStatus> {
     super('argocd-status');
   }
 
-  /** Reads current reachability from the backend. */
   protected async fetchState(): Promise<ArgocdStatus> {
     const response = await httpClient<ArgocdStatusResponse>('/api/v1/reachability');
     return toStatus(response.data);

--- a/web/src/features/argocdStatus/useArgocdUnreachable.test.tsx
+++ b/web/src/features/argocdStatus/useArgocdUnreachable.test.tsx
@@ -38,7 +38,6 @@ describe('useArgocdUnreachable', () => {
     );
 
     const { result } = renderHook(() => useArgocdUnreachable(), { wrapper });
-    // Available by default -> not unreachable.
     expect(result.current).toBe(false);
 
     act(() => listener?.({ available: false, reason: 'argocd' }));

--- a/web/src/features/deployLock/DeployLockBanner.tsx
+++ b/web/src/features/deployLock/DeployLockBanner.tsx
@@ -10,7 +10,6 @@ const snackbarPosition: SxProps<Theme> = theme => ({
   },
 });
 
-/** Displays a warning banner anchored to the bottom of the viewport when the deploy lock is active. */
 export const DeployLockBanner = () => {
   const locked = useDeployLockState();
   const argocdUnreachable = useArgocdUnreachable();

--- a/web/src/features/deployLock/DeployLockBanner.tsx
+++ b/web/src/features/deployLock/DeployLockBanner.tsx
@@ -10,6 +10,7 @@ const snackbarPosition: SxProps<Theme> = theme => ({
   },
 });
 
+/** Renders nothing when the lock is off, or when the reachability banner owns the slot. */
 export const DeployLockBanner = () => {
   const locked = useDeployLockState();
   const argocdUnreachable = useArgocdUnreachable();

--- a/web/src/features/deployLock/DeployLockProvider.tsx
+++ b/web/src/features/deployLock/DeployLockProvider.tsx
@@ -36,7 +36,6 @@ export const DeployLockProvider = ({ children }: { children: ReactNode }) => {
   return <DeployLockContext.Provider value={value}>{children}</DeployLockContext.Provider>;
 };
 
-/** Hook exposing DeployLock context values (state + actions). */
 export const useDeployLock = (): DeployLockContextValue => {
   const context = useContext(DeployLockContext);
   if (!context) {

--- a/web/src/features/deployLock/DeployLockProvider.tsx
+++ b/web/src/features/deployLock/DeployLockProvider.tsx
@@ -36,6 +36,7 @@ export const DeployLockProvider = ({ children }: { children: ReactNode }) => {
   return <DeployLockContext.Provider value={value}>{children}</DeployLockContext.Provider>;
 };
 
+/** Throws outside a DeployLockProvider. */
 export const useDeployLock = (): DeployLockContextValue => {
   const context = useContext(DeployLockContext);
   if (!context) {

--- a/web/src/features/deployLock/deployLockService.test.ts
+++ b/web/src/features/deployLock/deployLockService.test.ts
@@ -44,7 +44,6 @@ describe('DeployLockService', () => {
     return {
       started,
       count: () => pending.length,
-      // Resolves the nth outstanding fetch (0 = the oldest).
       resolveNth: (index: number, body: unknown) => pending[index](jsonResponse(body)),
       resolveWith: (body: unknown) => pending[pending.length - 1](jsonResponse(body)),
     };
@@ -118,8 +117,6 @@ describe('DeployLockService', () => {
   });
 
   it('does not let a slow REST fetch clobber a newer WebSocket transition', async () => {
-    // A reconcile fetch is held pending while a WS transition lands, then resolves
-    // with the now-stale value; the WS state must win.
     mockFetch([{ body: false }]);
     const service = new DeployLockService();
     const listener = vi.fn();
@@ -139,8 +136,6 @@ describe('DeployLockService', () => {
   });
 
   it('does not let a slow REST fetch clobber a just-issued lock operation', async () => {
-    // A reconnect reconcile can be in flight when the operator hits lock; the
-    // explicit operation is newer than the fetch and must not be reverted.
     mockFetch([{ body: false }]);
     const service = new DeployLockService();
     const listener = vi.fn();
@@ -269,7 +264,6 @@ describe('DeployLockService', () => {
     MockWebSocket.instances[0].onclose?.();
     await vi.waitUntil(() => MockWebSocket.instances.length === 2);
 
-    // The lock was set while the socket was down.
     mockFetch([{ body: true }]);
     listener.mockClear();
     MockWebSocket.instances[1].open();
@@ -345,7 +339,7 @@ describe('DeployLockService', () => {
 
     unsubscribe();
     resolveWith(true);
-    await pending; // the stale result has now been fully processed (or dropped)
+    await pending;
 
     mockFetch([{ body: false }]);
     const listener = vi.fn();

--- a/web/src/features/deployLock/deployLockService.ts
+++ b/web/src/features/deployLock/deployLockService.ts
@@ -16,7 +16,6 @@ export class DeployLockService extends WsStatusService<boolean> {
     super('deploy-lock');
   }
 
-  /** Reads the current lock state from the backend. */
   protected async fetchState(): Promise<boolean> {
     const response = await httpClient<boolean>('/api/v1/deploy-lock');
     return Boolean(response.data);
@@ -33,18 +32,12 @@ export class DeployLockService extends WsStatusService<boolean> {
     return undefined;
   }
 
-  /**
-   * Issues a POST request to enable the deploy lock and propagates the new state.
-   */
   public async setLock(): Promise<HttpResponse<unknown>> {
     const response = await httpClient('/api/v1/deploy-lock', { method: 'POST' });
     this.applyAuthoritative(true);
     return response;
   }
 
-  /**
-   * Issues a DELETE request to release the deploy lock and propagates the new state.
-   */
   public async releaseLock(): Promise<HttpResponse<unknown>> {
     const response = await httpClient('/api/v1/deploy-lock', { method: 'DELETE' });
     this.applyAuthoritative(false);

--- a/web/src/features/deployLock/useDeployLockState.ts
+++ b/web/src/features/deployLock/useDeployLockState.ts
@@ -1,6 +1,5 @@
 import { useDeployLock } from './DeployLockProvider';
 
-/** Returns the current deploy-lock status from the shared context. */
 export const useDeployLockState = () => {
   const { locked } = useDeployLock();
   return locked;

--- a/web/src/features/tasks/HistoryTasksList.test.tsx
+++ b/web/src/features/tasks/HistoryTasksList.test.tsx
@@ -60,7 +60,6 @@ vi.mock('./components/TasksDatagrid', () => ({
 
 const lastLayoutProps = () => layoutCalls.at(-1)!;
 
-/** Type guard ensuring a node is a concrete ReactElement before use in expectations. */
 const isReactElement = (node: ReactNode): node is ReactElement =>
   typeof node === 'object' && node !== null && 'type' in (node as Record<string, unknown>);
 

--- a/web/src/features/tasks/HistoryTasksList.tsx
+++ b/web/src/features/tasks/HistoryTasksList.tsx
@@ -7,9 +7,6 @@ import { EmptyState } from './components/EmptyState';
 
 const STORAGE_KEY_PER_PAGE = 'historyTasks.perPage';
 
-/**
- * React-admin list page surfacing historical tasks with filters.
- */
 export const HistoryTasksList = () => {
   useEffect(() => {
     const previousTitle = document.title;

--- a/web/src/features/tasks/RecentTasksList.tsx
+++ b/web/src/features/tasks/RecentTasksList.tsx
@@ -8,9 +8,7 @@ import { EmptyState } from './components/EmptyState';
 const STORAGE_KEY_PER_PAGE = 'recentTasks.perPage';
 const DEFAULT_PER_PAGE = 25;
 
-/**
- * Recent tasks list routed at `/` providing sortable columns, pagination, application filtering, and auto-refresh controls.
- */
+/** Routed at `/`. */
 export const RecentTasksList = () => {
   useEffect(() => {
     const previousTitle = document.title;

--- a/web/src/features/tasks/components/ActiveFilterBar.tsx
+++ b/web/src/features/tasks/components/ActiveFilterBar.tsx
@@ -65,10 +65,6 @@ const FilterChip = ({ chip }: { chip: FilterChipDescriptor }) => {
   );
 };
 
-/**
- * Renders the active-filter row beneath the toolbar. Hidden entirely when no
- * filters are active; otherwise lists removable chips and a "Clear all" link.
- */
 export const ActiveFilterBar = ({ chips, onClearAll }: ActiveFilterBarProps) => {
   if (chips.length === 0) {
     return null;

--- a/web/src/features/tasks/components/AppCell.tsx
+++ b/web/src/features/tasks/components/AppCell.tsx
@@ -6,7 +6,6 @@ interface AppCellProps {
   readonly app: string;
 }
 
-/** Stable hash → swatch index for a given app name. */
 const hashIndex = (name: string, modulo: number): number => {
   let hash = 0;
   for (let i = 0; i < name.length; i += 1) {
@@ -37,7 +36,10 @@ interface ProjectLinkInfo {
   readonly href?: string;
 }
 
-/** Splits a project string into either a plain label or a host + last-segment + href triple. */
+/**
+ * For a URL, `label` is host + the final path segment only — mid-path segments
+ * are dropped. Anything else passes through unchanged.
+ */
 export const describeProject = (project: string): ProjectLinkInfo => {
   const isUrl = project.startsWith('http://') || project.startsWith('https://');
   if (!isUrl) {
@@ -54,9 +56,6 @@ export const describeProject = (project: string): ProjectLinkInfo => {
   return { isUrl: true, label, href: project };
 };
 
-/**
- * Renders an application cell with a colour-coded monogram and the app name.
- */
 export const AppCell = ({ app }: AppCellProps) => {
   const theme = useTheme();
   const swatches = theme.palette.mode === 'dark' ? tokens.monogramSwatchesDark : tokens.monogramSwatches;

--- a/web/src/features/tasks/components/ApplicationFilter.tsx
+++ b/web/src/features/tasks/components/ApplicationFilter.tsx
@@ -97,5 +97,6 @@ export const ApplicationFilter = ({
   );
 };
 
+/** The persisted filter, normalised; "" when nothing usable is stored. */
 export const readInitialApplication = (storageKey: string = DEFAULT_STORAGE_KEY): string =>
   readStoredApp(storageKey);

--- a/web/src/features/tasks/components/ApplicationFilter.tsx
+++ b/web/src/features/tasks/components/ApplicationFilter.tsx
@@ -8,7 +8,10 @@ import { tokens } from '../../../theme/tokens';
 
 const DEFAULT_STORAGE_KEY = 'recentTasks.app';
 
-/** Normalizes application filter inputs, collapsing null-like strings into empty values. */
+/**
+ * The literal string "null" collapses to '' alongside blanks and non-strings:
+ * storage and URL round-trips turn an absent filter into that literal.
+ */
 export const normalizeApplicationFilterValue = (value?: string | null): string => {
   if (typeof value !== 'string') {
     return '';
@@ -22,13 +25,9 @@ export const normalizeApplicationFilterValue = (value?: string | null): string =
   return value;
 };
 
-/** Reads the persisted application filter (if any) from localStorage. */
 const readStoredApp = (storageKey: string) =>
   normalizeApplicationFilterValue(getBrowserWindow()?.localStorage?.getItem(storageKey));
 
-/**
- * Autocomplete component used to filter tasks by application name.
- */
 export const ApplicationFilter = ({
   records,
   value,
@@ -98,6 +97,5 @@ export const ApplicationFilter = ({
   );
 };
 
-/** Convenience helper for initializing filters from localStorage. */
 export const readInitialApplication = (storageKey: string = DEFAULT_STORAGE_KEY): string =>
   readStoredApp(storageKey);

--- a/web/src/features/tasks/components/DurationField.tsx
+++ b/web/src/features/tasks/components/DurationField.tsx
@@ -8,7 +8,6 @@ interface DurationFieldProps {
   readonly record: Task;
 }
 
-/** Returns a 1-second ticker that re-renders the consumer for live duration updates. */
 const useNowTicker = (enabled: boolean, intervalMs: number = 1000) => {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {

--- a/web/src/features/tasks/components/EmptyCell.tsx
+++ b/web/src/features/tasks/components/EmptyCell.tsx
@@ -1,9 +1,6 @@
 import { Typography } from '@mui/material';
 
-/**
- * Renders a muted em-dash placeholder for empty table cells so the grid stays
- * visually quiet without dropping alignment.
- */
+/** An em-dash rather than an empty string, so the grid keeps its alignment. */
 export const EmptyCell = () => (
   <Typography component="span" variant="body2" sx={{ color: 'text.disabled' }}>
     —

--- a/web/src/features/tasks/components/EmptyState.tsx
+++ b/web/src/features/tasks/components/EmptyState.tsx
@@ -59,7 +59,6 @@ interface EmptyStateCtaProps {
   readonly onClick: () => void;
 }
 
-/** Convenience CTA button that matches the design's "Clear filters" affordance. */
 export const EmptyStateCta = ({ label, onClick }: EmptyStateCtaProps) => (
   <Button variant="outlined" size="small" onClick={onClick} sx={{ mt: 1 }}>
     {label}

--- a/web/src/features/tasks/components/HistoryFilters.tsx
+++ b/web/src/features/tasks/components/HistoryFilters.tsx
@@ -48,7 +48,6 @@ const STORAGE_KEY = 'historyTasks';
 
 const TRIGGER_FORMAT: Intl.DateTimeFormatOptions = { day: '2-digit', month: 'short', year: 'numeric' };
 
-/** Date range + application filters powering the history list. */
 export const HistoryFilters = () => {
   const { data } = useListContext<Task>();
   const { formatDate } = useTimezone();

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -19,13 +19,11 @@ interface ImageRowProps {
   readonly image: Image;
 }
 
-/** Widest, in px, a tag badge may grow before its label is trimmed with an ellipsis. */
 export const TAG_MAX_WIDTH = 120;
 
 /**
- * Single repo + tag-chip row, rendered identically for primary and expanded entries.
- * The tag badge never wraps or shrinks — a hyphenated tag would otherwise break after
- * the hyphen and spill out of the fixed-height pill. The full tag stays in the tooltip.
+ * The tag badge never wraps or shrinks — a hyphenated tag would otherwise break
+ * after the hyphen and spill out of the fixed-height pill.
  */
 const ImageRow = ({ image }: ImageRowProps) => (
   <Stack
@@ -78,11 +76,7 @@ const ImageRow = ({ image }: ImageRowProps) => (
   </Stack>
 );
 
-/**
- * Compact image cell. Renders the first image:tag inline; remaining images
- * collapse behind a "+N more" toggle that expands the cell in-place. The
- * toggle stops propagation so it doesn't trigger a row navigation.
- */
+/** The "+N more" toggle stops propagation so it does not also expand the row. */
 export const ImagesCell = ({ images }: ImagesCellProps) => {
   const [expanded, setExpanded] = useState(false);
   const handleToggle = useCallback(

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -19,6 +19,7 @@ interface ImageRowProps {
   readonly image: Image;
 }
 
+/** Widest a tag badge may grow, in px, before its label is ellipsised. */
 export const TAG_MAX_WIDTH = 120;
 
 /**

--- a/web/src/features/tasks/components/ListToolbar.tsx
+++ b/web/src/features/tasks/components/ListToolbar.tsx
@@ -7,7 +7,6 @@ interface ListToolbarProps {
 }
 
 /**
- * Layout shell for the toolbar row above the task tables.
  * Left slot is page-specific (status tabs or date-range picker); right slot
  * holds search + refresh controls (Recent only).
  */

--- a/web/src/features/tasks/components/RecentTasksToolbar.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.tsx
@@ -34,7 +34,6 @@ const SCHEMA: FilterStateSchema<RecentFiltersValues> = {
   },
 };
 
-/** Toolbar with status tabs, application filter, search, and the refresh control. */
 export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?: string }) => {
   const { data } = useListContext<Task>();
   const records = useMemo(() => (Array.isArray(data) ? data : []), [data]);

--- a/web/src/features/tasks/components/RefreshControl.tsx
+++ b/web/src/features/tasks/components/RefreshControl.tsx
@@ -56,9 +56,8 @@ const readStoredInterval = (storageKey: string, fallback: number) => {
 };
 
 /**
- * Three-segment refresh pill: live indicator (with pulsing dot + countdown),
- * interval select, manual reload button. Reads pause reasons + interval from
- * the surrounding TaskListProvider so hover/expand can freeze the timer.
+ * Reads pause reasons and the interval from the surrounding TaskListProvider,
+ * so hover and row-expand elsewhere can freeze this timer.
  */
 export const RefreshControl = ({ onRefresh, storageKey = 'recentTasks.refreshInterval' }: RefreshControlProps) => {
   const theme = useTheme();
@@ -83,20 +82,17 @@ export const RefreshControl = ({ onRefresh, storageKey = 'recentTasks.refreshInt
     }
   }, [storageKey, intervalSec, setIntervalSec]);
 
-  // Persist interval changes.
   useEffect(() => {
     safeSetItem(storageKey, String(intervalSec));
   }, [storageKey, intervalSec]);
 
-  // Reset remaining when interval changes or after a refetch.
   useEffect(() => {
     setRemaining(intervalSec);
   }, [intervalSec, state.lastRefetchedAt]);
 
-  // Tick down once per second when not paused. The state-updater function
-  // intentionally has no side effects (firing onRefresh from inside the
-  // updater would run twice under StrictMode and is discouraged by React);
-  // the separate effect below watches `remaining === 0` to refetch.
+  // The state-updater function intentionally has no side effects: firing
+  // onRefresh from inside the updater would run twice under StrictMode. The
+  // separate effect below watches `remaining === 0` to refetch.
   useEffect(() => {
     if (intervalSec === 0 || paused) {
       return undefined;

--- a/web/src/features/tasks/components/RollbackIndicator.tsx
+++ b/web/src/features/tasks/components/RollbackIndicator.tsx
@@ -6,9 +6,8 @@ export interface RollbackIndicatorProps {
 }
 
 /**
- * Compact marker rendered next to a task's status to flag that the deployment
- * returns to a previously deployed version. Renders nothing for regular
- * (non-rollback) deployments so it can be dropped into any status cell without
+ * Flags a deployment that returns to a previously deployed version. Renders
+ * nothing otherwise, so it can be dropped into any status cell without
  * reserving layout space.
  */
 export const RollbackIndicator = ({ isRollback }: RollbackIndicatorProps) => {

--- a/web/src/features/tasks/components/SearchFilteredView.tsx
+++ b/web/src/features/tasks/components/SearchFilteredView.tsx
@@ -19,17 +19,9 @@ interface SearchFilteredViewProps {
 }
 
 /**
- * Client-side filter for the task table. Reads the active search query
- * from `TaskListContext`, narrows the *currently loaded page* to records
- * whose app / author / image substring matches, and re-publishes a
- * filtered list context for the children.
- *
- * Important: this is intentionally a page-scoped filter, not a search
- * across the entire backend. Callers (placeholder text, active-filter
- * chip) should reflect that scope so users do not assume a global search.
- *
- * When the query is empty this component is a no-op pass-through, so it
- * is safe to slot above any task list page.
+ * Narrows the *currently loaded page*, not the whole backend, and that scope is
+ * intentional. Callers (placeholder text, active-filter chip) should reflect it
+ * so users do not assume a global search.
  */
 export const SearchFilteredView = ({ children }: SearchFilteredViewProps) => {
   const ctx = useListContext<Task>();

--- a/web/src/features/tasks/components/SearchInput.tsx
+++ b/web/src/features/tasks/components/SearchInput.tsx
@@ -13,14 +13,12 @@ interface SearchInputProps {
 }
 
 /**
- * Lightweight client-side search input for the toolbar.
- * Debounces user input by 200 ms before bubbling up so callers can filter
- * the loaded page without thrashing. Holds the auto-refresh paused while
- * focused (and briefly after blur) so the list does not reshuffle mid-keystroke.
+ * Callers filter the already-loaded page with this; it is not a server query.
+ * Auto-refresh is held paused while focused (and briefly after blur) so the
+ * list does not reshuffle mid-keystroke.
  *
- * Below 1200 px (or when there is no value to display), the input collapses
- * into a search icon button to keep the toolbar from squeezing other
- * controls; clicking expands it and auto-focuses for typing.
+ * Below 1200 px the input collapses into an icon button when it has no value,
+ * to keep the toolbar from squeezing the other controls.
  */
 export const SearchInput = ({
   value,
@@ -48,8 +46,8 @@ export const SearchInput = ({
     return () => globalThis.clearTimeout(handle);
   }, [draft, debounceMs, onChange, value]);
 
-  // Keep refresh paused while focused; release after a short grace period
-  // so the trailing debounced onChange does not race a fresh refetch.
+  // The release is delayed by a grace period so the trailing debounced
+  // onChange does not race a fresh refetch.
   useEffect(() => {
     if (focused) {
       setPauseActive(true);
@@ -59,11 +57,10 @@ export const SearchInput = ({
     return () => globalThis.clearTimeout(handle);
   }, [focused, debounceMs]);
 
-  // Keep the expanded/collapsed state in sync with the viewport and the
-  // active value. A non-empty value forces expansion so the query is always
-  // visible — collapsing it would hide the user's own input. While the user
-  // is typing we leave `expanded` alone; otherwise backspacing the last char
-  // (value → '') would collapse the input mid-keystroke on narrow viewports.
+  // A non-empty value forces expansion so the query stays visible — collapsing
+  // it would hide the user's own input. While the user is typing `expanded` is
+  // left alone; otherwise backspacing the last char (value → '') would collapse
+  // the input mid-keystroke on narrow viewports.
   useEffect(() => {
     if (focused) return;
     setExpanded(isWide || Boolean(value));

--- a/web/src/features/tasks/components/StatusPill.tsx
+++ b/web/src/features/tasks/components/StatusPill.tsx
@@ -8,10 +8,8 @@ export interface StatusPillProps {
 }
 
 /**
- * Inline status badge that replaces MUI Chip on the task tables. Renders as a
- * 24 px pill so a row of statuses reads as labels (not actionable buttons).
- * Picks light/dark background+foreground from `describeTaskStatus()` based on
- * the active palette mode.
+ * Renders as a 24 px pill so a row of statuses reads as labels, not as
+ * actionable buttons.
  */
 export const StatusPill = ({ status }: StatusPillProps) => {
   const theme = useTheme();

--- a/web/src/features/tasks/components/TaskListContext.tsx
+++ b/web/src/features/tasks/components/TaskListContext.tsx
@@ -80,6 +80,7 @@ interface TaskListContextValue {
    * list returns no rows under active filters. Returns an unregister fn.
    */
   readonly registerClearAll: (handler: () => void) => () => void;
+  /** Invokes whichever clear-all handler the current page registered. */
   readonly clearAll: () => void;
 }
 

--- a/web/src/features/tasks/components/TaskListContext.tsx
+++ b/web/src/features/tasks/components/TaskListContext.tsx
@@ -80,7 +80,6 @@ interface TaskListContextValue {
    * list returns no rows under active filters. Returns an unregister fn.
    */
   readonly registerClearAll: (handler: () => void) => () => void;
-  /** Invokes whichever clear-all handler the current page registered. */
   readonly clearAll: () => void;
 }
 
@@ -160,10 +159,7 @@ export const useTaskListContext = (): TaskListContextValue => {
   return ctx ?? noopValue;
 };
 
-/**
- * Pauses auto-refresh under a named reason for the lifetime of the calling
- * component. Pass `active=false` to opt out conditionally.
- */
+/** Pauses auto-refresh under a named reason for the calling component's lifetime. */
 export const usePauseRefresh = (reason: string, active = true): void => {
   const { pause, resume } = useTaskListContext();
   useEffect(() => {

--- a/web/src/features/tasks/components/TaskListLayout.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.test.tsx
@@ -50,8 +50,7 @@ vi.mock('react-admin', () => ({
   List: ListMock,
   Pagination: PaginationMock,
   useRefresh: () => refreshMock,
-  // SearchFilteredView + TaskListLayout body both read useListContext; expose a
-  // mutable stub so individual tests can drive the empty/populated branches.
+  // SearchFilteredView + TaskListLayout body both read useListContext.
   useListContext: () => listContextRef.current,
   ListContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -73,7 +72,6 @@ describe('TaskListLayout', () => {
 
   it('fills react-admin list props and renders header content when provided', () => {
     readPersistentPerPageMock.mockReturnValue(40);
-    // Non-empty result so the body renders children rather than the empty state.
     listContextRef.current = { data: [{ id: 1 }], total: 1 };
 
     render(
@@ -142,10 +140,8 @@ describe('TaskListLayout', () => {
       </TaskListLayout>,
     );
 
-    // The header (filters) stays mounted so the user can still pick a date range.
     expect(screen.getByText('Date filter')).toBeInTheDocument();
     expect(screen.getByTestId('empty-state')).toBeInTheDocument();
-    // The datagrid children are replaced by the placeholder.
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
   });
 
@@ -168,7 +164,6 @@ describe('TaskListLayout', () => {
       </TaskListLayout>,
     );
 
-    // With active filters, defer to the datagrid's own filtered empty state.
     expect(screen.getByText('Date filter')).toBeInTheDocument();
     expect(screen.getByTestId('datagrid')).toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
@@ -196,9 +191,7 @@ describe('TaskListLayout', () => {
       </TaskListLayout>,
     );
 
-    // The header/filters stay mounted so the user can adjust the query and retry.
     expect(screen.getByText('Date filter')).toBeInTheDocument();
-    // A backend error must never masquerade as genuine emptiness.
     expect(screen.getByText('Couldn’t load tasks')).toBeInTheDocument();
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
@@ -238,8 +231,6 @@ describe('TaskListLayout', () => {
 
   it('keeps showing the skeleton (defers to children) while a request is pending', () => {
     readPersistentPerPageMock.mockReturnValue(25);
-    // isPending must win over an error left over from a prior fetch so a refetch
-    // shows the loading state rather than flashing the error panel.
     listContextRef.current = {
       data: [],
       total: 0,

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -18,14 +18,10 @@ interface TaskListLayoutProps {
 }
 
 /**
- * Renders the list body: the children (datagrid) normally, or the page-specific
- * empty placeholder when the backend returned zero rows and no filters are active.
- *
- * This gate lives here — inside <List> — rather than on <List empty>, because
- * react-admin renders the `empty` element *instead of* the entire list, which
- * drops the filter toolbar with it. Users would then land on an empty history
- * page with no way to widen the date range. Rendering the placeholder in the
- * body keeps the header/filters mounted above it. When filters are active we
+ * The empty gate lives here — inside <List> — rather than on <List empty>,
+ * because react-admin renders the `empty` element *instead of* the entire list,
+ * which drops the filter toolbar with it. Users would then land on an empty
+ * history page with no way to widen the date range. When filters are active we
  * defer to the datagrid's own filtered empty state (with its "Clear filters"
  * CTA), matching react-admin's original `shouldRenderEmptyPage` condition
  * (`!error && !isPending && total === 0 && !filterValues`).
@@ -33,15 +29,12 @@ interface TaskListLayoutProps {
  * A fetch error (a 5xx, a network drop, or the request timing out — see
  * REQUEST_TIMEOUT_MS in httpClient) is rendered as an explicit error state with
  * a retry, NOT as the empty placeholder or the datagrid's "no tasks" message: a
- * load failure must never masquerade as genuine emptiness. The header/filters
- * stay mounted above it so the user can still adjust the query and retry.
+ * load failure must never masquerade as genuine emptiness.
  *
  * The error panel is gated on `total === 0` so it only replaces the body when
  * there is nothing to show. react-admin keeps the previously loaded rows across
  * a refetch, so a transient auto-refresh failure keeps the populated grid (the
  * error is surfaced via react-admin's notification) instead of blanking it.
- * Its retry reloads every active query so the header's status counts recover
- * along with the rows.
  */
 const ListBody = ({
   emptyComponent,
@@ -75,10 +68,6 @@ const ListBody = ({
   return <>{children}</>;
 };
 
-/**
- * Shared scaffold for task list pages: wraps React-admin's <List> with the
- * toolbar/header, pagination persistence, and the empty/error body states.
- */
 export const TaskListLayout = ({
   title,
   perPageStorageKey,

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -17,11 +17,9 @@ import { TimeCell } from './TimeCell';
 import { usePauseRefresh, useTaskListContext } from './TaskListContext';
 
 /**
- * Renders the shared task table used by both recent and history views.
- * The leading expand chevron and a row click both toggle the inline
- * status-reason panel for rows that have one. The trailing "View" button is
- * the explicit affordance for navigating to the task detail page so the row
- * body remains a quiet expander.
+ * Shared by both the recent and history views. `rowClick="expand"` means any
+ * click inside a row toggles the status-reason panel, so nested links and
+ * buttons must stopPropagation.
  *
  * The wrapping div emits `pause('hover')` reasons through TaskListContext so
  * the toolbar's auto-refresh countdown freezes while the cursor is over the
@@ -34,8 +32,6 @@ export const TasksDatagrid = () => {
 
   // onMouseLeave is not guaranteed to fire if the component unmounts while the
   // cursor is still over the table (e.g. filter change or page leave mid-hover).
-  // Always clear the hover pause on unmount so the auto-refresh timer never
-  // gets stuck.
   useEffect(() => () => resume('hover'), [resume]);
 
   return (
@@ -188,11 +184,6 @@ const datagridSx: SxProps<Theme> = theme => {
   };
 };
 
-/**
- * Renders the project field. URLs become external links (clicks stopPropagation
- * so following the link does not also expand the row); plain strings render as
- * muted monospace text and inherit the row's click-to-expand behavior.
- */
 const ProjectCell = ({ project }: { project?: string | null }) => {
   if (!project) {
     return <EmptyCell />;
@@ -238,10 +229,6 @@ const ProjectCell = ({ project }: { project?: string | null }) => {
   );
 };
 
-/**
- * Explicit "View" affordance in the trailing Details column. stopPropagation
- * prevents the row-level expand from firing when the button is clicked.
- */
 const ViewButton = ({ id }: { id: string }) => (
   <Button
     component={RouterLink}
@@ -255,9 +242,7 @@ const ViewButton = ({ id }: { id: string }) => (
 );
 
 /**
- * Empty-state shown by the Datagrid when the loaded page returns zero rows
- * but the user still has filters / search active. Wraps EmptyState with a
- * "Clear filters" CTA that drains all three sinks (URL, storage, react-admin
+ * The "Clear filters" CTA drains all three sinks (URL, storage, react-admin
  * filterValues) via the page's registered clearAll handler — react-admin's
  * default ListNoResults only resets filterValues, leaving the toolbar chips
  * stuck.
@@ -288,7 +273,6 @@ const FilteredEmptyState = () => {
   );
 };
 
-/** Expanded row rendering the detailed status reason for a task. */
 const StatusReasonPanel = () => {
   const record = useRecordContext<Task>();
   // The panel mounts when a row expands and unmounts when it collapses, so a
@@ -297,9 +281,7 @@ const StatusReasonPanel = () => {
   return <StatusReasonContent record={record} />;
 };
 
-/**
- * Renders the status reason body independent of React-admin context to simplify testing.
- */
+/** Split from StatusReasonPanel so tests need no react-admin record context. */
 const StatusReasonContent = ({ record }: { record?: Task | null }) => {
   if (!record) {
     return null;
@@ -323,9 +305,6 @@ const StatusReasonContent = ({ record }: { record?: Task | null }) => {
   );
 };
 
-/**
- * Internal testing helpers used to verify formatted sub-components without rendering Datagrid context.
- */
 export const __testing = {
   ProjectCell,
   StatusReasonContent,

--- a/web/src/features/tasks/components/TimeCell.tsx
+++ b/web/src/features/tasks/components/TimeCell.tsx
@@ -22,9 +22,8 @@ const FULL_FORMAT: Intl.DateTimeFormatOptions = {
 };
 
 /**
- * Single-line time cell. The Created column passes `mode="date"` for the
- * absolute timestamp; the Updated column passes `mode="relative"` for the
- * relative-to-now string.
+ * The Created column passes `mode="date"`; the Updated column passes
+ * `mode="relative"`.
  */
 export const TimeCell = ({ ts, mode }: TimeCellProps) => {
   const { formatDate } = useTimezone();

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -71,7 +71,6 @@ describe('DateRangePicker', () => {
     fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
     const grid = screen.getByRole('grid', { name: 'Calendar' });
 
-    // Click "27" (today, Apr 27 in-month) then "20" (earlier, in-month) → swap.
     const cells = within(grid).getAllByRole('gridcell');
     const cell27 = cells.find(c => c.textContent === '27' && !c.hasAttribute('disabled'));
     const cell20 = cells.find(c => c.textContent === '20' && !c.hasAttribute('disabled'));

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -51,7 +51,6 @@ const formatTriggerLabel = (range: DateRangeValue, formatDate: (ts: number, opts
 const MONTH_FORMAT: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' };
 
 /**
- * Date range picker with preset shortcuts and a custom Monday-first calendar.
  * `value` is in Unix seconds; `onApply` fires only when the user clicks Apply
  * with a complete and dirty range. Computation honours the active timezone.
  */
@@ -64,7 +63,6 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
   const [viewYear, setViewYear] = useState(() => ymd(new Date(), timezone).year);
   const [viewMonth, setViewMonth] = useState(() => ymd(new Date(), timezone).month);
 
-  // Sync external value into the popover whenever it (re)opens.
   useEffect(() => {
     if (anchor) {
       setDraft(value);
@@ -104,7 +102,6 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
       }
 
       if (startSec < draft.start) {
-        // Swap: clicked date becomes the new start, previous start becomes the end.
         const previousStartDate = new Date(draft.start * 1000);
         setDraft({
           start: startSec,

--- a/web/src/features/tasks/components/dateRange/calendar.test.ts
+++ b/web/src/features/tasks/components/dateRange/calendar.test.ts
@@ -43,7 +43,6 @@ describe('calendar helpers', () => {
     expect(grid).toHaveLength(42);
     // April 1, 2026 is a Wednesday → grid starts on Mon Mar 30 2026.
     expect(grid[0].date.toISOString().slice(0, 10)).toBe('2026-03-30');
-    // The first cell that lands inside April should be index 2 (Wed Apr 1).
     expect(grid[2].date.toISOString().slice(0, 10)).toBe('2026-04-01');
     expect(grid[2].inMonth).toBe(true);
     expect(grid[0].inMonth).toBe(false);

--- a/web/src/features/tasks/components/dateRange/calendar.ts
+++ b/web/src/features/tasks/components/dateRange/calendar.ts
@@ -24,6 +24,7 @@ const mondayIndex = (date: Date, mode: TimezoneMode): number => {
   return (day + 6) % 7;
 };
 
+/** 00:00:00.000 on `input`'s day, in the given timezone mode. */
 export const startOfDay = (input: Date, mode: TimezoneMode): Date => {
   const date = new Date(input);
   if (mode === 'utc') {
@@ -34,6 +35,7 @@ export const startOfDay = (input: Date, mode: TimezoneMode): Date => {
   return date;
 };
 
+/** 23:59:59.000 — not .999 — on `input`'s day, in the given timezone mode. */
 export const endOfDay = (input: Date, mode: TimezoneMode): Date => {
   const date = new Date(input);
   if (mode === 'utc') {
@@ -52,6 +54,7 @@ export const ymd = (date: Date, mode: TimezoneMode): { year: number; month: numb
   return { year: date.getFullYear(), month: date.getMonth(), day: date.getDate() };
 };
 
+/** Midnight in `mode` for the given coordinates; `month` is 0-11, as in `Date`. */
 export const dateAt = (year: number, month: number, day: number, mode: TimezoneMode): Date => {
   if (mode === 'utc') {
     return new Date(Date.UTC(year, month, day, 0, 0, 0));
@@ -74,6 +77,7 @@ export const addDays = (date: Date, days: number, mode: TimezoneMode): Date => {
   return next;
 };
 
+/** Compares calendar days in `mode`, ignoring the time of day. */
 export const isSameDay = (a: Date, b: Date, mode: TimezoneMode): boolean => {
   const left = ymd(a, mode);
   const right = ymd(b, mode);
@@ -156,6 +160,7 @@ export const PRESETS: ReadonlyArray<PresetDescriptor> = [
   { id: 'this-month', label: 'This month', compute: thisMonth },
 ];
 
+/** The matching preset id, or null when the range is open or matches none. */
 export const matchPreset = (value: DateRangeValue, mode: TimezoneMode): string | null => {
   if (value.start === null || value.end === null) return null;
   for (const preset of PRESETS) {

--- a/web/src/features/tasks/components/dateRange/calendar.ts
+++ b/web/src/features/tasks/components/dateRange/calendar.ts
@@ -24,7 +24,6 @@ const mondayIndex = (date: Date, mode: TimezoneMode): number => {
   return (day + 6) % 7;
 };
 
-/** Returns a new Date set to 00:00:00.000 in the given timezone mode. */
 export const startOfDay = (input: Date, mode: TimezoneMode): Date => {
   const date = new Date(input);
   if (mode === 'utc') {
@@ -35,7 +34,6 @@ export const startOfDay = (input: Date, mode: TimezoneMode): Date => {
   return date;
 };
 
-/** Returns a new Date set to 23:59:59.000 in the given timezone mode. */
 export const endOfDay = (input: Date, mode: TimezoneMode): Date => {
   const date = new Date(input);
   if (mode === 'utc') {
@@ -54,7 +52,6 @@ export const ymd = (date: Date, mode: TimezoneMode): { year: number; month: numb
   return { year: date.getFullYear(), month: date.getMonth(), day: date.getDate() };
 };
 
-/** Builds a Date object representing midnight (in `mode`) for the given calendar coordinates. */
 export const dateAt = (year: number, month: number, day: number, mode: TimezoneMode): Date => {
   if (mode === 'utc') {
     return new Date(Date.UTC(year, month, day, 0, 0, 0));
@@ -77,7 +74,6 @@ export const addDays = (date: Date, days: number, mode: TimezoneMode): Date => {
   return next;
 };
 
-/** Returns true when two dates resolve to the same day in `mode`. */
 export const isSameDay = (a: Date, b: Date, mode: TimezoneMode): boolean => {
   const left = ymd(a, mode);
   const right = ymd(b, mode);
@@ -109,7 +105,6 @@ export interface PresetDescriptor {
   readonly compute: (mode: TimezoneMode) => DateRangeValue;
 }
 
-/** Converts a Date into Unix seconds. */
 const toSeconds = (date: Date): number => Math.floor(date.getTime() / MS_PER_SECOND);
 
 const today = (mode: TimezoneMode): DateRangeValue => {
@@ -161,7 +156,6 @@ export const PRESETS: ReadonlyArray<PresetDescriptor> = [
   { id: 'this-month', label: 'This month', compute: thisMonth },
 ];
 
-/** Identifies the preset that matches the given range (or null when no preset matches). */
 export const matchPreset = (value: DateRangeValue, mode: TimezoneMode): string | null => {
   if (value.start === null || value.end === null) return null;
   for (const preset of PRESETS) {

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -113,7 +113,6 @@ const computeRollbackState = (
   };
 };
 
-/** Builds the Argo CD application deep link from the config payload when possible. */
 const buildArgoCdUrl = (config: ConfigResponse | null, app?: string | null): string | null => {
   if (!config || !app) {
     return null;
@@ -132,7 +131,6 @@ const buildArgoCdUrl = (config: ConfigResponse | null, app?: string | null): str
   return null;
 };
 
-/** Derives the elapsed duration for the task, accounting for in-progress polling. */
 const computeDurationSeconds = (
   status: string | null,
   created: number | null,
@@ -147,7 +145,6 @@ const computeDurationSeconds = (
   return Math.max(0, effectiveUpdated - created);
 };
 
-/** Produces timeline entries for the created and updated timestamps shown in the UI. */
 const buildTimelineEntries = (
   created: number | null,
   updated: number | null,
@@ -175,7 +172,7 @@ const buildTimelineEntries = (
   return entries;
 };
 
-/** Displays the task detail screen at `/task/:id` mirroring the legacy Task View experience. */
+/** Routed at `/task/:id`. */
 export const TaskShow = () => {
   const { id } = useParams<{ id: string }>();
   const notify = useNotify();
@@ -580,7 +577,6 @@ interface InfoFieldProps {
 }
 
 /**
- * Displays a single piece of labeled metadata inside the task details view.
  * The label is block-level so that an inline value node, such as a link, still
  * starts on its own line below it.
  */
@@ -605,7 +601,6 @@ const InfoField = ({ label, value }: InfoFieldProps) => (
   </Box>
 );
 
-/** Renders the project field, converting URLs into external links. */
 const ProjectReference = ({ project }: { project?: string | null }) => {
   if (!project) {
     return <Typography variant="body1">—</Typography>;
@@ -632,7 +627,6 @@ const ProjectReference = ({ project }: { project?: string | null }) => {
   );
 };
 
-/** Visual row within the timeline stack with a connector to mimic the legacy UI flow. */
 const TimelineRow = ({
   entry,
   isLast,
@@ -674,7 +668,6 @@ const TimelineRow = ({
   </Stack>
 );
 
-/** Displays container images using monospace references and chip-style tags. */
 const ImagesList = ({
   images,
   hasAdditional,

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -33,6 +33,7 @@ const DEFAULT_PRESENTATION: TaskStatusPresentation = {
   pillFgDark: tokens.statusInfoFgDark,
 };
 
+/** An unrecognised status is echoed as its own label with neutral styling. */
 export const describeTaskStatus = (status?: string | null): TaskStatusPresentation => {
   if (!status) {
     return DEFAULT_PRESENTATION;

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -20,7 +20,6 @@ export interface TaskStatusPresentation {
   readonly pillFgDark: string;
 }
 
-/** Fallback rendering instructions when a status is unknown or missing. */
 const DEFAULT_PRESENTATION: TaskStatusPresentation = {
   label: 'Unknown',
   displayLabel: 'Unknown',
@@ -34,7 +33,6 @@ const DEFAULT_PRESENTATION: TaskStatusPresentation = {
   pillFgDark: tokens.statusInfoFgDark,
 };
 
-/** Describes how a task status should be rendered across chips, timelines, and alerts. */
 export const describeTaskStatus = (status?: string | null): TaskStatusPresentation => {
   if (!status) {
     return DEFAULT_PRESENTATION;

--- a/web/src/layout/AppLayout.tsx
+++ b/web/src/layout/AppLayout.tsx
@@ -25,7 +25,6 @@ const EmptyMenu = (): ReactElement | null => null;
  */
 const EmptySidebar = (_props: SidebarProps): ReactElement | null => null;
 
-/** Wraps react-admin Layout to inject our custom app bar, menu, and sidebar. */
 export const AppLayout = (props: LayoutProps) => (
   <Layout
     {...props}

--- a/web/src/layout/AppSplash.test.tsx
+++ b/web/src/layout/AppSplash.test.tsx
@@ -63,7 +63,6 @@ describe('AppSplash', () => {
     );
 
     expect(rule, `no reduced-motion rule emitted for .${dotClass}`).not.toBeNull();
-    // With the animation off, the resting dim state is what the user sees.
     expect(rule?.[1]).toContain('animation:none');
     expect(rule?.[1]).toContain('opacity:0.6');
   });

--- a/web/src/layout/components/AppNotification.tsx
+++ b/web/src/layout/components/AppNotification.tsx
@@ -28,13 +28,11 @@ const defaultSnackbarOffset: SxProps<Theme> = theme => ({
   },
 });
 
-/** Splits the MUI sx prop from the rest of the props helper components forward. */
 const extractSx = <T extends object>(input: T): [SxProps<Theme> | undefined, Omit<T, 'sx'>] => {
   const { sx, ...rest } = input as T & { sx?: SxProps<Theme> };
   return [sx, rest];
 };
 
-/** Maps react-admin notification types to MUI alert severities. */
 const severityFromType = (type?: string): AlertColor => {
   switch (type) {
     case 'error':
@@ -48,7 +46,9 @@ const severityFromType = (type?: string): AlertColor => {
 };
 
 /**
- * Custom notification component that mirrors react-admin notifications while supporting undo flows.
+ * Wired as react-admin's `notification` renderer in App.tsx, so it replaces the
+ * built-in one app-wide: there is no fallback, and dropping the undo-mutation
+ * handling here silently breaks undo for every notification.
  */
 export const AppNotification = (props: NotificationProps) => {
   const { autoHideDuration = 4000, anchorOrigin = defaultAnchorOrigin, className, type = 'info', ...rest } = props;
@@ -88,12 +88,10 @@ export const AppNotification = (props: NotificationProps) => {
     return undefined;
   }, [notifications, currentNotification, takeNotification]);
 
-  /** Closes the snackbar without triggering undo behavior. */
   const handleClose = useCallback(() => {
     setOpen(false);
   }, []);
 
-  /** Invoked after the snackbar exits to flush undoable mutations. */
   const handleExited = useCallback(() => {
     if (currentNotification?.notificationOptions?.undoable) {
       const mutation = takeMutation();
@@ -106,7 +104,6 @@ export const AppNotification = (props: NotificationProps) => {
     setCurrentNotification(undefined);
   }, [currentNotification, takeMutation]);
 
-  /** Executes the undo callback when the user presses the Undo button. */
   const handleUndo = useCallback(() => {
     const mutation = takeMutation();
     if (mutation) {

--- a/web/src/layout/components/AppTopBar.tsx
+++ b/web/src/layout/components/AppTopBar.tsx
@@ -53,7 +53,6 @@ const appBarStyles: SxProps<Theme> = theme => {
   };
 };
 
-/** Returns true when the supplied pathname matches a nav target path. */
 const routeIsActive = (pathname: string, target: string) => {
   if (target === '/') {
     return pathname === target;
@@ -61,10 +60,6 @@ const routeIsActive = (pathname: string, target: string) => {
   return pathname.startsWith(target);
 };
 
-/**
- * Branded application bar providing navigation shortcuts, docs/GitHub links,
- * timezone context, and access to the configuration drawer.
- */
 export const AppTopBar = (props: AppBarProps) => {
   const { sx: appBarSxProp, ...appBarProps } = props;
   const composedSx: SxProps<Theme> = appBarSxProp ? [appBarStyles, appBarSxProp] : appBarStyles;

--- a/web/src/layout/components/ConfigDrawer.test.tsx
+++ b/web/src/layout/components/ConfigDrawer.test.tsx
@@ -112,8 +112,6 @@ describe('ConfigDrawer', () => {
   });
 
   it('hides the deploy lock toggle while OIDC status is unknown', async () => {
-    // Default-deny during the config-loading / request-failed window: the toggle
-    // must not be rendered until OIDC status is known.
     oidcEnabledMock.mockReturnValue(null);
     renderDrawer();
 

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -27,9 +27,6 @@ interface ConfigDrawerProps {
   version: string;
 }
 
-/**
- * Side drawer that surfaces appearance, timezone, and deploy lock controls.
- */
 export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
   const [lockUpdating, setLockUpdating] = useState(false);
   const { mode, toggleMode } = useThemeMode();
@@ -59,7 +56,6 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
     lockHelperText = 'Deploy lock requires privileged access.';
   }
 
-  /** Toggles the deploy lock via the REST API and surfaces user feedback. */
   const handleDeployLockToggle = useCallback(async () => {
     if (!canToggleLock) {
       return;

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -121,7 +121,6 @@ describe('main entrypoint', () => {
     const { unmount } = render(secondTree);
 
     expect(screen.getByTestId('app-splash')).toHaveTextContent('Signing in…');
-    // Still the splash — the app tree waits for the bootstrap to settle.
     expect(screen.queryByTestId('app-component')).toBeNull();
 
     unmount();
@@ -157,8 +156,6 @@ describe('main entrypoint', () => {
     resolveBootstrap();
     await waitFor(() => expect(renderMock).toHaveBeenCalledTimes(2));
 
-    // Exactly two renders — neutral splash, then the app. A "Signing in…" render
-    // must never appear in between.
     expect(renderMock.mock.calls).toHaveLength(2);
 
     const splash = render(renderMock.mock.calls[0][0] as ReactElement);
@@ -187,7 +184,6 @@ describe('main entrypoint', () => {
     const { unmount } = render(renderMock.mock.calls[2][0] as ReactElement);
 
     expect(screen.getByTestId('splash-error')).toHaveTextContent('Could not start the sign-in');
-    // The status line still states what happened, next to the box saying why.
     expect(screen.getByTestId('app-splash')).toHaveTextContent('Sign-in failed');
     // Mounting react-admin here is what produced the silent, session-less app: it
     // immediately re-runs checkAuth and heads back to the broken provider.
@@ -210,7 +206,6 @@ describe('main entrypoint', () => {
     try {
       await import('./main');
 
-      // Nothing to retry while the sign-in is still in flight.
       const loading = render(renderMock.mock.calls[0][0] as ReactElement);
       expect(screen.queryByTestId('splash-retry')).toBeNull();
       loading.unmount();
@@ -237,7 +232,6 @@ describe('main entrypoint', () => {
 
     await import('./main');
 
-    // A rejected bootstrap must not leave the user stuck on the loading screen.
     await waitFor(() => expect(renderMock).toHaveBeenCalledTimes(2));
 
     const renderedTree = renderMock.mock.calls[1][0] as ReactElement;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,7 +15,6 @@ if (!rootElement) {
 
 const root = ReactDOM.createRoot(rootElement);
 
-/** Mounts the React application into the page root. */
 const renderApp = () => {
   root.render(
     <React.StrictMode>
@@ -29,9 +28,7 @@ const renderApp = () => {
 };
 
 /**
- * Mounts the loading screen shown while authentication is resolved.
- *
- * Nothing from `AppProviders` wraps it: the deploy-lock and ArgoCD-status
+ * Nothing from `AppProviders` wraps the splash: the deploy-lock and ArgoCD-status
  * providers start polling the API on mount, which must not happen before a token
  * exists. `AppSplash` carries its own theme.
  *

--- a/web/src/shared/hooks/useAutoRefresh.ts
+++ b/web/src/shared/hooks/useAutoRefresh.ts
@@ -1,10 +1,6 @@
 import { useEffect } from 'react';
 import { getBrowserWindow } from '../utils';
 
-/**
- * Triggers the provided handler at the given interval (in seconds).
- * When the interval is falsy the handler is not scheduled.
- */
 export const useAutoRefresh = (intervalSeconds: number, handler: () => void) => {
   useEffect(() => {
     if (!intervalSeconds) {

--- a/web/src/shared/hooks/useAutoRefresh.ts
+++ b/web/src/shared/hooks/useAutoRefresh.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { getBrowserWindow } from '../utils';
 
+/** A falsy `intervalSeconds` disables the timer. */
 export const useAutoRefresh = (intervalSeconds: number, handler: () => void) => {
   useEffect(() => {
     if (!intervalSeconds) {

--- a/web/src/shared/hooks/useFilterState.ts
+++ b/web/src/shared/hooks/useFilterState.ts
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { getBrowserWindow } from '../utils/browser';
 
 export interface FilterFieldSchema<V> {
+  /** Receives null when the param is absent from the URL. */
   readonly fromUrl: (raw: string | null) => V;
   /** Serialises a typed value to a URL search param, or null to drop the param. */
   readonly toUrl: (value: V) => string | null;

--- a/web/src/shared/hooks/useFilterState.ts
+++ b/web/src/shared/hooks/useFilterState.ts
@@ -4,9 +4,8 @@ import { useSearchParams } from 'react-router-dom';
 import { getBrowserWindow } from '../utils/browser';
 
 export interface FilterFieldSchema<V> {
-  /** Reads a URL search param (or null when missing) and returns the typed value. */
   readonly fromUrl: (raw: string | null) => V;
-  /** Serialises a typed value back to a URL search param, or null to drop the param. */
+  /** Serialises a typed value to a URL search param, or null to drop the param. */
   readonly toUrl: (value: V) => string | null;
   /** Writes the value into the react-admin filterValues object (key may differ). */
   readonly toFilter?: (value: V) => unknown;
@@ -125,8 +124,8 @@ const valuesEqual = <T>(a: T, b: T): boolean => {
 /**
  * Single owner of URL ⇄ react-admin filterValues ⇄ localStorage reconciliation.
  *
- * On mount: reads URL params first, falls back to localStorage, then defaults.
- * Push the merged values into react-admin's filterValues.
+ * On mount: URL params win, then localStorage, then defaults; the merged values
+ * are pushed into react-admin's filterValues.
  *
  * `setValue` / `setMany` update local state only — call `apply()` to mirror
  * pending values into the URL, storage, and filterValues. `applied` reflects
@@ -159,7 +158,6 @@ export const useFilterState = <T extends Record<string, unknown>>(
   const [values, setValues] = useState<T>(initial);
   const [applied, setApplied] = useState<T>(initial);
 
-  // On first mount, project initial state into the react-admin filter context.
   const hasMountedRef = useRef(false);
   useEffect(() => {
     if (hasMountedRef.current) return;
@@ -187,13 +185,11 @@ export const useFilterState = <T extends Record<string, unknown>>(
     (override?: T) => {
       const target = override ?? values;
 
-      // Mirror to react-admin filterValues.
       if (setFilters) {
         const merged = buildFilterValues(schema, target, filterValues as Record<string, unknown>);
         setFilters(merged, {}, false);
       }
 
-      // Mirror to URL.
       const params = new URLSearchParams(searchParams);
       (Object.keys(schema) as Array<keyof T>).forEach(key => {
         const field = schema[key];
@@ -207,7 +203,6 @@ export const useFilterState = <T extends Record<string, unknown>>(
       });
       setSearchParams(params, { replace: true });
 
-      // Mirror to localStorage.
       (Object.keys(schema) as Array<keyof T>).forEach(key => {
         const field = schema[key];
         writeStorageValue(storageKey, field, key as string, target[key]);

--- a/web/src/shared/hooks/useOidcEnabled.ts
+++ b/web/src/shared/hooks/useOidcEnabled.ts
@@ -8,10 +8,9 @@ interface ServerConfigResponse {
 }
 
 /**
- * Fetches server configuration to determine whether OIDC authentication is
- * enabled. Returns `null` while the request is in flight or when it fails so
- * callers can gate privileged actions conservatively (treating "unknown" as
- * "denied") instead of falling open if the /api/v1/config request errors.
+ * Returns `null` while the request is in flight or when it fails, so callers
+ * gate privileged actions conservatively (treating "unknown" as "denied")
+ * instead of falling open if the /api/v1/config request errors.
  */
 export const useOidcEnabled = (): boolean | null => {
   const [enabled, setEnabled] = useState<boolean | null>(null);

--- a/web/src/shared/hooks/usePersistentPerPage.ts
+++ b/web/src/shared/hooks/usePersistentPerPage.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { useListPaginationContext } from 'react-admin';
 import { getBrowserWindow } from '../utils';
 
-/** Retrieves the stored per-page value or falls back when absent/invalid. */
 const readPerPage = (storageKey: string, fallback: number) => {
   const storage = getBrowserWindow()?.localStorage;
   if (!storage) {
@@ -15,7 +14,6 @@ const readPerPage = (storageKey: string, fallback: number) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
-/** Persists the current per-page value to localStorage. */
 const writePerPage = (storageKey: string, value: number) => {
   const storage = getBrowserWindow()?.localStorage;
   if (!storage) {
@@ -24,15 +22,9 @@ const writePerPage = (storageKey: string, value: number) => {
   storage.setItem(storageKey, String(value));
 };
 
-/**
- * Reads the persisted `perPage` preference, falling back to the provided default when none is stored.
- */
 export const readPersistentPerPage = (storageKey: string, fallback: number) => readPerPage(storageKey, fallback);
 
-/**
- * React component that synchronizes the current list `perPage` value with local storage.
- * Must be rendered within a React-admin `<List>` so that the pagination context is available.
- */
+/** Must be rendered within a React-admin `<List>` for the pagination context. */
 export const PerPagePersistence = ({ storageKey }: { storageKey: string }) => {
   const { perPage } = useListPaginationContext();
 

--- a/web/src/shared/hooks/usePersistentPerPage.ts
+++ b/web/src/shared/hooks/usePersistentPerPage.ts
@@ -22,6 +22,7 @@ const writePerPage = (storageKey: string, value: number) => {
   storage.setItem(storageKey, String(value));
 };
 
+/** Falls back to `fallback` when nothing is stored or the stored value is unusable. */
 export const readPersistentPerPage = (storageKey: string, fallback: number) => readPerPage(storageKey, fallback);
 
 /** Must be rendered within a React-admin `<List>` for the pagination context. */

--- a/web/src/shared/providers/AppProviders.tsx
+++ b/web/src/shared/providers/AppProviders.tsx
@@ -10,10 +10,6 @@ interface AppProvidersProps {
   children: ReactNode;
 }
 
-/**
- * Hosts the global React providers (theme, timezone, ArgoCD-status, deploy-lock)
- * that wrap the React-admin workspace.
- */
 export const AppProviders = ({ children }: AppProvidersProps) => (
   <ThemeModeProvider>
     <TimezoneProvider>

--- a/web/src/shared/providers/TimezoneProvider.tsx
+++ b/web/src/shared/providers/TimezoneProvider.tsx
@@ -13,7 +13,6 @@ const STORAGE_KEY = 'argo-watcher:timezone';
 
 const TimezoneContext = createContext<TimezoneContextValue | undefined>(undefined);
 
-/** Reads the persisted timezone selection, defaulting to UTC when unset. */
 const readInitialTimezone = (): TimezoneMode => {
   const browserWindow = globalThis.window;
   if (!browserWindow) {
@@ -26,7 +25,6 @@ const readInitialTimezone = (): TimezoneMode => {
   return 'utc';
 };
 
-/** React context provider that exposes timezone selection and formatting helpers. */
 export const TimezoneProvider = ({ children }: { children: ReactNode }) => {
   const [timezone, setTimezone] = useState<TimezoneMode>(() => readInitialTimezone());
 
@@ -59,7 +57,6 @@ export const TimezoneProvider = ({ children }: { children: ReactNode }) => {
   return <TimezoneContext.Provider value={value}>{children}</TimezoneContext.Provider>;
 };
 
-/** Hook for consuming the timezone context (selection + formatter). */
 export const useTimezone = () => {
   const context = useContext(TimezoneContext);
   if (!context) {

--- a/web/src/shared/providers/TimezoneProvider.tsx
+++ b/web/src/shared/providers/TimezoneProvider.tsx
@@ -57,6 +57,7 @@ export const TimezoneProvider = ({ children }: { children: ReactNode }) => {
   return <TimezoneContext.Provider value={value}>{children}</TimezoneContext.Provider>;
 };
 
+/** Unlike the other context hooks, falls back to UTC outside its provider rather than throwing. */
 export const useTimezone = () => {
   const context = useContext(TimezoneContext);
   if (!context) {

--- a/web/src/shared/utils/browser.ts
+++ b/web/src/shared/utils/browser.ts
@@ -1,14 +1,5 @@
-/**
- * Returns the browser Window instance when running in DOM-capable environments.
- * Falls back to undefined when rendered on the server or during non-DOM tests.
- */
 export const getBrowserWindow = (): Window | undefined => globalThis.window ?? undefined;
 
-/**
- * Returns the browser Document instance when running with DOM access.
- * Useful for SSR-safe consumers that need to reference document conditionally.
- */
 export const getBrowserDocument = (): Document | undefined => globalThis.document ?? undefined;
 
-/** Indicates whether the current runtime exposes a Window object. */
 export const hasBrowserWindow = (): boolean => getBrowserWindow() !== undefined;

--- a/web/src/shared/utils/errors.ts
+++ b/web/src/shared/utils/errors.ts
@@ -9,6 +9,7 @@ export interface NormalizedError {
 const isHttpError = (error: unknown): error is HttpError =>
   typeof error === 'object' && error !== null && 'status' in error && 'message' in error;
 
+/** Accepts anything thrown — HttpError, Error, string, or an unrecognised value. */
 export const normalizeError = (error: unknown): NormalizedError => {
   if (isHttpError(error)) {
     return {

--- a/web/src/shared/utils/errors.ts
+++ b/web/src/shared/utils/errors.ts
@@ -6,11 +6,9 @@ export interface NormalizedError {
   details?: unknown;
 }
 
-/** Type guard that checks whether the provided value is a react-admin HttpError. */
 const isHttpError = (error: unknown): error is HttpError =>
   typeof error === 'object' && error !== null && 'status' in error && 'message' in error;
 
-/** Normalizes various thrown values into a consistent error payload for the UI. */
 export const normalizeError = (error: unknown): NormalizedError => {
   if (isHttpError(error)) {
     return {

--- a/web/src/shared/utils/permissions.ts
+++ b/web/src/shared/utils/permissions.ts
@@ -13,6 +13,7 @@ const getPrivilegedSet = (groups: GroupList): ReadonlySet<string> => {
   return cachedPrivilegedSet;
 };
 
+/** False unless `userGroups` is an array sharing a member with the privileged set. */
 export const hasPrivilegedAccess = (
   userGroups?: GroupList | null,
   privilegedGroups?: GroupList | null,

--- a/web/src/shared/utils/permissions.ts
+++ b/web/src/shared/utils/permissions.ts
@@ -1,10 +1,8 @@
-/** Determines whether the user belongs to any of the privileged groups. */
 type GroupList = ReadonlyArray<string>;
 
 let cachedPrivilegedGroups: GroupList | null = null;
 let cachedPrivilegedSet: ReadonlySet<string> | null = null;
 
-/** Returns a memoized Set for the provided privileged group array to avoid repeated allocations. */
 const getPrivilegedSet = (groups: GroupList): ReadonlySet<string> => {
   if (cachedPrivilegedGroups === groups && cachedPrivilegedSet) {
     return cachedPrivilegedSet;
@@ -15,10 +13,6 @@ const getPrivilegedSet = (groups: GroupList): ReadonlySet<string> => {
   return cachedPrivilegedSet;
 };
 
-/**
- * Determines whether the user belongs to any of the privileged groups.
- * Accepts an optional precomputed Set for call-sites that already maintain one.
- */
 export const hasPrivilegedAccess = (
   userGroups?: GroupList | null,
   privilegedGroups?: GroupList | null,

--- a/web/src/shared/utils/time.test.ts
+++ b/web/src/shared/utils/time.test.ts
@@ -7,8 +7,6 @@ import {
   relativeTimestamp,
 } from './time';
 
-/** Verifies the shared time formatting helpers cover edge cases and timer lifecycle management. */
-
 describe('time utilities', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/web/src/shared/utils/time.ts
+++ b/web/src/shared/utils/time.ts
@@ -9,7 +9,6 @@ export const DEFAULT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
 
 type SupportedTimestamp = Date | number | string | null | undefined;
 
-/** Converts supported timestamp inputs into a Date instance, returning null when invalid. */
 const toDate = (value: SupportedTimestamp): Date | null => {
   if (value === null || value === undefined) {
     return null;
@@ -20,8 +19,8 @@ const toDate = (value: SupportedTimestamp): Date | null => {
   }
 
   if (typeof value === 'number') {
-    // Unix timestamps stay below 10_000_000_000 seconds until the year 2286,
-    // so values under that threshold are interpreted as seconds instead of ms.
+    // Unix timestamps stay below 10_000_000_000 seconds until the year 2286, so
+    // values under that threshold are interpreted as seconds instead of ms.
     const normalized = value < 10_000_000_000 ? value * 1000 : value;
     return new Date(normalized);
   }
@@ -34,7 +33,6 @@ const toDate = (value: SupportedTimestamp): Date | null => {
   return new Date(parsed);
 };
 
-/** Formats timestamps with locale-aware date+time options, defaulting to en-GB. */
 export const formatDateTime = (
   value: SupportedTimestamp,
   locale: string | string[] = 'en-GB',
@@ -50,7 +48,6 @@ export const formatDateTime = (
 
 const pluralize = (value: number, unit: string) => `${value} ${unit}${value === 1 ? '' : 's'}`;
 
-/** Converts elapsed seconds into a human-readable relative duration string. */
 export const formatDuration = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) {
     return '—';
@@ -85,10 +82,9 @@ export const formatDuration = (seconds: number): string => {
 };
 
 /**
- * Formats elapsed seconds in dense monospace form ("1m 04s", "2h 03m", "—").
- * Used for table cells where vertical alignment matters; the legacy
- * `formatDuration` is preserved for prose contexts (status reasons, detail
- * pages) that read better as "2 minutes" rather than "2m 00s".
+ * Dense monospace form ("1m 04s", "2h 03m", "—") for table cells, where vertical
+ * alignment matters. `formatDuration` is kept for prose contexts (status
+ * reasons, detail pages) that read better as "2 minutes" than as "2m 00s".
  */
 export const formatDurationCompact = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) {
@@ -116,7 +112,6 @@ export const formatDurationCompact = (seconds: number): string => {
   return `${days}d ${pad(remHours)}h`;
 };
 
-/** Formats timestamps as "X minutes ago" relative to now. */
 export const formatRelativeTime = (value: SupportedTimestamp) => {
   const date = toDate(value);
   if (!date) {
@@ -128,7 +123,6 @@ export const formatRelativeTime = (value: SupportedTimestamp) => {
   return `${formatDuration(differenceSeconds)} ago`;
 };
 
-/** Returns a UNIX timestamp offset by the provided seconds from the current moment. */
 export const relativeTimestamp = (offsetSeconds: number) => {
   if (!Number.isFinite(offsetSeconds) || offsetSeconds < 0) {
     return Math.floor(Date.now() / 1000);

--- a/web/src/shared/utils/time.ts
+++ b/web/src/shared/utils/time.ts
@@ -33,6 +33,7 @@ const toDate = (value: SupportedTimestamp): Date | null => {
   return new Date(parsed);
 };
 
+/** Returns "—" when the value cannot be parsed as a timestamp. */
 export const formatDateTime = (
   value: SupportedTimestamp,
   locale: string | string[] = 'en-GB',
@@ -48,6 +49,7 @@ export const formatDateTime = (
 
 const pluralize = (value: number, unit: string) => `${value} ${unit}${value === 1 ? '' : 's'}`;
 
+/** Prose form ("2 minutes"); "—" for a negative or non-finite input. */
 export const formatDuration = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) {
     return '—';
@@ -112,6 +114,7 @@ export const formatDurationCompact = (seconds: number): string => {
   return `${days}d ${pad(remHours)}h`;
 };
 
+/** "<duration> ago", never negative; "—" when the value cannot be parsed. */
 export const formatRelativeTime = (value: SupportedTimestamp) => {
   const date = toDate(value);
   if (!date) {
@@ -123,6 +126,7 @@ export const formatRelativeTime = (value: SupportedTimestamp) => {
   return `${formatDuration(differenceSeconds)} ago`;
 };
 
+/** UNIX seconds `offsetSeconds` in the past; a negative or non-finite offset yields now. */
 export const relativeTimestamp = (offsetSeconds: number) => {
   if (!Number.isFinite(offsetSeconds) || offsetSeconds < 0) {
     return Math.floor(Date.now() / 1000);

--- a/web/src/test/mockWebSocket.ts
+++ b/web/src/test/mockWebSocket.ts
@@ -49,6 +49,7 @@ export class MockWebSocket {
     this.onmessage?.({ data } as { data: string });
   }
 
+  /** Every instance constructed since the last reset, in creation order. */
   static readonly instances: MockWebSocket[] = [];
 
   static reset() {

--- a/web/src/test/mockWebSocket.ts
+++ b/web/src/test/mockWebSocket.ts
@@ -1,8 +1,4 @@
 /**
- * Minimal WebSocket stand-in for unit tests. Records every constructed instance
- * and exposes hooks to drive the open/message/close callbacks by hand, so a test
- * can sequence a handshake, a pushed frame and a drop deterministically.
- *
  * Install with `vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)`
  * and call `MockWebSocket.reset()` in `beforeEach` to clear the instance list.
  */
@@ -19,7 +15,6 @@ export class MockWebSocket {
     MockWebSocket.instances.push(this);
   }
 
-  /** Fires the open handler, as the browser does once the handshake completes. */
   public open() {
     this.onopen?.();
   }
@@ -38,12 +33,10 @@ export class MockWebSocket {
     }
   }
 
-  /** Delivers the close event to the handler. */
   public fireClose() {
     this.onclose?.();
   }
 
-  /** Delivers a text frame to the message handler. */
   public emit(message: string) {
     this.onmessage?.({ data: message });
   }
@@ -56,7 +49,6 @@ export class MockWebSocket {
     this.onmessage?.({ data } as { data: string });
   }
 
-  /** Every instance constructed since the last reset, in creation order. */
   static readonly instances: MockWebSocket[] = [];
 
   static reset() {

--- a/web/src/theme/ThemeModeProvider.tsx
+++ b/web/src/theme/ThemeModeProvider.tsx
@@ -14,19 +14,16 @@ const STORAGE_KEY = 'argo-watcher.theme-mode';
 
 const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(undefined);
 
-/** Safely resolves the global window object when running in the browser. */
 const resolveWindow = () => {
   const maybeWindow = (globalThis as typeof globalThis & { window?: Window }).window;
   return maybeWindow ?? undefined;
 };
 
-/** Safely resolves the global document object when running in the browser. */
 const resolveDocument = () => {
   const maybeDocument = (globalThis as typeof globalThis & { document?: Document }).document;
   return maybeDocument ?? undefined;
 };
 
-/** Reads the preferred theme mode from storage or matchMedia fallbacks. */
 const readInitialMode = (): PaletteMode => {
   const browserWindow = resolveWindow();
   if (browserWindow) {
@@ -84,7 +81,6 @@ export const ThemeModeProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-/** Hook to access the current palette mode, toggle handler, and theme instance. */
 export const useThemeMode = (): ThemeModeContextValue => {
   const context = useContext(ThemeModeContext);
   if (!context) {

--- a/web/src/theme/ThemeModeProvider.tsx
+++ b/web/src/theme/ThemeModeProvider.tsx
@@ -81,6 +81,7 @@ export const ThemeModeProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
+/** Throws outside a ThemeModeProvider. */
 export const useThemeMode = (): ThemeModeContextValue => {
   const context = useContext(ThemeModeContext);
   if (!context) {

--- a/web/src/theme/index.ts
+++ b/web/src/theme/index.ts
@@ -2,7 +2,6 @@ import type { PaletteMode, ThemeOptions } from '@mui/material';
 import { createTheme, lighten } from '@mui/material/styles';
 import { tokens } from './tokens';
 
-/** Derives the design tokens (palette, typography, overrides) for the requested palette mode. */
 const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   palette: {
     mode,
@@ -96,7 +95,6 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   },
 });
 
-/** Convenient wrapper to build the MUI theme based on the current palette mode. */
 export const createAppTheme = (mode: PaletteMode) => createTheme(getDesignTokens(mode));
 
 export const lightTheme = createAppTheme('light');

--- a/web/src/theme/tokens.ts
+++ b/web/src/theme/tokens.ts
@@ -4,12 +4,10 @@
  * and only then be referenced from `theme/index.ts` or component code.
  */
 export const tokens = {
-  // brand
   ink: '#2E3B55',
   accent: '#5B7CFA',
   accentSoft: '#EEF2FF',
 
-  // status pill backgrounds/foregrounds (light mode)
   statusDeployedBg: '#E8F5E9',
   statusDeployedFg: '#2E7D32',
   statusFailedBg: '#FDECEA',
@@ -36,13 +34,15 @@ export const tokens = {
   liveFg: '#2E7D32',
   liveFgDark: '#81C784',
 
-  // monogram swatches (AppCell) — picked by stable hash of the app name
+  // monogram swatches (AppCell) — picked by stable hash of the app name. Index N
+  // of both lists must be the same hue: AppCell picks the index, then the mode,
+  // so a mismatch recolours an app's monogram when the theme is toggled.
   monogramSwatches: [
-    { bg: '#EEF2FF', fg: '#5B7CFA' }, // blue
-    { bg: '#FFF4E5', fg: '#ED6C02' }, // amber
-    { bg: '#E8F5E9', fg: '#2E7D32' }, // green
-    { bg: '#FBEAFF', fg: '#7B1FA2' }, // purple
-    { bg: '#FDECEA', fg: '#D32F2F' }, // red
+    { bg: '#EEF2FF', fg: '#5B7CFA' },
+    { bg: '#FFF4E5', fg: '#ED6C02' },
+    { bg: '#E8F5E9', fg: '#2E7D32' },
+    { bg: '#FBEAFF', fg: '#7B1FA2' },
+    { bg: '#FDECEA', fg: '#D32F2F' },
   ],
   monogramSwatchesDark: [
     { bg: 'rgba(91, 124, 250, 0.20)', fg: '#A5B4FC' },
@@ -52,7 +52,6 @@ export const tokens = {
     { bg: 'rgba(211, 47, 47, 0.22)', fg: '#FCA5A5' },
   ],
 
-  // surfaces
   canvas: '#F6F7F9',
   surface: '#FFFFFF',
   surface2: '#FAFBFD',
@@ -64,13 +63,11 @@ export const tokens = {
   surfaceDark: '#15213B',
   surface2Dark: '#1A2746',
 
-  // lines
   divider: 'rgba(46, 59, 85, 0.12)',
   dividerStrong: 'rgba(46, 59, 85, 0.22)',
   dividerDark: 'rgba(226, 232, 240, 0.12)',
   dividerStrongDark: 'rgba(226, 232, 240, 0.22)',
 
-  // text
   textPrimary: '#1A2238',
   textSecondary: '#5A6478',
   textDisabled: '#8B94A8',
@@ -78,17 +75,14 @@ export const tokens = {
   textSecondaryDark: '#CBD5F5',
   textDisabledDark: '#64748B',
 
-  // type
   fontSans: '"Roboto","Helvetica","Arial",sans-serif',
   fontMono: '"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace',
 
-  // radii
   radiusSm: 6,
   radiusMd: 8,
   radiusLg: 12,
   radiusPill: 999,
 
-  // row hover (subtle wash on table rows)
   rowHoverLight: '#F9FAFC',
   rowHoverDark: 'rgba(91, 124, 250, 0.08)',
 } as const;


### PR DESCRIPTION
Frontend counterpart to #543, which covered the Go packages. Six commits, one
per module: auth+data, features/tasks, deployLock+argocdStatus, shared+theme,
layout+entrypoint, and the Playwright suite.

Removes docstrings that restated a symbol's own name, section banners, and test
comments repeating the assertion below them. Rationale explaining a non-obvious
choice stays: react-admin's empty/error gating, the WebSocket ordering guards,
the OIDC threat-model notes, and why each Playwright spec is a browser test
rather than a unit test.

A few docstrings were rewritten rather than cut, where they carried a contract
the signature does not — `describeProject` drops mid-path URL segments,
`normalizeApplicationFilterValue` treats the literal `"null"` as empty,
`AppNotification` is react-admin's only notification renderer, and `signIn`
resolves when the browser leaves the provider, not when the app has loaded. One
`SearchInput` docstring that contradicted the code was corrected.

No executable code changed: 80 files, all comment lines. oxlint, the 438 vitest
tests, and `typecheck:e2e` pass.