### PR TITLE
fix(client): refuse a redirect that steps down from https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- The client now refuses a redirect that moves it from `https` to plain `http`, instead of
+  following it with the deploy token or CI JWT attached. Go's HTTP client compares only
+  hostnames when deciding whether a credential may cross a redirect, so a `Location` header
+  pointing at `http://` on the same host would have put the credential on the wire in the
+  clear. Such a deployment now fails immediately naming both endpoints, rather than being
+  retried as a network blip. Only stepping down from TLS is refused: a client pointed at an
+  `http://` URL keeps working, and so does any redirect that stays on `https`.
 - Bumped the Go toolchain to `1.26.6`, resolving six standard library vulnerabilities
   reachable from this code base in `go1.26.5`: `GO-2026-6218` (`net/url`), `GO-2026-6090`
   (`crypto/tls`), `GO-2026-6089` and `GO-2026-5026` (`net/http`), `GO-2026-6088`

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -137,6 +137,25 @@ GitOps repository — whoever answers for the redirect target receives it on eve
 
 ---
 
+## Client refuses a redirect away from https
+
+**Symptom:** The deployment fails immediately with
+`refused to follow a redirect away from https`, naming the endpoint that answered and the
+plain-`http` target it pointed at.
+
+**Meaning:** `ARGO_WATCHER_URL` is an `https` URL, but something on the path answers it
+with a `Location` on plain `http`. Go's HTTP client carries `Authorization` across such a
+redirect as long as the hostname is unchanged, so following it would put the deploy token
+or CI JWT on the wire in the clear. The client refuses instead, and does not retry — the
+redirect is a property of the configuration, not a transient failure.
+
+**Fix:** Point `ARGO_WATCHER_URL` at the endpoint that serves the API over TLS, or stop
+the ingress in front of it from downgrading API requests. Only stepping down from TLS is
+refused — a client deliberately pointed at an `http://` URL keeps working, unless the
+chain has already reached `https` by the time it is redirected back.
+
+---
+
 ## Image is not part of application
 
 **Symptom:** The deployment fails immediately with `Image "<name>" is not part of application "<app>"`, followed by the list of images the application defines.

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -36,4 +36,4 @@ required.
 
 ## Retry Behavior
 
-While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses from the server) up to 3 times with a fixed 2-second delay before giving up. This retry count and delay are not configurable. Terminal failures (`4xx` responses, invalid tokens, malformed responses) fail immediately, and task submission (the initial `POST`) is not retried.
+While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses from the server) up to 3 times with a fixed 2-second delay before giving up. This retry count and delay are not configurable. Terminal failures (`4xx` responses, invalid tokens, malformed responses, a redirect that steps down from `https`) fail immediately, and task submission (the initial `POST`) is not retried.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -103,7 +104,7 @@ func NewWatcher(baseUrl string, debugMode bool, timeout time.Duration) *Watcher 
 	// caller assigns it after construction (see setupWatcher).
 	watcher.client = &http.Client{
 		Timeout:       timeout,
-		CheckRedirect: watcher.dropCredentialOnHostChange,
+		CheckRedirect: watcher.guardRedirect,
 	}
 	return watcher
 }
@@ -112,21 +113,31 @@ func NewWatcher(baseUrl string, debugMode bool, timeout time.Duration) *Watcher 
 // replaces.
 const maxRedirects = 10
 
-// dropCredentialOnHostChange strips the deploy-token header from a redirect that
-// leaves the original host. net/http does this for Authorization (so the JWT is
-// already covered) but not for custom headers, and the deploy token authorizes git
-// write-back for every application — it must not be handed to a host the operator did
-// not configure.
+var errInsecureRedirect = errors.New("refused to follow a redirect away from https")
+
+// guardRedirect decides whether a redirect may be followed and with which headers.
 //
-// Dropping it turns off git write-back, which surfaces later as a rollout that fails
-// blaming the image or the timeout, so the loss is reported here where the cause is still
-// known. The warning covers both credentials by asking whether the outgoing request still
-// carries one, rather than assuming a host change drops it: net/http compares hostnames
-// with the port excluded, so it keeps Authorization across a port-only change and across
-// apex-to-subdomain, both of which this function still treats as a host change.
-func (watcher *Watcher) dropCredentialOnHostChange(request *http.Request, via []*http.Request) error {
+// A step down from https to http is refused: net/http compares only hostnames when
+// deciding to carry Authorization, so the credential would otherwise reach a plaintext
+// hop. The scheme is compared against the hop just taken, so a deployment that starts on
+// http keeps working.
+//
+// The deploy-token header is stripped when the redirect leaves the original host: net/http
+// does that for Authorization but not for custom headers, and the deploy token authorizes
+// git write-back for every application. Losing it turns off write-back, which surfaces
+// later as a rollout that fails blaming the image or the timeout, so it is reported here
+// where the cause is still known. The warning asks whether the outgoing request still
+// carries a credential rather than assuming a host change drops it — net/http compares
+// hostnames with the port excluded, so Authorization survives a port-only change.
+func (watcher *Watcher) guardRedirect(request *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+
+	previous := via[len(via)-1]
+	if previous.URL.Scheme == "https" && request.URL.Scheme != "https" {
+		return fmt.Errorf("%w: %q redirected to %q. Point ARGO_WATCHER_URL at the https endpoint",
+			errInsecureRedirect, previous.URL.Host, request.URL.Scheme+"://"+request.URL.Host)
 	}
 
 	if request.URL.Host == via[0].URL.Host {

--- a/internal/client/credential_test.go
+++ b/internal/client/credential_test.go
@@ -404,12 +404,12 @@ func TestCrossHostRedirectIsReported(t *testing.T) {
 	})
 }
 
-// TestDropCredentialOnHostChangeRedirectLimit drives the hook directly rather than through
+// TestGuardRedirectLimit drives the hook directly rather than through
 // httptest, so the redirect-limit arm is not paid for at getJSON's transient-retry
 // backoff. Setting CheckRedirect replaces net/http's own limit, making this branch the only
 // thing bounding a redirect loop — and it must return before the credential is touched, or
 // a request that is never sent would still report write-back as lost.
-func TestDropCredentialOnHostChangeRedirectLimit(t *testing.T) {
+func TestGuardRedirectLimit(t *testing.T) {
 	newRequest := func(t *testing.T, rawURL string) *http.Request {
 		t.Helper()
 		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
@@ -443,7 +443,7 @@ func TestDropCredentialOnHostChangeRedirectLimit(t *testing.T) {
 
 		var err error
 		output := capture(t, func() {
-			err = watcher.dropCredentialOnHostChange(request, via(t, maxRedirects))
+			err = watcher.guardRedirect(request, via(t, maxRedirects))
 		})
 
 		require.EqualError(t, err, "stopped after 10 redirects")
@@ -459,13 +459,114 @@ func TestDropCredentialOnHostChangeRedirectLimit(t *testing.T) {
 
 		var err error
 		output := capture(t, func() {
-			err = watcher.dropCredentialOnHostChange(request, via(t, maxRedirects-1))
+			err = watcher.guardRedirect(request, via(t, maxRedirects-1))
 		})
 
 		require.NoError(t, err)
 		assert.Empty(t, request.Header.Get(deployTokenHeader))
 		assert.Contains(t, output, "without git write-back")
 	})
+}
+
+// net/http keeps Authorization across an https -> http redirect to the same hostname, so
+// without this guard a Location header can move a credentialed request onto plaintext. A
+// deployment that starts on http is a deliberate choice and must keep working.
+func TestRedirectSchemeDowngrade(t *testing.T) {
+	newRequest := func(t *testing.T, rawURL string) *http.Request {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		require.NoError(t, err)
+		return req
+	}
+
+	newWatcher := func() *Watcher {
+		return setupWatcher(&Config{Url: "https://origin.example.com", Token: "s3cr3t-deploy-token", Timeout: time.Second})
+	}
+
+	cases := []struct {
+		name    string
+		via     []string
+		target  string
+		refused bool
+	}{
+		{name: "https to http on the same host", via: []string{"https://origin.example.com/"}, target: "http://origin.example.com/", refused: true},
+		{name: "https to http on another host", via: []string{"https://origin.example.com/"}, target: "http://elsewhere.example.com/", refused: true},
+		{name: "https to https", via: []string{"https://origin.example.com/"}, target: "https://origin.example.com/moved"},
+		{name: "http to http", via: []string{"http://origin.example.com/"}, target: "http://origin.example.com/moved"},
+		{name: "http to https", via: []string{"http://origin.example.com/"}, target: "https://origin.example.com/"},
+		{
+			// Compared against the hop just taken, not the first request.
+			name:    "http upgraded to https then downgraded",
+			via:     []string{"http://origin.example.com/", "https://origin.example.com/"},
+			target:  "http://origin.example.com/",
+			refused: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			via := make([]*http.Request, 0, len(tc.via))
+			for _, rawURL := range tc.via {
+				via = append(via, newRequest(t, rawURL))
+			}
+
+			err := newWatcher().guardRedirect(newRequest(t, tc.target), via)
+
+			if !tc.refused {
+				assert.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, errInsecureRedirect)
+			// The operator has to be able to tell which hop downgraded, and the secret
+			// must never reach a CI log.
+			assert.Contains(t, err.Error(), mustHost(t, tc.via[len(tc.via)-1]))
+			assert.Contains(t, err.Error(), mustHost(t, tc.target))
+			assert.Contains(t, err.Error(), "ARGO_WATCHER_URL")
+			assert.NotContains(t, err.Error(), "s3cr3t-deploy-token")
+		})
+	}
+
+	// The refusal is unconditional: a plaintext hop is refused even with nothing to
+	// expose, so the guard cannot be defeated by adding a token to a working pipeline.
+	t.Run("refused with no credential configured", func(t *testing.T) {
+		watcher := setupWatcher(&Config{Url: "https://origin.example.com", Timeout: time.Second})
+
+		err := watcher.guardRedirect(
+			newRequest(t, "http://origin.example.com/"),
+			[]*http.Request{newRequest(t, "https://origin.example.com/")},
+		)
+
+		require.ErrorIs(t, err, errInsecureRedirect)
+	})
+}
+
+func TestRedirectDowngradeIsRefusedInFlight(t *testing.T) {
+	var plainSaw string
+	var plainHits int
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		plainHits++
+		plainSaw = r.Header.Get(deployTokenHeader)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(models.TaskStatus{Status: models.StatusDeployedMessage, Id: taskId})
+	}))
+	defer plain.Close()
+
+	var originHits int
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originHits++
+		http.Redirect(w, r, plain.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	watcher := setupWatcher(&Config{Url: origin.URL, Token: "s3cr3t-deploy-token", Timeout: 30 * time.Second})
+	watcher.client.Transport = origin.Client().Transport // trust the test server's certificate
+
+	_, err := watcher.getTaskStatus(taskId)
+
+	require.ErrorIs(t, err, errInsecureRedirect)
+	assert.Zero(t, plainHits, "the plaintext hop must never be made")
+	assert.Empty(t, plainSaw)
+	assert.Equal(t, 1, originHits, "a downgrade is permanent, so it must not be retried")
 }
 
 func mustPort(t *testing.T, rawURL string) string {

--- a/internal/client/utility.go
+++ b/internal/client/utility.go
@@ -62,6 +62,9 @@ func (watcher *Watcher) getJSON(url string, v interface{}) error {
 func (watcher *Watcher) getJSONOnce(url string, v interface{}) error {
 	resp, err := watcher.doRequest(http.MethodGet, url, nil)
 	if err != nil {
+		if errors.Is(err, errInsecureRedirect) {
+			return err // a misconfiguration, not a blip — retrying never clears it
+		}
 		// Network-level failure: connection refused/reset, DNS, timeout.
 		return transientError{err}
 	}


### PR DESCRIPTION
The client followed a redirect that stepped down from `https` to plain `http` while still
carrying its credential. Go's HTTP client compares only hostnames when deciding whether
`Authorization` may cross a redirect, so a `Location` header pointing at `http://` on the
same host handed the CI JWT to a plaintext hop; the deploy-token header was dropped only
when the host itself changed.

`guardRedirect` (formerly `dropCredentialOnHostChange`) now refuses such a redirect before
the request is sent, so the plaintext hop never happens. The error names both endpoints and
points at `ARGO_WATCHER_URL`, and it is classified as terminal rather than retried as a
transient network failure — the redirect is a property of the configuration, not a blip.

The scheme is compared against the hop just taken rather than the original request, so a
chain that has reached TLS cannot step back off it. A client deliberately pointed at an
`http://` URL is unaffected, as is any redirect that stays on `https`.

Covered by a table over the scheme combinations — including the credential-less case, since
the refusal is unconditional by design — plus an end-to-end test over a real TLS server
redirecting to a plaintext one, asserting the plaintext handler is never reached and the
origin is hit exactly once. Documented under Security in the changelog, with a
troubleshooting entry for the new failure.