### PR TITLE
docs: revalidate every page against the code and cut the bloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,25 @@ Argo Watcher bridges the gap between your CI pipeline and Argo CD, providing rea
 
 </div>
 
-## The Problem
+## The problem
 
-In a typical GitOps workflow, a CI pipeline builds an image, pushes it to a registry, and updates a Git repository. Argo CD then detects the change and deploys the new image. The problem is that the CI pipeline has no direct knowledge of the deployment's outcome. Did it succeed? Did it fail? The pipeline is left in the dark.
+A CI pipeline builds an image, pushes it, and updates a Git repository. Argo CD picks the change up and deploys it — and the pipeline never learns the outcome. Did the rollout succeed? Did it fail? It reports success either way.
 
-## The Solution
+## The solution
 
-Argo Watcher introduces a control loop that monitors your Argo CD applications for health and sync status changes. It acts as a bridge, reporting the deployment's final state back to the CI pipeline. This provides a clear, synchronous result for an asynchronous process.
+Argo Watcher watches the Argo CD application for the images the pipeline just built and reports the deployment's final state back to it, turning an asynchronous process into a result the pipeline can branch on.
 
-## Key Features
+## Features
 
-- **Deployment Tracking**: Monitors Argo CD applications and reports on their health and sync status.
-- **CI Integration**: A lightweight client that can be integrated into any CI/CD pipeline to wait for a successful deployment.
-- **Real-time Web UI**: A comprehensive dashboard to visualize deployment status, history, and application state.
-- **Built-in GitOps Updater**: An optional, standalone service to update image tags in your GitOps repository, as an alternative to the Argo CD Image Updater.
-- **Deployment Locking**: Schedule maintenance windows or manually lock deployments to prevent unintended changes.
-- **Notifications**: Send deployment status notifications to webhooks.
-- **Authentication**: Supports JWT and any OIDC provider (Keycloak, Authentik, …) for secure access to the server and UI.
+- **Deployment tracking** — monitors health and sync status of Argo CD applications.
+- **CI client** — a small binary that waits for the deployment and exits with a matching status code.
+- **Real-time Web UI** — deployment status, history, and per-task detail, pushed over a WebSocket.
+- **Built-in GitOps updater** — optionally commits image tags to your GitOps repository, replacing Argo CD Image Updater.
+- **Deployment lock** — freeze deployments on a schedule or on demand.
+- **Notifications** — webhook or Mattermost, on deployment start and result.
+- **Authentication** — a deploy token or JWT for pipelines, any OIDC provider (Keycloak, Authentik, …) for the Web UI.
 
 ## Architecture
-
-Argo Watcher consists of three main components: the **Server**, the **Client**, and the **Web UI**.
 
 ```mermaid
 graph LR
@@ -69,16 +67,14 @@ graph LR
     Server -- "Report Result" --> Client
 ```
 
-## How It Works
+## How it works
 
-1.  **Trigger**: Your CI pipeline builds a new image and pushes it to a registry.
-2.  **Monitor**: The pipeline then runs the Argo Watcher client, telling it which application and image to track.
-3.  **Update**: The image tag is updated in your GitOps repository, either by the Argo CD Image Updater or Argo Watcher's built-in updater.
-4.  **Deploy**: Argo CD detects the change and starts deploying the new image.
-5.  **Track & Report**: The Argo Watcher server continuously polls the Argo CD API. As the deployment progresses, it streams status updates to the Web UI and reports the final status (e.g., `deployed`, `failed`) back to the client.
-6.  **Complete**: The client exits with a status code that reflects the deployment outcome, allowing your CI pipeline to proceed or fail accordingly.
+1. Your pipeline builds and pushes an image, then runs the Argo Watcher client with the application and image to track.
+2. The tag is updated in your GitOps repository — by Argo Watcher's built-in updater, or by Argo CD Image Updater.
+3. Argo CD syncs, while the server polls its API and streams the task's progress to the Web UI.
+4. The final status (`deployed`, `failed`, …) goes back to the client, which exits accordingly, and your pipeline proceeds or fails.
 
-## Getting Started
+## Getting started
 
 The fastest way to try Argo Watcher is the bundled Docker Compose stack. It runs the server, a Postgres database, the Web UI, and a mock Argo CD, so you can exercise the full task lifecycle locally without a cluster:
 
@@ -94,11 +90,11 @@ To deploy to a real Kubernetes cluster with Helm and wire the client (`ghcr.io/s
 
 ## Documentation
 
-For more detailed information on configuration, API usage, and advanced features, please visit our documentation at [argo-watcher.readthedocs.io](https://argo-watcher.readthedocs.io).
+Configuration, the API, and every guide: [argo-watcher.readthedocs.io](https://argo-watcher.readthedocs.io).
 
 ## Contributing
 
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome — **open an issue before writing code**. What a change needs to satisfy is in [CONTRIBUTING.md](.github/CONTRIBUTING.md); local setup is in the [Development guide](https://argo-watcher.readthedocs.io/en/latest/contributing/development/).
 
 ## License
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,253 +1,134 @@
 # Development
 
-This guide covers setting up a local development environment for Argo Watcher.
+Setting up a local environment. What a change must satisfy before it can be merged is in [CONTRIBUTING.md](https://github.com/shini4i/argo-watcher/blob/main/.github/CONTRIBUTING.md).
 
 ## Prerequisites
 
-- **Go 1.26+**
-- **Node.js 24+** (for frontend development; `nix develop` provides it)
-- **Docker** and **Docker Compose** (for running dependencies locally)
-- **[Task](https://taskfile.dev/)** (task runner, replaces Make)
-- **[pre-commit](https://pre-commit.com/)** (Git hooks for code quality)
+- **Go** — the version in `go.mod` is authoritative
+- **Node.js 24+** for the frontend
+- **Docker** and Docker Compose
+- **[Task](https://taskfile.dev/)** — every automation lives in `Taskfile.yml`
+- **[pre-commit](https://pre-commit.com/)** — `pre-commit install`
 
-Install the Git hooks:
+`nix develop` provides all of the above plus the scanners CI runs (`trufflehog`, `gosec`, `govulncheck`, `trivy`, `zizmor`). Without Nix, install `trufflehog` yourself — one pre-commit hook is a secret scan and fails without it.
 
-```bash
-pre-commit install
-```
-
-One hook is a [TruffleHog](https://github.com/trufflesecurity/trufflehog) secret scan that needs the `trufflehog` binary on `$PATH`. `nix develop` provides it along with the other scanners used in CI (`gosec`, `govulncheck`, `trivy`, `zizmor`); without Nix, install `trufflehog` manually.
-
-Install Go tooling (mock generator, swagger, migration tool):
+Then install the Go tooling (`swag`, `mockgen`, `migrate`):
 
 ```bash
 task install-deps
 ```
 
-## Task Runner
-
-The project uses [Task](https://taskfile.dev/) as a build and automation tool. All common development operations are defined in `Taskfile.yml`.
-
-### Available Tasks
-
-| Task                | Description                                                       |
-|---------------------|-------------------------------------------------------------------|
-| `task install-deps` | Install Go development tools (swag, mockgen, migrate)              |
-| `task mocks`        | Generate mock interfaces for unit tests                            |
-| `task docs`         | Generate the Swagger JSON spec                                     |
-| `task test`         | Run the full test suite (generates mocks and docs first)           |
-| `task test-integration` | Run integration tests against live Gitea, Toxiproxy + Keycloak (requires Docker) |
-| `task build`        | Build the Go binary                                                 |
-| `task build-ui`     | Build the React frontend bundle                                    |
-| `task lint-web`     | Lint the React frontend code                                       |
-| `task test-web`     | Run React frontend unit tests                                      |
-| `task test-web-e2e` | Run the Playwright browser suite against the built UI (requires Docker) |
-| `task bootstrap`    | Start all Docker Compose services                                  |
-| `task teardown`     | Stop all Docker Compose services                                   |
-
-Run any task with:
+## Everything with Docker Compose
 
 ```bash
-task <task-name>
-```
-
-## Quick Start with Docker Compose
-
-The fastest way to get a full development environment running:
-
-```bash
-task bootstrap
-```
-
-This starts PostgreSQL, runs database migrations, and prepares the backend and frontend services via Docker Compose.
-
-To stop everything:
-
-```bash
+task bootstrap    # postgres + migrations + backend + frontend + mock Argo CD
 task teardown
 ```
 
-## Back-End Development
+The Web UI is then on [http://localhost:3100](http://localhost:3100) and the API on `8080`. See the [Quick Start](../getting-started/quick-start.md) for driving a task through it.
 
-If you prefer to run services individually without Docker Compose, follow the steps below.
+## Running the pieces directly
 
-### Generate Mocks and Swagger Spec
-
-Before compiling or testing, generate the required mock classes and swagger spec:
+Generated mocks and the Swagger spec are inputs to the build, so create them first:
 
 ```bash
 task mocks
 task docs
 ```
 
-### Start the Mock Argo CD Server
-
-The project includes a mock Argo CD server for local development:
+Start the mock Argo CD (port `8081`):
 
 ```bash
-cd cmd/mock
-go run .
+go run ./cmd/mock
 ```
 
-This starts a mock server on port `8081` that simulates the Argo CD API.
-
-### Start Argo Watcher (In-Memory Mode)
-
-For development without a database:
+Then the server, in-memory:
 
 ```bash
-cd cmd/argo-watcher
-go mod download
-LOG_LEVEL=debug ARGO_URL=http://localhost:8081 ARGO_TOKEN=example STATE_TYPE=in-memory go run .
+LOG_LEVEL=debug ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
+  STATE_TYPE=in-memory go run ./cmd/argo-watcher
 ```
 
-### Start Argo Watcher (PostgreSQL Mode)
-
-Start the database and run migrations:
+Or against Postgres:
 
 ```bash
 docker compose up -d postgres migrations
+
+LOG_LEVEL=debug ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
+  STATE_TYPE=postgres DB_HOST=localhost DB_PORT=5432 \
+  DB_USER=watcher DB_PASSWORD=watcher DB_NAME=watcher \
+  go run ./cmd/argo-watcher
 ```
 
-Then start the server:
-
-```bash
-cd cmd/argo-watcher
-go mod tidy
-LOG_LEVEL=debug \
-  ARGO_URL=http://localhost:8081 \
-  ARGO_TOKEN=example \
-  STATE_TYPE=postgres \
-  DB_USER=watcher \
-  DB_PASSWORD=watcher \
-  DB_NAME=watcher \
-  go run .
-```
-
-## Front-End Development
+The frontend dev server, with hot reload on [http://localhost:5173](http://localhost:5173), proxies `/api` and `/ws` to `localhost:8080`:
 
 ```bash
 cd web
 npm install
-npm start
+npm run dev
 ```
 
-The development server opens at [http://localhost:3000](http://localhost:3000).
+## Tasks
 
-## Running Tests
+| Task | Description |
+|---|---|
+| `task install-deps` | Install `swag`, `mockgen` and `migrate` |
+| `task mocks` | Generate the gomock mocks (into the gitignored `internal/mocks/`) |
+| `task docs` | Generate the Swagger spec into `web/public/swagger/` |
+| `task build` | Build the server binary |
+| `task build-ui` | Build the frontend bundle into `web/dist` |
+| `task test` | Backend tests (generates mocks and docs first) |
+| `task test-integration` | GitOps updater against real Gitea + Toxiproxy, and the Keycloak auth flow (Docker) |
+| `task test-web` | Frontend unit tests (Vitest) |
+| `task test-web-e2e` | Playwright browser suite against the built UI (Docker) |
+| `task lint-web` | Lint the frontend (oxlint) |
+| `task bootstrap` / `task teardown` | Bring the Compose stack up / down |
 
-### Full Test Suite
+`task --list` shows the rest, including the kind-cluster helpers.
 
-Run all backend tests (this also generates mocks and swagger docs automatically):
+## Tests
 
-```bash
-task test
-```
-
-### Backend Unit Tests Only
-
-```bash
-cd cmd/argo-watcher
-go test -v ./...
-```
-
-To run a specific test suite:
+`task test` needs Postgres on `localhost:5432` with the credentials above — `docker compose up -d postgres migrations` provides exactly that. A single suite:
 
 ```bash
 go test -v -run TestArgoStatusUpdaterCheck ./...
 ```
 
-### Integration Tests
+**Integration tests** (`task test-integration`) exercise the GitOps updater against a real Gitea with TCP fault injection through Toxiproxy, plus privileged and unprivileged access to the deploy lock against a real Keycloak. The task brings the `integration` Compose profile up and tears it down afterwards; if a previous run is still up, `docker compose --profile integration down -v` first to avoid port conflicts.
 
-Integration tests exercise the GitOps updater against a real Gitea instance with TCP fault injection via Toxiproxy, and the Keycloak auth flow (privileged vs non-privileged access to the deploy lock) against a real Keycloak. Docker must be running before you start them.
+**Browser tests** (`task test-web-e2e`) cover what jsdom cannot: the top-level OIDC redirect and the path it returns to, session recovery across a reload, the server's SPA fallback for deep-linked task URLs, the live WebSocket behind the deploy-lock banner, and the privileged write flows for a privileged versus a regular user. The task builds `web/dist`, brings Keycloak up, and lets Playwright start two servers (`8100` without OIDC, `8101` with) plus the mock Argo CD. Specs live in `web/e2e/`.
 
-```bash
-task test-integration
-```
+**The end-to-end lab** in [`test/e2e/`](https://github.com/shini4i/argo-watcher/tree/main/test/e2e) runs real Argo CD, Gitea and a race-detector build on a kind cluster, once per release. Its README covers the phases and how to add one.
 
-This command brings up the `integration` Docker Compose profile (Gitea, Toxiproxy, and Keycloak), runs the tests, then tears the stack down automatically. If the integration stack is already running from a previous session, run `docker compose --profile integration down -v` before re-running the task to avoid port conflicts.
+## Swagger spec
 
-### Frontend Tests
+The spec is generated from [swag](https://github.com/swaggo/swag) annotations on the handlers — the annotations are the source of truth, so update them in the same commit as a route or model change. `task docs` regenerates `web/public/swagger/swagger.json` (gitignored); `task build-ui` copies the Swagger UI assets next to it into `web/dist/swagger/`. The server then serves the explorer at `/swagger/index.html`.
 
-```bash
-task test-web
-```
-
-### Browser (Playwright) Tests
-
-The jsdom suite above mounts components directly and has no real navigation, so a
-separate Playwright suite covers what only a browser can show: the top-level OIDC
-redirect and the path it returns to, session recovery across a reload, the Go
-server's SPA fallback for deep-linked task URLs, the live WebSocket driving the
-deploy-lock banner, and the privileged write flows (rollback, toggling the lock)
-with their gating for a privileged vs a regular user. Docker must be running.
-
-```bash
-task test-web-e2e
-```
-
-The task builds `web/dist`, brings Keycloak up from the `integration` Compose
-profile, and lets Playwright start the servers it drives: two `argo-watcher`
-instances (ports 8100 without OIDC, 8101 with) plus the mock Argo CD API. Both
-serve the built bundle as static files, which is how the production image runs.
-Specs live in `web/e2e/`, split into the `no-auth` and `auth` projects.
-
-### Frontend Linting
-
-```bash
-task lint-web
-```
-
-## Swagger Documentation
-
-The Swagger spec is generated from Go annotations in the source code using [swag](https://github.com/swaggo/swag).
-
-To regenerate the spec:
-
-```bash
-task docs
-```
-
-This outputs `web/public/swagger/swagger.json`. During `task build-ui`, Vite copies the Swagger UI assets alongside the spec into `web/dist/swagger/`.
-
-!!! note
-    Regenerate the spec whenever API annotations, request/response models, or documented routes change.
-
-Once the server is running, the Swagger UI is accessible at:
-
-```text
-http://localhost:8080/swagger/index.html
-```
-
-For a summary of available API endpoints, see the [API Reference](../reference/api.md) page.
-
-## Project Structure
+## Layout
 
 ```text
 cmd/
-  argo-watcher/     # Main server binary
+  argo-watcher/     # server binary
   client/           # CLI client binary
-  mock/             # Mock Argo CD server for development
-db/
-  migrations/       # PostgreSQL migration files
-docs/               # MkDocs documentation source
+  mock/             # mock Argo CD for local development
+db/migrations/      # PostgreSQL migrations
+docs/               # this documentation (MkDocs)
 internal/
-  argocd/           # Argo CD API client and git write-back
-  auth/             # Authentication (OIDC, JWT, deploy token)
-  client/           # CLI client logic
-  config/           # Environment-variable configuration
-  helpers/          # Shared utility functions
-  lock/             # Deployment lock logic
+  argocd/           # Argo CD client, rollout monitoring, git write-back
+  auth/             # OIDC, JWT and deploy-token authentication
+  client/           # client logic
+  config/           # environment-variable configuration
+  helpers/          # shared utilities
+  lock/             # deployment lock
   logging/          # slog setup
-  migrate/          # Database migration runner
-  mocks/            # Generated gomock mocks for tests (gitignored, `task mocks`)
-  models/           # Data models
-  notifications/    # Webhook notification sender
-  prometheus/       # Metrics definitions
-  server/           # HTTP server and routes
-  state/            # State management (in-memory and PostgreSQL)
-  updater/          # GitOps updater logic
-test/
-  e2e/              # Disposable kind-based end-to-end lab
+  migrate/          # migration runner
+  mocks/            # generated mocks (gitignored)
+  models/           # data models
+  notifications/    # webhook and Mattermost notifiers
+  prometheus/       # metrics
+  server/           # HTTP server, routes, WebSocket
+  state/            # in-memory and PostgreSQL state
+  updater/          # git operations
+test/e2e/           # kind-based end-to-end lab
 web/                # React/TypeScript frontend
 ```

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,7 +1,5 @@
 # Contributing
 
-Guidelines for contributing to Argo Watcher.
-
-- **[Contribution Guide](https://github.com/shini4i/argo-watcher/blob/main/.github/CONTRIBUTING.md)** — What is expected of a change before it can be merged: project standards, test coverage, and the issue-first workflow.
-- **[Development](development.md)** — Set up a local development environment and build from source.
-- **[Style Guide](style.md)** — Documentation style conventions.
+- **[Contribution Guide](https://github.com/shini4i/argo-watcher/blob/main/.github/CONTRIBUTING.md)** — what a change must satisfy before it can be merged.
+- **[Development](development.md)** — set up a local environment and run the suites.
+- **[Style Guide](style.md)** — documentation conventions.

--- a/docs/contributing/style.md
+++ b/docs/contributing/style.md
@@ -1,71 +1,50 @@
 # Documentation Style Guide
 
-## Bullets
+Conventions for the pages under `docs/`. The goal is a page a reader can act on, not a page that covers everything.
 
-Use `-` for all bullet points. Do not use `--`.
+## Writing
 
-```markdown
-- Item one
-- Item two
-  - Nested item
-```
-
-## Admonitions
-
-Use the correct admonition type for the context:
-
-- `!!! warning` — For actual warnings: data loss, breaking changes, security issues, or irreversible actions.
-- `!!! tip` — For optional optimizations, best practices, or helpful hints.
-- `!!! note` — For asides, additional context, or clarifications that don't fit the main flow.
+- Lead with what the reader needs. Background comes after, or not at all.
+- Cut anything that survives deletion without changing the meaning.
+- Prefer a table or a code block over a paragraph describing the same thing.
+- Explain a *why* only when it is not obvious and still true — a security trade-off, an upstream bug, a counter-intuitive constraint. Never document what the code used to do.
+- Address the reader as "you"; call the software "Argo Watcher".
 
 ## Terminology
 
-Keep terminology consistent across all docs:
+- **Argo Watcher** — the product. Two words, both capitalized, never hyphenated. `argo-watcher` only when naming the binary, image, or Helm release.
+- **Argo CD** — two words, no hyphen.
+- **GitOps** — capital G and O, no hyphen.
+- **Web UI** — not "web interface" or "the frontend".
+- **deploy token** — lowercase in prose; `ARGO_WATCHER_DEPLOY_TOKEN` when naming the variable.
 
-- **Argo Watcher** — The product name. Always hyphenated and capitalized.
-- **Argo CD** — Two words, no hyphen, both capitalized.
-- **deploy token** — Lowercase when used as a prose noun. `DEPLOY_TOKEN` when referring to an environment variable name.
-- **GitOps** — Capital G and O, no hyphen.
-- **Web UI** — Always "Web UI", not "web interface" or "UI".
+## Formatting
 
-## Tables
+- **Bullets** use `-`.
+- **Dashes** in prose are em dashes (`—`), never `--`.
+- **Headings**: `#` for the page title, `##` for sections, `###` below that. Short and descriptive — headings are anchors other pages link to, so renaming one means updating those links.
+- **Tables**: left-align text, right-align numbers (`|---:|`), skip centre alignment.
+- **Code**: always tag the language on a fenced block. Backtick variables, paths, headers and commands inline.
 
-- **String columns** — Left-align.
-- **Numeric columns** — Right-align.
-- **Avoid centre alignment.**
+## Admonitions
 
-Use the `right` attribute in markdown table syntax when needed:
+Use the type that matches the stakes, and keep them rare — a page of admonitions reads as a page of noise.
 
-```markdown
-| Name | Count |
-|------|------:|
-| Item | 42    |
-```
+- `!!! warning` — data loss, a security consequence, or something irreversible.
+- `!!! note` — a caveat or clarification that would interrupt the main flow.
+- `!!! tip` — an optional improvement.
 
-## Code and Commands
+## Links
 
-- Inline code: use backticks for variables, file paths, and command names.
-- Code blocks: specify the language for syntax highlighting.
-- Commands: use code formatting for environment variables and flags.
-
-## Headings
-
-- Use `#` for page titles (H1).
-- Use `##` for major sections.
-- Use `###` for subsections.
-- Keep heading text short and descriptive.
-
-## Cross-references
-
-Use relative links: `[text](../other-page.md)` or `[text](../section/page.md)`.
+Use relative paths between pages: `[Installation](../guides/install.md)`. `mkdocs build --strict` fails on a broken one, so it is worth running before opening a PR.
 
 ## Images
 
-Include a `<figcaption>` with every image to provide context:
+Include alt text describing what the image shows. Wrap it in a `<figure>` when a caption adds something the surrounding prose does not:
 
 ```markdown
 <figure markdown="span">
-  ![Alt text](path/to/image.png)
-  <figcaption>Descriptive caption</figcaption>
+  ![Deployment lock toggle](path/to/image.png)
+  <figcaption>The lock toggle appears only for privileged users.</figcaption>
 </figure>
 ```

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,89 +1,56 @@
 # Concepts
 
-## What is Argo Watcher?
+## The problem
 
-A feedback loop for your GitOps workflow. Argo Watcher bridges the gap between your CI pipeline and Argo CD, providing real-time status and visibility into your deployments. Stop guessing whether your deployment succeeded — Argo Watcher tells your pipeline exactly what happened.
+A CI pipeline builds an image, pushes it, and updates a Git repository. Argo CD picks the change up and deploys it. The pipeline never learns the outcome: it cannot tell a successful rollout from a failed one, so it reports success as soon as the commit lands.
 
-## The Problem
+## The solution
 
-In a typical GitOps workflow, a CI pipeline builds an image, pushes it to a registry, and updates a Git repository. Argo CD then detects the change and deploys the new image. The problem is that the CI pipeline has **no direct knowledge of the deployment outcome**. Did it succeed? Did it fail? The pipeline is left in the dark.
+Argo Watcher watches the Argo CD application for the images the pipeline just built and reports the deployment's final state back to it — turning an asynchronous process into a result the pipeline can branch on.
 
-## The Solution
+## Server, client, and updater
 
-Argo Watcher introduces a control loop that monitors your Argo CD applications for health and sync status changes. It acts as a bridge, reporting the deployment's final state back to the CI pipeline. This provides a clear, synchronous result for an asynchronous process.
+- **Server** — the long-running service. It talks to Argo CD, persists task state, exposes the HTTP API, and serves the Web UI, which shows every task in real time.
+- **Client** — a small CLI for CI/CD pipelines. It creates a task, waits for the result, and exits with a matching status code.
+- **Updater** — an optional part of the server that commits image-tag changes to your GitOps repository, replacing Argo CD Image Updater.
 
-## Architecture: Server, Client, and Updater
+## Task lifecycle
 
-Argo Watcher is composed of three concerns. The **Server** is the long-running service that talks to Argo CD, persists task state, exposes the HTTP API, and serves the Web UI. The **Client** is a lightweight CLI that runs inside CI/CD pipelines — it creates a task, waits for the result, and exits with a status code that the pipeline can branch on. The **Updater** is an optional subsystem inside the server that commits image-tag changes to your GitOps repository, replacing Argo CD Image Updater for projects that prefer a single tool.
+`POST /api/v1/tasks` answers `202 Accepted` with `"status": "accepted"`; the task itself is stored as **in progress** and then moves to one of the terminal states below.
 
-The Web UI is bundled with the server and gives operators a real-time view of every task as it transitions through its lifecycle.
+| Status | Meaning |
+|---|---|
+| `in progress` | Waiting for the requested images to be running, synced, and healthy. |
+| `deployed` | The application is synced and healthy with the requested images. |
+| `failed` | Argo CD reported a health or sync failure, `DEPLOYMENT_TIMEOUT` elapsed, or the application finished rolling out without ever declaring the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)). |
+| `app not found` | Argo CD has no application with that name, or the token cannot see it. |
+| `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure (`failed_deployment`); `argocd_unavailable` tells you whether Argo CD was the reason. |
+| `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure. |
 
-## Task Lifecycle
+Two rules keep supersession from cancelling unrelated work: only in-progress tasks that share an image with the new deployment are cancelled, and a deployment can only cancel one that presented no more authority than itself — a task submitted without a credential never cancels one submitted with a valid deploy token or JWT.
 
-A task in Argo Watcher moves through the following states:
+## Deployment locking
 
-1. **Pending** — Task created, waiting for the expected image to appear in Argo CD.
-2. **In Progress** — Image detected in Argo CD, deployment is syncing or running.
-3. **Deployed** — Deployment succeeded; application is healthy and synced.
-4. **Failed** — Deployment did not become healthy and synced before `DEPLOYMENT_TIMEOUT` elapsed, Argo CD reported a health/sync failure, or the application finished rolling out without ever defining the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)).
-5. **App Not Found** — Argo CD has no application with the requested name (or the token lacks permission to see it).
-6. **Aborted** — Argo Watcher could not confirm the deployment's outcome: Argo CD (or a proxy in front of it) was unreachable during the check (connection refused, DNS failure, TLS error, a timed-out API request, or a 5xx response), or the task remained in progress past the staleness window. The status reason records the cause. An aborted deployment still counts as a failure (`failed_deployment`); the `argocd_unavailable` gauge indicates when Argo CD itself was the reason.
-7. **Cancelled** — Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Only in-progress tasks that share an image with the new deployment are cancelled, so independent per-image deployments of the same application do not cancel each other. A deployment can also only cancel one that presented no more authority than itself: a task submitted without a credential never cancels one submitted with a valid deploy token or JWT. Unlike Failed, a cancelled task is not counted as a deployment failure.
+A lock pauses new deployments, either on a [schedule](../guides/deployment-lock.md#scheduled-lockdown) or [manually](../guides/deployment-lock.md#manual-lockdown), for maintenance windows and emergencies. While it is held every deploy request is rejected. The lock is server-global; there is no per-application lock.
 
-## Deployment Locking
+## Built-in updater vs Argo CD Image Updater
 
-Deployment locking allows you to pause new deployments during maintenance windows or emergency situations. When a deployment is locked, new tasks will fail if their application is locked. Locks can be scheduled or manual and include annotations describing why the lock was applied.
+Argo Watcher can reach your GitOps repository in two ways:
 
-## Built-in GitOps Updater vs Argo CD Image Updater
+- **Built-in GitOps updater** — Argo Watcher commits the image tag itself. One tool, and the commit happens at deploy time instead of on a scan interval.
+- **Argo CD Image Updater** — a separate tool watches the registry and commits; Argo Watcher only monitors the rollout.
 
-Argo Watcher can update image tags in your GitOps repository in two ways:
-
-- **Argo CD Image Updater** — A separate tool that watches registries and commits tag updates. Argo Watcher only monitors the deployment.
-- **Built-in GitOps Updater** — Argo Watcher commits image updates itself, eliminating the need for a separate tool.
-
-Use the built-in updater if you want a simpler architecture. Use Argo CD Image Updater if you prefer a decoupled design or have complex image scanning requirements.
-
-## Deployment Workflows
-
-Argo Watcher supports two primary workflows depending on how image tags are updated in your GitOps repository.
-
-### With Argo CD Image Updater
-
-In this workflow, Argo Watcher only monitors the deployment. The image tag update is handled by Argo CD Image Updater.
+Pick the built-in updater for a simpler architecture, Image Updater if you want registry scanning or a decoupled design. Either way the monitoring half is identical:
 
 ```mermaid
 graph LR
-    Dev[Developer] --> Commit{Commit}
-    Commit --> Pipeline[Pipeline Triggered]
-    Pipeline --> Docker[Image Built]
-    Docker --> Task[Task Added to Argo Watcher]
-    Task --> Check[Check Argo CD API]
-    Check --> Decision{Expected Image?}
-    Decision -->|Yes| Success[Success]
-    Decision -->|No, image not defined by the app| Failed
-    Decision -->|No| Retry[Retry API Check]
-    Retry --> Timeout{Timeout?}
-    Timeout -->|Yes| Failed[Failed]
-    Timeout -->|No| Check
-```
-
-### With Built-in GitOps Updater
-
-In this workflow, Argo Watcher handles both the image tag update and deployment monitoring, eliminating the need for Argo CD Image Updater entirely.
-
-```mermaid
-graph LR
-    Dev[Developer] --> Commit{Commit}
-    Commit --> Pipeline[Pipeline Triggered]
-    Pipeline --> Docker[Image Built]
-    Docker --> Task[Task Added to Argo Watcher]
-    Task --> ImageUpdate[Commit to GitOps Repo]
-    ImageUpdate --> Check[Check Argo CD API]
-    Check --> Decision{Expected Image?}
-    Decision -->|Yes| Success[Success]
-    Decision -->|No, image not defined by the app| Failed
-    Decision -->|No| Retry[Retry API Check]
-    Retry --> Timeout{Timeout?}
-    Timeout -->|Yes| Failed[Failed]
-    Timeout -->|No| Check
+    Pipeline[Pipeline] --> Docker[Image built]
+    Docker --> Task[Task created in Argo Watcher]
+    Task --> Update["Commit to GitOps repo<br/>(built-in updater only)"]
+    Update --> Check[Check Argo CD API]
+    Check --> Decision{Expected image?}
+    Decision -->|Yes| Success[deployed]
+    Decision -->|Not declared by the app| Failed[failed]
+    Decision -->|Not yet| Retry[Retry until timeout]
+    Retry --> Check
 ```

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,6 +1,4 @@
 # Getting Started
 
-New to Argo Watcher? Start here.
-
-- **[Quick Start](quick-start.md)** — Get a running instance in 5 minutes with Docker Compose.
-- **[Concepts](concepts.md)** — Understand the architecture, problem, and key ideas behind Argo Watcher.
+- **[Quick Start](quick-start.md)** — a running instance in five minutes, with Docker Compose.
+- **[Concepts](concepts.md)** — the problem, the pieces, and the task lifecycle.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,16 +1,14 @@
 # Quick Start
 
-Get a running Argo Watcher instance in five minutes. This walkthrough uses the project's bundled Docker Compose stack, which includes the server, a Postgres database, the Web UI, and a mock Argo CD service so you can exercise the full task lifecycle without a real Argo CD cluster.
+Run Argo Watcher locally in five minutes. The bundled Docker Compose stack includes the server, Postgres, the Web UI, and a mock Argo CD, so you can drive a full task lifecycle without a cluster.
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
-- [Git](https://git-scm.com/) for cloning the repository
-- [`curl`](https://curl.se/) (or any HTTP client)
+- [Git](https://git-scm.com/)
+- [`curl`](https://curl.se/) and [`jq`](https://jqlang.github.io/jq/)
 
 ## 1. Start the stack
-
-Clone the repository and bring everything up:
 
 ```bash
 git clone https://github.com/shini4i/argo-watcher.git
@@ -18,32 +16,21 @@ cd argo-watcher
 docker compose up
 ```
 
-Compose starts five services:
+Five services come up: `postgres` (task storage), `migrations` (schema), `mock` (a stand-in Argo CD API on `8081`), `backend` (the server on `8080`), and `frontend` (the Web UI on `3100`).
 
-- `postgres` — Storage backend for tasks.
-- `migrations` — Applies the database schema.
-- `mock` — Stand-in for the Argo CD API on port `8081`.
-- `backend` — The Argo Watcher server on port `8080`.
-- `frontend` — The Web UI on port `3100`.
+The first run spends a couple of minutes compiling the Go binaries.
 
-The first run takes a couple of minutes to compile the Go binaries. Subsequent restarts are much faster.
-
-## 2. Verify the server is healthy
-
-In a new terminal:
+## 2. Check the server is healthy
 
 ```bash
 curl -s http://localhost:8080/readyz
 ```
 
-You should see a `200 OK` response with `{"status":"up"}`, meaning the server is
-serving and its state backend is reachable. See
-[Health and probe endpoints](../reference/api.md#health-and-probe-endpoints) for the
-full set.
+`{"status":"up"}` means the server is serving and its state backend is reachable. See [Health and probe endpoints](../reference/api.md#health-and-probe-endpoints) for the difference between `/readyz` and `/livez`.
 
 ## 3. Submit a task
 
-Create a task that asks Argo Watcher to verify a particular image is deployed:
+The mock Argo CD knows three applications — `app`, `app2` and `app4` — and reports `app` as synced, healthy, and running `app:v0.0.1`. Ask Argo Watcher to confirm exactly that:
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/tasks \
@@ -53,28 +40,26 @@ curl -X POST http://localhost:8080/api/v1/tasks \
 EOF
 ```
 
-The server responds with `202 Accepted` and the task ID:
+The server answers `202 Accepted` with the task id:
 
 ```json
 { "id": "...", "status": "accepted" }
 ```
 
-## 4. Watch the task transition states
-
-Poll the task to see it transition through its lifecycle:
+## 4. Watch the task reach its final state
 
 ```bash
 curl -s "http://localhost:8080/api/v1/tasks/<task-id>" | jq
 ```
 
-Because the mock Argo CD service simulates a successful deployment, the task progresses from `in progress` to `deployed` within a few seconds. Refer to [Concepts → Task Lifecycle](concepts.md#task-lifecycle) for an explanation of each state.
+The task starts as `in progress` and becomes `deployed` within a few seconds. Submit one for an application the mock does not know and it ends as `app not found` instead — [Concepts → Task Lifecycle](concepts.md#task-lifecycle) explains each state.
 
 ## 5. Open the Web UI
 
-Visit [http://localhost:3100](http://localhost:3100) to see the dashboard. You should find your task listed, along with its current status and timing details.
+Visit [http://localhost:3100](http://localhost:3100). Your task is listed with its status and timings.
 
 ## Where to next
 
-- **[Installation](../guides/install.md)** — Deploy Argo Watcher to a real Kubernetes cluster.
-- **[Concepts](concepts.md)** — Understand how the components fit together.
-- **[API Reference](../reference/api.md)** — Explore the full HTTP API.
+- **[Installation](../guides/install.md)** — deploy to a real Kubernetes cluster.
+- **[Concepts](concepts.md)** — how the components fit together.
+- **[API Reference](../reference/api.md)** — the full HTTP API.

--- a/docs/guides/deployment-lock.md
+++ b/docs/guides/deployment-lock.md
@@ -1,0 +1,68 @@
+# Deployment Lock
+
+A deployment lock freezes deploys — for a maintenance window, a release freeze, or an incident. While it is held every `POST /api/v1/tasks` is rejected with `406` and `lockdown is active, deployments are not accepted`. The lock is server-global: it applies to every application, and there is no per-application lock.
+
+There are two ways to hold it: a recurring schedule, and a manual toggle.
+
+## Scheduled lockdown
+
+Set the windows in the chart:
+
+```yaml
+scheduledLockdown:
+  - "Wed 20:00 - Thu 08:00"
+  - "Fri 20:00 - Mon 08:00"
+```
+
+or directly, as one comma-separated string:
+
+```yaml
+extraEnvs:
+  - name: LOCKDOWN_SCHEDULE
+    value: "Wed 20:00 - Thu 08:00, Fri 20:00 - Mon 08:00"
+```
+
+Deploys are then rejected between Wednesday 20:00 and Thursday 08:00, and between Friday 20:00 and Monday 08:00. The Web UI banner appears and disappears on its own within a few seconds of a window opening or closing; no page refresh is needed.
+
+!!! warning
+    Windows are evaluated in the **server's** timezone, which is UTC in the published image unless you set `TZ`.
+
+## Manual lockdown
+
+!!! note
+    Manual locking requires OIDC authentication. Without an auth backend the server does not register `POST`/`DELETE /api/v1/deploy-lock` and the Web UI shows no lock toggle. Scheduled lockdown works either way.
+
+### From the Web UI
+
+Click the **Argo Watcher** logo to open the configuration drawer, then use the switch in its **Deploy Lock** section — it reads *Lock engaged* or *Lock released*. Users outside `OIDC_PRIVILEGED_GROUPS` see the switch disabled, with "Deploy lock requires privileged access."
+
+![Deployment lock toggle in the Web UI](https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher/deployment-lock.png)
+
+### From the API
+
+Both calls need a token from a user in one of the `OIDC_PRIVILEGED_GROUPS`, in the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` name still works):
+
+```bash
+# Hold the lock
+curl -X POST -H "Oidc-Authorization: $TOKEN" \
+  https://argo-watcher.example.com/api/v1/deploy-lock
+
+# Release it
+curl -X DELETE -H "Oidc-Authorization: $TOKEN" \
+  https://argo-watcher.example.com/api/v1/deploy-lock
+```
+
+Reading the state — `GET /api/v1/deploy-lock` — needs no privileged group, though with OIDC enabled it does need some credential like the other reads. See [Protected endpoints](oidc.md#protected-endpoints).
+
+### Releasing during a scheduled window
+
+Releasing the lock inside a scheduled window does not cancel the schedule: it **suppresses it for 15 minutes**, after which the window applies again unless it has closed meanwhile. Setting the lock again clears a pending suppression.
+
+## Multiple replicas
+
+With `STATE_TYPE=postgres` the manual lock and its suppression live in the database, so a lock set through any replica rejects deploys on all of them and survives a restart. Enforcement is immediate — every deploy request resolves the lock state at that moment. Web UI clients see the banner change within a few seconds, when their replica next samples the state; the operator who made the change sees it right away.
+
+With `STATE_TYPE=in-memory` the lock lives in the process that served the request. That is correct for a single replica — the only supported configuration for in-memory state — but it is lost on restart.
+
+!!! warning
+    If the database cannot be read, the lock state is unknown and deploys are rejected as though a lock were held. Rejecting a deployment during an outage is recoverable; letting one through during a freeze is not. See [All deployments rejected as locked](../operations/troubleshooting.md#all-deployments-rejected-as-locked-but-nobody-set-a-lock).

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -1,23 +1,16 @@
-# Git Integration
+# GitOps Updater
 
-Argo Watcher includes a built-in GitOps updater that commits image tag changes directly to your GitOps repository. This eliminates the need for Argo CD Image Updater and removes the additional deployment latency it can introduce when managing a large number of images.
+Argo Watcher can commit image-tag changes to your GitOps repository itself, replacing Argo CD Image Updater. The commit happens as part of the deployment, so there is no scan interval to wait through — which is what makes it faster when many images are in play.
 
-!!! tip
-    If you are currently using Argo CD Image Updater and want to migrate, see the [Migrating from Argo CD Image Updater](#migrating-from-argo-cd-image-updater) section.
+Already on Argo CD Image Updater? See [Migrating from Argo CD Image Updater](#migrating-from-argo-cd-image-updater).
 
 ## Prerequisites
 
-This guide assumes you already have a working Argo Watcher installation. If not, complete the [Installation](install.md) guide first.
+A working [installation](install.md), plus:
 
-Before enabling the GitOps updater, you need to:
-
-1. **Create an authentication secret** (choose one approach):
-    - **Deploy token** -- Generate an arbitrary string and add it to the Argo Watcher Kubernetes secret under the `ARGO_WATCHER_DEPLOY_TOKEN` key. This approach is planned for deprecation in v1.0.0.
-    - **JWT secret (recommended)** -- Generate a secret for signing JWT tokens (see [Generating the JWT Secret](#generating-the-jwt-secret)) and add it to the Argo Watcher Kubernetes secret under the `JWT_SECRET` key.
-
-2. **Create an SSH key secret** -- Generate an SSH key pair and store the private key in a Kubernetes secret. By default, Argo Watcher expects the key under the `sshPrivateKey` field, but this is configurable via the Helm chart.
-
-3. **Update the Helm chart values** -- Add the updater configuration:
+1. **A credential the client can present.** Either a **JWT** (recommended, see [JWT configuration](#jwt-configuration)) stored under the `JWT_SECRET` key of the Argo Watcher secret, or an arbitrary string under `ARGO_WATCHER_DEPLOY_TOKEN` — the deploy token is planned for deprecation in v1.0.0. Without a valid credential the write-back is skipped, and the deployment fails blaming the image instead ([why](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped)).
+2. **An SSH key with write access** to the GitOps repository, stored in a Kubernetes secret (the chart reads the `sshPrivateKey` key by default).
+3. **Chart values pointing at that key:**
 
     ```yaml
     updater:
@@ -26,64 +19,11 @@ Before enabling the GitOps updater, you need to:
       commitEmail: "argo-watcher@example.com"
     ```
 
-## JWT Configuration
+    The chart also mounts a `ssh_known_hosts` file and points `SSH_KNOWN_HOSTS` at it. Host key verification is on, so a host missing from it fails the push — add yours via `updater.extraKnownHosts` or `updater.knownHostsConfigMap`.
 
-JWT is the recommended authentication method for the GitOps updater. It provides fine-grained control over which applications a token can deploy to.
+## Application configuration
 
-### Generating the JWT Secret
-
-The `JWT_SECRET` is a symmetric key used to sign and verify tokens (HMAC). It is not generated for you -- you create it once and store it in the Argo Watcher Kubernetes secret under the `JWT_SECRET` key. The same secret is later used to sign tokens (see [Generating a JWT Token](#generating-a-jwt-token)).
-
-Generate a 256-bit random secret with `openssl`:
-
-```bash
-openssl rand -base64 32
-```
-
-!!! warning
-    Treat this value as a credential. Anyone who knows it can mint valid deployment tokens. Store it only in the Kubernetes secret, never commit it to Git, and rotate it if it is ever exposed.
-
-### JWT Payload Structure
-
-```json
-{
-  "sub": "argo-watcher-client",
-  "cluster": "prod",
-  "allowed_apps": ["app1", "app2"],
-  "iat": 1773352800,
-  "exp": 1804888800
-}
-```
-
-| Field          | Validated | Description                                                                 |
-|----------------|-----------|-----------------------------------------------------------------------------|
-| `exp`          | Yes       | Expiration timestamp (Unix epoch). **Required.** Tokens without `exp` are rejected. |
-| `iat`          | Yes       | Issued-at timestamp (Unix epoch). Tokens with a future `iat` are rejected. Use `date +%s` to generate. |
-| `nbf`          | Yes       | Not-before timestamp (Unix epoch). Optional. Enforced by the underlying JWT library -- tokens used before this time are rejected. |
-| `sub`          | No        | Token subject. Informational only (e.g., service name or team identifier). Not validated by the server. |
-| `cluster`      | No        | Cluster identifier. Informational only. Not validated by the server.        |
-| `allowed_apps` | No        | List of Argo CD application names this token can deploy to. Use `"*"` to allow all applications. |
-
-!!! note
-    Application-level filtering based on `allowed_apps` is not yet implemented and is expected in a future release. The `sub` and `cluster` claims are reserved for future use.
-
-### Generating a JWT Token
-
-You can use [jwt-cli](https://github.com/mike-engel/jwt-cli) to generate tokens:
-
-```bash
-jwt encode \
-  --secret="YOUR_JWT_SECRET" \
-  '{"sub":"argo-watcher-client","cluster":"prod","allowed_apps":["app1"],"iat":1773352800,"exp":1804888800}'
-```
-
-Replace `YOUR_JWT_SECRET` with the value stored in the `JWT_SECRET` key of your Kubernetes secret. Update the `iat` and `exp` timestamps as appropriate.
-
-## Application Configuration
-
-Argo Watcher uses Argo CD application annotations to determine how to manage image tag updates. All configuration is applied directly to the Argo CD Application resource.
-
-### Required Annotations
+Argo Watcher reads annotations on the Argo CD `Application` resource. The minimum is:
 
 ```yaml
 metadata:
@@ -93,18 +33,18 @@ metadata:
     argo-watcher/app.helm.image-tag: "app.image.tag"
 ```
 
-**How annotations work:**
+- `managed` enables write-back for this application.
+- `managed-images` maps an alias (`app`) to a full image name; comma-separate several.
+- `<alias>.helm.image-tag` is the Helm value path the new tag is written to.
 
-- `argo-watcher/managed` -- Enables Argo Watcher management for this application.
-- `argo-watcher/managed-images` -- Maps an alias (`app`) to a full image name. The alias is used to reference the image in other annotations.
-- `argo-watcher/ALIAS.helm.image-tag` -- Specifies the Helm value path where the image tag should be written. Replace `ALIAS` with the alias defined in `managed-images`.
+Every annotation is listed in the [annotations reference](../reference/annotations.md).
 
 !!! warning
-    When processing annotations, Argo Watcher associates an image with all aliases that share the same image name. You cannot use different release strategies for aliases that use the same image.
+    An image is associated with **every** alias sharing its name, so two aliases pointing at the same image cannot use different release strategies.
 
-### Multi-Source Applications
+### Multi-source applications
 
-Argo CD supports applications with multiple sources. To use the GitOps updater with multi-source applications, add the following annotations:
+For an application built from `spec.sources` (plural), name the write-back target explicitly:
 
 ```yaml
 metadata:
@@ -118,22 +58,17 @@ metadata:
 ```
 
 !!! warning
-    `write-back-repo`, `write-back-branch`, and `write-back-path` are honored **only** for applications using `spec.sources` (plural, multi-source). For a single-`spec.source` application these three annotations are silently ignored — Argo Watcher derives the repo, branch, and path from the application's existing source instead; only `write-back-filename` is still read.
+    `write-back-repo`, `write-back-branch` and `write-back-path` are honored **only** for multi-source applications. On a single-`spec.source` application they are silently ignored — the repo, branch and path come from the application's own source, and only `write-back-filename` is still read.
 
-For an application named `Demo`, Argo Watcher creates or updates the override file at:
+The override file name is derived from the application name, so application `Demo` gets:
 
 ```text
 sandbox/charts/demo/.argocd-source-demo.yaml
 ```
 
-!!! note
-    The override file path is derived from the application name. This is the currently supported approach for reliably identifying the correct file to update.
+### Fire-and-forget mode
 
-### Fire-and-Forget Mode
-
-In some cases, you may want to update the image tag without waiting for the deployment to complete. This is useful for applications that only contain `CronJob` resources, where the updated image won't be running immediately.
-
-Add the following annotation to enable this mode:
+When the new image will not run on its own — an application containing only `CronJob` resources, for instance — annotate it:
 
 ```yaml
 metadata:
@@ -141,17 +76,11 @@ metadata:
     argo-watcher/fire-and-forget: "true"
 ```
 
-When this annotation is set, Argo Watcher commits the image tag change and immediately marks the deployment as `deployed` without monitoring the application status.
+Argo Watcher then commits the tag and marks the task `deployed` immediately, without monitoring the rollout.
 
-### Custom Commit Messages
+### Custom commit messages
 
-The default commit message format is:
-
-```text
-argo-watcher(appName): update image tag
-```
-
-You can customize the commit message using a Go template in the `COMMIT_MESSAGE_FORMAT` environment variable:
+The default message is `argo-watcher(appName): update image tag`. Override it with a Go template in `COMMIT_MESSAGE_FORMAT`:
 
 ```yaml
 extraEnvs:
@@ -165,35 +94,76 @@ extraEnvs:
       {{end}}
 ```
 
-For available template variables, see the [Notifications](notifications.md#available-template-variables) page.
+The available fields are the same ones the [notification templates](notifications.md#template-variables) use.
 
-## CI/CD Configuration
+## JWT configuration
 
-After configuring the server and application annotations, update your CI/CD pipeline to provide the authentication token.
+JWT is the recommended credential: unlike the shared deploy token, each pipeline can hold its own, with an expiry.
 
-**Using a deploy token** (planned for deprecation):
+### The signing secret
+
+`JWT_SECRET` is a symmetric HMAC key you generate once and store in the Argo Watcher secret:
 
 ```bash
+openssl rand -base64 32
+```
+
+!!! warning
+    Anyone holding this value can mint deployment tokens. Keep it in the Kubernetes secret only, never in Git, and rotate it if it leaks.
+
+### Claims
+
+```json
+{
+  "sub": "argo-watcher-client",
+  "cluster": "prod",
+  "allowed_apps": ["app1", "app2"],
+  "iat": 1773352800,
+  "exp": 1804888800
+}
+```
+
+| Claim | Validated | Notes |
+|---|---|---|
+| `exp` | Yes | **Required.** A token without it is rejected. |
+| `iat` | Yes | A future `iat` is rejected. `date +%s` gives you the current value. |
+| `nbf` | Yes | Optional; enforced by the JWT library. |
+| `sub` | No | Informational — service or team name. |
+| `cluster` | No | Informational. |
+| `allowed_apps` | No | **Not enforced yet.** Per-application restriction is planned; today any valid token authorizes any application. |
+
+### Minting a token
+
+With [jwt-cli](https://github.com/mike-engel/jwt-cli):
+
+```bash
+jwt encode \
+  --secret="YOUR_JWT_SECRET" \
+  '{"sub":"argo-watcher-client","cluster":"prod","allowed_apps":["app1"],"iat":1773352800,"exp":1804888800}'
+```
+
+## Pipeline configuration
+
+Pass the credential to the client:
+
+```bash
+# JWT (recommended). The raw token, with no "Bearer " prefix, so CI can mask it.
+export BEARER_TOKEN="your_jwt_token"
+
+# Or the deploy token (planned for deprecation)
 export ARGO_WATCHER_DEPLOY_TOKEN=your_deploy_token
 ```
 
-**Using JWT (recommended):**
-
-```bash
-# Set the raw token — no "Bearer " prefix — so it can be masked as a CI variable.
-export BEARER_TOKEN="your_jwt_token"
-```
-
-See the [Installation](install.md#client-setup) guide for complete CI/CD pipeline examples.
+The [installation guide](install.md#run-the-client-in-ci) has complete pipeline examples.
 
 !!! warning
-    Argo Watcher uses the provided image tag value as-is, without validation. Ensure the tag is valid and corresponds to an image that exists in the registry.
+    The image tag is used as given, without validation. A tag that does not exist in the registry is committed anyway, and the deployment then fails on the pull.
 
-## Batch Write-Back
+## Batch write-back
 
-By default, each application's write-back is serialized behind a per-repository lock: when many applications deploy to the **same** GitOps repository at once, each one clones, commits, and pushes on its own, one after another. Under heavy concurrency (for example, ten simultaneous deployments to a shared repo) this serialized tail can grow to minutes.
+By default each application's write-back takes a per-repository lock and clones, commits, and pushes on its own. When many applications deploy to the **same** repository at once, that serialized tail can reach minutes.
 
-Batch write-back is an **opt-in** mode that coalesces concurrent write-backs to the same repository into a single clone and a single push. Enable it with:
+Batch mode coalesces write-backs to one repository into a single clone and push:
 
 ```yaml
 extraEnvs:
@@ -203,110 +173,20 @@ extraEnvs:
     value: "20"
 ```
 
-### How it works
+Batching is contention-driven, so it costs nothing when there is no contention: a write-back for an idle repository flushes immediately, while ones arriving during an in-flight flush are queued and flushed together as soon as it completes. Each flush makes **one commit per application** — preserving per-app history and `COMMIT_MESSAGE_FORMAT` — followed by a single push. `GIT_BATCH_MAX_SIZE` bounds one flush; the rest carries into the next.
 
-Batching is **contention-driven**, so it adds no latency when there is no contention:
+Correctness is unchanged. Each application writes its own `.argocd-source-<app>.yaml`, so applications in a batch cannot conflict; a misconfigured application fails alone; a superseded deployment is dropped from the batch rather than committing a stale tag; and a push that loses a race re-clones onto the new tip and re-applies, exactly as the serialized path does. `GIT_OP_TIMEOUT` and `GIT_MAX_ATTEMPTS` apply to the batch as a whole. With multiple replicas each coalesces its own write-backs, and the Postgres advisory lock still serializes pushes between them.
 
-- A write-back for an **idle** repository flushes immediately, exactly as before.
-- Write-backs that arrive while a flush for the same repository is already in flight — cloning, pushing, or waiting on the lock — are queued and flushed **together** the moment the current flush completes.
-
-Each flush produces **one commit per application** (preserving per-app history and your `COMMIT_MESSAGE_FORMAT`), followed by a **single push**. `GIT_BATCH_MAX_SIZE` bounds how many applications are committed in one flush; anything beyond it is carried into the next flush.
-
-### Reliability
-
-Batching does not change the correctness guarantees of the write-back:
-
-- Each application writes its own override file (`.argocd-source-<app>.yaml`), so applications in a batch never conflict with each other.
-- A misconfigured application fails on its own without affecting the rest of the batch.
-- A deployment superseded by a newer one for the same app is dropped from the batch and never commits a stale tag.
-- If the push loses a race with an external commit, the whole batch re-clones onto the new remote tip, re-applies, and re-pushes — the same no-clobber recovery used by the serialized path.
-- The retry budget (`GIT_OP_TIMEOUT`, `GIT_MAX_ATTEMPTS`) applies to the batch as a whole.
-- On a graceful shutdown, in-flight retries stop at the next retry boundary instead of spending the remaining budget, so queued commits get a chance to land before the process exits. Two limits are worth knowing. An attempt already running is not interrupted and is bounded only by `GIT_OP_TIMEOUT` (90s by default, longer than the shutdown budget), so a write-back stuck on an unreachable remote can still be cut off mid-attempt — keep `GIT_OP_TIMEOUT` under 25s if that matters. And a clean drain still does not guarantee the task's **final status** is recorded: nothing waits for the deployment tracker to persist it once the write-back returns, so a task interrupted by a restart may stay `in progress` until the obsolete-task sweep marks it `aborted`, whatever the write-back did. Treat the GitOps repository, not the task status, as the record of what was committed across a restart.
-
-In a high-availability (multi-replica) deployment, each replica coalesces its own in-flight write-backs; the cross-replica Postgres advisory lock still serializes pushes between replicas, so correctness is unchanged.
-
-The `gitops_batch_size` metric records how many applications were coalesced into each flush — a distribution skewed toward `1` means little batching is happening (low contention).
-
-## Deployment Locking
-
-Argo Watcher supports a deployment lock mechanism to prevent changes during maintenance windows or other critical periods. When a lock is active, all new deployment tasks are rejected.
-
-### Scheduled Lockdown
-
-Define recurring maintenance windows using a schedule:
-
-```yaml
-extraEnvs:
-  - name: LOCKDOWN_SCHEDULE
-    value: "Wed 20:00 - Thu 08:00, Fri 20:00 - Mon 08:00"
-```
-
-Or use the Helm chart values:
-
-```yaml
-scheduledLockdown:
-  - "Wed 20:00 - Thu 08:00"
-  - "Fri 20:00 - Mon 08:00"
-```
-
-In this example, deployments are blocked between Wednesday 20:00 and Thursday 08:00, and between Friday 20:00 and Monday 08:00.
-
-The Web UI lockdown banner updates automatically (within a few seconds) when a scheduled window begins or ends — no page refresh is needed.
-
-### Manual Lockdown
-
-!!! note
-    Manual locking requires OIDC authentication (`OIDC_ENABLED=true`; the legacy `KEYCLOAK_ENABLED=true` still works). Without an auth backend the server does not register the `POST`/`DELETE /api/v1/deploy-lock` endpoints (requests return `404 Not Found`) and the Web UI does not show the lock toggle. Scheduled lockdown (above) works regardless of authentication. Reading the lock status needs no privileged group, but with OIDC enabled it does need a credential — see [Protected endpoints](oidc.md#protected-endpoints). See also [OIDC / SSO Integration](oidc.md).
-
-#### Via API
-
-Set a lock:
-
-```bash
-curl -X POST https://argo-watcher.example.com/api/v1/deploy-lock
-```
-
-Release a lock:
-
-```bash
-curl -X DELETE https://argo-watcher.example.com/api/v1/deploy-lock
-```
-
-!!! note
-    When OIDC authentication is enabled, the deploy lock API endpoints require a token from a user in one of the `OIDC_PRIVILEGED_GROUPS`, sent via the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` header is still accepted).
-
-#### Via Web UI
-
-Click the **Argo Watcher** logo in the Web UI and toggle the **Lockdown Mode** switch.
-
-![Deployment Lock UI](https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher/deployment-lock.png)
-
-!!! note
-    When OIDC authentication is enabled, you must be authenticated to manage the deployment lock.
-
-#### Releasing a Lock During a Scheduled Window
-
-Releasing the lock while a scheduled lockdown window is open does not cancel the schedule: it suppresses it for 15 minutes, after which the window takes effect again (unless it has closed meanwhile). Setting the lock again clears a pending suppression.
-
-### Behaviour With Multiple Replicas
-
-With `STATE_TYPE=postgres`, the manual lock and its temporary suppression are stored in the database, so a lock set through any replica rejects deployments on all of them, and it survives a restart. Enforcement is immediate: every deploy request resolves the lock state at that moment, so a lock set on one replica rejects the next deploy that reaches any other replica. Web UI clients see the banner update within a few seconds, when their replica's watcher next samples the state — including on the replica that served the lock request. The operator who set or released the lock sees their own change reflected right away.
-
-With `STATE_TYPE=in-memory` the lock lives in the process that served the request. That is correct for a single replica — the only supported configuration for in-memory state — but the lock is lost on restart.
+Watch `gitops_batch_size` to see whether batching is doing anything: a distribution clustered at `1` means there is no contention to collapse.
 
 !!! warning
-    If the database is unreachable, the lock state cannot be read and deployments are rejected as if a lock were active. Rejecting a deployment during an outage is recoverable; letting one through during a freeze is not.
+    A graceful shutdown stops retries at the next boundary but never interrupts the attempt in flight, and that attempt is bounded by `GIT_OP_TIMEOUT` (90s default) rather than the 25s shutdown budget. Keep `GIT_OP_TIMEOUT` under 25s if queued commits should land instead of being abandoned on restart. A clean drain still says nothing about the task's final **status** — see [Tasks stay "in progress" after a server restart](../operations/troubleshooting.md#tasks-stay-in-progress-after-a-server-restart).
 
 ## Migrating from Argo CD Image Updater
 
-If you are currently using Argo CD Image Updater, follow these steps to migrate an application to Argo Watcher:
-
-**1. Replace the Image Updater annotations:**
-
-Remove the existing Argo CD Image Updater annotations:
+**1. Remove the Image Updater annotations:**
 
 ```yaml
-# Remove these annotations
 argocd-image-updater.argoproj.io/image-list: app=registry.example.com/group-name/project-name
 argocd-image-updater.argoproj.io/app.update-strategy: latest
 argocd-image-updater.argoproj.io/app.helm.image-name: app.image.repository
@@ -314,15 +194,14 @@ argocd-image-updater.argoproj.io/app.helm.image-tag: app.image.tag
 argocd-image-updater.argoproj.io/app.allow-tags: regexp:^\d{7}-stage
 ```
 
-**2. Add the Argo Watcher annotations:**
+**2. Add the Argo Watcher ones:**
 
 ```yaml
-# Add these annotations
 argo-watcher/managed: "true"
 argo-watcher/managed-images: "app=registry.example.com/group-name/project-name"
 argo-watcher/app.helm.image-tag: "app.image.tag"
 ```
 
-**3. Update your CI/CD pipeline** to include the Argo Watcher client step and authentication token (see [CI/CD Configuration](#cicd-configuration)).
+**3. Add the client step** and its credential to the pipeline (see [Pipeline configuration](#pipeline-configuration)).
 
-**4. Test the migration** on a non-production application first, then roll out to the rest of your applications.
+**4. Test on a non-production application** before rolling out to the rest.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,7 +2,8 @@
 
 Step-by-step instructions for common tasks and integrations.
 
-- **[Installation](install.md)** — Deploy Argo Watcher on Kubernetes with Helm or raw manifests.
+- **[Installation](install.md)** — Deploy the server with Helm and wire the client into your pipeline.
 - **[GitOps Updater](gitops-updater.md)** — Use Argo Watcher to update image tags in your Git repository.
-- **[Notifications](notifications.md)** — Send deployment status updates to external services.
-- **[OIDC / SSO Integration](oidc.md)** — Secure Argo Watcher with any OIDC provider (Keycloak, Authentik, …).
+- **[Notifications](notifications.md)** — Report deployments to a webhook or Mattermost.
+- **[Deployment Lock](deployment-lock.md)** — Freeze deployments on a schedule or on demand.
+- **[OIDC / SSO](oidc.md)** — Secure Argo Watcher with any OIDC provider (Keycloak, Authentik, …).

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,21 +1,17 @@
 # Installation
 
-This guide covers deploying the Argo Watcher server in Kubernetes and integrating the client into your CI/CD pipeline.
+Deploy the Argo Watcher server on Kubernetes with the official Helm chart, then run the client in your pipeline. The chart is the supported install path — it owns the environment variables, probes, migrations, and volumes described here.
 
 ## Prerequisites
 
-Before installing Argo Watcher, ensure you have the following:
+- A Kubernetes cluster with [Argo CD](https://argo-cd.readthedocs.io/) installed
+- Helm 3
+- An Argo CD API token (below)
+- PostgreSQL, if you want task history to survive restarts or to run more than one replica
 
-- A running **Kubernetes cluster** with [Argo CD](https://argo-cd.readthedocs.io/) installed
-- **Helm 3** installed on your local machine
-- An **Argo CD API token** for the Argo Watcher service account (see [Argo CD API token](#argo-cd-api-token) below)
-- *(Optional)* A **PostgreSQL** database for persistent task storage
+### Argo CD API token
 
-### Argo CD API Token
-
-Argo Watcher needs an API token to communicate with Argo CD. While using the admin user works, it is recommended to create a dedicated service account with minimal permissions.
-
-Add the following to your Argo CD `argocd-rbac-cm` ConfigMap:
+Argo Watcher needs an Argo CD token. Use a dedicated account rather than `admin`. Add to the `argocd-rbac-cm` ConfigMap:
 
 ```yaml
 policy.csv: |
@@ -24,19 +20,13 @@ policy.csv: |
   g, watcher, role:watcher
 ```
 
-Then create the `watcher` account and generate a token using the Argo CD CLI:
+Then create the `watcher` account and mint a token:
 
 ```bash
 argocd account generate-token --account watcher
 ```
 
-## Server Installation
-
-Argo Watcher server is designed to run in a Kubernetes environment. You can deploy it using the official [Helm chart](https://artifacthub.io/packages/helm/shini4i/argo-watcher).
-
-### Helm Chart
-
-Add the Helm repository and install the chart:
+## Install the server
 
 ```bash
 helm repo add shini4i https://shini4i.github.io/charts/
@@ -44,22 +34,21 @@ helm repo update
 helm install argo-watcher shini4i/argo-watcher -f values.yaml
 ```
 
-Below is an example `values.yaml` configuration:
+A minimal `values.yaml`:
 
 ```yaml
-# Credentials for accessing Argo CD
 argo:
   url: https://argocd.argocd.svc.cluster.local
-  # Secret containing the ARGO_TOKEN key
-  # Optionally include ARGO_WATCHER_DEPLOY_TOKEN (must match the client-side value)
+  # Secret holding ARGO_TOKEN, plus ARGO_WATCHER_DEPLOY_TOKEN if you use the updater
   secretName: "argo-watcher"
+  # DEPLOYMENT_TIMEOUT in seconds; the chart's default is 300, not the binary's 900
+  timeout: 300
 
-# Built-in GitOps updater configuration (optional)
+# Built-in GitOps updater (optional)
 updater:
   sshSecretName: "ssh-secret"
 
-# PostgreSQL configuration for persistent task storage
-# Omit or set enabled: false to use in-memory storage (non-HA, data lost on restart)
+# Persistent task storage. Omit to run in-memory (single replica, lost on restart)
 postgres:
   enabled: true
   host: argo-watcher-postgresql.argo-watcher-postgresql.svc.cluster.local
@@ -67,7 +56,6 @@ postgres:
   user: argo-watcher
   secretName: "argo-watcher-postgresql"
 
-# Ingress configuration for the API and Web UI
 ingress:
   enabled: true
   hosts:
@@ -81,140 +69,103 @@ ingress:
         - argo-watcher.example.com
 ```
 
-### Environment Variables
+The chart maps its own values onto the server's environment variables and exposes `extraEnvs` for anything it does not cover. Every variable is listed in [Server Environment Variables](../reference/server-env.md); OIDC has [its own values block](oidc.md#helm-chart-values).
 
-All server environment variables are documented in the [Server Environment Variables](../reference/server-env.md) reference page. When using the Helm chart, most variables are set through chart values automatically.
+!!! note
+    The chart sets `livenessProbe` to `/livez` and `readinessProbe` to `/readyz`, which is the correct pairing — see [Health and probe endpoints](../reference/api.md#health-and-probe-endpoints) before overriding either.
 
-### Database Setup
+### Database setup
 
-When using PostgreSQL for persistent storage (`STATE_TYPE=postgres`), the database must be initialized before starting the server.
+With `postgres.enabled: true` the chart runs migrations for you: a `pre-install`/`pre-upgrade` hook Job executes `argo-watcher --migrate` before the server starts. `helm install` and `helm upgrade` are all you need.
 
-#### Using the Helm Chart
-
-If you deploy PostgreSQL alongside Argo Watcher using the Helm chart, migrations run automatically before every install and upgrade. The chart schedules a `pre-install`/`pre-upgrade` hook Job that executes `argo-watcher --migrate` against the configured database, so there is nothing to run manually.
-
-#### Manual Migration
-
-If you manage your database separately, run the migrations using the [golang-migrate](https://github.com/golang-migrate/migrate) tool:
+If you manage the database outside the chart, apply the migrations yourself with [golang-migrate](https://github.com/golang-migrate/migrate):
 
 ```bash
 migrate -path db/migrations \
   -database "postgresql://<user>:<password>@<host>:<port>/<dbname>?sslmode=disable" up
 ```
 
-!!! tip
-    The project includes a Docker Compose setup with automatic migrations for local development. See the [Development](../contributing/development.md) guide for details.
+See [Database](../operations/database.md) for the schema, backups, and sizing.
 
-## Client Setup
+## Run the client in CI
 
-The Argo Watcher client is a lightweight CLI tool distributed as a Docker image at [`ghcr.io/shini4i/argo-watcher-client`](https://ghcr.io/shini4i/argo-watcher-client).
+The client is a container image: [`ghcr.io/shini4i/argo-watcher-client`](https://ghcr.io/shini4i/argo-watcher-client). It reads its configuration from the environment ([full list](../reference/client-env.md)) and exits non-zero when the deployment does not succeed.
 
-All client environment variables are documented in the [Client Environment Variables](../reference/client-env.md) reference page.
+Pin a release tag rather than `latest`.
 
-### GitLab CI/CD
+=== "GitLab CI"
 
-Below is a complete GitLab CI/CD example that builds an image with Kaniko and monitors the deployment with Argo Watcher.
+    ```yaml
+    stages:
+      - deploy
 
-```yaml
-stages:
-  - deploy
+    build:
+      stage: deploy
+      image:
+        name: gcr.io/kaniko-project/executor:v1.9.0-debug
+        entrypoint: [""]
+      script:
+        - /kaniko/executor
+          --context "${CI_PROJECT_DIR}"
+          --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
+          --destination "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}"
+      rules:
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
-# Build a new Docker image
-build:
-  stage: deploy
-  image:
-    name: gcr.io/kaniko-project/executor:v1.9.0-debug
-    entrypoint: [""]
-  script:
-    - /kaniko/executor
-      --context "${CI_PROJECT_DIR}"
-      --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
-      --destination "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}"
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    watch:
+      stage: deploy
+      image: ghcr.io/shini4i/argo-watcher-client:<VERSION>
+      variables:
+        ARGO_WATCHER_URL: https://argo-watcher.example.com
+        ARGO_APP: example
+        COMMIT_AUTHOR: $GITLAB_USER_EMAIL
+        PROJECT_NAME: $CI_PROJECT_PATH
+        IMAGES: $CI_REGISTRY_IMAGE
+        IMAGE_TAG: $CI_COMMIT_SHORT_SHA
+      script:
+        - /client
+      needs: [build]
+      rules:
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    ```
 
-# Monitor deployment with Argo Watcher
-watch:
-  stage: deploy
-  image: ghcr.io/shini4i/argo-watcher-client:<VERSION>
-  variables:
-    ARGO_WATCHER_URL: https://argo-watcher.example.com
-    ARGO_APP: example
-    COMMIT_AUTHOR: $GITLAB_USER_EMAIL
-    PROJECT_NAME: $CI_PROJECT_PATH
-    IMAGES: $CI_REGISTRY_IMAGE
-    IMAGE_TAG: $CI_COMMIT_SHORT_SHA
-    DEBUG: "1"
-  script:
-    - /client
-  needs: [build]
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      when: success
-```
+=== "GitHub Actions"
 
-!!! warning
-    Replace `<VERSION>` with a specific Argo Watcher release tag (e.g., `v0.8.0`). Avoid using `latest` in production.
+    ```yaml
+    name: Deploy and Monitor
 
-### GitHub Actions
+    on:
+      push:
+        branches: [main]
 
-Below is an equivalent example for GitHub Actions.
+    jobs:
+      build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
 
-```yaml
-name: Deploy and Monitor
+          - name: Build and push image
+            run: |
+              docker build -t ${{ vars.REGISTRY_IMAGE }}:${{ github.sha }} .
+              docker push ${{ vars.REGISTRY_IMAGE }}:${{ github.sha }}
 
-on:
-  push:
-    branches: [main]
+          - name: Monitor deployment
+            run: |
+              docker run --rm \
+                -e ARGO_WATCHER_URL=https://argo-watcher.example.com \
+                -e ARGO_APP=example \
+                -e COMMIT_AUTHOR="${{ github.actor }}" \
+                -e PROJECT_NAME="${{ github.repository }}" \
+                -e IMAGES="${{ vars.REGISTRY_IMAGE }}" \
+                -e IMAGE_TAG="${{ github.sha }}" \
+                ghcr.io/shini4i/argo-watcher-client:<VERSION>
+    ```
 
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+Set `DEBUG=1` while wiring this up: the client then logs the equivalent cURL commands, with credentials redacted.
 
-      - name: Build and push Docker image
-        # Your preferred Docker build step here
-        run: |
-          docker build -t ${{ vars.REGISTRY_IMAGE }}:${{ github.sha }} .
-          docker push ${{ vars.REGISTRY_IMAGE }}:${{ github.sha }}
+## Next steps
 
-      - name: Monitor deployment
-        run: |
-          docker run --rm \
-            -e ARGO_WATCHER_URL=https://argo-watcher.example.com \
-            -e ARGO_APP=example \
-            -e COMMIT_AUTHOR="${{ github.actor }}" \
-            -e PROJECT_NAME="${{ github.repository }}" \
-            -e IMAGES="${{ vars.REGISTRY_IMAGE }}" \
-            -e IMAGE_TAG="${{ github.sha }}" \
-            -e DEBUG=1 \
-            ghcr.io/shini4i/argo-watcher-client:<VERSION>
-```
-
-## Troubleshooting
-
-### Server does not start
-
-- Verify that `ARGO_URL` and `ARGO_TOKEN` are set correctly and that the server can reach the Argo CD API.
-- If using `STATE_TYPE=postgres`, ensure the database is accessible and migrations have been applied.
-- Check the server logs by setting `LOG_LEVEL=debug` for verbose output.
-
-### Client exits with a non-zero code
-
-- Confirm that the `ARGO_WATCHER_URL` is reachable from the CI runner.
-- Check that the `ARGO_APP` name matches an application registered in Argo CD.
-- Verify that the `IMAGES` and `IMAGE_TAG` values correspond to the image that was actually built and pushed.
-- If using the built-in GitOps updater, ensure `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN` is set.
-
-### Deployment times out
-
-- The default `DEPLOYMENT_TIMEOUT` is `900` seconds (15 minutes). Increase the value to accommodate longer rollouts.
-- Verify that Argo CD can detect and sync the updated image tag. Check the Argo CD UI for sync errors.
-- If using the built-in GitOps updater, ensure the SSH key has write access to the target repository.
-
-### Web UI is not accessible
-
-- Confirm that the Ingress resource is configured correctly and the TLS certificate is valid.
-- Verify that `STATIC_FILES_PATH` points to the correct directory containing the built UI assets.
+- [GitOps Updater](gitops-updater.md) — let Argo Watcher commit the image tag.
+- [Notifications](notifications.md) — report deployments to Slack, Mattermost, or a webhook.
+- [OIDC / SSO](oidc.md) — put the Web UI behind your identity provider.
+- [Troubleshooting](../operations/troubleshooting.md) — what to do when a deployment does not behave.

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -1,130 +1,86 @@
 # Notifications
 
-Argo Watcher can send deployment status notifications to external services via webhooks. This is useful for integrating with Slack, Microsoft Teams, PagerDuty, or any custom service that accepts HTTP POST requests.
+Argo Watcher reports deployments to external services in two ways: a generic webhook (Slack, Teams, PagerDuty, anything accepting an HTTP POST) and a Mattermost integration that threads its messages. Both can be enabled at once; each enabled strategy receives every event.
 
-## Webhook Events
+Two events are sent per deployment: one when the task is accepted (status `in progress`) and one when it reaches a final state (`deployed`, `failed`, `aborted`, `cancelled`, or `app not found`).
 
-The following events trigger a webhook notification:
+## Generic webhook
 
-- **Deployment started** -- Sent when a new deployment task is accepted.
-- **Deployment finished** -- Sent when a deployment succeeds or fails.
+| Variable | Description | Default | Example |
+|---|---|---|---|
+| `WEBHOOK_ENABLED` | Enable webhook notifications | `false` | |
+| `WEBHOOK_URL` | Where to POST | | `https://example.com/events` |
+| `WEBHOOK_CONTENT_TYPE` | `Content-Type` of the request | `application/json` | |
+| `WEBHOOK_FORMAT` | Go template rendering the request body | | `{"app": "{{.App}}", "status": "{{.Status}}"}` |
+| `WEBHOOK_AUTHORIZATION_HEADER_NAME` | Header carrying the credential | `Authorization` | `X-Token` |
+| `WEBHOOK_AUTHORIZATION_HEADER_VALUE` | Its value | | `Bearer token` |
+| `WEBHOOK_ALLOWED_RESPONSE_CODES` | Response codes treated as success | `200` | `200,201,202` |
 
-## Configuration
+Argo Watcher does not sign the payload; the receiver authenticates the request through the authorization header above, so treat `WEBHOOK_URL` itself as a secret when the receiver has no other check.
 
-| Variable                             | Description                                          | Default         | Example                                       |
-|--------------------------------------|------------------------------------------------------|-----------------|-----------------------------------------------|
-| `WEBHOOK_ENABLED`                    | Enable webhook notifications                         | `false`         |                                               |
-| `WEBHOOK_URL`                        | URL to send the webhook POST request to             |                 | `https://example.com/events`                  |
-| `WEBHOOK_CONTENT_TYPE`               | Content-Type header for webhook requests             | `application/json` |                                            |
-| `WEBHOOK_FORMAT`                     | Go template string defining the webhook payload     |                 | `{"app": "{{.App}}", "status": "{{.Status}}"}` |
-| `WEBHOOK_AUTHORIZATION_HEADER_NAME`  | Name of the authorization header                     | `Authorization` |                                               |
-| `WEBHOOK_AUTHORIZATION_HEADER_VALUE` | Value of the authorization header                    |                 | `Bearer token`                                |
-| `WEBHOOK_ALLOWED_RESPONSE_CODES`     | Comma-separated list of accepted HTTP response codes | `200`           | `200,201,202`                                 |
+### Template variables
 
-## Available Template Variables
+`WEBHOOK_FORMAT` (and `MATTERMOST_FORMAT`) is a [Go template](https://pkg.go.dev/text/template) rendered over the task:
 
-The `WEBHOOK_FORMAT` value is a [Go template](https://pkg.go.dev/text/template) string. The following variables are available:
-
-| Variable  | Type      | Description                               | Example          |
-|-----------|-----------|-------------------------------------------|------------------|
-| `Id`      | `string`  | Unique task identifier (UUID)             | `"be8c42c0-..."` |
-| `Created` | `float64` | Task creation time (Unix timestamp)       | `1648390029.0`   |
-| `Updated` | `float64` | Last update time (Unix timestamp)         | `1648390145.0`   |
-| `App`     | `string`  | Argo CD application name                  | `"my-app"`       |
-| `Author`  | `string`  | Person who triggered the deployment       | `"John Doe"`     |
-| `Project` | `string`  | Business project identifier               | `"Demo"`         |
-| `Images`  | `[]Image` | List of images being deployed (see below) |                  |
-| `Status`  | `string`  | Current deployment status                 | `"deployed"`     |
-| `IsRollback` | `bool` | `true` when the deployment returns to a previously deployed version | `true` |
-| `RollbackTargetId` | `string` | ID of the earlier task this deployment rolls back to (empty when not a rollback) | `"be8c42c0-..."` |
-
-### The Image Object
-
-Each item in the `Images` list has the following fields:
-
-| Field   | Type     | Description               | Example                                |
-|---------|----------|---------------------------|----------------------------------------|
-| `Image` | `string` | Full image name (no tag)  | `"ghcr.io/shini4i/argo-watcher"`       |
-| `Tag`   | `string` | Image tag being deployed  | `"v0.8.0"`                             |
+| Variable | Type | Description |
+|---|---|---|
+| `Id` | `string` | Task id (UUID) |
+| `Created` | `float64` | Creation time, Unix seconds |
+| `Updated` | `float64` | Last update, Unix seconds |
+| `App` | `string` | Argo CD application name |
+| `Author` | `string` | Who triggered the deployment |
+| `Project` | `string` | Business project identifier |
+| `Images` | `[]Image` | Images being deployed; each has `.Image` (name, no tag) and `.Tag` |
+| `Status` | `string` | Current status, e.g. `deployed` |
+| `StatusReason` | `string` | Why it failed; empty on success |
+| `IsRollback` | `bool` | `true` when returning to a previously deployed version |
+| `RollbackTargetId` | `string` | Id of the task being rolled back to; empty otherwise |
 
 !!! tip
-    Use `{{range .Images}}` to iterate over the images list in your template. Pay attention to variable types -- for example, `Created` and `Updated` are `float64` values, not strings.
+    `Created` and `Updated` are numbers, not strings. Iterate images with `{{range .Images}}`.
 
-## Examples
+### Examples
 
-### Simple JSON Payload
+A minimal JSON body:
 
 ```bash
 WEBHOOK_FORMAT='{"app": "{{.App}}", "status": "{{.Status}}", "author": "{{.Author}}"}'
 ```
 
-Produces:
-
-```json
-{
-  "app": "my-app",
-  "status": "deployed",
-  "author": "John Doe"
-}
-```
-
-### Detailed Payload with Images
+Every image, with tags:
 
 ```bash
-WEBHOOK_FORMAT='{"app": "{{.App}}", "status": "{{.Status}}", "author": "{{.Author}}", "project": "{{.Project}}", "images": [{{range $i, $img := .Images}}{{if $i}},{{end}}{"image": "{{$img.Image}}", "tag": "{{$img.Tag}}"}{{end}}]}'
+WEBHOOK_FORMAT='{"app": "{{.App}}", "status": "{{.Status}}", "images": [{{range $i, $img := .Images}}{{if $i}},{{end}}{"image": "{{$img.Image}}", "tag": "{{$img.Tag}}"}{{end}}]}'
 ```
 
-Produces:
-
-```json
-{
-  "app": "my-app",
-  "status": "deployed",
-  "author": "John Doe",
-  "project": "Demo",
-  "images": [
-    {"image": "ghcr.io/shini4i/argo-watcher", "tag": "v0.8.0"}
-  ]
-}
-```
-
-### Slack-Compatible Payload
+A Slack message that calls out rollbacks and failure reasons:
 
 ```bash
-WEBHOOK_FORMAT='{"text": "Deployment of *{{.App}}* by {{.Author}}: {{.Status}}"}'
-```
-
-### Highlighting Rollbacks
-
-Use `IsRollback` to call out deployments that return to a previously deployed version:
-
-```bash
-WEBHOOK_FORMAT='{"text": "{{if .IsRollback}}:rewind: ROLLBACK of {{else}}Deployment of {{end}}*{{.App}}* by {{.Author}}: {{.Status}}"}'
+WEBHOOK_FORMAT='{"text": "{{if .IsRollback}}:rewind: ROLLBACK of {{else}}Deployment of {{end}}*{{.App}}* by {{.Author}}: {{.Status}}{{with .StatusReason}} — {{.}}{{end}}"}'
 ```
 
 ## Mattermost
 
-The generic webhook sends an independent message per event, which gets noisy. The Mattermost strategy uses the Mattermost REST API instead: the deployment start creates a root channel post, and the deployment result is posted as a **thread reply** to it, mentioning the task author (`@<Author>`).
+The generic webhook posts each event independently, which gets noisy. The Mattermost strategy uses the REST API instead: the start event creates a root post and the result is a **thread reply** to it, mentioning the author.
 
-It requires a [bot account](https://docs.mattermost.com/integrations/cloud-bot-accounts.html) with access to the target channel; incoming webhooks cannot reply in threads.
+It needs a [bot account](https://docs.mattermost.com/integrations/cloud-bot-accounts.html) with access to the channel — incoming webhooks cannot reply in threads.
 
-### Configuration
+| Variable | Description | Default |
+|---|---|---|
+| `MATTERMOST_ENABLED` | Enable Mattermost notifications | `false` |
+| `MATTERMOST_URL` | Base URL of the instance, without `/api/v4` | |
+| `MATTERMOST_TOKEN` | Bot access token | |
+| `MATTERMOST_CHANNEL_ID` | Target channel id (the 26-character id, not the name) | |
+| `MATTERMOST_FORMAT` | Go template rendering the post (markdown) | |
+| `MATTERMOST_MENTION_AUTHOR` | Prepend `@<Author>` to every post | `false` |
 
-| Variable                | Description                                                     | Default | Example                        |
-|-------------------------|-----------------------------------------------------------------|---------|--------------------------------|
-| `MATTERMOST_ENABLED`    | Enable Mattermost notifications                                 | `false` |                                |
-| `MATTERMOST_URL`        | Base URL of the Mattermost instance (without `/api/v4`)         |         | `https://mattermost.example.com` |
-| `MATTERMOST_TOKEN`      | Bot account access token                                        |         |                                |
-| `MATTERMOST_CHANNEL_ID` | Target channel id (26-character id, not the channel name)       |         | `qz3c4kx8w3nqir6nqz3c4kx8w3`   |
-| `MATTERMOST_FORMAT`     | Go template rendering the post message (markdown)               |         | see below                      |
-| `MATTERMOST_MENTION_AUTHOR` | Prepend `@<Author>` to every post to notify the deploy author | `false` | `true`                       |
-
-`MATTERMOST_FORMAT` uses the same template variables as `WEBHOOK_FORMAT`. The rendered text becomes the post `message`; branch on `{{.Status}}` to distinguish the start and result posts. With `MATTERMOST_MENTION_AUTHOR=true` the author mention is prepended automatically to every post, so the template does not need `{{.Author}}`. The mention only notifies when `Author` matches a Mattermost username.
+Branch on `{{.Status}}` to tell the start post from the result:
 
 ```bash
 MATTERMOST_FORMAT='{{if eq .Status "in progress"}}:rocket: Deploying **{{.App}}** {{range $i, $img := .Images}}{{if $i}}, {{end}}`{{$img.Tag}}`{{end}}{{else if eq .Status "deployed"}}:white_check_mark: **{{.App}}** deployed{{else}}:x: **{{.App}}**: {{.Status}}{{end}}'
 ```
 
-Both strategies can be enabled at the same time; each enabled strategy receives every event.
+With `MATTERMOST_MENTION_AUTHOR=true` the mention is prepended for you, so the template does not need `{{.Author}}`. It only notifies someone when `Author` happens to match a Mattermost username.
 
-> **Note:** the mapping between the start post and its thread is kept in memory. If argo-watcher restarts mid-deployment (or runs with multiple replicas), the result is posted as a regular channel message instead of a thread reply.
+!!! note
+    The link between a start post and its thread is held in memory. If Argo Watcher restarts mid-deployment — or runs with several replicas — the result is posted as a normal channel message instead of a reply.

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -1,251 +1,158 @@
-# OIDC / SSO Integration
+# OIDC / SSO
 
-Argo Watcher supports any [OpenID Connect](https://openid.net/connect/) (OIDC) provider — such as [Keycloak](https://www.keycloak.org/) or [Authentik](https://goauthentik.io/) — for user authentication and group-based access control. When enabled, all users must authenticate through your provider before accessing the Web UI or performing privileged operations.
+Argo Watcher authenticates users against any [OpenID Connect](https://openid.net/connect/) provider — Keycloak, Authentik, or another — and uses group membership for privileged actions. With OIDC enabled, users sign in before they see any task, and the endpoints the Web UI reads require a credential.
 
-## How It Works
+With OIDC disabled (the default) nothing is protected: there is no backend to validate a credential against.
 
-When OIDC integration is enabled:
+## How it works
 
-1. Users are redirected to the provider's login page before they can view any tasks in the Web UI.
-2. The user's token is validated by the Argo Watcher backend by calling the provider's **userinfo** endpoint, which the backend discovers automatically from the issuer's [discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html) (`<issuer>/.well-known/openid-configuration`).
-3. The backend **requires a credential on its read endpoints** — being signed in is enough, no group membership needed. See [Protected endpoints](#protected-endpoints).
-4. Users who belong to one of the configured **privileged groups** see a **Redeploy** button on the task details page and can manage the [deployment lock](gitops-updater.md#deployment-locking).
+1. The browser is redirected to the provider before the Web UI loads any data (Authorization Code + PKCE, a top-level redirect — not a hidden iframe).
+2. The backend validates the token by calling the provider's **userinfo** endpoint, which it discovers from `<issuer>/.well-known/openid-configuration`. Discovery happens lazily on the first validation, so a provider that is briefly down at boot does not stop Argo Watcher from starting.
+3. Reads the Web UI performs require a credential — being signed in is enough, no group needed.
+4. Users in a **privileged group** additionally get the **Rollback to this version** button on a task, and control of the [deployment lock](deployment-lock.md).
 
-With OIDC disabled, every endpoint stays open exactly as before — there is no auth backend to validate against.
+The browser performs discovery and the code exchange itself, so the issuer must be reachable **from the browser as well as from the server**. When a sign-in cannot complete, the Web UI stops on its loading screen and names the reason instead of bouncing back to the provider — see [Web UI stops on "Sign-in failed"](../operations/troubleshooting.md#web-ui-stops-on-sign-in-failed).
 
-!!! note
-    The backend discovers the userinfo endpoint lazily, on the first token validation — not at startup — so a provider that is briefly unreachable when Argo Watcher boots does not prevent it from starting.
+## Configuration
 
-The browser performs discovery too, for the login redirect and the code exchange, so the issuer must be reachable **from the browser as well as from the server**. When a sign-in cannot be completed, the Web UI stops on its loading screen and states the reason — the provider's own error code, or the discovery URL it could not read — rather than returning to the provider: see [Web UI stops on "Sign-in failed"](../operations/troubleshooting.md#web-ui-stops-on-sign-in-failed).
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `OIDC_ENABLED` | Turn OIDC on | `false` | No |
+| `OIDC_ISSUER_URL` | The provider's issuer URL, used for discovery | | When enabled |
+| `OIDC_CLIENT_ID` | Client id registered with the provider | | When enabled |
+| `OIDC_PRIVILEGED_GROUPS` | Comma-separated groups allowed to roll back and to manage the lock | | No |
+| `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
+| `OIDC_REQUIRE_TASK_READ_AUTH` | Also require a credential on `GET /api/v1/tasks/{id}` | `false` | No |
+
+The server refuses to start with `OIDC_ENABLED=true` and no issuer or client id. Leaving `OIDC_PRIVILEGED_GROUPS` empty is valid — it simply means nobody is privileged.
+
+`OIDC_ISSUER_URL` is whatever the provider advertises as its `issuer`:
+
+| Provider | Typical issuer URL |
+|---|---|
+| Keycloak | `https://keycloak.example.com/realms/<realm>` |
+| Authentik | `https://authentik.example.com/application/o/<app-slug>/` |
+
+### Helm chart values
+
+The chart has a dedicated block; `extraEnvs` is not needed:
+
+```yaml
+oidc:
+  enabled: true
+  issuerUrl: "https://keycloak.example.com/realms/your-realm"
+  clientId: "argo-watcher"
+  privilegedGroups:
+    - platform-team
+    - sre-team
+  # tokenValidationInterval: 300000
+```
+
+### `OIDC_TOKEN_VALIDATION_INTERVAL`
+
+Every authorization decision means asking the provider's userinfo endpoint about the token. The Web UI refreshes on a timer, so doing that per request would turn every open tab into a stream of provider traffic; a decision is reused for this interval instead — one userinfo call per token per interval, however many requests arrive.
+
+The interval is the upper bound on how stale a **read** authorization can be, and each decision is additionally capped by the token's own expiry, so it never outlives the credential. `0` validates every request.
+
+Privileged actions are exempt and always re-verify against the provider, so removing a user from `OIDC_PRIVILEGED_GROUPS` takes effect immediately. Clicking a lock toggle is rare enough that the extra round trip costs nothing.
+
+## Provider setup
+
+You need a **public** client (Authorization Code + PKCE). Two settings are dictated by how the Web UI signs in; the rest is provider-specific.
+
+### Redirect URI and web origin
+
+- **Redirect URI** — the application's base URL **including the trailing slash**: `https://argo-watcher.example.com/`, or `https://example.com/argo-watcher/` under a sub-path. The same value is used as the post-logout redirect. Providers match it exactly, and a mismatch fails the login on the provider's own error page.
+- **Web origin** — the application's origin (scheme, host, port; no path). After the redirect the browser reads group membership from the userinfo endpoint with an `Authorization` header, so that request must be allowed cross-origin. Keycloak has a separate **Web origins** field; other providers derive it from the redirect URI.
+
+    Get the origin wrong and **sign-in still succeeds** — the failure is quiet: the userinfo call is blocked, group membership comes back empty, and every privileged control stays hidden. That is the same symptom as a missing `groups` claim, so check both when a user who should have the rollback button or the lock switch does not.
+
+!!! tip "Keycloak / Authentik"
+    Keycloak: set **Valid redirect URIs** and **Web origins** in the client settings — both are needed. Authentik: set **Redirect URI** on the OAuth2/OIDC provider to the same value.
+
+The provider commonly lives on another domain. That is supported — the flow is a top-level redirect precisely so it does not depend on third-party cookies — but it is also why the web origin matters.
+
+`test/keycloak/argo-watcher-e2e-realm.json` in the repository is a minimal working client definition (public, PKCE `S256`, exact redirect URI, web origin, `groups` mapper). The browser test suite signs in against it on every run, so it stays correct.
+
+### The `groups` claim
+
+The provider must emit a `groups` claim in **both** the ID token and the **userinfo** response. The Web UI gates its buttons on userinfo — the same source the backend independently enforces on — and falls back to the ID-token claim if that call fails. The backend has no fallback: while userinfo is unreachable it refuses every privileged action, so the UI may briefly offer a button the API then rejects.
+
+The claim must be bound to a scope Argo Watcher actually requests. It only ever requests `openid profile email`, so bind it to `profile`, `email`, or `openid` — a claim behind a separate `groups` scope is never emitted.
+
+!!! tip "Keycloak / Authentik"
+    Keycloak: create a **Group Membership** mapper with **Token Claim Name** `groups` and **Add to userinfo** enabled, attached to the client or to a default client scope. Authentik: create a **Scope Mapping** emitting `groups` and attach it to `profile` or `email` — not to a dedicated `groups` scope, which is never requested.
 
 ## Protected endpoints
 
-Enabling OIDC closes the endpoints only the Web UI consumes. Nothing else reads
-them, so no deployment pipeline is affected.
+Enabling OIDC closes the endpoints only the Web UI consumes, so no pipeline is affected.
 
 | Endpoint | With OIDC enabled |
-|----------|-------------------|
+|---|---|
 | `GET /api/v1/tasks` | Credential required |
 | `GET /api/v1/version` | Credential required |
 | `GET /api/v1/reachability` | Credential required |
 | `GET /api/v1/deploy-lock` | Credential required |
 | `POST`/`DELETE /api/v1/deploy-lock` | Credential required **and** privileged group |
-| `POST /api/v1/tasks` | Unchanged — optional credential (governs git write-back) |
-| `GET /api/v1/tasks/{id}` | **Open** unless `OIDC_REQUIRE_TASK_READ_AUTH=true` — see below |
-| `GET /api/v1/config` | **Open** — the Web UI reads the issuer and client id from it before it can obtain a token |
+| `/ws` | Credential required — as a subprotocol from a browser ([why](#the-websocket-handshake)) |
+| `POST /api/v1/tasks` | Unchanged — optional credential, which governs the git write-back |
+| `GET /api/v1/tasks/{id}` | **Open** unless `OIDC_REQUIRE_TASK_READ_AUTH=true` ([below](#closing-the-task-lookup)) |
+| `GET /api/v1/config` | **Open** — the Web UI reads the issuer and client id from it before it can hold a token |
 | `/livez`, `/readyz`, `/metrics` | **Open** — probes and Prometheus cannot perform an OIDC flow |
-| `/ws` | Credential required — as a subprotocol from a browser, see [The WebSocket handshake](#the-websocket-handshake) |
 
-Any configured credential is accepted on the reads: an OIDC session, the
-`ARGO_WATCHER_DEPLOY_TOKEN`, or a [JWT](gitops-updater.md#jwt-configuration).
-Read access is deliberately **not** limited to `OIDC_PRIVILEGED_GROUPS` — that gate
-applies to the deploy lock only.
+Any configured credential is accepted on a read: an OIDC session, the `ARGO_WATCHER_DEPLOY_TOKEN`, or a [JWT](gitops-updater.md#jwt-configuration). Read access is deliberately **not** limited to `OIDC_PRIVILEGED_GROUPS` — that gate covers the deploy lock only.
 
 !!! warning "`GET /api/v1/tasks/{id}` is open by default"
-    The Argo Watcher client polls `GET /api/v1/tasks/{id}` for the whole length of
-    every deployment. Requiring a credential there rejects any client too old to send
-    one, so the lookup stays open until you close it deliberately with
-    `OIDC_REQUIRE_TASK_READ_AUTH` (below). The task id is a random v4 UUID returned
-    only to the submitter, and the enumerable `GET /api/v1/tasks` list is protected,
-    so the exposure is limited to callers that already hold a task id — but a task id
-    appearing in a CI log or a webhook payload is enough to read that task's app,
-    author, project, images and status. The `unauthenticated_reads` metric reports how
-    many such reads still arrive without a credential; see
-    [Tracking the read-auth migration](../operations/observability.md#tracking-the-read-auth-migration).
+    The client polls this endpoint for the whole length of every deployment, so requiring a credential rejects any client too old to send one. The task id is a random v4 UUID handed only to the submitter, and the enumerable `GET /api/v1/tasks` list is protected — but anyone holding a task id (from a CI log or a webhook payload) can read that task's app, author, project, images and status. The `unauthenticated_reads` metric counts such reads; see [Tracking the read-auth migration](../operations/observability.md#tracking-the-read-auth-migration).
 
 ### Closing the task lookup
 
-The client presents its credential — `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`,
-whichever is configured — on the status poll as well as on the submission. Once every
-pipeline runs a client that does so, set:
+The client presents its credential — `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`, whichever is set — on status polls as well as on submission, from v0.15.0 onwards. Once every pipeline runs such a client, set:
 
 ```shell
 OIDC_REQUIRE_TASK_READ_AUTH=true
 ```
 
-`GET /api/v1/tasks/{id}` then requires a credential like every other read, leaving
-`GET /api/v1/config` as the only open `/api/v1` read (alongside the probe endpoints
-and `/metrics`, which cannot perform an OIDC flow).
+`GET /api/v1/tasks/{id}` then requires a credential like every other read, leaving `GET /api/v1/config` as the only open `/api/v1` read.
 
-Two things to know before flipping it:
+Three things to know first:
 
-- **It rejects pipelines that send no credential.** A client that submits tasks without
-  a token still gets its task accepted, then fails on the first status poll with `401`.
-  Wait until `unauthenticated_reads` has stayed at zero across a full deployment cycle
-  for every project — that counter exists to answer exactly this question.
-- **A zero counter means a credential was sent, not that it was accepted.** The counter
-  records presence only, so a wrong deploy token reads as migrated. A `BEARER_TOKEN`
-  JWT must also outlive the longest deployment: it is checked on every status poll
-  once this is on, not only at submission.
-- **It requires `OIDC_ENABLED=true`.** With OIDC disabled no read is protected, so the
-  server refuses to start rather than accept a setting that would not take effect.
+- **It fails every pipeline that sends no credential.** Such a task is still accepted, then fails on its first status poll with `401`. Wait until `unauthenticated_reads` has stayed at zero across a full deployment cycle for every project.
+- **A zero counter means a credential was *sent*, not accepted.** The counter records presence only, so a wrong deploy token reads as migrated. A `BEARER_TOKEN` JWT must also outlive the longest deployment: with this on it is checked on every poll, not only at submission.
+- **It requires `OIDC_ENABLED=true`.** Otherwise the server refuses to start rather than accept a setting that could not take effect.
 
-A provider outage is still reported as `503`, which the client retries, rather than
-`401`, which it treats as terminal.
+A provider outage is reported as `503`, which the client retries, not `401`, which it treats as terminal.
 
 ### The WebSocket handshake
 
-`/ws` requires a credential like the other reads — it broadcasts the deployment-lock and
-Argo CD reachability transitions that `GET /api/v1/deploy-lock` and
-`GET /api/v1/reachability` are gated on, so leaving it open would make gating those
-cosmetic. No task data crosses the socket.
+`/ws` is gated like the other reads: it broadcasts the deployment-lock and Argo CD reachability transitions that `GET /api/v1/deploy-lock` and `GET /api/v1/reachability` are gated on, so leaving it open would make gating those cosmetic. No task data crosses the socket.
 
-A browser cannot attach a header to a WebSocket handshake — the API takes a URL and a
-subprotocol list — so the Web UI offers its token as a subprotocol instead:
+A browser cannot set a header on a WebSocket handshake — the API takes a URL and a subprotocol list — so the Web UI offers its token as a subprotocol:
 
 ```text
 Sec-WebSocket-Protocol: argo-watcher.v1, argo-watcher.token.<access-token>
 ```
 
-The server negotiates `argo-watcher.v1` and never echoes the token entry. Clients that
-can set headers (the CLI, monitoring probes) send `Oidc-Authorization`,
-`ARGO_WATCHER_DEPLOY_TOKEN` or `Authorization` as usual and need no subprotocol. A
-handshake carrying no credential is refused with `401` before the connection is
-upgraded; one whose provider cannot be reached is refused with `503`.
+The server negotiates `argo-watcher.v1` and never echoes the token entry. Clients that can set headers (the CLI, monitoring probes) send `Oidc-Authorization`, `ARGO_WATCHER_DEPLOY_TOKEN` or `Authorization` as usual. A handshake with no credential is refused `401` before the upgrade; one whose provider cannot be reached is refused `503`.
 
-### If the provider is unreachable
+### When the provider is unreachable
 
-A read whose credential could not be checked because the provider itself is
-unreachable returns **503 Service Unavailable**, not 401. The Web UI treats a 401 as
-a dead session and signs the user out, so a brief provider outage must not be
-reported as an authentication failure. Cached decisions (see
-`OIDC_TOKEN_VALIDATION_INTERVAL` below) keep working during the outage.
-
-## Prerequisites
-
-You need a fully configured OIDC provider with a **public** client application (Authorization Code + PKCE) set up for Argo Watcher. Two client settings are dictated by how the Web UI signs in, and are covered below; anything else is provider-specific — refer to your provider's documentation.
-
-### Redirect URI and web origin
-
-The Web UI signs in with a **top-level redirect** (not a hidden iframe), so the provider must allow the browser back:
-
-- **Redirect URI** — the application's base URL **including the trailing slash**, e.g. `https://argo-watcher.example.com/`. When Argo Watcher is served under a sub-path, include it: `https://example.com/argo-watcher/`. The same value is used as the post-logout redirect URI. Providers match this exactly, and a mismatch fails the login on the provider's own error page, before Argo Watcher is ever reached.
-- **Web origin** — the application's origin (scheme, host, port; no path). After the redirect the browser reads group membership straight from the provider's userinfo endpoint, and that request carries an `Authorization` header, so the provider must allow it cross-origin. Providers differ here: Keycloak has a separate **Web origins** field, while others derive it from the registered redirect URI.
-
-    Get this wrong and **sign-in still succeeds** — the failure surfaces later, and quietly: the userinfo call is blocked, group membership comes back empty, and every privileged control stays hidden. That is the same symptom as a missing `groups` claim below, so check both when the rollback button or the deploy-lock toggle does not appear for a user who should have them.
-
-`test/keycloak/argo-watcher-e2e-realm.json` in the repository is a minimal working client definition — public, authorization code with PKCE (`S256`), an exact redirect URI, a web origin, and the `groups` mapper below. The browser test suite signs in against it on every run, so it stays a correct reference.
-
-!!! tip "Keycloak"
-    Set **Valid redirect URIs** and **Web origins** in the client's settings. Both are needed: with Web origins empty, users sign in normally and then have no privileged controls.
-
-!!! tip "Authentik"
-    Set **Redirect URI** on the OAuth2/OIDC provider to the same value.
-
-!!! note
-    The provider commonly runs on a different domain than Argo Watcher. That is supported — the flow is a top-level redirect precisely so it does not depend on third-party cookies — but it does mean the userinfo call is cross-origin, which is what the web origin setting is for.
-
-### The `groups` claim
-
-Every provider must satisfy one requirement: emit a `groups` claim in **both** the ID token and the **userinfo** response. Both are used: the Web UI gates its buttons on userinfo, the same source the backend independently enforces on, and falls back to the ID-token claim when that call fails. The backend has no such fallback — while userinfo is unreachable it refuses every privileged action, so the UI may still show a rollback button or a deploy-lock toggle that the API then rejects. The claim must be gated behind a scope Argo Watcher actually requests. Argo Watcher only ever requests `openid profile email`, so the claim must be bound to `profile` or `email` (or the base `openid` scope) — a claim gated behind a separate `groups` scope is never evaluated, and group membership comes back empty.
-
-The steps below are the same requirement expressed in each provider's configuration model.
-
-!!! tip "Keycloak"
-    Create a **Group Membership** protocol mapper in the client configuration. Set the **Token Claim Name** to `groups` and enable **Add to userinfo**. Attach the mapper to the client directly or to a default client scope (`profile`/`email`) so it is always included.
-
-!!! tip "Authentik"
-    Create a **Scope Mapping** that emits a `groups` claim and attach it to the `profile` or `email` scope. Do **not** put it behind a dedicated `groups` scope: Authentik only evaluates a scope mapping when its scope is requested, and Argo Watcher never requests a `groups` scope, so the claim would never be emitted.
-
-## Configuration
-
-The following environment variables control the OIDC integration:
-
-| Variable                         | Description                                                              | Default | Required    |
-|----------------------------------|--------------------------------------------------------------------------|---------|-------------|
-| `OIDC_ENABLED`                   | Enable OIDC authentication                                               | `false` | No          |
-| `OIDC_ISSUER_URL`                | The provider's issuer URL (used for discovery)                           |         | Conditional |
-| `OIDC_CLIENT_ID`                 | Client ID registered with the provider                                   |         | Conditional |
-| `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (in milliseconds) a provider decision about a token may be reused | `300000` | No          |
-| `OIDC_PRIVILEGED_GROUPS`         | Comma-separated list of groups with elevated permissions                 |         | Conditional |
-
-All `Conditional` variables are required when `OIDC_ENABLED` is set to `true`.
-
-### `OIDC_TOKEN_VALIDATION_INTERVAL`
-
-Every authorization decision is made by asking the provider's userinfo endpoint
-about the token. Since the Web UI refreshes on a timer, doing that per request
-would turn each open browser tab into a steady stream of provider traffic, so a
-decision is reused for this interval — one userinfo call per token per interval,
-regardless of how many requests arrive.
-
-The interval is the upper bound on how stale a **read** authorization can be. Each
-decision is additionally capped by the token's own expiry, so it can never outlive
-the credential it describes. Setting it to `0` validates every request against the
-provider.
-
-Privileged actions — managing the deployment lock — are exempt: they always
-re-verify against the provider, so removing a user from `OIDC_PRIVILEGED_GROUPS`
-takes effect immediately rather than within the interval. A lock click is a rare
-human action, so the extra round trip costs nothing.
-
-!!! note
-    The default is `300000` (5 minutes), matched to typical access-token lifetimes.
-
-### The issuer URL
-
-`OIDC_ISSUER_URL` is the value the provider advertises as its `issuer`. Argo Watcher appends `/.well-known/openid-configuration` to it to discover the userinfo endpoint.
-
-| Provider  | Typical issuer URL                                        |
-|-----------|-----------------------------------------------------------|
-| Keycloak  | `https://keycloak.example.com/realms/<realm>`             |
-| Authentik | `https://authentik.example.com/application/o/<app-slug>/` |
-
-### Example: Keycloak
-
-```bash
-OIDC_ENABLED=true
-OIDC_ISSUER_URL=https://keycloak.example.com/realms/your-realm
-OIDC_CLIENT_ID=argo-watcher
-OIDC_PRIVILEGED_GROUPS=platform-team,sre-team
-```
-
-### Example: Authentik
-
-```bash
-OIDC_ENABLED=true
-OIDC_ISSUER_URL=https://authentik.example.com/application/o/argo-watcher/
-OIDC_CLIENT_ID=argo-watcher
-OIDC_PRIVILEGED_GROUPS=platform-team,sre-team
-```
-
-### Helm Chart Values
-
-When deploying with the Helm chart, set the configuration via `extraEnvs` in `values.yaml`:
-
-```yaml
-extraEnvs:
-  - name: OIDC_ENABLED
-    value: "true"
-  - name: OIDC_ISSUER_URL
-    value: "https://keycloak.example.com/realms/your-realm"
-  - name: OIDC_CLIENT_ID
-    value: "argo-watcher"
-  - name: OIDC_PRIVILEGED_GROUPS
-    value: "platform-team,sre-team"
-```
+A read whose credential could not be checked returns **503 Service Unavailable**, never 401. The Web UI treats a 401 as a dead session and signs the user out, so a brief provider outage must not look like an authentication failure. Cached decisions keep working throughout.
 
 ## Migrating from `KEYCLOAK_*`
 
-Earlier releases were Keycloak-specific and used `KEYCLOAK_*` variables. These are **deprecated but still honored** — existing deployments keep working with no change. When the `OIDC_*` variables are unset, Argo Watcher maps the legacy ones automatically and logs a one-time deprecation warning:
+Earlier releases were Keycloak-specific. The old variables are **deprecated but still honored** — existing deployments keep working — and are mapped automatically when their `OIDC_*` counterparts are unset, with a one-time deprecation warning in the log.
 
-| Deprecated                           | Replacement                                                                 |
-|--------------------------------------|-----------------------------------------------------------------------------|
-| `KEYCLOAK_ENABLED`                   | `OIDC_ENABLED`                                                              |
-| `KEYCLOAK_URL` + `KEYCLOAK_REALM`    | `OIDC_ISSUER_URL` (synthesized as `<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>`) |
-| `KEYCLOAK_CLIENT_ID`                 | `OIDC_CLIENT_ID`                                                            |
-| `KEYCLOAK_TOKEN_VALIDATION_INTERVAL` | `OIDC_TOKEN_VALIDATION_INTERVAL`                                            |
-| `KEYCLOAK_PRIVILEGED_GROUPS`         | `OIDC_PRIVILEGED_GROUPS`                                                    |
+| Deprecated | Replacement |
+|---|---|
+| `KEYCLOAK_ENABLED` | `OIDC_ENABLED` |
+| `KEYCLOAK_URL` + `KEYCLOAK_REALM` | `OIDC_ISSUER_URL` (synthesized as `<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>`) |
+| `KEYCLOAK_CLIENT_ID` | `OIDC_CLIENT_ID` |
+| `KEYCLOAK_TOKEN_VALIDATION_INTERVAL` | `OIDC_TOKEN_VALIDATION_INTERVAL` |
+| `KEYCLOAK_PRIVILEGED_GROUPS` | `OIDC_PRIVILEGED_GROUPS` |
 
-`OIDC_*` takes precedence when both are set. The `/api/v1/config` endpoint continues to expose the auth block under a legacy `keycloak` key (mirroring the new `oidc` key) for backward compatibility.
+`OIDC_*` wins when both are set. `GET /api/v1/config` still mirrors the auth block under a legacy `keycloak` key alongside the new `oidc` one, and both the `Oidc-Authorization` and `Keycloak-Authorization` headers are accepted.
 
-## Privileged Groups
+## Privileged groups
 
-Users in privileged groups receive additional capabilities in the Web UI:
-
-- **Redeploy button** — Visible on the task details page, allowing privileged users to trigger a redeployment.
-- **Deployment lock management** — Privileged users can enable or disable the [deployment lock](gitops-updater.md#deployment-locking) via the Web UI.
-
-## Future Improvements
-
-- [ ] RBAC support to restrict redeployment on a per-application basis
+Members of `OIDC_PRIVILEGED_GROUPS` get two things: the **Rollback to this version** button on a task page, which is hidden from everyone else, and the [deployment lock](deployment-lock.md) switch, which others see disabled. Restricting rollback per application is not implemented yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,11 @@ hide:
 
 # Argo Watcher
 
-!!! note "Documentation is a work in progress"
-    These docs are being actively reorganised and rewritten. Expect rough edges, occasional gaps, and the odd inaccuracy. If something looks wrong, please [open an issue](https://github.com/shini4i/argo-watcher/issues) or use the pencil icon at the top right of any page to suggest a fix.
-
 **A feedback loop for your GitOps workflow.**
 
 Argo Watcher bridges the gap between your CI pipeline and Argo CD, providing real-time status and visibility into your deployments. Stop guessing whether your deployment succeeded — Argo Watcher tells your pipeline exactly what happened.
+
+If a page looks wrong, [open an issue](https://github.com/shini4i/argo-watcher/issues) or use the pencil icon at the top right to suggest a fix.
 
 ```mermaid
 graph LR

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -21,7 +21,7 @@ There are two tables. `tasks` stores every deployment task and its status; index
 | `author` | `varchar(255) NOT NULL` | Deployment author identifier. |
 | `project` | `varchar(255) NOT NULL` | Business project identifier. |
 
-`deploy_lock` holds the [manual deploy lock](../guides/gitops-updater.md#deployment-locking) so it applies to every replica and survives restarts. It is seeded by the migration and always holds exactly one row.
+`deploy_lock` holds the [manual deploy lock](../guides/deployment-lock.md#manual-lockdown) so it applies to every replica and survives restarts. It is seeded by the migration and always holds exactly one row.
 
 | Column | Type | Notes |
 |---|---|---|
@@ -71,7 +71,7 @@ pg_dump --no-owner --no-acl \
   | gzip > "argo-watcher-$(date -u +%Y%m%d).sql.gz"
 ```
 
-A daily dump retained for 30 days is a sensible baseline. If the deployment volume is high or you treat the audit history as critical, increase retention rather than frequency — there's no point dumping more than once an hour given the workload.
+A daily dump retained for 30 days is a sensible baseline. If you treat the deployment history as an audit trail, increase retention rather than frequency.
 
 Restore with `psql` after recreating the database:
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,44 +1,43 @@
 # Observability
 
-The Argo Watcher server exposes Prometheus metrics on the same port as the API (default `8080`) at the `/metrics` endpoint. Scrape it like any other Prometheus target:
+The server exposes Prometheus metrics at `/metrics`, on the same port as the API. With the Helm chart, set `podMonitor.enabled: true` to have Prometheus Operator scrape it; otherwise add a target:
 
 ```yaml
 scrape_configs:
   - job_name: argo-watcher
     static_configs:
       - targets: ["argo-watcher.example.com:8080"]
-    metrics_path: /metrics
 ```
 
-## Exposed metrics
+## Metrics
 
-The server emits twelve metrics today, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go).
+Twelve metrics, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go), plus the standard Go runtime ones (`go_*`, `process_*`).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `failed_deployment` | gauge | `app` | Per-application failed deployment count since the last success. Reset to 0 when an application deploys successfully. Includes deployments aborted because Argo CD was unreachable — a deployment that could not be confirmed counts as failed regardless of cause; `argocd_unavailable` separately indicates whether Argo CD itself was the reason. |
-| `processed_deployments` | counter | `app` | Total deployments processed since server startup, per application. |
-| `argocd_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach the Argo CD API, `0` otherwise. Independent of the state backend (see `state_unavailable`). |
-| `state_unavailable` | gauge | (none) | `1` when Argo Watcher cannot reach its state backend (database), `0` otherwise. Independent of Argo CD. |
-| `in_progress_tasks` | gauge | (none) | Number of tasks currently in progress (between submission and terminal state). |
-| `argocd_refresh_duration_seconds` | histogram | `app` | Duration of ArgoCD application refresh requests, to surface slow or stuck refreshes. Recorded only when the status check requests a refresh. |
-| `gitops_writeback_duration_seconds` | histogram | `app` | Time the git write-back held the per-repo lock, covering the clone/commit/push cycle plus any retries and backoff. |
-| `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting to acquire the per-repository git write-back lock. High values mean tasks are queued behind concurrent write-backs to the same repo. |
-| `deployment_duration_seconds` | histogram | `app` | End-to-end wall-clock time of a successful deployment, from the start of rollout monitoring until the app reached the deployed state. Only successful deployments are observed (a failure's duration is dominated by the timeout). |
-| `gitops_batch_size` | histogram | (none) | Number of applications coalesced into a single batch write-back flush. Only observed when `GIT_BATCH_WRITEBACK` is enabled; a distribution skewed toward 1 means little batching is happening (low contention). See the [GitOps Updater](../guides/gitops-updater.md#batch-write-back) guide. |
-| `gitops_writeback_skipped_unvalidated` | counter | `app` | Deployments of an application annotated `argo-watcher/managed: "true"` whose task carried no valid credential, so the new image tag was never committed. Any non-zero value is a misconfiguration. The deployment that follows normally fails blaming the image or the timeout rather than the credential, which is what this counter identifies — see [Image tag is never committed](troubleshooting.md#image-tag-is-never-committed-write-back-skipped). Task submission takes an optional credential by design, so anyone who can reach the endpoint and knows a managed application's name can also raise this counter; treat a rise as "investigate", not automatically "a pipeline of ours regressed". |
-| `unauthenticated_reads` | counter | `path`, `app` | Reads served without a credential on the endpoints deliberately left open while OIDC auth is enabled (currently `GET /api/v1/tasks/{id}`). Zero only when every caller presents a credential; `app` names the application whose pipeline still polls without one, and is `unknown` when the read matched no task or one whose submission carried no credential (an app name from an uncredentialed caller is unbounded, so it never becomes a label). See [Tracking the read-auth migration](#tracking-the-read-auth-migration). |
+| `failed_deployment` | gauge | `app` | Failed deployments since that application's last success; reset to 0 on success. Includes deployments aborted because Argo CD was unreachable. |
+| `processed_deployments` | counter | `app` | Deployments processed since startup. |
+| `in_progress_tasks` | gauge | | Tasks between submission and a terminal state. |
+| `argocd_unavailable` | gauge | | `1` while the Argo CD API is unreachable. |
+| `state_unavailable` | gauge | | `1` while the state backend (database) is unreachable. |
+| `deployment_duration_seconds` | histogram | `app` | End-to-end time of a **successful** deployment, from the start of monitoring to `deployed`. Failures are excluded: their duration is just the timeout. |
+| `argocd_refresh_duration_seconds` | histogram | `app` | Argo CD application refresh requests. Recorded only when the status check asks for a refresh. |
+| `gitops_writeback_duration_seconds` | histogram | `app` | Time the write-back held the per-repo lock: clone, commit, push, retries and backoff. |
+| `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting for that lock. High values mean write-backs are queued behind each other. |
+| `gitops_batch_size` | histogram | | Applications coalesced into one batch flush. Only with `GIT_BATCH_WRITEBACK`; clustered at `1` means no contention to collapse. |
+| `gitops_writeback_skipped_unvalidated` | counter | `app` | Deployments of a `argo-watcher/managed` application whose task carried no valid credential, so the tag was never committed. Any non-zero value is a misconfiguration. |
+| `unauthenticated_reads` | counter | `path`, `app` | Reads served without a credential on the endpoints left open while OIDC is enabled (currently `GET /api/v1/tasks/{id}`). |
 
-!!! note "The `app` label and uncredentialed submissions"
-    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so a name that arrives that way is reported as `app="unknown"` instead of becoming its own series, which would let anyone able to reach the endpoint create unbounded Prometheus series. This affects `processed_deployments`, `unauthenticated_reads`, and `failed_deployment` when the failure happens before Argo CD confirms the application exists. A deployment submitted with a deploy token, JWT or OIDC session is labelled with its real application throughout.
+!!! note "Why some series say `app="unknown"`"
+    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so a name arriving that way is labelled `unknown` rather than becoming its own series, which would let anyone reaching the endpoint create unbounded series. This affects `processed_deployments`, `unauthenticated_reads`, and `failed_deployment` when the failure precedes Argo CD confirming the application exists. Deployments submitted with a credential are labelled with their real application throughout.
 
-In addition, the standard Go runtime metrics from the Prometheus client library are exposed (`go_*`, `process_*`).
+    The same openness means anyone who can reach the endpoint and knows a managed application's name can raise `gitops_writeback_skipped_unvalidated`. Treat a rise as "investigate", not automatically "our pipeline regressed".
 
-The same cached reachability that drives `argocd_unavailable` and `state_unavailable` is exposed for polling (and to bootstrap the Web UI's "unreachable" banner) via `GET /api/v1/reachability`, which returns `{"available":bool,"reason":"argocd"|"database"|"both"}` (`reason` is omitted when available). The banner uses `reason` to name which subsystem is down.
+The cached reachability behind `argocd_unavailable` and `state_unavailable` is also readable at `GET /api/v1/reachability`, which returns `{"available":bool,"reason":"argocd"|"database"|"both"}` (`reason` omitted when available). The Web UI's banner uses `reason` to name what is down.
 
 ## Suggested alerts
 
-These alerts cover the failure modes the metrics are designed to catch. Tune the thresholds to your environment.
+Thresholds are starting points; tune them.
 
 ```yaml
 groups:
@@ -51,9 +50,18 @@ groups:
           severity: critical
         annotations:
           summary: Argo Watcher cannot reach the Argo CD API
+          description: No task will progress until connectivity is restored.
+
+      - alert: ArgoWatcherStateUnreachable
+        expr: state_unavailable == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Argo Watcher cannot reach its state backend
           description: |
-            argo_watcher has reported argocd_unavailable=1 for more than 5 minutes.
-            Tasks will not progress until connectivity is restored.
+            Pods are unready and, with STATE_TYPE=postgres, deploy requests are
+            rejected as locked because the lock state cannot be read.
 
       - alert: ArgoWatcherFailingDeployments
         expr: failed_deployment > 3
@@ -62,9 +70,7 @@ groups:
           severity: warning
         annotations:
           summary: "{{ $labels.app }} has failed {{ $value }} times in a row"
-          description: |
-            The application has not deployed successfully for more than 10 minutes.
-            Inspect the most recent task in the Web UI for the failure reason.
+          description: Check the most recent task in the Web UI for the failure reason.
 
       - alert: ArgoWatcherTaskBacklog
         expr: in_progress_tasks > 50
@@ -73,9 +79,7 @@ groups:
           severity: warning
         annotations:
           summary: Task backlog growing on argo-watcher
-          description: |
-            More than 50 tasks have been in progress for over 15 minutes.
-            Check Argo CD sync performance and DEPLOYMENT_TIMEOUT.
+          description: Check Argo CD sync performance and DEPLOYMENT_TIMEOUT.
 
       - alert: ArgoWatcherSlowRefresh
         expr: histogram_quantile(0.95, sum by (app, le) (rate(argocd_refresh_duration_seconds_bucket[10m]))) > 30
@@ -83,12 +87,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "{{ $labels.app }} ArgoCD refresh is slow"
+          summary: "{{ $labels.app }} Argo CD refresh is slow"
           description: |
-            The p95 ArgoCD refresh for this application exceeds 30s. A refresh that never
-            settles (e.g. an app with a constantly-reconciling CronJob) can stall the
-            deployment check — set the per-task refresh override (or ARGO_REFRESH_APP) to
-            false for such apps.
+            A refresh that never settles (an app with a constantly-reconciling
+            CronJob, for example) stalls the deployment check. Set TASK_REFRESH
+            (or ARGO_REFRESH_APP) to false for such applications.
 
       - alert: ArgoWatcherSlowGitWriteback
         expr: histogram_quantile(0.95, sum by (app, le) (rate(gitops_writeback_duration_seconds_bucket[10m]))) > 60
@@ -98,11 +101,9 @@ groups:
         annotations:
           summary: "{{ $labels.app }} git write-back is slow"
           description: |
-            The p95 git write-back for this application exceeds 60s, which points to push
-            contention (retries/backoff) or, on a repo with an unusually large working tree,
-            slow transfer of that tree (history depth is not a factor — clone and fetch are
-            shallow). Check gitops_lock_wait_duration_seconds for the same app to see whether
-            it is queued behind other write-backs to the same repository.
+            Points to push contention or a repository with a very large working
+            tree (history depth is not a factor — clone and fetch are shallow).
+            Compare gitops_lock_wait_duration_seconds for the same app.
 
       - alert: ArgoWatcherWritebackSkipped
         expr: increase(gitops_writeback_skipped_unvalidated[1h]) > 0
@@ -112,103 +113,46 @@ groups:
         annotations:
           summary: "{{ $labels.app }} deploys without git write-back"
           description: |
-            The application is annotated for write-back but its deployments arrive without a
-            valid credential, so the image tag is never committed. Those deployments then
-            fail blaming the image or the timeout (or, under fire-and-forget, report success),
-            which is why this counter is the signal. Check that the pipeline sets
-            ARGO_WATCHER_DEPLOY_TOKEN or BEARER_TOKEN, and that nothing between the client
-            and argo-watcher redirects to a different host — a credential is not carried
-            across a host change.
+            The application is annotated for write-back but its deployments carry
+            no valid credential, so the tag is never committed. Check that the
+            pipeline sets ARGO_WATCHER_DEPLOY_TOKEN or BEARER_TOKEN, and that
+            nothing redirects the client to a different host.
 ```
 
 ## Example dashboard
 
-A ready-made Grafana dashboard lives in the repository at
-[`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json).
-It has an **Overview** row that illustrates the core metrics in aggregate
-(availability, in-progress tasks, deployment counts, failing apps) — the opt-in
-`gitops_batch_size` metric and the newer `state_unavailable` metric have no panel
-yet — and a
-**Per-Application Breakdown** row driven by an `Application` template variable, so
-you can select one app (or several) and see its deployment counts, failures,
-end-to-end deployment duration, and the refresh / write-back / lock-wait latency
-percentiles.
+A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
 
-Import it into any Grafana by uploading the JSON (**Dashboards → New → Import**),
-or spin up a self-contained Prometheus + Grafana stack next to the dev server:
+Import it through **Dashboards → New → Import**, or run it next to the dev server:
 
 ```bash
 docker compose --profile monitoring up
 ```
 
+That starts Prometheus (scraping the dev `backend`) and Grafana with the datasource and dashboard provisioned, at <http://localhost:3001> — anonymous admin, no login. Drive a few deployments through the client to fill the panels.
+
 ![Argo Watcher Grafana dashboard](https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher/grafana-dashboard.png)
 
-This starts Prometheus (scraping the dev `backend`) and Grafana with the
-datasource and dashboard already provisioned. Open Grafana at
-<http://localhost:3001> — anonymous admin access is enabled for local use, so no
-login is required. Drive a few deployments through the client to populate the
-panels.
+The **Git Write-back Duration** and **Git Lock Wait Duration** panels only fill for applications using write-back (`argo-watcher/managed`); they stay empty for status-only deployments.
 
-The two **Git Write-back Duration** and **Git Lock Wait Duration** panels only
-populate for applications using GitOps write-back (`argo-watcher/managed`); they
-stay empty for status-only deployments.
-
-## Grafana panel queries
-
-If you would rather build your own panels, these three cover the most useful
-operational views.
-
-### Active in-progress tasks
+### Useful queries
 
 ```promql
-sum(in_progress_tasks)
+sum(in_progress_tasks)                          # live workload
+topk(5, failed_deployment)                      # which apps need attention
+sum(rate(processed_deployments[1h])) by (app)    # deployment frequency per app
 ```
-
-Use a stat or graph panel to monitor live workload. Pair with `argocd_unavailable` on the same dashboard.
-
-### Top 5 apps with consecutive failures
-
-```promql
-topk(5, failed_deployment)
-```
-
-A bar gauge highlights which applications need attention. Drill into each app via the Argo Watcher Web UI to see the underlying task failures.
-
-### Deployments per hour, per app
-
-```promql
-sum(rate(processed_deployments[1h])) by (app)
-```
-
-A graph panel showing deployment frequency per application — useful for capacity planning and identifying applications that suddenly stop deploying.
 
 ## Tracking the read-auth migration
 
-With [OIDC authentication](../guides/oidc.md) enabled, the browser-facing reads
-require a credential, but `GET /api/v1/tasks/{id}` stays open by default: the Argo
-Watcher client polls it for the whole length of every deployment, and a client too old
-to send a credential on that poll would fail every deployment it drives. The
-`unauthenticated_reads` counter measures how much of your fleet is still in that
-state:
+With [OIDC](../guides/oidc.md) enabled the browser-facing reads require a credential, but `GET /api/v1/tasks/{id}` stays open by default: the client polls it throughout every deployment, and a client too old to send a credential there would fail every deployment it drives. `unauthenticated_reads` measures how much of the fleet is still in that state:
 
 ```promql
 sum(rate(unauthenticated_reads[1h])) by (app)
 ```
 
-That names the applications to chase: each one is a pipeline running a client that
-sends no credential. Group by `path` instead for the endpoint breakdown. Every pipeline
-that upgrades to a client sending its credential on reads drops out of this figure. When it reaches zero and stays there across a full deployment cycle for
-every project, no caller depends on the exemption and you can withdraw it with
-`OIDC_REQUIRE_TASK_READ_AUTH=true` — see
-[Closing the task lookup](../guides/oidc.md#closing-the-task-lookup). A read without a
-credential is then rejected before it is served, so the counter stops moving — and the
-series disappears from `/metrics` after the next restart, which matters if you alert on
-it with `absent()`.
+Each application named is a pipeline running such a client; group by `path` for the endpoint breakdown. When the figure reaches zero and stays there across a full deployment cycle for every project, nothing depends on the exemption and you can close it with `OIDC_REQUIRE_TASK_READ_AUTH=true` — see [Closing the task lookup](../guides/oidc.md#closing-the-task-lookup).
 
-Nothing is logged per request — the endpoint is polled continuously during a
-deployment, so a log line per read would bury everything else.
+Two caveats: the counter records that a credential was *present*, not that it was valid, and once the endpoint is closed the counter stops moving and its series disappears from `/metrics` after the next restart — which matters if you alert on it with `absent()`.
 
-## Where to look next
-
-- **[Troubleshooting](troubleshooting.md)** — Operational runbook keyed off the same symptoms these metrics flag.
-- **[Database](database.md)** — Backup, sizing, and migration guidance.
+Nothing is logged per read; the endpoint is polled continuously during a deployment, so a line per read would bury everything else.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,183 +1,150 @@
 # Troubleshooting
 
-Each entry follows the same shape: **Symptom · Likely cause · How to verify · Fix.** When a symptom shows up in monitoring first, [Observability](observability.md) tells you which metric to look at; this page tells you what to do once you have.
-
+Symptom-driven. Each entry names the likely causes, how to confirm which one it is, and the fix. When a problem shows up in monitoring first, [Observability](observability.md) says which metric to look at.
 
 ## Server does not start
 
-**Symptom:** The Argo Watcher server pod fails to start or repeatedly crashes.
+**Symptom:** the pod never becomes ready, or restarts repeatedly.
 
-**Likely causes:**
-- `ARGO_URL` or `ARGO_TOKEN` are incorrect or missing.
-- The server cannot reach the Argo CD API.
-- If using `STATE_TYPE=postgres`, the database is not accessible or migrations have not been applied. The server (and `--migrate`) fail fast within `DB_CONNECT_TIMEOUT` seconds (default 10) instead of hanging on the OS TCP timeout; check the logs right after the `Connecting to PostgreSQL database...` line for the connection error.
+**Likely causes**
 
-**How to verify:**
-- Check the server logs: `kubectl logs -f <pod-name>` or `docker logs <container-name>`.
-- Set `LOG_LEVEL=debug` for verbose output.
-- Verify connectivity: `curl -H "Authorization: Bearer $ARGO_TOKEN" $ARGO_URL/api/v1/applications`.
+- `ARGO_URL` or `ARGO_TOKEN` is wrong, or Argo CD is unreachable from the pod.
+- A configuration error. The server reports every invalid or missing variable in a single startup error.
+- With `STATE_TYPE=postgres`: the database is unreachable, or the migrations have not been applied. Startup fails within `DB_CONNECT_TIMEOUT` seconds (default 10) rather than hanging — look right after the `Connecting to PostgreSQL database...` log line.
 
-**Fix:**
-1. Confirm that `ARGO_URL` is the correct Argo CD API URL (e.g., `https://argocd.example.com`).
-2. Generate a new token if the existing one is expired or invalid.
-3. If using Postgres, run migrations: `goose -dir ./migrations postgres "$DATABASE_URL" up`.
+**How to verify**
 
----
+```bash
+kubectl logs <pod>                     # the startup error names what is wrong
+curl -H "Authorization: Bearer $ARGO_TOKEN" $ARGO_URL/api/v1/applications
+```
+
+**Fix**
+
+1. Point `ARGO_URL` at the Argo CD API and mint a fresh token if the current one is rejected.
+2. Apply the migrations. With the Helm chart, `helm upgrade` runs them as a hook Job; otherwise run [golang-migrate](https://github.com/golang-migrate/migrate) yourself:
+
+    ```bash
+    migrate -path db/migrations -database "$DATABASE_URL" up
+    ```
 
 ## Client exits with a non-zero code
 
-**Symptom:** The Argo Watcher client in a CI/CD pipeline returns a non-zero exit code, failing the build.
+**Symptom:** the client fails the CI job.
 
-**Likely causes:**
-- The `ARGO_WATCHER_URL` is not reachable from the CI runner.
-- The `ARGO_APP` name does not match an application in Argo CD.
-- The `IMAGES` or `IMAGE_TAG` do not correspond to the built image.
-- The client timed out waiting for the deployment to complete.
-- Argo CD (or the state backend) is unreachable — the server now fails the submission fast with a `503` `{"status":"down"}` response instead of hanging until the client's own HTTP timeout, and the Web UI shows an "unreachable" banner naming the affected subsystem (ArgoCD, the state backend, or both) until connectivity is restored.
-- Argo CD became unreachable *during* the deployment check (timeout, DNS/TLS error, connection refused, or a `5xx` response). The task is recorded as `aborted` and the client logs `The deployment was aborted before its outcome could be confirmed. See the reason below.` followed by the task's status reason (e.g. `ArgoCD API Error: ...`). The application itself may be healthy — check Argo CD directly before blaming the deployment.
-- A newer deployment of one of the same images was submitted while this one was still in progress, so the server cancelled this task (client logs `The deployment was cancelled because a newer deployment superseded it`). Only tasks sharing an image with the newer deployment are cancelled; independent per-image deployments of the same application do not cancel each other. A deployment also only cancels one that presented no more authority than itself, so an uncredentialed deployment never cancels a credentialed one still in flight. This is by design, not a real failure — confirm the newer deployment succeeded; no other action is needed.
+Read the client's last log line first — it distinguishes these:
 
-**How to verify:**
-- Check the client logs in the CI output.
-- Manually test reachability: `curl $ARGO_WATCHER_URL/readyz` from the CI runner.
-- Verify the app name: `argocd app get <ARGO_APP>`.
-- Check the image that was pushed to the registry.
+| Client says | Meaning |
+|---|---|
+| `The deployment has failed` | Argo CD reported a failure, or the timeout elapsed. Continue with [Deployment times out](#deployment-times-out). |
+| `Application <name> does not exist` | `ARGO_APP` does not match an Argo CD application (names are case-sensitive). |
+| `Image "<name>" is not part of application` | The application does not declare that image — see [Image is not part of application](#image-is-not-part-of-application). |
+| `The deployment was aborted before its outcome could be confirmed` | Argo CD became unreachable during the check. The application itself may be perfectly healthy — check Argo CD before blaming the deployment. |
+| `The deployment was cancelled because a newer deployment superseded it` | Expected, not a fault: a newer deployment of the same image took over. Confirm that one succeeded; nothing else to do. |
+| `refused to follow a redirect away from https` | See [Client refuses a redirect away from https](#client-refuses-a-redirect-away-from-https). |
+| A `503 {"status":"down"}` on submission | Argo CD or the state backend is unreachable, so the server rejects the submission fast instead of letting the client wait. The Web UI shows a banner naming which. |
 
-> **Note:** While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses) up to 3 times with a 2-second backoff, so a single blip is not fatal. A non-zero exit here means the failure persisted past those retries or was terminal (`4xx`, invalid token).
+**Also check**
 
-**Fix:**
-1. Ensure `ARGO_WATCHER_URL` is accessible from the CI environment (check firewall rules and DNS).
-2. Verify the application name in `ARGO_APP` matches Argo CD exactly (case-sensitive).
-3. Confirm that `IMAGES` and `IMAGE_TAG` match the tag that was pushed.
-4. Increase `DEPLOYMENT_TIMEOUT` if deployments consistently take longer than 900 seconds.
+- `ARGO_WATCHER_URL` is reachable from the runner: `curl $ARGO_WATCHER_URL/readyz`.
+- `IMAGES` and `IMAGE_TAG` match what was actually built and pushed.
 
----
+!!! note
+    Transient failures while polling (network errors, `5xx`) are retried three times, two seconds apart, so a single blip is not fatal. A non-zero exit means the failure persisted or was terminal.
 
 ## Deployment times out
 
-**Symptom:** The client reports "deployment timed out" even though the application is deploying correctly.
+**Symptom:** the deployment fails on the timeout although the application looks fine in Argo CD.
 
-**Likely causes:**
-- The default `DEPLOYMENT_TIMEOUT` (900 seconds / 15 minutes) is too short for the workload.
-- Argo CD is not detecting the image update.
-- The requested image is not part of the application at all. This normally fails immediately rather than timing out — see [Image is not part of application](#image-is-not-part-of-application) for the cases where it cannot be detected.
-- When relying on the built-in GitOps updater: the task was submitted without a valid deploy token or JWT, so the write-back was silently skipped and Argo CD never received the new tag. (If image tags are committed by other means — Argo CD Image Updater, your CI — this is expected and not the cause.)
+**Likely causes**
 
-**How to verify:**
-- Check the Argo CD UI to confirm the application is syncing and the new image is being deployed.
-- Verify that the image tag annotation was correctly set: `kubectl describe app <ARGO_APP> -o yaml | grep -A5 argo-watcher`.
-- Confirm the CI job actually supplied `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`. For an application annotated `argo-watcher/managed: "true"` the server logs a warning — "application is managed by the watcher but the task presented no valid credential" — and increments `gitops_writeback_skipped_unvalidated`; see [Image tag is never committed](#image-tag-is-never-committed-write-back-skipped).
+- The timeout is genuinely too short. The binary defaults to 900s, but the **Helm chart sets 300s** via `argo.timeout`.
+- Argo CD never received the new tag. When you rely on the built-in updater, the usual reason is a task submitted without a valid credential — see [Image tag is never committed](#image-tag-is-never-committed-write-back-skipped). (If tags are committed by other means, this is not it.)
+- The requested image is not part of the application, and the fail-fast check is off. See [Image is not part of application](#image-is-not-part-of-application).
 
-**Fix:**
-1. Increase `DEPLOYMENT_TIMEOUT` to accommodate your typical rollout duration.
-2. If using the built-in GitOps updater, verify the SSH key has write access to the target repository.
-3. Check Argo CD logs for sync errors: `kubectl logs -l app.kubernetes.io/name=argocd-application-controller`.
+**How to verify**
 
----
+```bash
+kubectl get app <ARGO_APP> -n argocd -o yaml | grep -A5 argo-watcher   # annotations
+kubectl logs -l app.kubernetes.io/name=argocd-application-controller   # sync errors
+```
+
+**Fix**
+
+1. Raise `argo.timeout` (chart) or `DEPLOYMENT_TIMEOUT` to cover your slowest rollout.
+2. If the updater should have committed the tag, confirm the pipeline sets `ARGO_WATCHER_DEPLOY_TOKEN` or `BEARER_TOKEN`, and that the SSH key can write to the repository.
 
 ## Image tag is never committed (write-back skipped)
 
-**Symptom:** The server logs `Skipping git repo update: application is managed by the
-watcher but the task presented no valid credential` and
-`gitops_writeback_skipped_unvalidated` rises for that application.
+**Symptom:** the server logs `Skipping git repo update: application is managed by the watcher but the task presented no valid credential`, and `gitops_writeback_skipped_unvalidated` rises for that application.
 
-Write-back requires a credential on `POST /api/v1/tasks`. Without one the task is still
-accepted and monitored — submission is deliberately open — but the new tag is never
-committed, so what the pipeline reports next does not name the real cause:
+Write-back needs a credential on `POST /api/v1/tasks`. Without one the task is still accepted and monitored — submission is deliberately open — but the tag is never committed, and what the pipeline reports next does not name the real cause:
 
 | Application | What the deployment reports |
 |---|---|
-| Normal | Fails as `Image "<name>" is not part of application "<app>"` — the image is genuinely absent, because the commit that would have added it never happened. |
-| Normal, with image validation off (`ARGO_REFRESH_APP=false`, `refresh: false`, or `argo-watcher/skip-image-validation`) | Waits out `DEPLOYMENT_TIMEOUT`, then fails. |
+| Normal | `Image "<name>" is not part of application "<app>"` — the image really is absent, because the commit never happened. |
+| Image validation off (`ARGO_REFRESH_APP=false`, `TASK_REFRESH=false`, or `argo-watcher/skip-image-validation`) | Waits out `DEPLOYMENT_TIMEOUT`, then fails. |
 | `argo-watcher/fire-and-forget: "true"` | **Reports success.** The rollout is never checked, so nothing contradicts it. |
-| Redeploy of a tag the application already runs | Reports success, correctly — there was nothing to commit. |
+| Redeploy of a tag it already runs | Reports success, correctly — there was nothing to commit. |
 
-So a failure here usually blames the image or the clock. The server-side warning and
-counter above are what identify the credential as the cause.
+The server warning and the counter are what identify the credential as the cause.
 
-**Likely causes:**
+**Likely causes**
+
 - The pipeline sets neither `ARGO_WATCHER_DEPLOY_TOKEN` nor `BEARER_TOKEN`.
-- The value does not match the server's `ARGO_WATCHER_DEPLOY_TOKEN` / `JWT_SECRET`.
-- **Something between the client and the server redirects to a different host.** A
-  credential is generally not carried across a host change, so it never reaches the server.
-  The two credentials behave differently:
-    - `Authorization` (`BEARER_TOKEN`) is stripped by Go's HTTP client on **every** client
-      version — but only when the *hostname* changes. Go compares hostnames with the port
-      excluded, so it is preserved across a port-only change (`host:8080` → `host:9090`) and
-      when the target is a subdomain of the original (`example.com` → `sub.example.com`).
-      A sibling hostname is not a subdomain: `watcher.example.com` →
-      `watcher.int.example.com` drops it.
-    - `ARGO_WATCHER_DEPLOY_TOKEN` is a custom header, which Go always forwards, so the
-      client deletes it itself on any change of host **or port** — from v0.15.0 onwards.
-      Earlier clients forwarded it, so this can appear on a client upgrade with nothing
-      else changing.
+- The value does not match the server's `ARGO_WATCHER_DEPLOY_TOKEN` or `JWT_SECRET`.
+- **Something redirects the client to a different host**, and a credential does not survive that hop. The two behave differently:
+    - `Authorization` (`BEARER_TOKEN`) is stripped by Go's HTTP client on every client version, but only when the *hostname* changes. A port-only change (`host:8080` → `host:9090`) keeps it, and so does a move to a subdomain (`example.com` → `sub.example.com`). A sibling host does not: `watcher.example.com` → `watcher.int.example.com` drops it.
+    - `ARGO_WATCHER_DEPLOY_TOKEN` is a custom header, which Go always forwards, so from v0.15.0 the client deletes it itself on any change of host **or** port. Earlier clients forwarded it, so this can appear on a client upgrade with nothing else changing.
 
-  Clients from this release onward log a warning naming both hosts, once per run, whenever
-  a credential does not survive the hop.
+    Clients from v0.15.0 log one warning naming both hosts when a credential does not survive the hop.
 
-**How to verify:**
+**How to verify**
+
 ```bash
 curl -sSI "$ARGO_WATCHER_URL/api/v1/config"
 ```
-A `200` means there is no redirect. A `301`, `302`, `307` or `308` with a `Location`
-pointing at a different hostname is the cause. (A `301`/`302` on the API path breaks
-submission outright, since Go rewrites the `POST` to a `GET`; a `307`/`308` preserves the
-request and loses only the credential.)
 
-**Fix:**
+`200` means there is no redirect. A `301`, `302`, `307` or `308` whose `Location` points at another hostname is the cause. (A `301`/`302` on an API path breaks submission outright, since Go rewrites the `POST` to a `GET`; a `307`/`308` keeps the request and loses only the credential.)
+
+**Fix**
+
 1. Point `ARGO_WATCHER_URL` at the hostname that actually serves the API.
-2. If the pipelines cannot be changed, serve both hostnames from the same ingress instead
-   of redirecting one to the other — then there is no host change. Redirecting browser
-   navigation while passing `/api/v1/*` and `/ws` through keeps the canonical URL in the
-   address bar.
+2. If the pipelines cannot change, serve both hostnames from the same ingress instead of redirecting between them. Redirecting browser navigation while passing `/api/v1/*` and `/ws` through keeps the canonical URL in the address bar.
 
-Do not work around this by allowing the credential to follow the redirect. The deploy
-token does not expire, is not scoped to an application, and authorizes commits to the
-GitOps repository — whoever answers for the redirect target receives it on every request.
-
----
+!!! warning
+    Do not work around this by letting the credential follow the redirect. The deploy token does not expire, is not scoped to an application, and authorizes commits to your GitOps repository — whoever answers for the redirect target would receive it on every request.
 
 ## Client refuses a redirect away from https
 
-**Symptom:** The deployment fails immediately with
-`refused to follow a redirect away from https`, naming the endpoint that answered and the
-plain-`http` target it pointed at.
+**Symptom:** the deployment fails immediately with `refused to follow a redirect away from https`, naming the endpoint that answered and the plain-`http` target it pointed at.
 
-**Meaning:** `ARGO_WATCHER_URL` is an `https` URL, but something on the path answers it
-with a `Location` on plain `http`. Go's HTTP client carries `Authorization` across such a
-redirect as long as the hostname is unchanged, so following it would put the deploy token
-or CI JWT on the wire in the clear. The client refuses instead, and does not retry — the
-redirect is a property of the configuration, not a transient failure.
+**Meaning:** `ARGO_WATCHER_URL` is an `https` URL but something on the path redirects to plain `http`. Go carries `Authorization` across such a redirect when the hostname is unchanged, so following it would put the deploy token or CI JWT on the wire in the clear. The client refuses and does not retry — this is configuration, not a blip.
 
-**Fix:** Point `ARGO_WATCHER_URL` at the endpoint that serves the API over TLS, or stop
-the ingress in front of it from downgrading API requests. Only stepping down from TLS is
-refused — a client deliberately pointed at an `http://` URL keeps working, unless the
-chain has already reached `https` by the time it is redirected back.
-
----
+**Fix:** point `ARGO_WATCHER_URL` at the endpoint that serves the API over TLS, or stop the ingress from downgrading API requests. Only stepping *down* from TLS is refused; a client deliberately pointed at an `http://` URL keeps working.
 
 ## Image is not part of application
 
-**Symptom:** The deployment fails immediately with `Image "<name>" is not part of application "<app>"`, followed by the list of images the application defines.
+**Symptom:** the deployment fails immediately with `Image "<name>" is not part of application "<app>"`, followed by the images the application does declare.
 
-**Meaning:** The application finished rolling out — synced and healthy — but its desired state does not declare the requested image at all, so waiting for that image to appear would only burn the task's timeout. Argo Watcher reads the desired state from Argo CD's managed resources, not from the running pods, so a workload that has no pod yet (an untriggered `CronJob`, a `Deployment` scaled to zero) still counts as declaring its image.
+**Meaning:** the application finished rolling out — synced and healthy — but its desired state never declares the requested image, so waiting would only burn the timeout. The desired state comes from Argo CD's managed resources, not from running pods, so a workload with no pod yet (an untriggered `CronJob`, a `Deployment` scaled to zero) still counts as declaring its image.
 
-**Likely causes:**
-- The image name is misspelled, or the registry prefix does not match what the manifests use.
-- The deployment targets a real but different application — one that exists, so it is not reported as `app not found`, but does not contain this image.
+**Likely causes**
 
-**How to verify:** Compare the requested image with the list in the failure reason, or run `argocd app manifests <app> | grep image:`.
+- The image name is misspelled, or its registry prefix does not match the manifests.
+- The deployment targets a real but different application — it exists, so it is not `app not found`, but it does not contain this image.
+- The tag was never committed: see [Image tag is never committed](#image-tag-is-never-committed-write-back-skipped).
 
-**Fix:** Correct the image name, or the `ARGO_APP`, in the deployment request.
+**How to verify:** compare the requested image against the list in the failure reason, or run `argocd app manifests <app> | grep image:`.
 
-**When the check does not run:** it needs a freshly reconciled application, so it is skipped entirely when `ARGO_REFRESH_APP` is `false` or the task sets `refresh: false`. Without a refresh the desired state may be older than the deployment, and a legitimate image could look absent.
+**When the check does not run:** it needs a freshly reconciled application, so it is skipped when `ARGO_REFRESH_APP` is `false` or the task sets `TASK_REFRESH=false`.
 
-**When the check is wrong:** two kinds of image are part of an application but never appear in the desired state Argo CD reports, so deploying them would hit this failure even though the image name is correct:
+**When the check is wrong:** two kinds of image belong to an application yet never appear in the desired state Argo CD reports, so a correct name still fails:
 
-- **Images used only by a sync hook.** Argo CD omits hook resources from its managed-resources response, so an image that appears only in, say, a PreSync migration Job is invisible.
-- **Images named by a custom resource.** If the application manages a CR and an operator creates the actual workload from it, that workload is not a managed resource of the application, and the CR usually names the image in a field of its own rather than in a pod template.
+- **Images used only by a sync hook** — Argo CD omits hook resources, so an image appearing only in a PreSync migration Job is invisible.
+- **Images named by a custom resource** — if an operator creates the workload from a CR, that workload is not a managed resource of the application.
 
-Annotate such an application to turn the check off for it. Its deployments then behave exactly as before: they keep polling for the image and fail only when the timeout expires.
+Turn the check off for such an application. Its deployments then poll for the image and fail only on the timeout, exactly as before:
 
 ```yaml
 metadata:
@@ -185,174 +152,152 @@ metadata:
     argo-watcher/skip-image-validation: "true"
 ```
 
----
+## Tasks stay "in progress" after a server restart
+
+**Symptom:** after a rolling restart or eviction, tasks that were deploying stay `in progress` and are later marked `aborted`, even though Argo CD shows the deployment succeeded.
+
+**Cause:** a deployment being tracked when the process exits is not handed to another replica, and nothing waits for the tracker to persist a final status. The row is later reaped by the obsolete-task sweep, which marks `in progress` rows older than an hour as `aborted` — bookkeeping only, so the recorded status can disagree with what really happened.
+
+This is expected on any restart and is **not** fixed by tuning the shutdown budget: a graceful shutdown protects the git commit, not the task status. Until task ownership survives a pod replacement, treat the GitOps repository and Argo CD as the record of what happened.
+
+**How to verify**
+
+```bash
+kubectl logs <pod> --previous | grep -i shutdown
+```
+
+`git write-back batch drain did not finish before the shutdown deadline` means queued commits were abandoned mid-flush — that part *is* tunable.
+
+**Fix**
+
+1. Check the GitOps repository for the commit. If it is missing, re-run the pipeline job — an interrupted write-back is not resumed.
+2. Graceful shutdown needs up to 25s: raise `terminationGracePeriodSeconds` if it is below the Kubernetes default of 30s, and keep `GIT_OP_TIMEOUT` under the shutdown budget so an in-flight attempt can finish.
 
 ## Web UI is not accessible
 
-**Symptom:** The Argo Watcher Web UI returns a 404, connection refused, or certificate error.
+**Symptom:** 404, connection refused, or a certificate error.
 
-**Likely causes:**
-- The Ingress resource is not configured correctly.
-- TLS certificate is missing or invalid.
-- Static UI files are not in the expected location.
+**How to verify**
 
-**How to verify:**
-- Check Ingress status: `kubectl describe ingress argo-watcher`.
-- Verify the Ingress rule points to the correct service and port.
-- Check that the TLS certificate is valid: `echo | openssl s_client -servername <domain> -connect <host>:443`.
+```bash
+kubectl describe ingress argo-watcher
+echo | openssl s_client -servername <domain> -connect <host>:443
+curl -s $ARGO_WATCHER_URL/livez
+```
 
-**Fix:**
-1. Ensure the Ingress resource is created and its status shows a valid IP/hostname.
-2. Verify the TLS certificate is installed and references the correct secret.
-3. Check that `STATIC_FILES_PATH` in the Argo Watcher server config points to the directory containing the built UI assets (typically `/app/static` in Docker).
-4. Restart the server pod to pick up any configuration changes.
+**Fix**
 
----
+1. Confirm the Ingress has an address and points at the service and its container port.
+2. Confirm the TLS secret exists and matches the host.
+3. Confirm `STATIC_FILES_PATH` points at the built UI assets (`/app/static` in the published image). A server with no assets there answers `404` for every UI path while the API keeps working.
 
 ## Web UI stops on "Sign-in failed"
 
-**Symptom:** With [OIDC](../guides/oidc.md) enabled, the Web UI shows its loading screen with a red error box beneath the logo and never reaches the task list. It does not return to the identity provider on its own.
+**Symptom:** with [OIDC](../guides/oidc.md) enabled, the loading screen shows a red error box under the logo and never reaches the task list. It does not return to the provider on its own.
 
-**Likely causes:** the box names the one that applies.
+**The box names the cause:**
 
-- *Could not start the sign-in* — the browser never got as far as the provider, almost always because it could not read the discovery document at `<issuer>/.well-known/openid-configuration`. Most often `OIDC_ISSUER_URL` is an address only the server can resolve (an in-cluster Service name), or the provider does not answer that document cross-origin. The box's second line carries the browser's own message, which also covers the rarer case of browser storage refusing the sign-in state.
-- *The identity provider rejected the sign-in* — the provider answered with an OAuth error. The box shows the provider's own code (`invalid_scope`, `access_denied`, `invalid_client`, …) and description.
-- *The sign-in response could not be completed* — the response came back but the browser could not match the sign-in it started: browser storage was cleared mid-flow, a callback URL was reopened from history or a bookmark, or the clock skew between browser and provider is too large.
-- *Argo Watcher is misconfigured for OIDC* — the server reports OIDC as enabled without an issuer URL or a client id.
+- *Could not start the sign-in* — the browser never reached the provider, almost always because it could not read `<issuer>/.well-known/openid-configuration`. Usually `OIDC_ISSUER_URL` is an address only the server can resolve (an in-cluster Service name), or the provider does not answer that document cross-origin. The second line carries the browser's own message.
+- *The identity provider rejected the sign-in* — the provider returned an OAuth error; the box shows its code (`invalid_scope`, `access_denied`, `invalid_client`, …).
+- *The sign-in response could not be completed* — the response came back but could not be matched to the sign-in that started: storage cleared mid-flow, a callback URL reopened from history, or too much clock skew.
+- *Argo Watcher is misconfigured for OIDC* — the server reports OIDC as enabled without an issuer or a client id.
 
-**How to verify:**
+**How to verify**
 
-- Open the discovery URL named in the box in the same browser. It must return JSON; a DNS error, a TLS warning, or a CORS failure in the browser console is the cause.
-- For a rejected sign-in, look up the shown code in your provider's documentation, and check the client registration against [Redirect URI and web origin](../guides/oidc.md#redirect-uri-and-web-origin).
-- Check the server's OIDC settings: `curl -s $ARGO_WATCHER_URL/api/v1/config | jq .oidc`.
+- Open the discovery URL from the box in the same browser. It must return JSON; a DNS error, TLS warning, or CORS failure in the console is the cause.
+- Check the server's view: `curl -s $ARGO_WATCHER_URL/api/v1/config | jq .oidc`.
 
-**Fix:**
+**Fix**
 
-1. Set `OIDC_ISSUER_URL` to the issuer as users' browsers reach it, not as the pod reaches it. Both must work: the browser performs discovery and the code exchange, and the server validates tokens against the same issuer.
-2. Correct the client registration the shown error code points at — permitted scopes (`openid profile email`), exact redirect URI, web origin, and user or group assignment.
-3. Press **Try again** in the error box once the provider is fixed. Nothing is cached across the retry; it re-runs the whole sign-in.
-
----
+1. Set `OIDC_ISSUER_URL` to the issuer as users' browsers reach it — both browser and server must be able to use it.
+2. Correct whatever the error code points at: permitted scopes (`openid profile email`), exact redirect URI, web origin, group or user assignment. See [Redirect URI and web origin](../guides/oidc.md#redirect-uri-and-web-origin).
+3. Press **Try again**. Nothing is cached across the retry.
 
 ## Web UI does not update without a refresh
 
-**Symptom:** The Web UI loads, but task status and deploy-lock changes only appear after a manual page refresh.
+**Symptom:** task status and deploy-lock changes appear only after a manual page reload.
 
-**Likely cause:** A reverse proxy or load balancer in front of the server is stripping the `Upgrade` and `Connection` headers, so the WebSocket handshake on `/ws` never happens and the server answers 400.
+**Likely cause:** a proxy in front of the server strips the `Upgrade` and `Connection` headers, so the WebSocket handshake on `/ws` never happens and the server answers `400`.
 
-With [OIDC](../guides/oidc.md#the-websocket-handshake) enabled there is a second candidate: a proxy that forwards the upgrade but strips `Sec-WebSocket-Protocol` removes the credential the browser sends there, and the handshake is refused with 401.
+With [OIDC](../guides/oidc.md#the-websocket-handshake) enabled there is a second candidate: a proxy that forwards the upgrade but strips `Sec-WebSocket-Protocol` removes the credential the browser sends there, and the handshake is refused `401`.
 
-**How to verify:**
-- Set `LOG_LEVEL=debug` and look for `non-upgrade request to /ws`. It logs the `upgrade` and `connection` header values that actually arrived — an empty `upgrade` means the proxy dropped it before the request reached Argo Watcher.
-- A `rejecting unauthenticated websocket` warning in the server log, while the REST reads work in the same browser, points at a stripped `Sec-WebSocket-Protocol` rather than a session problem.
+**How to verify:** with `LOG_LEVEL=debug`, look for `non-upgrade request to /ws` — it logs the `upgrade` and `connection` values that actually arrived. A `rejecting unauthenticated websocket` warning while REST reads work in the same browser points at a stripped subprotocol rather than a dead session.
 
-**Fix:**
-1. Enable WebSocket support on the proxy. For nginx, forward the headers explicitly:
-   ```nginx
-   proxy_set_header Upgrade $http_upgrade;
-   proxy_set_header Connection "upgrade";
-   ```
-2. On an nginx Ingress, confirm the read/send timeouts are long enough to keep the connection open (`nginx.ingress.kubernetes.io/proxy-read-timeout`).
+**Fix**
 
----
+1. Enable WebSocket support on the proxy. For nginx:
+
+    ```nginx
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    ```
+
+2. On an nginx Ingress, make sure the read timeout is long enough to hold the connection open (`nginx.ingress.kubernetes.io/proxy-read-timeout`).
 
 ## All deployments rejected as locked, but nobody set a lock
 
-**Symptom:** Every deployment is rejected with `406` and `lockdown is active, deployments are not accepted`, while no manual lock was set and no scheduled window is open.
+**Symptom:** every deployment is rejected with `406` and `lockdown is active, deployments are not accepted`, with no manual lock set and no scheduled window open.
 
-**Likely causes:** With `STATE_TYPE=postgres` the lock state lives in the database. If it cannot be read, the server fails closed and treats the unknown state as locked. Two different problems produce that:
+**Cause:** with `STATE_TYPE=postgres` the lock lives in the database. If it cannot be read the server fails closed and treats the unknown state as locked. Two different problems do that: the database is unreachable, or the `deploy_lock` table does not exist because migration `000006` was never applied.
 
-- The database is unreachable.
-- The `deploy_lock` table does not exist because migration `000006` has not been applied — the database itself is perfectly healthy.
+**How to verify**
 
-**How to verify:**
 - `GET /api/v1/deploy-lock` returns `true`.
-- The server log contains `failed to read deploy lock state, assuming locked`. The error on that line tells the two causes apart: a connection error for an outage, `relation "deploy_lock" does not exist` for a missing migration.
-- `/reachability` reports the `database` reason only for a genuine outage. A healthy `/reachability` alongside a permanent lock points at the migration.
+- The log contains `failed to read deploy lock state, assuming locked`. The error on that line tells the two apart: a connection error for an outage, `relation "deploy_lock" does not exist` for a missing migration.
+- `/api/v1/reachability` reports the `database` reason only for a genuine outage. A healthy reachability response alongside a permanent lock points at the migration.
 
-**Fix:** Restore database connectivity, or [apply the migrations](database.md#migrations). Lock resolution returns to normal on the next successful read; no manual intervention on the lock itself is needed.
-
----
+**Fix:** restore connectivity, or [apply the migrations](database.md#migrations). Lock resolution returns to normal on the next successful read.
 
 ## Lock will not release
 
-**Symptom:** Deployments stay blocked after releasing the deploy lock. The lock is server-global — there is no per-application lock.
+**Symptom:** deployments stay blocked after releasing the [deploy lock](../guides/deployment-lock.md).
 
-**Likely causes:**
-- A [scheduled lockdown](../guides/gitops-updater.md#scheduled-lockdown) window is open. Releasing the lock during a window only suppresses it for 15 minutes, after which it takes effect again.
-- The `DELETE` never reached the server: the state-changing endpoints are only registered when OIDC is enabled (otherwise the request falls through to the Web UI and answers `200` with HTML), and they require a token from a user in one of the `OIDC_PRIVILEGED_GROUPS` (otherwise `401`).
-- The lock state cannot be read at all — see [All deployments rejected as locked, but nobody set a lock](#all-deployments-rejected-as-locked-but-nobody-set-a-lock).
+**Likely causes**
 
-**How to verify:**
-- Read the current state: `curl -H "Oidc-Authorization: $OIDC_TOKEN" $ARGO_WATCHER_URL/api/v1/deploy-lock` (with OIDC enabled any credential works and no privileged group is needed; with OIDC disabled the header can be omitted).
-- Check the response code of the release itself:
-  ```bash
-  curl -i -X DELETE -H "Oidc-Authorization: $OIDC_TOKEN" $ARGO_WATCHER_URL/api/v1/deploy-lock
-  ```
-  A `200` carrying HTML (`Content-Type: text/html`) rather than JSON means OIDC is disabled, so the endpoint does not exist and the Web UI answered instead. `401` means the token was rejected or the user is not in a privileged group, and `500` means the lock state could not be persisted (the reason is in the server log).
-- Check whether `LOCKDOWN_SCHEDULE` covers the current time. The server evaluates schedules in its own timezone, which is UTC in the published container image unless `TZ` is set.
+- A [scheduled window](../guides/deployment-lock.md#scheduled-lockdown) is open. Releasing inside a window only suppresses it for 15 minutes.
+- The `DELETE` never reached the server: those endpoints exist only when OIDC is enabled, and require a privileged group.
+- The lock state cannot be read at all — see [the entry above](#all-deployments-rejected-as-locked-but-nobody-set-a-lock).
 
-**Fix:**
-1. Re-issue the `DELETE` with a token belonging to a privileged group.
-2. If a scheduled window is the cause, either wait for it to close or remove the window from `LOCKDOWN_SCHEDULE` — a release cannot cancel a schedule, only suppress it for 15 minutes at a time.
+**How to verify**
 
----
+```bash
+curl -i -X DELETE -H "Oidc-Authorization: $OIDC_TOKEN" \
+  $ARGO_WATCHER_URL/api/v1/deploy-lock
+```
+
+- `200` with `Content-Type: text/html` means OIDC is disabled, so the endpoint does not exist and the Web UI answered instead.
+- `401` means the token was rejected or the user is not in a privileged group.
+- `500` means the state could not be persisted; the reason is in the server log.
+
+Also check whether `LOCKDOWN_SCHEDULE` covers the current time. Schedules are evaluated in the server's timezone, which is UTC in the published image unless `TZ` is set.
+
+**Fix:** re-issue the `DELETE` with a privileged token, or remove the window from `LOCKDOWN_SCHEDULE` — a release cannot cancel a schedule, only suppress it for 15 minutes at a time.
 
 ## Webhook not firing
 
-**Symptom:** Deployment status notifications are not being sent to the configured webhook.
+**Symptom:** no notifications arrive for deployments.
 
-**Likely causes:**
-- The webhook URL is incorrect or unreachable.
-- The webhook signature does not match the configured secret.
-- Template variable syntax is incorrect.
-- The webhook endpoint is not accepting POST requests.
+**Likely causes**
 
-**How to verify:**
-- Check the server logs for webhook delivery errors: `LOG_LEVEL=debug`.
-- Verify the webhook URL is reachable: `curl -X POST <webhook_url>`.
-- Test the signature: Argo Watcher uses SHA256 HMAC of the payload body with the secret.
+- `WEBHOOK_ENABLED` is not `true`, or `WEBHOOK_URL` is unset or unreachable from the server.
+- The receiver answers with a code that is not in `WEBHOOK_ALLOWED_RESPONSE_CODES` (default `200` only). A receiver replying `201` or `204` counts as a failure until you list it.
+- The receiver rejects the request because `WEBHOOK_AUTHORIZATION_HEADER_NAME`/`_VALUE` do not match what it expects, or `WEBHOOK_CONTENT_TYPE` does not match the body.
+- `WEBHOOK_FORMAT` references a field that does not exist. (A template that does not *parse* fails startup instead, so the server would not be running.)
 
-**Fix:**
-1. Verify the webhook URL is correct and accessible from the Argo Watcher server.
-2. Test the webhook payload locally before deploying.
-3. Check that all template variables are valid — refer to [Webhook Template Variables](../guides/notifications.md#available-template-variables).
-4. Ensure the webhook endpoint is configured to accept POST requests with JSON payloads.
+**How to verify**
 
----
+- Look for `Failed to dispatch notification` in the server log — it carries the response code and the receiver's body. `LOG_LEVEL=debug` additionally logs the rendered payload.
+- Reproduce the call by hand:
 
-## Tasks stay "in progress" after a server restart
+    ```bash
+    curl -i -X POST "$WEBHOOK_URL" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: $WEBHOOK_AUTHORIZATION_HEADER_VALUE" \
+      -d '{"app":"demo","status":"deployed"}'
+    ```
 
-**Symptom:** After a rolling restart or pod eviction, tasks that were deploying remain "in progress" and are only later marked "aborted", even though Argo CD shows the deployment succeeded.
+**Fix**
 
-**Cause:** A deployment being tracked when the process exits is not handed off to another replica, and nothing waits for the tracker to persist a final status before the process terminates. The task row is later reaped by the obsolete-task sweep, which marks "in progress" rows older than one hour as "aborted" — bookkeeping only, so the recorded status can disagree with what actually happened in Argo CD.
-
-This is expected on any restart and is **not** fixed by tuning the shutdown budget. A graceful shutdown protects the git commit and stops write-backs retrying past the deadline; it does not make the task's final status durable. Until task ownership survives a pod replacement, treat the GitOps repository and Argo CD as the record of what happened, not the task status.
-
-**How to verify:**
-- Check the shutdown logs of the previous pod: `kubectl logs <pod> --previous | grep -i shutdown`.
-- The warning `git write-back batch drain did not finish before the shutdown deadline` means queued git commits were abandoned mid-flush — that part *is* tunable, below.
-
-**Fix:**
-1. Confirm in your GitOps repository whether the image tag was committed. If it was not, re-run the pipeline job — an interrupted write-back is not resumed automatically.
-2. To stop losing the commit as well: graceful shutdown needs up to 25s, so raise `terminationGracePeriodSeconds` if it is below the Kubernetes default of 30s, and keep `GIT_OP_TIMEOUT` under the shutdown budget so an in-flight attempt can finish during the drain.
-
-## Task is stuck in "pending" state
-
-**Symptom:** A task created in Argo Watcher is stuck and does not transition to "in progress" or "failed".
-
-**Likely causes:**
-- The expected image has not been updated in Argo CD yet.
-- Argo CD API is unreachable or returning stale data.
-- A deployment lock is preventing status updates.
-
-**How to verify:**
-- Check the Argo CD UI to confirm the image has been updated.
-- Verify the server can reach the Argo CD API: `kubectl exec -it <pod> -- curl -H "Authorization: Bearer $ARGO_TOKEN" $ARGO_URL/api/v1/applications/<app>`.
-- Check if the application is locked.
-
-**Fix:**
-1. Verify that the image tag was correctly updated in your GitOps repository.
-2. Manually refresh the application in Argo CD: `argocd app get <app> --refresh`.
-3. Increase `ARGO_API_TIMEOUT` if the Argo CD API is slow to respond.
-4. Restart the server pod to clear any cached state.
+1. Add every success code your receiver returns to `WEBHOOK_ALLOWED_RESPONSE_CODES`.
+2. Check the template fields against [Template variables](../guides/notifications.md#template-variables).
+3. Remember Argo Watcher does not sign the payload — the authorization header is the only credential it sends, so a receiver expecting a signature will always reject it.

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -1,27 +1,18 @@
-# Argo Application Annotations
+# Annotations
 
-Argo Watcher uses Kubernetes annotations on Argo CD Application objects to configure per-application behavior.
+Argo Watcher reads these annotations from the Argo CD `Application` resource. All are optional; see the [GitOps Updater guide](../guides/gitops-updater.md) for how they fit together.
 
-All annotations are prefixed with `argo-watcher/` and are optional unless otherwise noted.
+| Annotation | Example | Description |
+|---|---|---|
+| `argo-watcher/managed` | `"true"` | Enables Argo Watcher management, and with it the GitOps write-back. |
+| `argo-watcher/managed-images` | `app=registry.example.com/group/project` | Maps an alias to a full image name; comma-separated for several. |
+| `argo-watcher/<alias>.helm.image-tag` | `app.image.tag` | Helm value path the new tag is written to, keyed by an alias from `managed-images`. |
+| `argo-watcher/write-back-filename` | `values-override.yaml` | Overrides the override-file name (derived from the app name by default). |
+| `argo-watcher/write-back-repo` | `git@github.com:example/gitops.git` | Write-back repository. **Multi-source applications only.** |
+| `argo-watcher/write-back-branch` | `main` | Write-back branch. **Multi-source applications only.** |
+| `argo-watcher/write-back-path` | `sandbox/charts/demo` | Write-back path. **Multi-source applications only.** |
+| `argo-watcher/fire-and-forget` | `"true"` | Commits the tag and marks the task `deployed` without monitoring the rollout. |
+| `argo-watcher/skip-image-validation` | `"true"` | Turns off the [fail-fast image check](../operations/troubleshooting.md#image-is-not-part-of-application), so deployments wait for the timeout instead. |
 
-## Annotation Reference
-
-| Annotation | Scope | Example | Description |
-|---|---|---|---|
-| `argo-watcher/managed` | Application | `true` | Enables Argo Watcher management (and the GitOps write-back) for this application. |
-| `argo-watcher/managed-images` | Application | `app=registry.example.com/group/project` | Maps an alias to a full image name; comma-separated for multiple. |
-| `argo-watcher/<alias>.helm.image-tag` | Application | `app.image.tag` | Helm value path the new tag is written to, keyed by the alias from `managed-images`. |
-| `argo-watcher/write-back-repo` | Application (multi-source only) | `git@github.com:example/gitops.git` | Overrides the write-back repo. Honored only when the app uses `spec.sources` (plural). |
-| `argo-watcher/write-back-branch` | Application (multi-source only) | `main` | Overrides the write-back branch (multi-source only). |
-| `argo-watcher/write-back-path` | Application (multi-source only) | `sandbox/charts/demo` | Overrides the write-back path (multi-source only). |
-| `argo-watcher/write-back-filename` | Application | `values-override.yaml` | Overrides the override-file name (default is derived from the app name). |
-| `argo-watcher/fire-and-forget` | Application | `true` | Commits the tag and marks the deployment `deployed` without monitoring status. |
-| `argo-watcher/skip-image-validation` | Application | `true` | Turns off the [fail-fast image check](../operations/troubleshooting.md#image-is-not-part-of-application) for this application, so its deployments wait for the timeout instead. |
-
-See the [Git Integration guide](../guides/gitops-updater.md) for full usage and examples.
-
-## Usage in Guides
-
-For detailed examples of how to use annotations in your deployments, see:
-- [GitOps Updater Guide](../guides/gitops-updater.md)
-- [Deployment Locking](../guides/gitops-updater.md#deployment-locking)
+!!! warning
+    The three `write-back-*` location annotations are honored only when the application uses `spec.sources` (plural). On a single-source application they are silently ignored — the location comes from the application's own source.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,95 +1,73 @@
 # API Reference
 
-Argo Watcher exposes a REST API for managing deployment tasks, querying status, and controlling the deployment lock. The API is served by the Argo Watcher server, typically at port `8080`.
-
-## Base URL
-
-All API endpoints are prefixed with `/api/v1` unless otherwise noted.
-
-```text
-https://argo-watcher.example.com/api/v1
-```
-
-## Authentication
-
-Credentials serve two purposes: authorizing the built-in [GitOps Updater](../guides/gitops-updater.md)'s git write-back, and — when [OIDC authentication](../guides/oidc.md) is enabled — reading the API at all. Provide one of:
-
-- **Deploy token** — Pass the `ARGO_WATCHER_DEPLOY_TOKEN` value in the header of the same name.
-- **JWT token** — Pass the JWT in the `Authorization` header. The raw token is accepted directly (e.g. `Authorization: eyJhbGci...`); a `Bearer <token>` value is also accepted for backward compatibility.
-- **OIDC session** — Pass the access token in the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` name is still accepted).
-
-### Read access
-
-With OIDC **disabled** — the default — every endpoint is readable without a credential.
-
-With OIDC **enabled**, the endpoints the Web UI consumes require one: `GET /api/v1/tasks`, `/version`, `/reachability` and `/deploy-lock`. Any of the credentials above is accepted; group membership is not required for reads. The `/ws` WebSocket is gated too; a browser passes its token as the `argo-watcher.token.<token>` subprotocol, since it cannot set a header on the handshake. Two endpoints stay open by default — `GET /api/v1/tasks/{id}` (the lookup the client polls, guarded only by the unguessable task id) and `GET /api/v1/config` (the Web UI bootstraps its login from it). Setting `OIDC_REQUIRE_TASK_READ_AUTH=true` gates the task lookup as well, which requires every client polling it to present a credential; see [Closing the task lookup](../guides/oidc.md#closing-the-task-lookup). `GET /api/v1/config` cannot be gated. See [Protected endpoints](../guides/oidc.md#protected-endpoints) for the full table and the caveats.
-
-A read rejected for a missing or invalid credential returns `401 Unauthorized`. A read whose credential could not be checked because the OIDC provider was unreachable returns `503 Service Unavailable` — the distinction exists so a provider outage does not read as a dead session.
-
-A task submitted **without** a credential is still accepted (`202 Accepted`) and its rollout is monitored normally — argo-watcher simply does not perform the git write-back. It also cannot cancel a deployment that was submitted with one: superseding only applies to in-flight tasks that presented no more authority than the new task, so an uncredentialed submission can never abort a credentialed deployment's write-back. This is the expected setup when the image tag is updated by other means (e.g. Argo CD Image Updater or your CI pipeline) and argo-watcher only tracks the resulting rollout. If you instead rely on the built-in updater to commit the tag and omit the credential, the write-back is skipped: the deployment then fails fast as `Image "<name>" is not part of application "<app>"` — the image really is absent, because the commit that would have added it never happened — or waits out `DEPLOYMENT_TIMEOUT` when image validation is off. See [Image tag is never committed](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped) for how to confirm and fix it. A token that is **present but invalid or expired** returns `401 Unauthorized`.
-
-The state-changing `POST`/`DELETE /api/v1/deploy-lock` endpoints are only registered when [OIDC authentication](../guides/oidc.md) is enabled, and require a session belonging to one of the `OIDC_PRIVILEGED_GROUPS` (sent via the `Oidc-Authorization` header; the legacy `Keycloak-Authorization` header is still accepted); when OIDC is disabled these endpoints are not registered at all, and the request falls through to the Web UI's catch-all handler — so it answers `200 OK` with an HTML body rather than an API error. Check the `Content-Type`, not the status code, to tell "not exposed" from a successful call. The read-only `GET /api/v1/deploy-lock` needs no privileged group, but with OIDC enabled it does need a credential like the other reads above.
+The server exposes a REST API on its own port (default `8080`), with every endpoint under `/api/v1` except the probes, `/metrics`, `/ws` and `/swagger`.
 
 ## Conventions
 
-- All request and response bodies are JSON.
-- Successful task submissions return `202 Accepted` with the new task ID.
-- Validation failures return `406 Not Acceptable` with an `error` field describing the problem.
-- Authentication failures return `401 Unauthorized` with an `error` field describing whether no credentials were provided or the token was rejected.
-- Unexpected server-side problems return `500 Internal Server Error`.
+- Request and response bodies are JSON.
+- A submitted task returns `202 Accepted` with its id.
+- Validation failures return `406 Not Acceptable` with an `error` field naming the problem.
+- Authentication failures return `401 Unauthorized`, and `503 Service Unavailable` when the credential could not be checked because the OIDC provider was unreachable.
+- Server-side problems return `500 Internal Server Error`.
+
+## Authentication
+
+A credential does two things: it authorizes the [GitOps updater](../guides/gitops-updater.md)'s write-back, and — when [OIDC](../guides/oidc.md) is enabled — it is what lets you read the API at all. Any one of:
+
+| Credential | How to send it |
+|---|---|
+| Deploy token | `ARGO_WATCHER_DEPLOY_TOKEN: <token>` |
+| JWT | `Authorization: <token>` (raw; `Bearer <token>` also accepted) |
+| OIDC session | `Oidc-Authorization: <access token>` (legacy `Keycloak-Authorization` also accepted) |
+
+### Reads
+
+With OIDC **disabled** — the default — every endpoint is readable without a credential.
+
+With OIDC **enabled**, the endpoints the Web UI consumes require one, group membership is not needed, and two stay open on purpose: `GET /api/v1/tasks/{id}` (guarded by the unguessable task id, and closable with `OIDC_REQUIRE_TASK_READ_AUTH`) and `GET /api/v1/config`, which the Web UI reads before it can hold a token. [Protected endpoints](../guides/oidc.md#protected-endpoints) has the full table.
+
+### Submitting a task
+
+`POST /api/v1/tasks` takes an **optional** credential:
+
+- **With a valid credential** the task is authorized: the git write-back runs, and the task can supersede an in-flight deployment of the same images.
+- **Without one** the task is still accepted (`202`) and monitored normally — the expected setup when image tags are committed elsewhere (Argo CD Image Updater, your pipeline). The write-back is skipped, and it cannot cancel a deployment that did present a credential.
+- **With an invalid or expired one** the request is rejected `401`.
+
+An unauthorized task on an application that relies on the built-in updater fails in a way that does not name the credential: usually `Image "<name>" is not part of application "<app>"`, or a timeout when image validation is off. [Image tag is never committed](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped) explains how to confirm it.
+
+### Managing the deploy lock
+
+`POST` and `DELETE /api/v1/deploy-lock` are **registered only when OIDC is enabled**, and require a session in one of the `OIDC_PRIVILEGED_GROUPS`. With OIDC disabled they are not routes at all: the request falls through to the Web UI's catch-all and answers `200 OK` with an HTML body. Check the `Content-Type`, not the status code, to tell "not exposed" from a successful call.
+
+`GET /api/v1/deploy-lock` needs no privileged group, but with OIDC enabled it needs a credential like every other read.
 
 ## Health and probe endpoints
 
-Two unauthenticated endpoints report server health. They answer different questions,
-and wiring the wrong one to a Kubernetes probe has real consequences.
+Two unauthenticated endpoints report health. They answer different questions, and wiring the wrong one to a probe has consequences.
 
 | Endpoint | Checks | Use as |
-|----------|--------|--------|
-| `GET /livez` | Nothing but that the process is still serving requests | Liveness probe |
+|---|---|---|
+| `GET /livez` | Only that the process is still serving | Liveness probe |
 | `GET /readyz` | Not shutting down, **and** the state backend answers | Readiness probe |
 
-Both return `{"status":"up"}` on success and `503` with `{"status":"down","reason":"..."}`
-otherwise — `shutting down` during a graceful shutdown, `state backend unreachable` when
-the database cannot be pinged.
+Both return `{"status":"up"}`, or `503` with `{"status":"down","reason":"..."}` — `shutting down` during a graceful shutdown, `state backend unreachable` when the database cannot be pinged.
 
-!!! warning "Do not point a liveness probe at `/readyz`"
-    A liveness failure gets the container restarted, and a restart cannot reach a
-    database that is down. Probing the state backend for liveness turns a recoverable
-    outage into a fleet-wide `CrashLoopBackoff` while every replica is still able to
-    serve task history and the unreachable banner. That is why `/livez` checks no
-    dependency at all.
+!!! warning "Never point a liveness probe at `/readyz`"
+    A liveness failure restarts the container, and a restart cannot fix a database that is down. Probing the state backend for liveness turns a recoverable outage into a fleet-wide `CrashLoopBackoff` while every replica could still serve task history and the unreachable banner. That is why `/livez` checks no dependency.
 
-A startup probe is not needed and is not recommended. The server binds its listener
-only after its configuration, Argo CD client, and state backend are all initialised, so
-there is no window in which it answers requests but is not yet ready. If the state
-backend is unreachable at boot the process exits rather than starting degraded, which a
-startup probe could not observe anyway.
+A startup probe is unnecessary: the server binds its listener only after its configuration, Argo CD client and state backend are initialised, and exits rather than starting degraded.
 
-**Argo CD reachability is deliberately absent from both probes.** An Argo CD outage
-degrades Argo Watcher — new deployments are rejected fast and the Web UI shows a banner
-naming the cause — but the server must keep serving precisely then. Alert on the
-`argocd_unavailable` metric or poll `GET /api/v1/reachability` instead.
+**Argo CD reachability is deliberately absent from both probes.** An Argo CD outage degrades Argo Watcher — deployments are rejected fast and the Web UI shows a banner — but the server must keep serving precisely then. Alert on the `argocd_unavailable` metric or poll `GET /api/v1/reachability` instead.
 
 ### Readiness during shutdown
 
-On `SIGTERM` the server fails `/readyz` immediately, keeps serving normally for five
-seconds so the endpoint removal can propagate through kube-proxy and any ingress
-controller, and only then closes its listener and drains in-flight requests, WebSocket
-connections, and queued git write-backs. A readiness probe is what makes that window
-useful; without one, traffic keeps arriving at a pod that has already stopped
-accepting it. The whole sequence is bounded to fit the default 30-second
-`terminationGracePeriodSeconds`.
+On `SIGTERM` the server fails `/readyz` immediately, then keeps serving normally for five seconds so the endpoint removal can propagate through kube-proxy and any ingress controller, and only then closes its listener and drains in-flight requests, WebSocket connections, and queued git write-backs. Without a readiness probe that window is wasted and traffic keeps arriving at a pod that has stopped accepting it. The whole sequence is bounded to fit the default 30-second `terminationGracePeriodSeconds`.
 
 ## Endpoints
 
-The full endpoint catalog is rendered live from the OpenAPI spec maintained alongside the source code. Use the explorer below to inspect routes, request and response schemas, and try requests against your own server.
+Rendered from the OpenAPI spec generated from the handlers, so it cannot drift from the code. Expand a route to see its schemas, or try it against your own server.
 
 <swagger-ui src="swagger.json"/>
 
-## Swagger UI bundled with the server
-
-The Argo Watcher server also bundles the same Swagger UI at `/swagger/index.html`, which is convenient when working against a deployed instance:
-
-```text
-https://argo-watcher.example.com/swagger/index.html
-```
+The server bundles the same explorer at `/swagger/index.html`, which is handier against a live instance.

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -1,39 +1,39 @@
 # Client Environment Variables
 
-The Argo Watcher client is a lightweight CLI tool distributed as a Docker image at [`ghcr.io/shini4i/argo-watcher-client`](https://ghcr.io/shini4i/argo-watcher-client). These environment variables control the client's behavior when monitoring deployments.
+The client is a small CLI shipped as [`ghcr.io/shini4i/argo-watcher-client`](https://ghcr.io/shini4i/argo-watcher-client). It reads everything from the environment, submits one task, waits for it, and exits non-zero if the deployment did not succeed.
 
-## Required Variables
+## Required
 
-| Variable       | Description                                                                                       |
-|----------------|---------------------------------------------------------------------------------------------------|
-| `ARGO_WATCHER_URL`          | URL of the Argo Watcher server instance                                                          |
-| `ARGO_APP`                  | Name of the Argo CD application to monitor                                                       |
-| `COMMIT_AUTHOR`             | Person who triggered the deployment                                                              |
-| `PROJECT_NAME`              | Identifier for the business project (not the Argo CD project)                                    |
-| `IMAGES`                    | Comma-separated list of image names expected to contain the specified tag                        |
-| `IMAGE_TAG`                 | Image tag expected to be deployed                                                                |
+| Variable | Description |
+|---|---|
+| `ARGO_WATCHER_URL` | URL of the Argo Watcher server |
+| `ARGO_APP` | Argo CD application to monitor |
+| `IMAGES` | Comma-separated image names expected to carry `IMAGE_TAG` |
+| `IMAGE_TAG` | Image tag expected to be deployed |
+| `COMMIT_AUTHOR` | Who triggered the deployment |
+| `PROJECT_NAME` | Business project identifier (not the Argo CD project) |
 
-## Optional Variables
+## Optional
 
-| Variable                    | Description                                                                                       |
-|-----------------------------|---------------------------------------------------------------------------------------------------|
-| `ARGO_WATCHER_DEPLOY_TOKEN` | Deploy token for Git image override (required when using the built-in GitOps updater)            |
-| `BEARER_TOKEN`              | JWT for authentication. Set the raw token (e.g. `eyJhbGci...`) so it is maskable as a GitLab CI variable; a legacy `Bearer <token>` value is still accepted. Takes precedence over `ARGO_WATCHER_DEPLOY_TOKEN` when both are set. |
-| `TIMEOUT`                   | HTTP request timeout (e.g. `60s`, `2m`)                                                         |
-| `TASK_TIMEOUT`              | Maximum time (in seconds) to wait for a task to complete; unset keeps the server's `DEPLOYMENT_TIMEOUT` |
-| `TASK_REFRESH`              | Override the server's refresh setting for this deployment (`true`/`false`); unset keeps the server default |
-| `RETRY_INTERVAL`            | Interval between status polling attempts (e.g. `15s`, `1m`)                                    |
-| `EXPECTED_DEPLOY_TIME`      | Expected deployment duration; affects polling behavior (e.g. `15m`, `30m`)                     |
-| `DEBUG`                     | Enable verbose debug output                                                                      |
+| Variable | Description | Default |
+|---|---|---|
+| `BEARER_TOKEN` | JWT authorizing the deployment. Takes precedence over `ARGO_WATCHER_DEPLOY_TOKEN`. | |
+| `ARGO_WATCHER_DEPLOY_TOKEN` | Shared deploy token, the alternative to a JWT | |
+| `TIMEOUT` | Per-request HTTP timeout | `60s` |
+| `RETRY_INTERVAL` | Wait between status polls | `15s` |
+| `TASK_TIMEOUT` | Seconds the server should wait for this deployment; unset keeps the server's `DEPLOYMENT_TIMEOUT` | |
+| `TASK_REFRESH` | `true`/`false` override of the server's `ARGO_REFRESH_APP` for this deployment | |
+| `EXPECTED_DEPLOY_TIME` | After this long, the client's log line changes to "taking longer than expected". Nothing else changes. | `15m` |
+| `DEBUG` | Log the equivalent cURL commands, with credentials redacted | `false` |
+
+Set `BEARER_TOKEN` to the raw token (`eyJhbGci...`) so CI can mask it; a legacy `Bearer <token>` value is still accepted.
 
 ## Authentication
 
-The configured credential is presented on every request the client makes — the task
-submission and the status polls that follow it. A server running with
-[`OIDC_REQUIRE_TASK_READ_AUTH`](server-env.md) therefore serves this client, and one
-running without it is unaffected: the extra header is ignored where no credential is
-required.
+The configured credential is sent on every request — the submission and each status poll. A server running with [`OIDC_REQUIRE_TASK_READ_AUTH`](server-env.md#authentication) therefore accepts this client, and a server without it ignores the extra header.
 
-## Retry Behavior
+A credential is dropped rather than forwarded when a redirect changes the host, and the client logs one warning naming both hosts. See [Image tag is never committed](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped).
 
-While polling for deployment status, the client automatically retries transient failures (network errors or `5xx` responses from the server) up to 3 times with a fixed 2-second delay before giving up. This retry count and delay are not configurable. Terminal failures (`4xx` responses, invalid tokens, malformed responses, a redirect that steps down from `https`) fail immediately, and task submission (the initial `POST`) is not retried.
+## Retries
+
+While polling, the client retries transient failures — network errors and `5xx` responses — three times, two seconds apart. Neither is configurable. Terminal failures fail immediately: `4xx` responses, a rejected token, a malformed response, or a redirect that steps down from `https`. The initial `POST` is not retried at all.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,8 +1,6 @@
 # Reference
 
-Technical reference material for Argo Watcher.
-
-- **[API Reference](api.md)** — REST API endpoints, authentication, and examples.
-- **[Server Environment Variables](server-env.md)** — Server configuration options.
-- **[Client Environment Variables](client-env.md)** — Client configuration options.
-- **[Annotations](annotations.md)** — Argo application annotations.
+- **[API Reference](api.md)** — endpoints, authentication, probes.
+- **[Server Environment Variables](server-env.md)** — every server setting, its default, and whether it is required.
+- **[Client Environment Variables](client-env.md)** — what the CI client reads.
+- **[Annotations](annotations.md)** — the `argo-watcher/*` annotations on an Argo CD Application.

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -88,7 +88,7 @@ Read when the built-in [GitOps updater](../guides/gitops-updater.md) is in use.
 |---|---|---|
 | `SSH_KEY_PATH` | Private SSH key used to push (required to enable the updater) | |
 | `SSH_KEY_PASS` | Passphrase for that key | |
-| `SSH_KNOWN_HOSTS` | `known_hosts` file used to verify the remote host | SSH defaults |
+| `SSH_KNOWN_HOSTS` | `known_hosts` file(s) used to verify the remote host, colon-separated | `~/.ssh/known_hosts`, `/etc/ssh/ssh_known_hosts` |
 | `SSH_COMMIT_USER` | Commit author name | `argo-watcher` |
 | `SSH_COMMIT_MAIL` | Commit author email | `argo-watcher@example.com` |
 | `COMMIT_MESSAGE_FORMAT` | Go template for the commit message | built-in format |
@@ -98,7 +98,7 @@ Read when the built-in [GitOps updater](../guides/gitops-updater.md) is in use.
 | `GIT_BATCH_MAX_SIZE` | Applications committed per batch flush | `20` |
 | `GIT_TIMEOUT` | **Deprecated.** Used as `GIT_OP_TIMEOUT` when that is unset | |
 
-Host key verification is on: a remote missing from `SSH_KNOWN_HOSTS` fails the push. The chart writes the file and sets this variable for you.
+Host key verification is on: a remote whose key is not listed fails the push. `SSH_KNOWN_HOSTS` is read by go-git rather than by argo-watcher's own configuration, which is why it has no `GitConfig` field. The chart writes the file and sets the variable for you.
 
 ### Retry and timeout budget
 

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -1,80 +1,113 @@
 # Server Environment Variables
 
-The Argo Watcher server supports the following environment variables. When using the Helm chart, most of these are set through chart values automatically.
+Every setting the server reads from the environment. With the Helm chart most of these are set for you from chart values; anything the chart has no value for goes in `extraEnvs`.
 
-On startup, any missing required or invalid variables are reported together in a single error that lists every offending variable, so you can fix them all in one pass instead of one restart at a time.
+On startup all missing or invalid variables are reported together in one error, so a broken configuration takes one restart to fix, not one per variable.
 
-## Core Settings
+## Core
 
-| Variable            | Description                                                     | Default     | Required    |
-|---------------------|-----------------------------------------------------------------|-------------|-------------|
-| `ARGO_URL`          | Argo CD server URL                                              |             | Yes         |
-| `ARGO_TOKEN`        | Argo CD API token                                               |             | Yes         |
-| `ARGO_API_TIMEOUT`    | Timeout for Argo CD API calls, in seconds                       | `60`        | No          |
-| `DEPLOYMENT_TIMEOUT`  | Maximum time (in seconds) to wait for a deployment to complete  | `900`       | No          |
-| `ARGO_REFRESH_APP`    | Refresh the application during status checks                    | `true`      | No          |
-| `ARGO_API_RETRIES`    | Total retry attempts for Argo CD API calls (1-10)               | `3`         | No          |
-| `ACCEPT_SUSPENDED_APP`| Accept "Suspended" health status as valid                       | `false`     | No          |
-| `STATE_TYPE`          | Storage backend: `in-memory` (non-HA) or `postgres` (HA)       |             | Yes         |
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `ARGO_URL` | Argo CD server URL | | Yes |
+| `ARGO_TOKEN` | Argo CD API token | | Yes |
+| `STATE_TYPE` | Storage backend: `in-memory` (single replica) or `postgres` | | Yes |
+| `DEPLOYMENT_TIMEOUT` | Seconds to wait for a deployment to finish | `900` | No |
+| `ARGO_API_TIMEOUT` | Timeout for Argo CD API calls, in seconds | `60` | No |
+| `ARGO_API_RETRIES` | Total attempts per Argo CD API call (1–10) | `3` | No |
+| `ARGO_REFRESH_APP` | Refresh the application during status checks | `true` | No |
+| `ACCEPT_SUSPENDED_APP` | Treat a `Suspended` health status as deployed | `false` | No |
 
-## Server Settings
+Turning `ARGO_REFRESH_APP` off also disables the [fail-fast image check](../operations/troubleshooting.md#image-is-not-part-of-application), which needs a freshly reconciled application.
 
-| Variable            | Description                                                     | Default     | Required    |
-|---------------------|-----------------------------------------------------------------|-------------|-------------|
-| `HOST`              | Host address for the Argo Watcher server                        | `0.0.0.0`  | No          |
-| `PORT`              | Port for the Argo Watcher server                                | `8080`      | No          |
-| `STATIC_FILES_PATH` | Path to the Web UI static files                                 | `static`    | No          |
-| `SKIP_TLS_VERIFY`     | Skip TLS certificate verification for API calls                 | `false`     | No          |
-| `DOCKER_IMAGES_PROXY` | Registry proxy URL for image existence checks                   |             | No          |
-| `ARGO_URL_ALIAS`      | URL alias for generating externally visible Argo CD app links   |             | No          |
+## Server
 
-## Logging
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `HOST` | Listen address | `0.0.0.0` | No |
+| `PORT` | Listen port | `8080` | No |
+| `STATIC_FILES_PATH` | Directory holding the built Web UI | `static` | No |
+| `LOG_LEVEL` | `debug`, `info`, `warn` or `error` | `info` | No |
+| `SKIP_TLS_VERIFY` | Skip TLS verification on outgoing API calls | `false` | No |
+| `ARGO_URL_ALIAS` | Externally reachable Argo CD URL, used in generated app links | | No |
+| `DOCKER_IMAGES_PROXY` | Registry proxy prefix to tolerate when matching images | | No |
+| `REPO_CACHE_PATH` | Where GitOps repository clones are cached | `/data` | No |
 
-| Variable     | Description                                                            | Default | Required |
-|--------------|------------------------------------------------------------------------|---------|----------|
-| `LOG_LEVEL`  | Log verbosity level (`debug`, `info`, `warn`, `error`)                | `info`  | No       |
+The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you must change the other.
 
-## Authentication & Feature Flags
+## Authentication
 
-These variables control authentication and optional features. See the linked guides for full configuration details.
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `ARGO_WATCHER_DEPLOY_TOKEN` | Shared token clients present to authorize a write-back | | No |
+| `JWT_SECRET` | HMAC secret for validating client JWTs | | No |
+| `OIDC_ENABLED` | Enable OIDC authentication | `false` | No |
+| `OIDC_ISSUER_URL` | Provider issuer URL, used for discovery | | When OIDC is on |
+| `OIDC_CLIENT_ID` | Client id registered with the provider | | When OIDC is on |
+| `OIDC_PRIVILEGED_GROUPS` | Groups allowed to roll back a task and manage the deploy lock | | No |
+| `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
+| `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}` too | `false` | No |
 
-| Variable                    | Description                                                                  | Default | Required    |
-|-----------------------------|------------------------------------------------------------------------------|---------|-------------|
-| `ARGO_WATCHER_DEPLOY_TOKEN` | Shared token for validating client requests. See [GitOps Updater](../guides/gitops-updater.md). |         | No          |
-| `JWT_SECRET`                | Secret key for signing and validating JWT tokens. See [GitOps Updater](../guides/gitops-updater.md#jwt-configuration). |         | No          |
-| `OIDC_ENABLED`              | Enable OIDC authentication (Keycloak, Authentik, …). Also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The legacy `KEYCLOAK_*` variables remain honored but are deprecated. | `false` | No          |
-| `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}`, the last read left open. Requires `OIDC_ENABLED=true`; the server refuses to start otherwise. Fails every deployment driven by a client that sends no credential — which includes **every client older than v0.15.0**, since presenting a credential on status polls was added in that release. Check `unauthenticated_reads` before enabling; see [Closing the task lookup](../guides/oidc.md#closing-the-task-lookup). | `false` | No          |
-| `WEBHOOK_ENABLED`           | Enable webhook notifications. See [Notifications](../guides/notifications.md).         | `false` | No          |
-| `LOCKDOWN_SCHEDULE`         | Recurring deployment lock schedule. See [Deployment Locking](../guides/gitops-updater.md#deployment-locking). |         | No          |
+Enabling OIDC also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The legacy `KEYCLOAK_*` variables are still honored but deprecated ([migration table](../guides/oidc.md#migrating-from-keycloak_)).
 
-## Database Settings
+`OIDC_REQUIRE_TASK_READ_AUTH` fails every deployment driven by a client that sends no credential on reads, which includes **every client older than v0.15.0**. It also requires `OIDC_ENABLED=true`; the server refuses to start otherwise. Check `unauthenticated_reads` first — see [Closing the task lookup](../guides/oidc.md#closing-the-task-lookup).
 
-These variables are required when `STATE_TYPE` is set to `postgres`.
+## Features
 
-| Variable      | Description       | Default     | Required      |
-|---------------|-------------------|-------------|---------------|
-| `DB_HOST`     | Database host     |             | Conditional   |
-| `DB_PORT`     | Database port     |             | Conditional   |
-| `DB_NAME`     | Database name     |             | Conditional   |
-| `DB_USER`     | Database username |             | Conditional   |
-| `DB_PASSWORD` | Database password |             | Conditional   |
-| `DB_SSL_MODE` | PostgreSQL SSL mode | `disable` | No            |
-| `DB_TIMEZONE` | Database timezone | `UTC`       | No            |
-| `DB_CONNECT_TIMEOUT` | Max seconds to wait for the initial DB connection before failing (must be at least 1) | `10` | No |
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `LOCKDOWN_SCHEDULE` | Recurring deploy freeze, e.g. `Fri 20:00 - Mon 08:00` | | No |
+| `WEBHOOK_ENABLED` | Enable webhook notifications | `false` | No |
+| `MATTERMOST_ENABLED` | Enable Mattermost notifications | `false` | No |
 
-## Git Integration Settings
+The remaining `WEBHOOK_*` and `MATTERMOST_*` variables are documented in [Notifications](../guides/notifications.md); the schedule format in [Deployment Lock](../guides/deployment-lock.md).
 
-These variables are required when using the built-in GitOps updater. See the [GitOps Updater](../guides/gitops-updater.md) guide for full details.
+## Database
 
-| Variable              | Description                                             | Default | Required    |
-|-----------------------|---------------------------------------------------------|---------|-------------|
-| `SSH_KEY_PATH`        | Path to the SSH key for Git repository access           |         | Conditional |
-| `SSH_KEY_PASS`        | Passphrase for the SSH key                              |         | No          |
-| `SSH_COMMIT_USER`     | Git commit author name                                  | `argo-watcher` | No          |
-| `SSH_COMMIT_MAIL`     | Git commit author email                                 | `argo-watcher@example.com` | No          |
-| `COMMIT_MESSAGE_FORMAT` | Go template string for commit messages                |         | No          |
-| `GIT_OP_TIMEOUT`      | Per-attempt wall-clock budget for one clone + update cycle. The worst-case total wall clock for the full retry loop is `GIT_OP_TIMEOUT × GIT_MAX_ATTEMPTS`, plus a small jittered backoff between attempts (capped-exponential, starting near 250ms and never exceeding 2s per retry — early retries fire fast to win a git push race under contention). Accepts a Go duration string (e.g. `30s`, `2m`). Must be greater than zero. During a graceful shutdown the write-back drain gets only what is left of the server's fixed 25s shutdown budget (shared with the HTTP and WebSocket drain phases), so an attempt at the 90s default cannot finish — keep this comfortably below 25s if in-flight commits should land rather than be abandoned on restart. This affects whether the commit reaches git, not whether the task's final status is recorded; see [Tasks stay "in progress" after a server restart](../operations/troubleshooting.md). | `90s` | No |
-| `GIT_MAX_ATTEMPTS`    | Total attempts (initial + retries) before giving up on a git update. The final attempt invalidates the on-disk cache and performs a fresh clone, so a poisoned cache self-heals without operator intervention. Raising this hardens the write-back against a competing writer on a shared repo; a task superseded by a newer deployment for the same app aborts its write-back (re-checked before every attempt) instead of committing a stale tag, so a larger value does not let an older deployment overwrite a newer one. Must be greater than zero. | `5` | No |
-| `GIT_TIMEOUT`         | **Deprecated.** Legacy per-call budget. When set and `GIT_OP_TIMEOUT` is unset, the value is used directly as `GIT_OP_TIMEOUT` (1:1 mapping, preserving the original per-call budget). Set `GIT_OP_TIMEOUT` explicitly to silence the deprecation warning. | — | No |
-| `GIT_BATCH_WRITEBACK` | Opt-in batch write-back mode. When enabled, concurrent write-backs to the same repository are coalesced into a single clone and push instead of each taking the per-repo lock on its own, collapsing the tail latency seen when many apps deploy to one GitOps repo at once. Off by default; the serialized per-app path is unchanged when disabled. See the [GitOps Updater](../guides/gitops-updater.md#batch-write-back) guide. | `false` | No |
-| `GIT_BATCH_MAX_SIZE`  | Maximum number of applications committed in a single batch flush (one commit per app, then one push). Only meaningful when `GIT_BATCH_WRITEBACK` is enabled, where it must be greater than zero. The pending queue keeps accumulating across flushes until drained, so this bounds one flush, not total in-flight work. | `20` | No |
+Required when `STATE_TYPE=postgres`. The server builds its DSN from these; `DB_DSN` overrides the result if you need connection parameters the individual variables do not cover.
+
+| Variable | Description | Default |
+|---|---|---|
+| `DB_HOST` | Database host | |
+| `DB_PORT` | Database port | |
+| `DB_NAME` | Database name | |
+| `DB_USER` | Database user | |
+| `DB_PASSWORD` | Database password | |
+| `DB_SSL_MODE` | PostgreSQL SSL mode | `disable` |
+| `DB_TIMEZONE` | Session timezone | `UTC` |
+| `DB_CONNECT_TIMEOUT` | Seconds to wait for the initial connection (at least 1) | `10` |
+| `DB_DSN` | Full DSN, replacing the one built from the variables above | built from `DB_*` |
+| `DB_MIGRATIONS_PATH` | Migrations directory used by `argo-watcher --migrate` | `/app/db/migrations` |
+
+`DB_CONNECT_TIMEOUT` is enforced even when `DB_DSN` is set explicitly, so an unreachable database fails fast instead of hanging on the OS TCP timeout.
+
+## GitOps updater
+
+Read when the built-in [GitOps updater](../guides/gitops-updater.md) is in use.
+
+| Variable | Description | Default |
+|---|---|---|
+| `SSH_KEY_PATH` | Private SSH key used to push (required to enable the updater) | |
+| `SSH_KEY_PASS` | Passphrase for that key | |
+| `SSH_KNOWN_HOSTS` | `known_hosts` file used to verify the remote host | SSH defaults |
+| `SSH_COMMIT_USER` | Commit author name | `argo-watcher` |
+| `SSH_COMMIT_MAIL` | Commit author email | `argo-watcher@example.com` |
+| `COMMIT_MESSAGE_FORMAT` | Go template for the commit message | built-in format |
+| `GIT_OP_TIMEOUT` | Wall-clock budget for **one** clone + update attempt | `90s` |
+| `GIT_MAX_ATTEMPTS` | Total attempts (initial + retries) before giving up | `5` |
+| `GIT_BATCH_WRITEBACK` | Coalesce concurrent write-backs to one repo | `false` |
+| `GIT_BATCH_MAX_SIZE` | Applications committed per batch flush | `20` |
+| `GIT_TIMEOUT` | **Deprecated.** Used as `GIT_OP_TIMEOUT` when that is unset | |
+
+Host key verification is on: a remote missing from `SSH_KNOWN_HOSTS` fails the push. The chart writes the file and sets this variable for you.
+
+### Retry and timeout budget
+
+`GIT_OP_TIMEOUT` bounds a single attempt, not the whole loop — worst case is `GIT_OP_TIMEOUT × GIT_MAX_ATTEMPTS` plus jittered backoff between attempts (capped-exponential, from roughly 250ms to at most 2s, deliberately tight so a retry can win a push race).
+
+Retries exist for contention on a shared repository: each attempt re-fetches, re-applies and re-pushes, and the final attempt discards the on-disk cache and clones fresh, so a poisoned cache heals itself. Raising `GIT_MAX_ATTEMPTS` cannot let an older deployment overwrite a newer one — a superseded task aborts its write-back before every attempt.
+
+### During shutdown
+
+The whole shutdown sequence has a fixed 25-second budget (it must fit the default 30-second `terminationGracePeriodSeconds`), shared with the HTTP and WebSocket drains. An attempt already running is not interrupted, so at the 90-second default a write-back stuck on an unreachable remote is cut off mid-attempt. Keep `GIT_OP_TIMEOUT` below 25s if in-flight commits should land rather than be abandoned on restart.
+
+This decides whether the **commit** reaches Git, not whether the task's final status is recorded — see [Tasks stay "in progress" after a server restart](../operations/troubleshooting.md#tasks-stay-in-progress-after-a-server-restart).

--- a/docs/snippets/quick-start/task.json
+++ b/docs/snippets/quick-start/task.json
@@ -1,11 +1,11 @@
 {
-  "app": "demo-app",
+  "app": "app",
   "author": "you@example.com",
   "project": "demo",
   "images": [
     {
-      "image": "ghcr.io/shini4i/example",
-      "tag": "v0.1.0"
+      "image": "app",
+      "tag": "v0.0.1"
     }
   ]
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,10 +59,14 @@ nav:
     - Installation: 'guides/install.md'
     - GitOps Updater: 'guides/gitops-updater.md'
     - Notifications: 'guides/notifications.md'
+    - Deployment Lock: 'guides/deployment-lock.md'
     - OIDC / SSO: 'guides/oidc.md'
   - Reference:
     - Overview: 'reference/index.md'
     - API Reference: 'reference/api.md'
+    - Server Variables: 'reference/server-env.md'
+    - Client Variables: 'reference/client-env.md'
+    - Annotations: 'reference/annotations.md'
   - Operations:
     - Overview: 'operations/index.md'
     - Observability: 'operations/observability.md'
@@ -72,6 +76,12 @@ nav:
     - Overview: 'contributing/index.md'
     - Development: 'contributing/development.md'
     - Style Guide: 'contributing/style.md'
+
+# A link to a heading that no longer exists is as broken as a link to a missing
+# page, so `mkdocs build --strict` must fail on both.
+validation:
+  links:
+    anchors: warn
 
 markdown_extensions:
   - pymdownx.tasklist:
@@ -103,12 +113,17 @@ markdown_extensions:
 
 plugins:
   - search
+  # git-committers needs the GitHub API and social fetches fonts, so both are
+  # limited to the Read the Docs build (READTHEDOCS=True there) — a local
+  # `mkdocs build --strict` must pass offline, without a token.
   - git-committers:
       repository: shini4i/argo-watcher
       branch: main
+      enabled: !ENV [READTHEDOCS, false]
   - git-revision-date-localized:
       enable_creation_date: true
-  - social
+  - social:
+      enabled: !ENV [READTHEDOCS, false]
   - glightbox
   - swagger-ui-tag
   - redirects:
@@ -137,27 +152,28 @@ plugins:
         GitOps repository.
       sections:
         Getting Started:
-          - getting-started/index.md: Starting point for new users, linking to Quick Start and Concepts.
+          - getting-started/index.md: Starting point for new users.
           - getting-started/quick-start.md: Run a local instance in five minutes with Docker Compose.
-          - getting-started/concepts.md: The problem Argo Watcher solves, its architecture, and key terms.
+          - getting-started/concepts.md: The problem Argo Watcher solves, its parts, and the task lifecycle.
         Guides:
           - guides/index.md: Index of task-oriented guides.
           - guides/install.md: Installing the server and client.
           - guides/gitops-updater.md: Configuring the GitOps Updater to commit image tag changes.
-          - guides/notifications.md: Sending deployment notifications.
+          - guides/notifications.md: Sending deployment notifications via webhook or Mattermost.
+          - guides/deployment-lock.md: Freezing deployments on a schedule or on demand.
           - guides/oidc.md: Securing the Web UI with OIDC (Keycloak, Authentik, or any OIDC provider).
         Reference:
           - reference/index.md: Index of technical reference material.
-          - reference/api.md: REST API endpoints, authentication, and examples.
+          - reference/api.md: REST API endpoints, authentication, and health probes.
           - reference/server-env.md: Server environment variables.
           - reference/client-env.md: Client environment variables.
-          - reference/annotations.md: Argo CD application annotations recognised by Argo Watcher.
+          - reference/annotations.md: The argo-watcher/* annotations on an Argo CD Application.
         Operations:
           - operations/index.md: Index of operational guides.
           - operations/observability.md: Prometheus metrics, suggested alerts, and an example Grafana dashboard.
-          - operations/database.md: Database backends and configuration.
+          - operations/database.md: Schema, migrations, backups, and sizing.
           - operations/troubleshooting.md: Diagnosing common problems.
         Contributing:
           - contributing/index.md: How to contribute.
           - contributing/development.md: Setting up a development environment.
-          - contributing/style.md: Documentation and code style guide.
+          - contributing/style.md: Documentation style guide.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,23 +1,20 @@
 # argo-watcher end-to-end lab
 
-A disposable, reproducible lab that runs **real** ArgoCD, Gitea, and
-argo-rollouts (the latter only for the `accept-suspended` canary-pause phase) on
-a single-node [kind](https://kind.sigs.k8s.io/) cluster and deploys argo-watcher
-built with the Go **race detector**. It exercises the code paths the fast test
-suites cannot: the real ArgoCD polling loop, sustained-concurrency data races,
-and the real git push path — once per release, not on every PR. The `smoke`,
-`failure-diagnostics`, and `race` phases drive the **real `cmd/client` binary**
-(not a hand-rolled HTTP call), so the tool users actually run is covered
-end-to-end: success (exit 0), a surfaced failure reason (exit 1), and the
-superseded/cancelled path (exit 1). The `load` soak stays a purpose-built
-concurrent driver (`load/`) — it asserts server behaviour under contention, not
-client behaviour.
+A disposable lab that runs **real** ArgoCD, Gitea, and argo-rollouts (the last
+only for the `accept-suspended` phase) on a single-node
+[kind](https://kind.sigs.k8s.io/) cluster, with argo-watcher built under the Go
+**race detector**. Nothing is mocked here, which is the point: it covers the real
+ArgoCD polling loop, the real git push path, and data races under sustained
+concurrency — once per release, not on every PR.
 
-Unlike the unit and integration suites, ArgoCD here is **not mocked**.
+The `smoke`, `failure-diagnostics` and `race` phases drive the **real
+`cmd/client` binary**, so the tool users actually run is covered end to end:
+success (exit 0), a surfaced failure reason (exit 1), and the superseded path
+(exit 1). The `load` soak keeps its purpose-built concurrent driver (`load/`) —
+it asserts server behaviour under contention, not client behaviour.
 
-This lab covers the backend and its real ArgoCD/git path only. Browser-level UI
-testing — the OIDC redirect, deep links, the deploy-lock WebSocket, rollback —
-lives separately in `web/e2e/` (Playwright, `task test-web-e2e`).
+Browser-level UI testing lives separately in `web/e2e/` (Playwright,
+`task test-web-e2e`).
 
 ## Prerequisites
 
@@ -207,8 +204,9 @@ again instead of re-establishing a forward.
 - **`shutdown-drain` follows the pod's logs before deleting it.** A recreated
   StatefulSet pod is a new object, so `kubectl logs --previous` would not have the
   terminated instance's shutdown logs; the script streams `logs -f` to a file
-  first, then deletes the pod with `--grace-period=60` so the full drain
-  (`srv.Shutdown` 30s + WS drain 10s) completes before SIGKILL.
+  first, then deletes the pod with `--grace-period=60` so the whole drain (the
+  server's fixed 25s shutdown budget: readiness delay, HTTP, WebSockets, then the
+  git write-back) completes before SIGKILL.
 - **Several config toggles are set globally via `values/argo-watcher.yaml`
   `extraEnvs`** so a single boot can assert them: `JWT_SECRET` (jwt-auth),
   `COMMIT_MESSAGE_FORMAT` (commit-format), `ACCEPT_SUSPENDED_APP` +

--- a/web/README.md
+++ b/web/README.md
@@ -1,158 +1,87 @@
-# Argo Watcher React-admin Frontend
+# Argo Watcher Web UI
 
-This workspace contains the Vite/React-admin rewrite of the Argo Watcher UI. The goals of the new shell are:
+The Web UI: Vite, React 19, React-admin 5, Material UI 9, TypeScript, oxlint, Vitest/jsdom, Playwright. Authentication goes through any OIDC provider via `oidc-client-ts`, with a fully anonymous mode when the backend reports `oidc.enabled = false`.
 
-- reduce custom dashboard code in favour of React-admin resources and generators
-- share layouts, deploy-lock state, and theming logic with the Go backend
-- keep the developer workflow fast (Vite + HMR) while still producing static assets that the Go server can embed
+The build output in `dist/` is what the Go server serves (`STATIC_FILES_PATH`), and what the Docker images copy in.
 
-React 19, React-admin 5, Material UI 9, Emotion, TypeScript, oxlint, and Vitest/JSDOM are the primary dependencies. Authentication uses any OIDC provider (Keycloak, Authentik, …) via `oidc-client-ts`, with a fully anonymous mode when the backend returns `oidc.enabled = false`.
+## Development
 
-## Directory Layout
+```bash
+nix develop        # or direnv allow — provides Go + Node toolchains and the Playwright browsers
+cd web
+npm install
+npm run dev        # http://localhost:5173, proxying /api and /ws to VITE_API_PROXY_TARGET
+```
 
-| Path | Purpose |
-| ---- | ------- |
-| `src/main.tsx` | React entry point that mounts `AppSplash` immediately, runs `bootstrapAuth()` to consume any OIDC authorization-code callback before mounting React-admin, then wires React Router, shared providers, and the `App` component. |
-| `src/App.tsx` | Placeholder React-admin shell; extend this file with `<Admin>` resources as migration phases land. |
-| `src/auth/` | Authentication helpers. `authProvider.ts` drives the OIDC provider (via `oidc-client-ts`) using config from `/api/v1/config`; `authFailure.ts` turns a provider error, an unusable callback, a redirect that never started, or an incomplete server config into the `AuthFailure` the splash screen shows; `tokenStore.ts` holds the bearer token in memory. |
-| `src/data/` | HTTP layer, React-admin `dataProvider` implementation targeting `/api/v1/tasks` and related endpoints, and `wsStatusService.ts`, the shared base for signals mirrored over REST + `/ws`. |
-| `src/features/` | Feature modules (currently `tasks/` and `deployLock/`). Each folder owns its components, hooks, and service logic. |
-| `src/layout/` | Reusable React-admin layout primitives (notifications, top bar, nav, etc.), plus `AppSplash.tsx`, the pre-mount loading screen. |
-| `src/shared/` | Cross-cutting hooks, context providers (timezone), and utilities (time formatting, OIDC toggle). |
-| `src/theme/` | Material UI theme factory plus `ThemeModeProvider` for light/dark persistence. |
-| `src/test/` | Test doubles shared across suites (currently the WebSocket stand-in). |
-| `e2e/` | Playwright browser specs, split into the `no-auth` and `auth` projects, plus `helpers.ts` (task seeding, Keycloak sign-in, token minting). |
-| `assets/` + `public/` | Static assets (logos, favicons) delivered verbatim by Vite. |
-| `dist/` | Build output consumed by the Go server (`STATIC_FILES_PATH`) or Docker images. Generated via `npm run build`. |
-
-## Environment & Runtime Configuration
-
-All configuration is driven through the backend plus a small set of Vite runtime variables:
-
-| Variable | Default | Usage |
-| -------- | ------- | ----- |
-| `VITE_API_PROXY_TARGET` | `http://localhost:8080` | Dev-only proxy target for `/api` + `/ws` when running `npm run dev`. |
-| `VITE_API_BASE_URL` | `''` (same origin) | Prepended to every REST call executed by `httpClient`. Set this when serving the SPA from a CDN or different domain. |
-| `VITE_WS_BASE_URL` | `''` (derived from `window.location`) | Optional WebSocket origin for the deploy-lock service. Provide when tunneling through another host. |
-
-OIDC settings (issuer URL, client_id, privileged groups) come from `/api/v1/config` under the `oidc` key. The frontend caches the config and only attempts SSO flows when `oidc.enabled` is true.
-
-## Development Workflow
-
-1. **Enter the dev shell (recommended)**
-   ```bash
-   nix develop        # or direnv allow (uses flake.nix to expose Go + Node toolchains)
-   ```
-   The shell exports `nodejs@24`, pnpm/corepack helpers, Vite shim, Go toolchain, and pre-commit hooks.
-
-2. **Install dependencies** (run once per clone or after package updates)
-   ```bash
-   cd web
-   npm install
-   ```
-
-3. **Start the Vite dev server**
-   ```bash
-   npm run dev
-   ```
-   - Serves `http://localhost:5173` with hot module reloading.
-   - Proxies `/api` to `VITE_API_PROXY_TARGET` and upgrades `/ws` for deploy-lock streaming.
-   - Ensure the Go API (or `docker-compose up`) is running locally on port 8080 unless you updated the proxy target.
-
-4. **Preview the production build locally**
-   ```bash
-   npm run build
-   npm run preview   # serves dist/ with the same routing as production
-   ```
-
-## npm Scripts
+The Go API must be running (`task bootstrap` from the repo root, or `go run ./cmd/argo-watcher`) unless you repoint the proxy.
 
 | Command | Description |
-| ------- | ----------- |
-| `npm run dev` | Vite dev server with proxy + HMR. |
-| `npm run build` | Production build with sourcemaps -> `web/dist`. |
-| `npm run preview` | Serves `dist/` to validate routing before shipping. |
-| `npm run lint` | oxlint (React, hooks, and TypeScript correctness rules; see `.oxlintrc.json`). |
-| `npm run test` | Vitest in CI mode (`--run`). Generates text + LCOV coverage. |
-| `npm run test:watch` | Interactive Vitest watch mode. |
-| `npm run test:ui` | Vitest UI (requires a browser) for debugging complex suites. |
-| `npm run test:e2e` | Playwright browser suite. Expects `web/dist` built and Keycloak up — `task test-web-e2e` from the repo root does both. |
-| `npm run typecheck:e2e` | Type-checks the node-side project (`playwright.config.ts`, `vite.config.ts`, `e2e/`). Playwright does not type-check specs, so this is a separate CI gate. `src/` is not covered. |
+|---|---|
+| `npm run dev` | Dev server with proxy and HMR |
+| `npm run build` | Production build with sourcemaps into `dist/` |
+| `npm run preview` | Serve `dist/` with production routing |
+| `npm run lint` | oxlint (see `.oxlintrc.json`) |
+| `npm run test` | Vitest once, with text + LCOV coverage |
+| `npm run test:watch` / `test:ui` | Interactive Vitest |
+| `npm run test:e2e` | Playwright — expects `dist/` built and Keycloak up; `task test-web-e2e` does both |
+| `npm run test:e2e:install` | Install the Chromium build Playwright drives |
+| `npm run typecheck:e2e` | Type-check the node-side project (`playwright.config.ts`, `vite.config.ts`, `e2e/`). Playwright does not type-check specs, so this is its own CI gate; `src/` is not covered. |
 
-## Data, Auth, and Real-time Architecture
+## Configuration
 
-- **HTTP client (`src/data/httpClient.ts`)** – wraps `fetch`, injects `Authorization`/`Oidc-Authorization` headers from `tokenStore`, normalises errors into `HttpError`, and provides helpers such as `buildQueryString`.
-- **React-admin `dataProvider` (`src/data/dataProvider.ts`)** – currently implements the `tasks` resource (list/detail/create) and infers pagination totals when the backend omits them. Extend this file when exposing additional Argo watcher endpoints.
-- **Auth provider (`src/auth/authProvider.ts`)** – fetches `/api/v1/config` and, when OIDC is enabled, drives an `oidc-client-ts` `UserManager` (Authorization Code + PKCE). `bootstrapAuth()` (called from `main.tsx` before React mounts) consumes the `?code=…&state=…` callback before the router's index redirect can strip it. It uses a top-level login redirect, relies on `automaticSilentRenew` for token renewal, keeps tokens in memory only, and reads group membership from the userinfo endpoint (the same source the backend enforces on) to expose permissions to React-admin. `checkAuth` never rejects for an unauthenticated user (which would trigger a logout loop) — it redirects instead. When OIDC is disabled, `bootstrapAuth()` is a no-op and the app renders immediately. `bootstrapAuth()` accepts an optional `onOidcEnabled` callback, invoked only once the config reports OIDC enabled and before any provider round trip; `main.tsx` uses it to narrow the splash status line from "Loading…" to "Signing in…", so an auth-less deployment is never told it is signing in. It resolves to an `AuthFailure | null` (see `authFailure.ts`): a non-null result means the sign-in cannot be completed, and `main.tsx` then leaves React-admin unmounted and shows the reason on the splash instead — mounting it would re-run `checkAuth` and head straight back to the provider that just failed. A `/api/v1/config` request that merely fails resolves `null` on purpose, so a restarting backend still renders the app.
-- **Pre-mount loading screen (`src/layout/AppSplash.tsx`)** – covers the window between page load and the React-admin mount, which is otherwise blank while `bootstrapAuth()` resolves the session. It brings its own dark theme and issues no requests: it must render outside `AppProviders`, whose deploy-lock and ArgoCD-status providers start polling the API on mount, before any token exists. Given an `error` prop it becomes the failure surface as well: the progress dots stop and an error box below the logo panel names the reason — the provider's own error code and description, or the discovery URL the browser could not read — with a **Try again** button as the only retry, since redirecting on its own is the loop this replaces.
-- **OIDC toggle hook (`src/shared/hooks/useOidcEnabled.ts`)** – tiny helper for gating UI affordances when running without identity.
-- **Live status services (`src/data/wsStatusService.ts`)** – shared base for a server-owned signal the UI mirrors: bootstrap over REST, then track transitions pushed on the `/ws` channel, with one socket per signal while listeners exist, reconnect-and-reconcile when the socket drops, and ordering guards so a slow REST response cannot overwrite a fresher push. `deployLockService` (`src/features/deployLock/`) extends it and adds the imperative lock/release operations; `argocdStatusService` (`src/features/argocdStatus/`) extends it read-only for ArgoCD reachability.
-- **Global providers (`src/shared/providers/AppProviders.tsx`)** – wraps the app with the theme mode, timezone, and deploy-lock providers, plus a global banner that reflects lock status.
+Everything runtime comes from the backend's `/api/v1/config` — issuer URL, client id, privileged groups — which the frontend caches and only acts on when `oidc.enabled` is true. Only three build-time variables exist:
 
-## Shared UX Infrastructure
+| Variable | Default | Purpose |
+|---|---|---|
+| `VITE_API_PROXY_TARGET` | `http://localhost:8080` | Dev-only proxy target for `/api` and `/ws` |
+| `VITE_API_BASE_URL` | `''` (same origin) | Prefix for every REST call — set it when serving the SPA from another origin |
+| `VITE_WS_BASE_URL` | `''` (from `window.location`) | WebSocket origin, when tunnelling through another host |
 
-- `ThemeModeProvider` persists light/dark preference in `localStorage`, syncs the `<html data-theme-mode>` attribute, and exposes `useThemeMode`.
-- `TimezoneProvider` stores the preferred timezone (`utc` vs `local`) and exposes helpers for deterministic formatting (`formatDateTime` lives in `shared/utils/time.ts`).
-- `layout/components` contains building blocks for notifications, navigation, and placeholders—extend these instead of forking React-admin defaults.
-- Feature folders follow the “colocate everything” pattern (components, hooks, tests alongside their feature) to keep future phases modular.
+## Layout
 
-## Testing & Quality Gates
+| Path | Purpose |
+|---|---|
+| `src/main.tsx` | Mounts `AppSplash` immediately, awaits `bootstrapAuth()` to consume any OIDC callback, then mounts React-admin with the shared providers. |
+| `src/App.tsx` | The React-admin shell: the `tasks` resource plus custom routes for history and task detail. |
+| `src/auth/` | `authProvider.ts` (OIDC via `oidc-client-ts`, configured from `/api/v1/config`), `authFailure.ts` (the `AuthFailure` the splash screen renders), `tokenStore.ts` (token in memory only). |
+| `src/data/` | `httpClient.ts`, the React-admin `dataProvider`, and `wsStatusService.ts` — the shared REST-bootstrap + `/ws` protocol. |
+| `src/features/` | Feature modules: `tasks/`, `deployLock/`, `argocdStatus/`. Each owns its components, hooks and services. |
+| `src/layout/` | Layout primitives (top bar, nav, notifications) and `AppSplash.tsx`, the pre-mount loading screen. |
+| `src/shared/` | Cross-cutting hooks, providers (theme mode, timezone) and utilities. |
+| `src/theme/` | MUI theme factory and `ThemeModeProvider` (light/dark, persisted in `localStorage`). |
+| `e2e/` | Playwright specs, split into the `no-auth` and `auth` projects, plus `helpers.ts`. |
+| `dist/` | Build output served by the Go server. |
 
-- Vitest runs in `jsdom` with globals + `vitest.setup.ts` (place shared mocks, `@testing-library/jest-dom`, etc.).
-- Tests live next to the code as `*.test.ts(x)` and are auto-discovered via `vitest.config.ts`.
-- Coverage reporters: text summary in CI plus LCOV for Codecov. Keep critical flows (auth provider, data provider, the shared WS status protocol, utilities) covered.
-- oxlint enforces React, hooks rules, and TypeScript correctness. Configure additional lint rules under `.oxlintrc.json` if new conventions emerge.
+## Design notes worth knowing before changing things
 
-### Browser tests (Playwright)
+- **`bootstrapAuth()` must be awaited in `main.tsx`, before React mounts.** It consumes the `?code=…&state=…` callback before the router's index redirect can strip it. Moving callback handling back into the React tree reintroduces a redirect loop.
+- **It resolves to `AuthFailure | null`.** Non-null means the sign-in cannot complete, and `main.tsx` then leaves React-admin unmounted and shows the reason on the splash — mounting it would re-run `checkAuth` and head straight back to the provider that just failed. A `/api/v1/config` request that merely *fails* resolves `null` on purpose, so a restarting backend still renders the app.
+- **`AppSplash` renders outside `AppProviders` and issues no requests.** Those providers start polling on mount, before any token exists. Given an `error` prop it becomes the failure surface, with **Try again** as the only retry.
+- **`checkAuth` never rejects for an unauthenticated user** — it redirects. Rejecting triggers a logout loop.
+- **Permissions come from the userinfo endpoint**, the same source the backend enforces on, so the UI cannot show a control the API will reject (except while userinfo is unreachable).
+- **`wsStatusService` owns the real-time protocol**: REST bootstrap, then `/ws` transitions, one socket per signal while listeners exist, reconnect-and-reconcile on drop, and ordering guards so a slow REST response cannot overwrite a fresher push. `deployLockService` adds the lock/release operations; `argocdStatusService` extends it read-only.
 
-`e2e/` covers what jsdom structurally cannot: real cross-document navigation, a
-real history stack, and a real WebSocket. Everything a component test can assert
-belongs in Vitest — this suite is deliberately small.
+## Testing
 
-Run it with `task test-web-e2e` from the repo root; `playwright.config.ts` starts
-what it drives (the mock Argo CD API and two `argo-watcher` instances serving the
-built bundle, on 8100 without OIDC and 8101 with), but Keycloak comes from the
-`integration` Compose profile and must already be up.
+Vitest runs in jsdom with `vitest.setup.ts`; tests live beside the code as `*.test.ts(x)`. Keep the auth provider, data provider, the shared WS protocol, and the utilities covered — coverage goes to Codecov.
+
+Playwright covers only what jsdom structurally cannot: real cross-document navigation, a real history stack, a real WebSocket.
 
 | Project | Covers |
-| ------- | ------ |
-| `no-auth` | The server's SPA fallback for a deep-linked task URL; Back from a directly-opened task page, where the detail view is the router's first history entry; and the auth-less deployment mode, which must render with no sign-in and offer no privileged controls. |
-| `auth` | The top-level OIDC redirect and the stripping of its callback query; returning to the linked task via `url_state`; session recovery through the SSO cookie after a reload; the deploy-lock banner arriving over the live socket and the lock being toggled from the drawer; rollback as a privileged user; and privilege gating of both controls for a privileged vs a regular realm user. |
-
-The Keycloak client in `test/keycloak/argo-watcher-e2e-realm.json` has the
-standard (authorization-code) flow enabled with the app's exact redirect URI
-`http://localhost:8101/` registered, which is what lets a browser complete the
-flow, and it requires PKCE (`S256`) — so a regression that stopped sending a code
-challenge fails every auth spec. The Go integration tests use the same client
-through the direct access grant, so both stay enabled.
+|---|---|
+| `no-auth` | The server's SPA fallback for a deep-linked task URL; Back from a directly-opened task page; and the auth-less mode, which must render with no sign-in and no privileged controls. |
+| `auth` | The top-level OIDC redirect and the stripping of its callback query; returning to the linked task via `url_state`; session recovery through the SSO cookie after a reload; the deploy-lock banner arriving over the live socket and being toggled from the drawer; rollback as a privileged user; and privilege gating for a privileged versus a regular user. |
 
 Two constraints when adding specs:
 
-- `@playwright/test` is pinned to the exact version of `playwright-driver` in
-  `flake.nix`, which supplies the browsers in the dev shell. Bump them together.
-- Both servers hold in-memory state that every spec seeds into, so the suite runs
-  single-worker. Give each seeded task a distinct author rather than assuming an
-  empty list, and never wait on the task table to decide the app has loaded — an
-  empty list has no column headers, so such a wait passes only when some earlier
-  spec happened to seed first. Use `expectAppLoaded` instead.
+- `@playwright/test` is pinned to the `playwright-driver` version in `flake.nix`, which supplies the browsers. Bump them together.
+- Both servers hold in-memory state that every spec seeds into, so the suite is single-worker. Give each seeded task a distinct author, and never wait on the task table to decide the app has loaded — an empty list has no column headers. Use `expectAppLoaded`.
 
-## Building & Shipping
-
-1. Run `npm run build` from `web/`.
-2. The output in `web/dist` is what the Go server serves when `STATIC_FILES_PATH` points to this directory (default). The Dockerfiles already copy `web/dist` into the container image during CI.
-3. If you need to publish the frontend separately (e.g., to an object store), upload the contents of `dist/` and set `VITE_API_BASE_URL`/`VITE_WS_BASE_URL` accordingly before building so the SPA calls the correct origin.
-
-## Extending the Frontend
-
-1. **Add new resources** – create a folder under `src/features/<resource>` with its pages, register the resource in `App.tsx`, and extend `dataProvider`.
-2. **Integrate new API endpoints** – implement helpers in `src/data/httpClient.ts` or compose smaller services similar to `deployLockService`.
-3. **UI building blocks** – prefer MUI components themed through `theme/index.ts`. Keep styling in Emotion for server-render compatibility down the line.
+The Keycloak client in `test/keycloak/argo-watcher-e2e-realm.json` has the authorization-code flow enabled with the exact redirect URI `http://localhost:8101/` and requires PKCE (`S256`), so a regression that stopped sending a code challenge fails every auth spec. The Go integration tests use the same client through the direct access grant, so both flows stay enabled.
 
 ## Troubleshooting
 
-- **Dev server cannot reach the API**: ensure `VITE_API_PROXY_TARGET` matches your backend host or export `VITE_API_BASE_URL` so the SPA calls the right origin.
-- **Endless OIDC redirects**: verify the provider's client lists the current app origin (including any base path) as a valid redirect URI. The login flow uses a top-level redirect, so the redirect URI must be allow-listed there. If the redirect URIs are correct and the loop only appears *after* a successful login, the callback query (`?code=…&state=…`) was stripped before `oidc-client-ts` could read it — this is why `bootstrapAuth()` must be awaited in `main.tsx` before React mounts; do not move the callback handling back into the React tree.
-- **WebSocket errors**: set `VITE_WS_BASE_URL` when proxying through TLS terminators that do not support upgrade requests, or confirm `/ws` is exposed by the Go server.
-- **Timezones look wrong**: toggle the timezone via the user menu (wired to `TimezoneProvider`). The selection lives under `argo-watcher:timezone`.
-
-This README should stay exhaustive—update it whenever you add scripts, env vars, or architectural pieces so contributors can onboard without spelunking through the codebase.
+- **Dev server cannot reach the API** — check `VITE_API_PROXY_TARGET`, or set `VITE_API_BASE_URL` to call another origin directly.
+- **Endless OIDC redirects** — the provider must list this app's origin (including any base path) as a valid redirect URI. If the loop only appears *after* a successful login, the callback query was stripped before `oidc-client-ts` read it; see the `bootstrapAuth()` note above.
+- **WebSocket errors** — confirm `/ws` is exposed and upgraded end to end; set `VITE_WS_BASE_URL` when a TLS terminator gets in the way.
+- **Timezones look wrong** — the preference lives under `argo-watcher:timezone` and is toggled from the user menu.


### PR DESCRIPTION
Checked the docs against the code instead of taking them at face value, and fixed what did not match.

Wrong before this PR:

- The Quick Start's sample task ended as `app not found`, not `deployed` — the bundled mock only serves `app`, `app2` and `app4`.
- A "Pending" task state that does not exist.
- `goose` migration commands, in a golang-migrate repo.
- A troubleshooting section on verifying the webhook HMAC signature, for a feature that was never built.
- `OIDC_PRIVILEGED_GROUPS` listed as required when OIDC is on.
- `npm start` on port 3000 (it is `npm run dev` on 5173).
- OIDC set up through `extraEnvs`, when the chart has an `oidc` block.
- "Redeploy" and "Lockdown Mode" — labels the Web UI does not use.

Also: `SSH_KNOWN_HOSTS`, `REPO_CACHE_PATH`, `DB_DSN`, `DB_MIGRATIONS_PATH` and the client's real defaults are documented now, and the chart's 300s deployment timeout is called out where it differs from the binary's 900s.

Structure and size:

- Deployment locking has its own guide instead of living inside the GitOps Updater page. Deep links to the old anchors no longer resolve.
- The server, client and annotation references are in the nav — they were reachable only from links inside other pages.
- Prose is down about a fifth: long explanations out of table cells, duplicated background dropped, two identical architecture diagrams merged.

`mkdocs build --strict` now fails on a link to a heading that no longer exists, and `git-committers`/`social` only run on Read the Docs so that check works offline.
