### PR TITLE
ci: pin the task version installed by setup-task

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -33,6 +33,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       # bats is absent from the runner image; shellcheck is present but pinned here
       # anyway, because the runner ships 0.9.0 while the flake devshell provides

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install build dependencies (swag for the UI's swagger step)
         run: task install-deps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps
@@ -129,6 +133,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps
@@ -207,6 +215,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         run: task install-deps

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -67,6 +67,10 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.52.0
 
       - name: Install environment dependencies
         # swag, for the swagger spec that task build-ui requires.


### PR DESCRIPTION
The `Install Task` step has been failing on GitHub API rate limits regularly.

`arduino/setup-task` defaults to `version: 3.x`. Resolving that wildcard calls `api.github.com/repos/go-task/task/git/refs/tags` **unauthenticated**, which draws on the 60 requests/hour anonymous quota shared by every GitHub-hosted runner on the same IP. Nine steps across seven workflows were each burning one of those calls per job.

Pinning an exact semver removes the call entirely — the action returns early when the input is valid semver and downloads the release asset directly, which is not on that quota. The `repo-token` input was the alternative, but it only authenticates the same call and raises the ceiling to 1000/h rather than removing it.

The version literal has to stay unprefixed and three-component: the early-return path builds `v${version}` itself, so `v3.52.0` would yield a `vv3.52.0` download URL, and `3.52` would parse as a YAML float.

Verified with `zizmor` (no findings) and by confirming both Taskfiles are schema `version: '3'` using only long-standing features, so nothing depended on floating to the newest release.