### PR TITLE
feat(observability): explain why an out-of-sync deployment failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses (`pgx`), instead of a second driver linked only for migrations. The `DB_*`
   variables, the migrations and the advisory lock that serializes them are unchanged, as
   is running migrations with the external `migrate` CLI.
+- A deployment that fails while the application is still out of sync now leads with what
+  Argo CD reports and how long the rollout was waited on — `Deployment failed: ArgoCD
+  reports sync status OutOfSync after waiting 3m45s.` — and answers the obvious question
+  next. When the revision the last sync applied differs from the one Argo CD now compares
+  against, the report names both and says the desired state has changed since that sync;
+  when they match, it says applying it did not converge the live state and lists the usual
+  causes. Either way it states whether auto-sync is enabled, which decides whether anyone
+  has to act. The last sync operation, which routinely reads `Succeeded` / `successfully
+  synced (all tasks run)`, now closes the report as context instead of opening it and
+  reading as a contradiction. Resources that only reach `Synced` by being deleted are
+  flagged `(requires pruning)`, and a report with none of this still names the last sync
+  operation rather than being blank.
+- Failure reports no longer list resources that applied cleanly. Argo CD reports a
+  successful apply with the hook phase `Running` and kubectl's own `configured` message, so
+  those resources used to appear as `Deployment(app)  Running with message
+  deployment.apps/app configured` in a list of things that had gone wrong — the single most
+  misleading line in the report. Only resources that actually failed are listed, the
+  section is now headed `Failed resources:` rather than `Failed hooks:` (a failed apply is
+  not a hook), and each line names the outcome that describes it instead of always the hook
+  phase, so a resource whose live object went unhealthy mid-sync no longer reads `Synced`.
 
 ### Fixed
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -112,13 +112,14 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 
 	sendNotification(task, updater.notifier)
 
-	// start bounds the deployment-duration metric and the "after waiting ..." clause of a failure
-	// message: a monotonic in-process clock over the rollout work only. It is taken after the start
-	// notification so a slow synchronous notifier does not inflate the measured duration, and
-	// deliberately not derived from task.Created (whose stored unit differs across state backends).
+	// start bounds the deployment-duration metric: a monotonic in-process clock over the whole
+	// deployment, write-back included. It is taken after the start notification so a slow
+	// synchronous notifier does not inflate the measured duration, and deliberately not derived
+	// from task.Created (whose stored unit differs across state backends). The failure message
+	// reports waited instead, which covers the rollout polling alone.
 	start := time.Now()
 
-	application, err := updater.waitForApplicationDeployment(task)
+	application, waited, err := updater.waitForApplicationDeployment(task)
 
 	var imageErr *ImageNotPartOfAppError
 
@@ -134,7 +135,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	case err != nil:
 		updater.monitor.HandleArgoAPIFailure(&task, err)
 	default:
-		updater.monitor.ProcessDeploymentResult(&task, application, time.Since(start))
+		updater.monitor.ProcessDeploymentResult(&task, application, waited)
 	}
 
 	// Only the deployed state is timed: a failure/abort/supersession is not a completed
@@ -147,20 +148,20 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	sendNotification(task, updater.notifier)
 }
 
-func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, error) {
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, time.Duration, error) {
 	if updater.monitor.taskSuperseded(task.Id) {
-		return nil, errTaskSuperseded
+		return nil, 0, errTaskSuperseded
 	}
 
 	// The initial fetch happens before the timed polling loop, so it is bounded only by
 	// the HTTP client's per-request timeout rather than the rollout deadline.
 	app, err := updater.monitor.FetchApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if err := updater.monitor.StoreInitialAppStatus(&task, app); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// The supersede predicate is re-checked inside the write-back retry loop so a
@@ -171,9 +172,9 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 		return updater.monitor.taskSuperseded(task.Id)
 	}); err != nil {
 		if errors.Is(err, ErrDeploymentSuperseded) {
-			return nil, errTaskSuperseded
+			return nil, 0, errTaskSuperseded
 		}
-		return nil, err
+		return nil, 0, err
 	}
 
 	return updater.monitor.WaitRollout(task)

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -112,10 +112,10 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 
 	sendNotification(task, updater.notifier)
 
-	// start bounds the deployment-duration metric: a monotonic in-process clock over the
-	// rollout work only. It is taken after the start notification so a slow synchronous
-	// notifier does not inflate the measured duration, and deliberately not derived from
-	// task.Created (whose stored unit differs across state backends).
+	// start bounds the deployment-duration metric and the "after waiting ..." clause of a failure
+	// message: a monotonic in-process clock over the rollout work only. It is taken after the start
+	// notification so a slow synchronous notifier does not inflate the measured duration, and
+	// deliberately not derived from task.Created (whose stored unit differs across state backends).
 	start := time.Now()
 
 	application, err := updater.waitForApplicationDeployment(task)
@@ -134,7 +134,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	case err != nil:
 		updater.monitor.HandleArgoAPIFailure(&task, err)
 	default:
-		updater.monitor.ProcessDeploymentResult(&task, application)
+		updater.monitor.ProcessDeploymentResult(&task, application, time.Since(start))
 	}
 
 	// Only the deployed state is timed: a failure/abort/supersession is not a completed

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -1309,13 +1309,13 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errors.New("network")).Times(1)
-		_, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, nil).Times(1)
-		_, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
 
@@ -1325,9 +1325,72 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app.Spec.Source.RepoURL = ""
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
-		_, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task)
 		assert.Error(t, err)
 	})
+}
+
+// TestArgoStatusUpdaterFailureDurationExcludesSetup pins what "after waiting ..." means: the time
+// the rollout was polled, not the time the deployment took. The initial fetch, the status write and
+// the git write-back all precede the polling loop, so counting them would tell a user a rollout
+// that failed on its first poll had waited out a slow write-back instead.
+func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	api := newArgoApiMock(ctrl)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	state := mocks.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(state, api, metrics)
+	state.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+	cfg := newUpdaterTestConfig(lock.NewInMemoryLocker())
+	cfg.WebhookConfig = nil
+	updater := initTestUpdater(t, cfg, argo)
+
+	task := models.Task{Id: "task-id", App: "demo", Images: []models.Image{{Image: "example.com/app", Tag: "v2"}}}
+
+	application := &models.Application{}
+	application.Status.Summary.Images = []string{"test-registry/example.com/app:v2"}
+	application.Status.Sync.Status = "OutOfSync"
+	application.Status.OperationState.Phase = "Succeeded"
+	application.Status.OperationState.Message = "successfully synced (all tasks run)"
+
+	// The pre-loop fetch is the one slow step; every poll after it returns at once, so a duration
+	// that counts the setup crosses a second while the polling itself does not.
+	setupDelay := 1200 * time.Millisecond
+	firstFetch := api.EXPECT().
+		GetApplication(gomock.Any(), task.App, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ bool) (*models.Application, error) {
+			time.Sleep(setupDelay)
+			return application, nil
+		})
+	api.EXPECT().
+		GetApplication(gomock.Any(), task.App, gomock.Any()).
+		Return(application, nil).
+		AnyTimes().
+		After(firstFetch)
+
+	var capturedReason string
+	metrics.EXPECT().AddInProgressTask()
+	metrics.EXPECT().RemoveInProgressTask()
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	updater.WaitForRollout(task)
+
+	assert.Equal(t,
+		"Deployment failed: ArgoCD reports sync status OutOfSync.\n\n"+
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+		capturedReason,
+		"the reported wait must exclude the %s spent before the polling loop", setupDelay)
 }
 
 func TestDeploymentMonitorWaitRollout(t *testing.T) {
@@ -1350,7 +1413,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 		app.Metadata.Annotations = map[string]string{"argo-watcher/fire-and-forget": "true"}
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
-		received, err := monitor.WaitRollout(task)
+		received, _, err := monitor.WaitRollout(task)
 		require.NoError(t, err)
 		assert.Equal(t, app, received)
 	})
@@ -1359,7 +1422,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 		errNotFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errNotFound).Times(1)
 
-		_, err := monitor.WaitRollout(task)
+		_, _, err := monitor.WaitRollout(task)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), errNotFound.Error())
 	})
@@ -1399,7 +1462,7 @@ func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
 		}).MinTimes(1).MaxTimes(3)
 
 	start := time.Now()
-	received, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err, "deadline expiry while polling must be swallowed so the caller reports the real status")
@@ -1443,7 +1506,7 @@ func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.
 			return nil, ctx.Err()
 		}).MinTimes(2).MaxTimes(3)
 
-	received, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task)
 	require.NoError(t, err)
 	assert.Equal(t, goodApp, received, "should report the last successfully-fetched application, not nil")
 }
@@ -1470,7 +1533,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 		Return(nil, unavailableErr).MinTimes(1)
 
-	received, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task)
 	require.Error(t, err)
 	assert.Nil(t, received)
 	assert.ErrorIs(t, err, unavailableErr,
@@ -1499,7 +1562,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesArgoAPIError(t *testing.T) {
 	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 		Return(nil, apiErr).MinTimes(1)
 
-	received, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task)
 	require.Error(t, err)
 	assert.Nil(t, received)
 

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -449,14 +449,25 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().AddInProgressTask()
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
-		// The sync reported no resources, so no resource listing is appended: the reason ends at
-		// the message line rather than carrying an empty "Resources:" header.
-		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
-			"Application deployment failed. Rollout status is not synced\n\n"+
-				"App status \"NotWorking\"\n"+
-				"App message \"Not working test app\"")
+		// The headline names ArgoCD's own sync status, and with no revisions, drifted resources or
+		// error conditions in the payload the report collapses to the last sync operation. The
+		// headline is matched by prefix on purpose: this path measures a real clock, so asserting
+		// the whole string would make the test fail on a loaded runner for a timing reason that has
+		// nothing to do with what it covers. The duration itself is pinned at the monitor seam, by
+		// TestDeploymentMonitorProcessDeploymentResultReportsTimeWaited.
+		var capturedReason string
+		stateMock.EXPECT().
+			SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+			DoAndReturn(func(_ string, _ string, reason string) error {
+				capturedReason = reason
+				return nil
+			})
 
 		updater.WaitForRollout(task)
+
+		assert.True(t, strings.HasPrefix(capturedReason, "Deployment failed: ArgoCD reports sync status Syncing"),
+			"unexpected headline: %s", capturedReason)
+		assert.Contains(t, capturedReason, "\n\nLast sync operation: NotWorking, message: \"Not working test app\"")
 	})
 
 	t.Run("Status Updater - Application not healthy", func(t *testing.T) {
@@ -559,7 +570,7 @@ func TestDeploymentMonitorHandleDeploymentFailureHandlesStateError(t *testing.T)
 		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
 		Return(errors.New("update failed"))
 
-	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotHealthy, application)
+	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotHealthy, application, 0)
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
 }
 
@@ -603,10 +614,57 @@ func TestDeploymentMonitorHandleDeploymentFailureEnrichesReasonFromResourceTree(
 			return nil
 		})
 
-	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application)
+	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application, 0)
 
 	assert.Contains(t, capturedReason, "Unhealthy resources:")
 	assert.Contains(t, capturedReason, `Pod(app-xyz) Degraded with message Back-off pulling image "example.com/app:v2": ErrImagePull`)
+}
+
+// TestDeploymentMonitorProcessDeploymentResultReportsTimeWaited pins the duration threading: the
+// wall-clock the rollout was polled for reaches the stored reason, which is what tells a user
+// whether the deployment ran out its window or failed on the spot. Only this seam is asserted —
+// ArgoStatusUpdater.WaitForRollout measures the duration off a real clock, and forcing that past a
+// second would buy a slow test rather than a stronger one.
+func TestDeploymentMonitorProcessDeploymentResultReportsTimeWaited(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	state := mocks.NewMockTaskRepository(ctrl)
+	api := newArgoApiMock(ctrl)
+
+	monitor := NewDeploymentMonitor(Argo{
+		metrics: metrics,
+		State:   state,
+		api:     api,
+	}, "", []retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+
+	task := models.Task{
+		Id:     "task-id",
+		App:    "demo",
+		Images: []models.Image{{Image: "example.com/app", Tag: "v2"}},
+	}
+	application := &models.Application{}
+	application.Status.Summary.Images = []string{"example.com/app:v2"}
+	application.Status.Sync.Status = "OutOfSync"
+	application.Status.OperationState.Phase = "Succeeded"
+	application.Status.OperationState.Message = "successfully synced (all tasks run)"
+
+	var capturedReason string
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	monitor.ProcessDeploymentResult(&task, application, 4*time.Minute)
+
+	assert.Equal(t,
+		"Deployment failed: ArgoCD reports sync status OutOfSync after waiting 4m0s.\n\n"+
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+		capturedReason)
 }
 
 // TestDeploymentMonitorHandleDeploymentFailureResourceTreeErrorIsNonFatal pins the best-effort
@@ -645,7 +703,7 @@ func TestDeploymentMonitorHandleDeploymentFailureResourceTreeErrorIsNonFatal(t *
 			return nil
 		})
 
-	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application)
+	monitor.handleDeploymentFailure(&task, models.ArgoRolloutAppNotAvailable, application, 0)
 
 	assert.Equal(t, models.StatusFailedMessage, task.Status)
 	assert.Contains(t, capturedReason, "Rollout status is not available")
@@ -1755,7 +1813,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.monitor.ProcessDeploymentResult(&task, app)
+		updater.monitor.ProcessDeploymentResult(&task, app, 0)
 		assert.Equal(t, models.StatusDeployedMessage, task.Status)
 	})
 
@@ -1769,7 +1827,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.monitor.ProcessDeploymentResult(&task, app)
+		updater.monitor.ProcessDeploymentResult(&task, app, 0)
 		assert.Equal(t, models.StatusDeployedMessage, task.Status)
 	})
 
@@ -1788,7 +1846,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.monitor.ProcessDeploymentResult(&task, app)
+		updater.monitor.ProcessDeploymentResult(&task, app, 0)
 		assert.Equal(t, models.StatusDeployedMessage, task.Status)
 	})
 
@@ -1801,7 +1859,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(gomock.Any(), models.StatusFailedMessage, gomock.Any())
 
-		updater.monitor.ProcessDeploymentResult(&task, app)
+		updater.monitor.ProcessDeploymentResult(&task, app, 0)
 		assert.Equal(t, models.StatusFailedMessage, task.Status)
 	})
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -162,12 +162,17 @@ func (monitor *DeploymentMonitor) StoreInitialAppStatus(task *models.Task, appli
 // stops immediately so no further ArgoCD API calls are made. Because the check
 // goes through the shared state, this works across replicas in an HA setup — the
 // cancelling deployment may be handled by a different replica than this poller.
-func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Application, error) {
+// The returned duration is how long the polling loop ran, which a failure report states as the
+// time the deployment waited. It covers this loop alone: the initial fetch, the status write and
+// the git write-back all precede it, and counting them would report a rollout that failed on the
+// first poll as one that waited out a slow write-back.
+func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Application, time.Duration, error) {
 	// application holds the most recent successfully-fetched state. It is deliberately assigned only
 	// inside the success branch so that a fetch aborted by the deadline (which returns a nil application)
 	// cannot clobber the last-known-good status we want to report on timeout.
 	var application *models.Application
 
+	start := time.Now()
 	refresh := monitor.resolveRefresh(task)
 	retryOptions, deadline := monitor.configureRetryOptions(task)
 
@@ -222,7 +227,7 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 		err = nil
 	}
 
-	return application, err
+	return application, time.Since(start), err
 }
 
 // rolloutStateAlreadyObserved reports whether err means the poll loop ended with the application's

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -280,8 +280,10 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 	return append(retryOptions, retry.Attempts(attempts)), helpers.MulDurationSaturating(attempts, delay)
 }
 
-// ProcessDeploymentResult determines if the deployment was successful and updates the appropriate status and metrics.
-func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, application *models.Application) {
+// ProcessDeploymentResult determines if the deployment was successful and updates the appropriate
+// status and metrics. waited is how long the rollout was polled, reported in the failure message so
+// the user can tell a rollout that ran out its window from one that failed immediately.
+func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, application *models.Application, waited time.Duration) {
 	status := application.GetRolloutStatus(task.ListImages(), monitor.registryProxyUrl, monitor.acceptSuspended)
 	if application.IsFireAndForgetModeActive() {
 		status = models.ArgoRolloutAppSuccess
@@ -290,7 +292,7 @@ func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, app
 	if status == models.ArgoRolloutAppSuccess {
 		monitor.handleDeploymentSuccess(task)
 	} else {
-		monitor.handleDeploymentFailure(task, status, application)
+		monitor.handleDeploymentFailure(task, status, application, waited)
 	}
 }
 
@@ -347,13 +349,13 @@ func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
 	task.Status = models.StatusDeployedMessage
 }
 
-func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application) {
+func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application, waited time.Duration) {
 	slog.Warn("App deployment failed.", "id", task.Id)
 	monitor.argo.metrics.AddFailedDeployment(task.App)
 	tree := monitor.fetchResourceTree(task)
 	reason := fmt.Sprintf(
-		"Application deployment failed. Rollout status is %s\n\n%s",
-		status,
+		"%s\n\n%s",
+		application.RolloutFailureHeadline(status, waited),
 		application.GetRolloutMessage(status, task.ListImages(), tree),
 	)
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, reason); err != nil {

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -220,7 +220,7 @@ func TestWaitRolloutFailsFastOnImageNotPartOfApp(t *testing.T) {
 	)
 	monitor.refreshApp = true
 
-	_, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task)
 
 	var imageErr *ImageNotPartOfAppError
 	require.ErrorAs(t, err, &imageErr)
@@ -253,7 +253,7 @@ func TestWaitRolloutValidatesDesiredImagesOnce(t *testing.T) {
 	)
 	monitor.refreshApp = true
 
-	_, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task)
 	require.NoError(t, err)
 }
 
@@ -285,7 +285,7 @@ func TestWaitRolloutSkipsValidationWithoutRefresh(t *testing.T) {
 	)
 
 	// No GetManagedResources expectation: any call is a failure.
-	_, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task)
 	require.NoError(t, err)
 }
 

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/shini4i/argo-watcher/internal/helpers"
 )
@@ -46,7 +47,10 @@ type ApplicationResource struct {
 	// Status is the resource's current sync state (example: OutOfSync). ArgoCD omits it for
 	// resources it does not compare, so an empty value means "not assessed", not "in sync".
 	Status string `json:"status"`
-	Health struct {
+	// RequiresPruning is set for a resource that exists only in the cluster: it reaches Synced
+	// by being deleted, which a sync without prune enabled never does.
+	RequiresPruning bool `json:"requiresPruning"`
+	Health          struct {
 		Message string `json:"message"`
 		Status  string `json:"status"`
 	} `json:"health"`
@@ -97,6 +101,10 @@ type ApplicationStatus struct {
 	}
 	Sync struct {
 		Status string `json:"status"`
+		// Revision is the revision the running comparison was performed against. Multi-source
+		// applications leave it empty and report one entry per source in Revisions instead.
+		Revision  string   `json:"revision"`
+		Revisions []string `json:"revisions"`
 	}
 }
 
@@ -105,6 +113,10 @@ type ApplicationStatusOperationState struct {
 	Message    string `json:"message"`
 	SyncResult struct {
 		Resources []ApplicationOperationResource `json:"resources"`
+		// Revision is the revision this sync applied, which is not necessarily the one the
+		// application is compared against now (see ApplicationStatus.Sync.Revision).
+		Revision  string   `json:"revision"`
+		Revisions []string `json:"revisions"`
 	} `json:"syncResult"`
 }
 
@@ -114,8 +126,24 @@ type ApplicationMetadata struct {
 }
 
 type ApplicationSpec struct {
-	Source  ApplicationSource   `json:"source"`
-	Sources []ApplicationSource `json:"sources"`
+	Source     ApplicationSource      `json:"source"`
+	Sources    []ApplicationSource    `json:"sources"`
+	SyncPolicy *ApplicationSyncPolicy `json:"syncPolicy"`
+}
+
+// ApplicationSyncPolicy mirrors spec.syncPolicy. A missing Automated block means ArgoCD applies
+// the desired state only when a sync is triggered, so drift persists until someone acts.
+type ApplicationSyncPolicy struct {
+	Automated *ApplicationSyncPolicyAutomated `json:"automated"`
+}
+
+type ApplicationSyncPolicyAutomated struct {
+	Prune    bool `json:"prune"`
+	SelfHeal bool `json:"selfHeal"`
+	// Enabled is ArgoCD's explicit opt-out: an automated block with enabled=false is inactive.
+	// A nil pointer means enabled, since the field is absent from every policy written before
+	// upstream introduced it.
+	Enabled *bool `json:"enabled"`
 }
 
 type ApplicationSource struct {
@@ -155,18 +183,40 @@ func (app *Application) GetRolloutStatus(rolloutImages []string, registryProxyUr
 	return ArgoRolloutAppSuccess
 }
 
+// RolloutFailureHeadline renders the first line of a deployment-failure report: what argo-watcher
+// observed, and for a drifted application how long it waited before giving up (zero omits the
+// duration). A "not synced" failure names ArgoCD's own sync status rather than the internal rollout
+// status, because "not synced" alongside a succeeded sync operation reads as a contradiction.
+func (app *Application) RolloutFailureHeadline(status string, waited time.Duration) string {
+	if status != ArgoRolloutAppNotSynced {
+		return fmt.Sprintf("Application deployment failed. Rollout status is %s", status)
+	}
+
+	syncStatus := app.Status.Sync.Status
+	if syncStatus == "" {
+		syncStatus = "unknown"
+	}
+
+	headline := fmt.Sprintf("Deployment failed: ArgoCD reports sync status %s", syncStatus)
+	// Anything under a second rounds to "0s", which reads as a bug rather than as a fast failure.
+	if rounded := waited.Round(time.Second); rounded >= time.Second {
+		headline += fmt.Sprintf(" after waiting %s", rounded)
+	}
+	return headline + "."
+}
+
 // GetRolloutMessage generates a rollout failure message.
 //
 // tree is ArgoCD's live resource tree (optional, may be nil). When present it is the
 // preferred source for the "Unhealthy resources" section because it alone carries the
 // pod-level failure cause (ImagePullBackOff / CrashLoopBackOff); when nil the message
 // falls back to the app's top-level Status.Resources, preserving the pre-tree behaviour.
-// The actionable diagnostics (terminal sync operation, failed hooks, unhealthy resources, and —
+// The actionable diagnostics (terminal sync operation, failed resources, unhealthy resources, and —
 // while the application is still Progressing — the resources that never became ready) are appended
 // to both the "not available" and "not healthy"/"degraded" failures so on-call users don't have to
 // context-switch into the ArgoCD UI regardless of how the rollout failed. The "not synced" failure
-// gets its own set instead: it fails on current drift, which the health-oriented sections cannot
-// describe (see buildSyncFailureDiagnostics).
+// is reported on its own terms instead: it fails on current drift, which the health-oriented
+// sections cannot describe (see buildSyncFailureReport).
 func (app *Application) GetRolloutMessage(status string, rolloutImages []string, tree *ApplicationTree) string {
 	switch status {
 	case ArgoRolloutAppNotAvailable:
@@ -181,16 +231,7 @@ func (app *Application) GetRolloutMessage(status string, rolloutImages []string,
 		// Base message has no resource listing, so fall back to Status.Resources when no tree.
 		return appendDiagnostics(base, app.buildFailureDiagnostics(tree, true))
 	case ArgoRolloutAppNotSynced:
-		base := fmt.Sprintf(
-			"App status \"%s\"\n"+
-				"App message \"%s\"",
-			app.Status.OperationState.Phase,
-			app.Status.OperationState.Message,
-		)
-		return appendDiagnostics(
-			appendResourceListing(base, app.ListSyncResultResources()),
-			app.buildSyncFailureDiagnostics(tree),
-		)
+		return app.buildSyncFailureReport(tree)
 	case ArgoRolloutAppNotHealthy, ArgoRolloutAppDegraded:
 		// Appends the same diagnostics as the "not available" path — a stalled rollout
 		// caused by a failing pod surfaces here just as often, and its cause lives in the tree.
@@ -235,19 +276,49 @@ func appendDiagnostics(base, diagnostics string) string {
 	return base + "\n\n" + diagnostics
 }
 
-// formatSyncResultResource renders a single sync-result resource line. Shared between full and filtered listings
-// so the user-facing failure-report format stays consistent if it ever changes.
-func formatSyncResultResource(r ApplicationOperationResource) string {
-	return fmt.Sprintf("%s(%s) %s %s with message %s", r.Kind, r.Name, r.HookType, r.HookPhase, r.Message)
+// syncResultOutcome picks the field that describes what happened to a sync-result resource.
+//
+// A sync status other than "Synced" is the most specific answer there is (SyncFailed, PruneSkipped).
+// Failing that, a terminal phase is preferred, because gitops-engine reports a resource whose live
+// object went Degraded mid-sync as phase "Failed" while leaving its sync status at "Synced" — and
+// "Synced" inside a list of failures reads as a contradiction. The sync status comes next, because
+// that same engine reports a *successful* apply as phase "Running", which reads as a resource stuck
+// mid-rollout when nothing is wrong. Any field can be absent: a hook that failed its dry run
+// carries a sync status but no phase at all.
+func syncResultOutcome(r ApplicationOperationResource) string {
+	switch {
+	case r.Status != "" && r.Status != "Synced":
+		return r.Status
+	case isTerminalFailurePhase(r.HookPhase):
+		return r.HookPhase
+	case r.Status != "":
+		return r.Status
+	default:
+		return r.HookPhase
+	}
 }
 
-// ListSyncResultResources returns one formatted line per sync-result resource.
-func (app *Application) ListSyncResultResources() []string {
-	list := make([]string, len(app.Status.OperationState.SyncResult.Resources))
-	for index := range app.Status.OperationState.SyncResult.Resources {
-		list[index] = formatSyncResultResource(app.Status.OperationState.SyncResult.Resources[index])
+// formatSyncResultResource renders a single sync-result resource line: the hook type when the
+// resource is one, then the field that describes its outcome. Absent fields are skipped rather
+// than rendered as blanks.
+func formatSyncResultResource(r ApplicationOperationResource) string {
+	var outcome []string
+
+	if r.HookType != "" {
+		outcome = append(outcome, r.HookType)
 	}
-	return list
+	if described := syncResultOutcome(r); described != "" {
+		outcome = append(outcome, described)
+	}
+
+	line := fmt.Sprintf("%s(%s)", r.Kind, r.Name)
+	if len(outcome) > 0 {
+		line += " " + strings.Join(outcome, " ")
+	}
+	if r.Message != "" {
+		line += " with message " + r.Message
+	}
+	return line
 }
 
 // formatHealthResource renders a single health-bearing resource line. Shared between full and filtered listings
@@ -277,6 +348,8 @@ func (app *Application) ListUnhealthyResources() []string {
 // listOutOfSyncResources returns one formatted line per top-level resource whose sync status is
 // not "Synced". Resources ArgoCD does not compare carry no status at all and are skipped: an empty
 // value means "not assessed" rather than "drifted", and reporting those would bury the real culprit.
+// A resource that only reaches Synced by being deleted is annotated, because a sync without prune
+// enabled will never do that and waiting cannot resolve it.
 func (app *Application) listOutOfSyncResources() []string {
 	var list []string
 
@@ -285,7 +358,11 @@ func (app *Application) listOutOfSyncResources() []string {
 		if resource.Status == "" || resource.Status == "Synced" {
 			continue
 		}
-		list = append(list, fmt.Sprintf("%s(%s) %s", resource.Kind, resource.Name, resource.Status))
+		line := fmt.Sprintf("%s(%s) %s", resource.Kind, resource.Name, resource.Status)
+		if resource.RequiresPruning {
+			line += " (requires pruning)"
+		}
+		list = append(list, line)
 	}
 	return list
 }
@@ -307,16 +384,20 @@ func (app *Application) listErrorConditions() []string {
 	return list
 }
 
-// buildSyncFailureDiagnostics builds the optional diagnostics suffix appended to the "not synced"
-// rollout failure. The base message reports the last sync *operation*, which routinely succeeded
-// while the application drifted straight back out of sync; the drift itself lives in the current
-// resource statuses, and the reason a comparison failed outright lives only in the conditions.
-// Each section is included only when it has content, so a failure with neither keeps its legacy output.
-func (app *Application) buildSyncFailureDiagnostics(tree *ApplicationTree) string {
+// buildSyncFailureReport renders the whole "not synced" failure report. The failure is decided by
+// the application's *current* sync status, while the last sync *operation* it ran routinely
+// succeeded — reporting the operation first made the two read as a contradiction, so the report
+// leads with why the application is still out of sync and closes with the operation as context.
+// Every section but the last is included only when it has content.
+func (app *Application) buildSyncFailureReport(tree *ApplicationTree) string {
 	var sections []string
 
-	// Errors come first: the resource listing is unbounded, so the one line naming the
-	// cause must not trail dozens of drift lines.
+	if explanation := app.buildDriftExplanation(); explanation != "" {
+		sections = append(sections, explanation)
+	}
+
+	// Errors come before the listings: the resource lists are unbounded, so the one line naming
+	// the cause must not trail dozens of drift lines.
 	if conditions := app.listErrorConditions(); len(conditions) > 0 {
 		sections = append(sections, "Sync errors:\n\t"+strings.Join(conditions, "\n\t"))
 	}
@@ -335,7 +416,150 @@ func (app *Application) buildSyncFailureDiagnostics(tree *ApplicationTree) strin
 		sections = append(sections, "Out-of-sync resources:\n\t"+strings.Join(resources, "\n\t"))
 	}
 
-	return strings.Join(sections, "\n\n")
+	if failed := app.listFailedSyncResultResources(); len(failed) > 0 {
+		sections = append(sections, "Failed resources:\n\t"+strings.Join(failed, "\n\t"))
+	}
+
+	return strings.Join(append(sections, app.lastSyncOperationLine()), "\n\n")
+}
+
+// buildDriftExplanation explains why an application whose last sync succeeded is still out of sync,
+// which is the question the report exists to answer. It compares the revision that sync applied
+// against the revision the running comparison uses: a different one means the desired state moved,
+// the same one means applying it did not converge the live state. It returns an empty string when
+// ArgoCD reported no revisions, or when the last sync did not succeed — matching revisions then mean
+// nothing was applied, not that applying it failed to stick.
+//
+// The wording deliberately claims no more than the two fields establish. Which revision is newer in
+// git history is not among it: a rollback, a revert or a retargeted branch all leave the comparison
+// pointing at an older revision.
+func (app *Application) buildDriftExplanation() string {
+	if app.Status.OperationState.Phase != "Succeeded" {
+		return ""
+	}
+
+	applied := newRevisions(app.Status.OperationState.SyncResult.Revision, app.Status.OperationState.SyncResult.Revisions)
+	compared := newRevisions(app.Status.Sync.Revision, app.Status.Sync.Revisions)
+	if applied.key == "" || compared.key == "" {
+		return ""
+	}
+
+	var explanation string
+	if applied.key == compared.key {
+		explanation = fmt.Sprintf(
+			"The last sync succeeded for %s and the application is still out of sync against exactly "+
+				"what that sync applied, so applying it did not converge the live state. Usual causes: "+
+				"a mutating admission webhook, a controller that owns a field the manifests also set "+
+				"(replicas versus an HPA), a resource that has to be pruned, or a sync that covered "+
+				"only some resources. Extra waiting is unlikely to help.",
+			applied.phrase,
+		)
+	} else {
+		explanation = fmt.Sprintf(
+			"The last sync applied %s, but ArgoCD now compares the application against %s, so the "+
+				"desired state has changed since that sync.",
+			applied.phrase, compared.phrase,
+		)
+	}
+
+	return explanation + "\n" + app.autoSyncNote()
+}
+
+// autoSyncNote states whether ArgoCD will act on the drift by itself, which decides whether the
+// operator has to. It accompanies the drift explanation rather than standing alone: on its own it
+// would add a line to every report that has nothing to explain.
+func (app *Application) autoSyncNote() string {
+	if !app.AutoSyncEnabled() {
+		return "Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered."
+	}
+
+	automated := app.Spec.SyncPolicy.Automated
+	return fmt.Sprintf("Auto-sync is enabled (prune %s, self-heal %s).",
+		onOff(automated.Prune), onOff(automated.SelfHeal))
+}
+
+// lastSyncOperationLine reports the outcome of the sync ArgoCD last ran. Unconditional, so a
+// report whose every other section emptied out still says something.
+func (app *Application) lastSyncOperationLine() string {
+	operation := app.Status.OperationState
+	if operation.Phase == "" && operation.Message == "" {
+		return "No sync operation is recorded for this application."
+	}
+
+	phase := operation.Phase
+	if phase == "" {
+		phase = "unknown"
+	}
+
+	line := "Last sync operation: " + phase
+	if operation.Message != "" {
+		line += fmt.Sprintf(", message: %q", operation.Message)
+	}
+	return line
+}
+
+// AutoSyncEnabled reports whether ArgoCD applies this application's desired state on its own.
+func (app *Application) AutoSyncEnabled() bool {
+	if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
+		return false
+	}
+	return app.Spec.SyncPolicy.Automated.Enabled == nil || *app.Spec.SyncPolicy.Automated.Enabled
+}
+
+func onOff(enabled bool) string {
+	if enabled {
+		return "on"
+	}
+	return "off"
+}
+
+// revisions is one of ArgoCD's revision reports: key is the untruncated value two reports are
+// compared by, phrase is how the failure message names them. Keeping the two apart matters — two
+// distinct commits can share an abbreviated prefix, and comparing the abbreviations would hand the
+// user the wrong verdict. An empty key means ArgoCD reported no revision at all.
+type revisions struct {
+	key    string
+	phrase string
+}
+
+// newRevisions reads a revision report from ArgoCD's pair of fields: a single-source application
+// fills revision, a multi-source one fills list with one entry per source. The list wins whenever
+// it holds more than one entry, so an application that reports both cannot have its verdict decided
+// by one source's revision while another source is the one that moved.
+func newRevisions(revision string, list []string) revisions {
+	if revision != "" && len(list) <= 1 {
+		return revisions{key: revision, phrase: "revision " + shortRevision(revision)}
+	}
+	if len(list) == 0 {
+		return revisions{}
+	}
+
+	short := make([]string, len(list))
+	for index := range list {
+		short[index] = shortRevision(list[index])
+	}
+
+	label := "revision "
+	if len(list) > 1 {
+		label = "revisions "
+	}
+	return revisions{key: strings.Join(list, ","), phrase: label + strings.Join(short, ", ")}
+}
+
+// shortRevision abbreviates a full git SHA to the seven characters ArgoCD's own UI shows. Anything
+// else — a tag, a branch, a chart version — is returned untouched.
+func shortRevision(revision string) string {
+	const shaLength = 40
+
+	if len(revision) != shaLength {
+		return revision
+	}
+	for _, char := range revision {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", char) {
+			return revision
+		}
+	}
+	return revision[:7]
 }
 
 // isTerminalFailurePhase reports whether the given ArgoCD phase value indicates a terminal failure. The same
@@ -358,12 +582,14 @@ func isProblemHealthStatus(status string) bool {
 	}
 }
 
-// listFailedSyncResultResources returns formatted lines for sync-result resources whose hook phase indicates failure.
+// listFailedSyncResultResources returns formatted lines for the sync-result resources that did not
+// go through: a hook that ended in a terminal failure phase, or an ordinary resource ArgoCD could
+// not apply. The rest of the sync result describes work that succeeded and is left out.
 func (app *Application) listFailedSyncResultResources() []string {
 	var list []string
 	for index := range app.Status.OperationState.SyncResult.Resources {
 		resource := app.Status.OperationState.SyncResult.Resources[index]
-		if !isTerminalFailurePhase(resource.HookPhase) {
+		if !isTerminalFailurePhase(resource.HookPhase) && resource.Status != "SyncFailed" {
 			continue
 		}
 		list = append(list, formatSyncResultResource(resource))
@@ -454,8 +680,8 @@ func (app *Application) buildFailureDiagnostics(tree *ApplicationTree, allowStat
 		sections = append(sections, opSection)
 	}
 
-	if hooks := app.listFailedSyncResultResources(); len(hooks) > 0 {
-		sections = append(sections, "Failed hooks:\n\t"+strings.Join(hooks, "\n\t"))
+	if failed := app.listFailedSyncResultResources(); len(failed) > 0 {
+		sections = append(sections, "Failed resources:\n\t"+strings.Join(failed, "\n\t"))
 	}
 
 	if resources := app.problemResourceLines(tree, allowStatusFallback); len(resources) > 0 {

--- a/internal/models/argo.go
+++ b/internal/models/argo.go
@@ -315,20 +315,23 @@ func formatSyncResultResource(r ApplicationOperationResource) string {
 	if len(outcome) > 0 {
 		line += " " + strings.Join(outcome, " ")
 	}
-	if r.Message != "" {
-		line += " with message " + r.Message
+	return withMessage(line, r.Message)
+}
+
+// withMessage appends a resource's own message to its rendered line. Every resource formatter goes
+// through it, so a resource that carries no message never trails an empty "with message" and all
+// three listings of the failure report read the same way.
+func withMessage(line, message string) string {
+	if message == "" {
+		return line
 	}
-	return line
+	return line + " with message " + message
 }
 
 // formatHealthResource renders a single health-bearing resource line. Shared between full and filtered listings
 // so the user-facing failure-report format stays consistent if it ever changes.
 func formatHealthResource(r ApplicationResource) string {
-	line := fmt.Sprintf("%s(%s) %s", r.Kind, r.Name, r.Health.Status)
-	if r.Health.Message != "" {
-		line += " with message " + r.Health.Message
-	}
-	return line
+	return withMessage(fmt.Sprintf("%s(%s) %s", r.Kind, r.Name, r.Health.Status), r.Health.Message)
 }
 
 // ListUnhealthyResources returns one formatted line per resource with a non-empty health status.
@@ -613,11 +616,7 @@ func (app *Application) listProblemResources() []string {
 // formatTreeNode renders a single resource-tree node line, mirroring formatHealthResource so
 // tree-sourced and Status.Resources-sourced "Unhealthy resources" lines look identical.
 func formatTreeNode(n ApplicationTreeNode) string {
-	line := fmt.Sprintf("%s(%s) %s", n.Kind, n.Name, n.Health.Status)
-	if n.Health.Message != "" {
-		line += " with message " + n.Health.Message
-	}
-	return line
+	return withMessage(fmt.Sprintf("%s(%s) %s", n.Kind, n.Name, n.Health.Status), n.Health.Message)
 }
 
 // ListProblemNodes returns formatted lines for resource-tree nodes whose health indicates a

--- a/internal/models/argo_test.go
+++ b/internal/models/argo_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListSyncResultResources(t *testing.T) {
+func TestListFailedSyncResultResources(t *testing.T) {
 	jsonData, err := os.ReadFile("testdata/failed-deployment.json")
 	if err != nil {
 		t.Fatalf("Failed to read JSON data file: %s", err)
@@ -20,14 +21,205 @@ func TestListSyncResultResources(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON data: %s", err)
 	}
 
-	resultResources := app.ListSyncResultResources()
-
+	// The successful PreSync hook in the payload must not be listed: a failure report that
+	// names resources which worked is what made these reports unreadable.
 	expectedResources := []string{
-		"Pod(app-migrations) PreSync Succeeded with message ",
 		"Job(app-job) PostSync Failed with message Job has reached the specified backoff limit",
 	}
 
-	assert.Equal(t, expectedResources, resultResources)
+	assert.Equal(t, expectedResources, app.listFailedSyncResultResources())
+}
+
+func TestFormatSyncResultResource(t *testing.T) {
+	t.Run("an ordinary resource is reported by its sync status, not its hook phase", func(t *testing.T) {
+		// gitops-engine sets HookPhase to "Running" for every successfully applied non-hook
+		// resource, so printing the phase here made a clean apply look like a stalled one.
+		assert.Equal(t,
+			"Deployment(order-management) SyncFailed with message error validating data",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Deployment",
+				Name:      "order-management",
+				Status:    "SyncFailed",
+				HookPhase: "Failed",
+				Message:   "error validating data",
+			}))
+	})
+
+	t.Run("a hook is reported by its type and phase", func(t *testing.T) {
+		assert.Equal(t,
+			"Job(app-migrations) PreSync Failed with message backoff limit reached",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Job",
+				Name:      "app-migrations",
+				Status:    "Synced",
+				HookType:  "PreSync",
+				HookPhase: "Failed",
+				Message:   "backoff limit reached",
+			}))
+	})
+
+	t.Run("an empty message leaves no dangling suffix", func(t *testing.T) {
+		assert.Equal(t,
+			"Job(app-migrations) PreSync Failed",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Job",
+				Name:      "app-migrations",
+				HookType:  "PreSync",
+				HookPhase: "Failed",
+			}))
+	})
+
+	t.Run("a terminal phase outranks the sync status", func(t *testing.T) {
+		// gitops-engine reports a resource whose live object went Degraded mid-sync as phase
+		// "Failed" while leaving the sync status at "Synced". Printing the status there would
+		// label the resource "Synced" inside the list of resources that failed.
+		assert.Equal(t,
+			"Deployment(order-management) Failed with message Deployment has 1 unavailable replica",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Deployment",
+				Name:      "order-management",
+				Status:    "Synced",
+				HookPhase: "Failed",
+				Message:   "Deployment has 1 unavailable replica",
+			}))
+	})
+
+	t.Run("a hook that failed its dry run has no phase to report", func(t *testing.T) {
+		// That path records the sync status and leaves the phase empty, so the outcome has to come
+		// from the status; rendering the empty phase left a blank where the failure should be.
+		assert.Equal(t,
+			"Job(app-migrations) PreSync SyncFailed with message error validating data",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:     "Job",
+				Name:     "app-migrations",
+				Status:   "SyncFailed",
+				HookType: "PreSync",
+				Message:  "error validating data",
+			}))
+	})
+
+	t.Run("a clean apply is described by its status, not by the engine's Running phase", func(t *testing.T) {
+		// The failure listing filters these out, so this shape reaches the formatter only from a
+		// future caller — the formatter still must not call a successful apply "Running".
+		assert.Equal(t,
+			"Deployment(order-management) Synced with message deployment.apps/order-management configured",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Deployment",
+				Name:      "order-management",
+				Status:    "Synced",
+				HookPhase: "Running",
+				Message:   "deployment.apps/order-management configured",
+			}))
+	})
+
+	t.Run("with no status at all the phase is the only outcome left", func(t *testing.T) {
+		assert.Equal(t,
+			"Pod(app-hook) PreSync Running",
+			formatSyncResultResource(ApplicationOperationResource{
+				Kind:      "Pod",
+				Name:      "app-hook",
+				HookType:  "PreSync",
+				HookPhase: "Running",
+			}))
+	})
+}
+
+func TestRolloutFailureHeadline(t *testing.T) {
+	tests := []struct {
+		name       string
+		syncStatus string
+		waited     time.Duration
+		expected   string
+	}{
+		{
+			"names the observed sync status and the time waited",
+			"OutOfSync", 225 * time.Second,
+			"Deployment failed: ArgoCD reports sync status OutOfSync after waiting 3m45s.",
+		},
+		{
+			"omits the duration when it is unknown",
+			"Unknown", 0,
+			"Deployment failed: ArgoCD reports sync status Unknown.",
+		},
+		{
+			// A payload ArgoCD has not compared yet carries no sync status, and "reports sync
+			// status ." is the kind of half sentence this report exists to stop producing.
+			"falls back to unknown when ArgoCD reported no sync status",
+			"", 225 * time.Second,
+			"Deployment failed: ArgoCD reports sync status unknown after waiting 3m45s.",
+		},
+		{
+			// Anything under a second rounds to "0s", which reads as a bug, not a fast failure.
+			"omits a sub-second duration rather than rounding it to zero",
+			"OutOfSync", 400 * time.Millisecond,
+			"Deployment failed: ArgoCD reports sync status OutOfSync.",
+		},
+		{
+			"rounds the duration to whole seconds",
+			"OutOfSync", 1500 * time.Millisecond,
+			"Deployment failed: ArgoCD reports sync status OutOfSync after waiting 2s.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			application := Application{}
+			application.Status.Sync.Status = test.syncStatus
+			assert.Equal(t, test.expected, application.RolloutFailureHeadline(ArgoRolloutAppNotSynced, test.waited))
+		})
+	}
+
+	t.Run("every other failure keeps the legacy headline", func(t *testing.T) {
+		application := Application{}
+		assert.Equal(t,
+			"Application deployment failed. Rollout status is not available",
+			application.RolloutFailureHeadline(ArgoRolloutAppNotAvailable, 225*time.Second))
+	})
+}
+
+func TestShortRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		expected string
+	}{
+		{"a full SHA is abbreviated", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "a1b2c3d"},
+		{"an uppercase SHA is abbreviated too", "A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0", "A1B2C3D"},
+		// Truncating a branch or chart reference would misname the revision in the report.
+		{"a 40-character non-hex revision is left alone", "release/2026-08-19-hotfix-order-mgmt-xyz", "release/2026-08-19-hotfix-order-mgmt-xyz"},
+		{"an already-short revision is left alone", "v1.2.3", "v1.2.3"},
+		{"an empty revision stays empty", "", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, shortRevision(test.revision))
+		})
+	}
+}
+
+func TestAutoSyncEnabled(t *testing.T) {
+	enabled, disabled := true, false
+
+	tests := []struct {
+		name     string
+		policy   *ApplicationSyncPolicy
+		expected bool
+	}{
+		{"no policy at all", nil, false},
+		{"policy without an automated block", &ApplicationSyncPolicy{}, false},
+		{"automated block", &ApplicationSyncPolicy{Automated: &ApplicationSyncPolicyAutomated{}}, true},
+		{"automated block explicitly enabled", &ApplicationSyncPolicy{Automated: &ApplicationSyncPolicyAutomated{Enabled: &enabled}}, true},
+		{"automated block explicitly disabled", &ApplicationSyncPolicy{Automated: &ApplicationSyncPolicyAutomated{Enabled: &disabled}}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			application := Application{}
+			application.Spec.SyncPolicy = test.policy
+			assert.Equal(t, test.expected, application.AutoSyncEnabled())
+		})
+	}
 }
 
 func TestListUnhealthyResources(t *testing.T) {
@@ -54,8 +246,9 @@ func TestListUnhealthyResources(t *testing.T) {
 
 func TestNotSyncedDiagnosticsFromPayload(t *testing.T) {
 	// Decodes a captured ArgoCD payload so the struct tags the not-synced report depends on —
-	// status.resources[].status and status.conditions — are exercised. Tests that build the
-	// Application in Go cannot catch a wrong tag, which would leave both sections silently empty.
+	// status.resources[].status, status.resources[].requiresPruning, status.conditions, both
+	// revisions and spec.syncPolicy — are exercised. Tests that build the Application in Go
+	// cannot catch a wrong tag, which would leave the sections silently empty.
 	jsonData, err := os.ReadFile("testdata/out-of-sync-deployment.json")
 	if err != nil {
 		t.Fatalf("Failed to read JSON data file: %s", err)
@@ -70,14 +263,44 @@ func TestNotSyncedDiagnosticsFromPayload(t *testing.T) {
 		app.GetRolloutStatus([]string{"product-catalog:v0.0.2"}, "", false))
 
 	assert.Equal(t,
-		"App status \"Succeeded\"\n"+
-			"App message \"successfully synced (all tasks run)\"\n"+
-			"Resources:\n"+
-			"\tDeployment(product-catalog)  Running with message deployment.apps/product-catalog configured\n\n"+
+		"The last sync applied revision b6a9f1c, but ArgoCD now compares the application against "+
+			"revision d4c2b0a, so the desired state has changed since that sync.\n"+
+			"Auto-sync is enabled (prune on, self-heal off).\n\n"+
 			"Sync errors:\n"+
 			"\tComparisonError: Failed to load target state: rpc error: code = Unknown\n\n"+
 			"Out-of-sync resources:\n"+
-			"\tDeployment(product-catalog) OutOfSync",
+			"\tDeployment(product-catalog) OutOfSync\n"+
+			"\tConfigMap(product-catalog-legacy) OutOfSync (requires pruning)\n\n"+
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+		app.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"product-catalog:v0.0.2"}, nil))
+}
+
+func TestNotSyncedDiagnosticsFromMultiSourcePayload(t *testing.T) {
+	// The sibling payload test covers the single-source tags. This one covers the three a
+	// multi-source application depends on — status.sync.revisions, syncResult.revisions and
+	// spec.syncPolicy.automated.enabled — because a wrong tag on any of them fails silently: the
+	// drift explanation would vanish, or an app with automated sync switched off would be reported
+	// as one ArgoCD is about to fix by itself.
+	jsonData, err := os.ReadFile("testdata/out-of-sync-multi-source.json")
+	if err != nil {
+		t.Fatalf("Failed to read JSON data file: %s", err)
+	}
+
+	var app Application
+	if err := json.Unmarshal(jsonData, &app); err != nil {
+		t.Fatalf("Failed to unmarshal JSON data: %s", err)
+	}
+
+	assert.Equal(t, ArgoRolloutAppNotSynced,
+		app.GetRolloutStatus([]string{"product-catalog:v0.0.2"}, "", false))
+
+	assert.Equal(t,
+		"The last sync applied revisions b6a9f1c, 1.14.2, but ArgoCD now compares the application "+
+			"against revisions b6a9f1c, 1.15.0, so the desired state has changed since that sync.\n"+
+			"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+			"Out-of-sync resources:\n"+
+			"\tDeployment(product-catalog) OutOfSync\n\n"+
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 		app.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"product-catalog:v0.0.2"}, nil))
 }
 
@@ -193,7 +416,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 		assert.Equal(t,
 			"List of current images (last app check):\n\tapp:v0.0.1\n\n"+
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
-				"Failed hooks:\n"+
+				"Failed resources:\n"+
 				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit",
 			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, nil))
 	})
@@ -284,7 +507,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Sync operation phase: Failed\n"+
 				"Sync operation message: one or more synchronization tasks completed unsuccessfully\n\n"+
-				"Failed hooks:\n"+
+				"Failed resources:\n"+
 				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit\n\n"+
 				"Unhealthy resources:\n"+
 				"\tPod(app-pod) Degraded with message Back-off restarting failed container",
@@ -363,7 +586,9 @@ func TestArgoRolloutMessage(t *testing.T) {
 		application.Status.OperationState.SyncResult.Resources[1].Namespace = "app"
 		images := []string{"ghcr.io/shini4i/argo-watcher:version1"}
 		assert.Equal(t,
-			"App status \"NotWorking\"\nApp message \"Not working test app\"\nResources:\n\tPod(app-migrations) PreSync Succeeded with message \n\tJob(app-job) PostSync Failed with message Job has reached the specified backoff limit",
+			"Failed resources:\n"+
+				"\tJob(app-job) PostSync Failed with message Job has reached the specified backoff limit\n\n"+
+				"Last sync operation: NotWorking, message: \"Not working test app\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, images, nil))
 	})
 
@@ -506,7 +731,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"List of expected images:\n\tapp:v0.0.2\n\n"+
 				"Sync operation phase: Failed\n"+
 				"Sync operation message: one or more synchronization tasks completed unsuccessfully\n\n"+
-				"Failed hooks:\n"+
+				"Failed resources:\n"+
 				"\tJob(app-migrations) PreSync Failed with message Job has reached the specified backoff limit\n\n"+
 				"Unhealthy resources:\n"+
 				"\tPod(app-xyz) Degraded with message Back-off pulling image \"app:v0.0.2\": ErrImagePull",
@@ -543,7 +768,7 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"\tDeployment(app) Degraded with message replicas unavailable\n\n"+
 				"Sync operation phase: Failed\n"+
 				"Sync operation message: sync failed\n\n"+
-				"Failed hooks:\n"+
+				"Failed resources:\n"+
 				"\tJob(app-migrations) PreSync Failed with message backoff",
 			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images, nil))
 	})
@@ -598,143 +823,118 @@ func TestArgoRolloutMessage(t *testing.T) {
 			application.GetRolloutMessage(ArgoRolloutAppNotHealthy, images, nil))
 	})
 
-	t.Run("Rollout message - not synced omits the Resources block when the sync result is empty", func(t *testing.T) {
-		// Same contract as the not-healthy arm: a sync that reported no resources must not leave a
-		// bare "Resources:" heading behind. All three arms format the listing the same way.
+	t.Run("Rollout message - not synced closes with the last sync operation", func(t *testing.T) {
+		// Every other section can empty out, so the operation line is what keeps the report from
+		// being blank. It closes the report deliberately: leading with a succeeded operation is
+		// what made the failure read as self-contradictory.
 		application := Application{}
 		application.Status.OperationState.Phase = "NotWorking"
 		application.Status.OperationState.Message = "Not working test app"
 		assert.Equal(t,
-			"App status \"NotWorking\"\n"+
-				"App message \"Not working test app\"",
+			"Last sync operation: NotWorking, message: \"Not working test app\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
-	t.Run("Rollout message - not synced reports the pod-level cause when the app is also degraded", func(t *testing.T) {
-		// A Degraded application that is still OutOfSync is classified "not synced", so this arm is
-		// the only place the crashlooping pod behind such a failure is ever reported. The cause lives
-		// in the resource tree alone — Status.Resources carries no pod health.
+	t.Run("Rollout message - not synced says so when no sync operation is recorded", func(t *testing.T) {
 		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Resources = []ApplicationResource{
-			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
-		}
-		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
-			treeNode("Pod", "product-catalog-abcde", "Degraded", "back-off 5m0s restarting failed container=app"),
-			treeNode("Service", "product-catalog", "Healthy", ""),
-		}}
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n\n"+
-				"Unhealthy resources:\n"+
-				"\tPod(product-catalog-abcde) Degraded with message back-off 5m0s restarting failed container=app\n\n"+
-				"Out-of-sync resources:\n"+
-				"\tDeployment(product-catalog) OutOfSync",
-			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
-	})
-
-	t.Run("Rollout message - not synced adds no Unhealthy block when the tree is clean", func(t *testing.T) {
-		// The tree is fetched on every failure, so a healthy one must leave the report untouched.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Resources = []ApplicationResource{
-			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
-		}
-		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
-			treeNode("Pod", "product-catalog-abcde", "Healthy", ""),
-		}}
-		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n\n"+
-				"Out-of-sync resources:\n"+
-				"\tDeployment(product-catalog) OutOfSync",
-			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
-	})
-
-	t.Run("Rollout message - not synced omits the Sync errors block when only warnings are present", func(t *testing.T) {
-		// The conditions filter emptying out must leave no trace: no header, no separator. Warnings
-		// are the common case on a healthy app, so this is the path most likely to regress.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Conditions = []ApplicationCondition{
-			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
-			{Type: "SharedResourceWarning", Message: "Resource is part of applications app-a and app-b"},
-		}
-		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"",
+			"No sync operation is recorded for this application.",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
-	t.Run("Rollout message - not synced omits the Out-of-sync block when no resource has drifted", func(t *testing.T) {
-		// The app-level sync status can be non-Synced while every top-level resource compares clean
-		// (or is not compared at all), so the resource filter must be able to empty out silently.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Resources = []ApplicationResource{
-			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
-			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
-		}
+	t.Run("Rollout message - not synced explains a superseded revision", func(t *testing.T) {
+		// The reported confusion: the sync operation succeeded while the application stayed out of
+		// sync, which reads as a contradiction until the report says the target moved underneath it.
+		//
+		// The wording claims no ordering between the two revisions on purpose — a rollback, a revert
+		// or a retargeted branch all leave the comparison pointing at an older revision, so calling
+		// it "newer" would send the operator looking for a commit that does not exist.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)",
+			"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "0f9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f10")
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"",
+			"The last sync applied revision a1b2c3d, but ArgoCD now compares the application against "+
+				"revision 0f9e8d7, so the desired state has changed since that sync.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
-	t.Run("Rollout message - not synced names the resources that are out of sync", func(t *testing.T) {
-		// The base message reports the last sync operation, which routinely succeeded while the app
-		// drifted straight back out of sync. Without this section the report names no culprit at all.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Resources = []ApplicationResource{
-			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
-			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
-			{Kind: "ConfigMap", Name: "product-catalog", Namespace: "app", Status: "Unknown"},
-			// A resource ArgoCD does not compare carries no status: absent means "not assessed",
-			// not "drifted", so it must not be reported as a culprit.
-			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
-		}
+	t.Run("Rollout message - not synced compares the untruncated revisions", func(t *testing.T) {
+		// Two distinct commits can share an abbreviated prefix. Comparing the abbreviations would
+		// report a moved target as drift that "will not converge" — the opposite verdict.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)",
+			"a1b2c3d0000000000000000000000000000000ff", "a1b2c3d1111111111111111111111111111111ff")
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n\n"+
-				"Out-of-sync resources:\n"+
-				"\tDeployment(product-catalog) OutOfSync\n"+
-				"\tConfigMap(product-catalog) Unknown",
+			"The last sync applied revision a1b2c3d, but ArgoCD now compares the application against "+
+				"revision a1b2c3d, so the desired state has changed since that sync.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
-	t.Run("Rollout message - not synced surfaces error conditions and ignores warnings", func(t *testing.T) {
-		// A sync status of "Unknown" means ArgoCD could not compare at all, and the reason lives
-		// only in the conditions. Warnings are advisory and would dilute the signal.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
-		application.Status.Conditions = []ApplicationCondition{
-			{Type: "ComparisonError", Message: "Failed to load target state: rpc error: code = Unknown"},
-			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
-			{Type: "InvalidSpecError", Message: "Application referencing project default which does not exist"},
-		}
+	t.Run("Rollout message - not synced calls out drift that will never converge", func(t *testing.T) {
+		// The same revision on both sides means the live state diverges right after being applied,
+		// so no amount of extra waiting helps. Saying that is the whole point of the section.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)",
+			"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0")
+		application.Spec.SyncPolicy = &ApplicationSyncPolicy{Automated: &ApplicationSyncPolicyAutomated{SelfHeal: true}}
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n\n"+
-				"Sync errors:\n"+
-				"\tComparisonError: Failed to load target state: rpc error: code = Unknown\n"+
-				"\tInvalidSpecError: Application referencing project default which does not exist",
+			"The last sync succeeded for revision a1b2c3d and the application is still out of sync "+
+				"against exactly what that sync applied, so applying it did not converge the live "+
+				"state. Usual causes: a mutating admission webhook, a controller that owns a field "+
+				"the manifests also set (replicas versus an HPA), a resource that has to be pruned, "+
+				"or a sync that covered only some resources. Extra waiting is unlikely to help.\n"+
+				"Auto-sync is enabled (prune off, self-heal on).\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
-	t.Run("Rollout message - not synced keeps the sync result listing alongside the drift diagnostics", func(t *testing.T) {
-		// The reported case: every resource applied cleanly ("configured"), the sync operation
-		// succeeded, and the app was still out of sync when the rollout timed out. Both blocks
-		// carry signal — the operation result and the drift that outlived it.
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+	t.Run("Rollout message - not synced reads correctly for a multi-source application", func(t *testing.T) {
+		// The plural phrase has to sit in a sentence that does not then refer to "that revision".
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Sync.Revisions = []string{"aaa1111", "bbb2222"}
+		application.Status.OperationState.SyncResult.Revisions = []string{"aaa1111", "bbb2222"}
+		assert.Equal(t,
+			"The last sync succeeded for revisions aaa1111, bbb2222 and the application is still out "+
+				"of sync against exactly what that sync applied, so applying it did not converge the "+
+				"live state. Usual causes: a mutating admission webhook, a controller that owns a "+
+				"field the manifests also set (replicas versus an HPA), a resource that has to be "+
+				"pruned, or a sync that covered only some resources. Extra waiting is unlikely to "+
+				"help.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced draws no revision verdict when the sync itself failed", func(t *testing.T) {
+		// The verdict compares a *successful* apply against the current comparison. After a failed
+		// sync, matching revisions mean nothing was applied, not that the live state drifts back.
+		application := notSyncedApp("Failed", "one or more synchronization tasks completed unsuccessfully",
+			"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0")
+		assert.Equal(t,
+			"Last sync operation: Failed, message: \"one or more synchronization tasks completed unsuccessfully\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced compares the revisions of a multi-source application", func(t *testing.T) {
+		// Multi-source applications report revisions[] and leave revision empty; comparing the two
+		// empty strings would label every such failure as permanent drift.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Sync.Revisions = []string{"aaa1111", "bbb2222"}
+		application.Status.OperationState.SyncResult.Revisions = []string{"aaa1111", "ccc3333"}
+		assert.Equal(t,
+			"The last sync applied revisions aaa1111, ccc3333, but ArgoCD now compares the application "+
+				"against revisions aaa1111, bbb2222, so the desired state has changed since that sync.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced drops the resources that applied cleanly", func(t *testing.T) {
+		// The reported case: every resource applied ("configured"), yet the report listed them as
+		// "Running" — gitops-engine's phase for a successful apply — which read as a stalled sync.
+		// Only the entry that actually failed belongs in a failure report.
+		application := notSyncedApp("Failed", "one or more synchronization tasks completed unsuccessfully", "", "")
 		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
 			{
 				Kind:      "Deployment",
@@ -745,24 +945,132 @@ func TestArgoRolloutMessage(t *testing.T) {
 				SyncPhase: "Sync",
 				Message:   "deployment.apps/product-catalog configured",
 			},
+			{
+				Kind:      "ConfigMap",
+				Name:      "product-catalog",
+				Namespace: "app",
+				Status:    "SyncFailed",
+				HookPhase: "Failed",
+				SyncPhase: "Sync",
+				Message:   "error validating data: unknown field \"dat\"",
+			},
 		}
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "ConfigMap", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		assert.Equal(t,
+			"Out-of-sync resources:\n"+
+				"\tConfigMap(product-catalog) OutOfSync\n\n"+
+				"Failed resources:\n"+
+				"\tConfigMap(product-catalog) SyncFailed with message error validating data: unknown field \"dat\"\n\n"+
+				"Last sync operation: Failed, message: \"one or more synchronization tasks completed unsuccessfully\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced reports the pod-level cause when the app is also degraded", func(t *testing.T) {
+		// A Degraded application that is still OutOfSync is classified "not synced", so this arm is
+		// the only place the crashlooping pod behind such a failure is ever reported. The cause lives
+		// in the resource tree alone — Status.Resources carries no pod health.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
 		application.Status.Resources = []ApplicationResource{
 			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
 		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "product-catalog-abcde", "Degraded", "back-off 5m0s restarting failed container=app"),
+			treeNode("Service", "product-catalog", "Healthy", ""),
+		}}
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n"+
-				"Resources:\n"+
-				"\tDeployment(product-catalog)  Running with message deployment.apps/product-catalog configured\n\n"+
+			"Unhealthy resources:\n"+
+				"\tPod(product-catalog-abcde) Degraded with message back-off 5m0s restarting failed container=app\n\n"+
 				"Out-of-sync resources:\n"+
-				"\tDeployment(product-catalog) OutOfSync",
+				"\tDeployment(product-catalog) OutOfSync\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
+	})
+
+	t.Run("Rollout message - not synced adds no Unhealthy block when the tree is clean", func(t *testing.T) {
+		// The tree is fetched on every failure, so a healthy one must leave the report untouched.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "product-catalog-abcde", "Healthy", ""),
+		}}
+		assert.Equal(t,
+			"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
+	})
+
+	t.Run("Rollout message - not synced omits the Sync errors block when only warnings are present", func(t *testing.T) {
+		// The conditions filter emptying out must leave no trace: no header, no separator. Warnings
+		// are the common case on a healthy app, so this is the path most likely to regress.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
+			{Type: "SharedResourceWarning", Message: "Resource is part of applications app-a and app-b"},
+		}
+		assert.Equal(t,
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced omits the Out-of-sync block when no resource has drifted", func(t *testing.T) {
+		// The app-level sync status can be non-Synced while every top-level resource compares clean
+		// (or is not compared at all), so the resource filter must be able to empty out silently.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
+			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
+		}
+		assert.Equal(t,
+			"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced names the resources that are out of sync", func(t *testing.T) {
+		// A resource that only exists in the cluster is annotated: it reaches Synced by being
+		// deleted, which a sync without prune never does, so no amount of waiting fixes it.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
+			{Kind: "Service", Name: "product-catalog", Namespace: "app", Status: "Synced"},
+			{Kind: "ConfigMap", Name: "product-catalog", Namespace: "app", Status: "Unknown"},
+			{Kind: "Secret", Name: "product-catalog-old", Namespace: "app", Status: "OutOfSync", RequiresPruning: true},
+			// A resource ArgoCD does not compare carries no status: absent means "not assessed",
+			// not "drifted", so it must not be reported as a culprit.
+			{Kind: "Endpoints", Name: "product-catalog", Namespace: "app"},
+		}
+		assert.Equal(t,
+			"Out-of-sync resources:\n"+
+				"\tDeployment(product-catalog) OutOfSync\n"+
+				"\tConfigMap(product-catalog) Unknown\n"+
+				"\tSecret(product-catalog-old) OutOfSync (requires pruning)\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced surfaces error conditions and ignores warnings", func(t *testing.T) {
+		// A sync status of "Unknown" means ArgoCD could not compare at all, and the reason lives
+		// only in the conditions. Warnings are advisory and would dilute the signal.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "ComparisonError", Message: "Failed to load target state: rpc error: code = Unknown"},
+			{Type: "OrphanedResourceWarning", Message: "Application has 1 orphaned resource"},
+			{Type: "InvalidSpecError", Message: "Application referencing project default which does not exist"},
+		}
+		assert.Equal(t,
+			"Sync errors:\n"+
+				"\tComparisonError: Failed to load target state: rpc error: code = Unknown\n"+
+				"\tInvalidSpecError: Application referencing project default which does not exist\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
 	})
 
 	t.Run("Rollout message - not synced reports drift and errors together", func(t *testing.T) {
-		application := Application{}
-		application.Status.OperationState.Phase = "Succeeded"
-		application.Status.OperationState.Message = "successfully synced (all tasks run)"
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
 		application.Status.Resources = []ApplicationResource{
 			{Kind: "Deployment", Name: "product-catalog", Namespace: "app", Status: "OutOfSync"},
 		}
@@ -770,13 +1078,152 @@ func TestArgoRolloutMessage(t *testing.T) {
 			{Type: "SyncError", Message: "Failed sync attempt to v1.2.3"},
 		}
 		assert.Equal(t,
-			"App status \"Succeeded\"\n"+
-				"App message \"successfully synced (all tasks run)\"\n\n"+
-				"Sync errors:\n"+
+			"Sync errors:\n"+
 				"\tSyncError: Failed sync attempt to v1.2.3\n\n"+
 				"Out-of-sync resources:\n"+
-				"\tDeployment(product-catalog) OutOfSync",
+				"\tDeployment(product-catalog) OutOfSync\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
 			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced names an operation whose phase is missing", func(t *testing.T) {
+		// The operation line is the one section that always renders, so both of its degenerate
+		// shapes are exactly what a user sees when ArgoCD's payload is sparse.
+		application := Application{}
+		application.Status.OperationState.Message = "Not working test app"
+		assert.Equal(t,
+			"Last sync operation: unknown, message: \"Not working test app\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced leaves no dangling comma without an operation message", func(t *testing.T) {
+		application := Application{}
+		application.Status.OperationState.Phase = "Running"
+		assert.Equal(t,
+			"Last sync operation: Running",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced draws no verdict when only one revision is known", func(t *testing.T) {
+		// Half the comparison is no comparison: rendering it would end the sentence at "against ."
+		// and the auto-sync note that rides along would be lost with it.
+		for _, test := range []struct{ name, applied, compared string }{
+			{"only the applied revision", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", ""},
+			{"only the compared revision", "", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", test.applied, test.compared)
+				assert.Equal(t,
+					"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+					application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+			})
+		}
+	})
+
+	t.Run("Rollout message - not synced keeps the phrase singular for a one-source revisions list", func(t *testing.T) {
+		// A single-source application whose payload uses revisions[] must not read "revisions abc".
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.OperationState.SyncResult.Revisions = []string{"aaa1111"}
+		application.Status.Sync.Revisions = []string{"bbb2222"}
+		assert.Equal(t,
+			"The last sync applied revision aaa1111, but ArgoCD now compares the application against "+
+				"revision bbb2222, so the desired state has changed since that sync.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced prefers the revisions list when both fields are populated", func(t *testing.T) {
+		// Deciding on the singular field would compare the first source only, so a second source
+		// that moved would be reported as drift that never converges — the opposite verdict.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "aaa1111", "aaa1111")
+		application.Status.OperationState.SyncResult.Revisions = []string{"aaa1111", "ccc3333"}
+		application.Status.Sync.Revisions = []string{"aaa1111", "bbb2222"}
+		assert.Equal(t,
+			"The last sync applied revisions aaa1111, ccc3333, but ArgoCD now compares the application "+
+				"against revisions aaa1111, bbb2222, so the desired state has changed since that sync.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced trusts the singular field over a one-entry list", func(t *testing.T) {
+		// A single-source application reports its revision in the singular field, so when a payload
+		// carries both the list adds no source to compare and the singular field decides. Only a
+		// list of more than one entry outranks it.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "aaa1111", "aaa1111")
+		application.Status.OperationState.SyncResult.Revisions = []string{"bbb2222"}
+		application.Status.Sync.Revisions = []string{"ccc3333"}
+		assert.Equal(t,
+			"The last sync succeeded for revision aaa1111 and the application is still out of sync "+
+				"against exactly what that sync applied, so applying it did not converge the live "+
+				"state. Usual causes: a mutating admission webhook, a controller that owns a field "+
+				"the manifests also set (replicas versus an HPA), a resource that has to be pruned, "+
+				"or a sync that covered only some resources. Extra waiting is unlikely to help.\n"+
+				"Auto-sync is disabled: ArgoCD applies the desired state only when a sync is triggered.\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced leaves a skipped prune out of the failed resources", func(t *testing.T) {
+		// A prune ArgoCD declined to perform is not a failure, and the out-of-sync listing already
+		// annotates it with "(requires pruning)" — reporting it twice would only dilute the signal.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)", "", "")
+		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
+			{
+				Kind:      "Secret",
+				Name:      "product-catalog-old",
+				Namespace: "app",
+				Status:    "PruneSkipped",
+				HookPhase: "Succeeded",
+				SyncPhase: "Sync",
+			},
+		}
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Secret", Name: "product-catalog-old", Namespace: "app", Status: "OutOfSync", RequiresPruning: true},
+		}
+		assert.Equal(t,
+			"Out-of-sync resources:\n"+
+				"\tSecret(product-catalog-old) OutOfSync (requires pruning)\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, nil))
+	})
+
+	t.Run("Rollout message - not synced orders every section of a full report", func(t *testing.T) {
+		// The section order is the substance of this report: the drift explanation answers the
+		// question first, and the sync operation — which routinely succeeded — closes it as context
+		// instead of opening it as an apparent contradiction. One assertion pins the whole shape.
+		application := notSyncedApp("Succeeded", "successfully synced (all tasks run)",
+			"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "0f9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f10")
+		application.Spec.SyncPolicy = &ApplicationSyncPolicy{Automated: &ApplicationSyncPolicyAutomated{Prune: true}}
+		application.Status.Conditions = []ApplicationCondition{
+			{Type: "SyncError", Message: "Failed sync attempt to v1.2.3"},
+		}
+		application.Status.Resources = []ApplicationResource{
+			{Kind: "Deployment", Name: "order-management", Namespace: "app", Status: "OutOfSync"},
+			{Kind: "Secret", Name: "order-management-old", Namespace: "app", Status: "OutOfSync", RequiresPruning: true},
+		}
+		application.Status.OperationState.SyncResult.Resources = []ApplicationOperationResource{
+			{Kind: "ConfigMap", Name: "order-management", Namespace: "app", Status: "SyncFailed", HookPhase: "Failed", Message: "error validating data"},
+		}
+		tree := &ApplicationTree{Nodes: []ApplicationTreeNode{
+			treeNode("Pod", "order-management-abcde", "Degraded", "back-off 5m0s restarting failed container=app"),
+		}}
+		assert.Equal(t,
+			"The last sync applied revision a1b2c3d, but ArgoCD now compares the application against "+
+				"revision 0f9e8d7, so the desired state has changed since that sync.\n"+
+				"Auto-sync is enabled (prune on, self-heal off).\n\n"+
+				"Sync errors:\n"+
+				"\tSyncError: Failed sync attempt to v1.2.3\n\n"+
+				"Unhealthy resources:\n"+
+				"\tPod(order-management-abcde) Degraded with message back-off 5m0s restarting failed container=app\n\n"+
+				"Out-of-sync resources:\n"+
+				"\tDeployment(order-management) OutOfSync\n"+
+				"\tSecret(order-management-old) OutOfSync (requires pruning)\n\n"+
+				"Failed resources:\n"+
+				"\tConfigMap(order-management) SyncFailed with message error validating data\n\n"+
+				"Last sync operation: Succeeded, message: \"successfully synced (all tasks run)\"",
+			application.GetRolloutMessage(ArgoRolloutAppNotSynced, []string{"app:v0.0.2"}, tree))
 	})
 
 	t.Run("Rollout message - not healthy reports what is still progressing when nothing is degraded", func(t *testing.T) {
@@ -854,6 +1301,19 @@ func TestArgoRolloutMessage(t *testing.T) {
 				"\tPod(app-xyz) Progressing with message Pod is in Pending state",
 			application.GetRolloutMessage(ArgoRolloutAppNotAvailable, images, tree))
 	})
+}
+
+// notSyncedApp builds the application shape a not-synced report starts from: the outcome of the
+// last sync operation, the revision that sync applied, and the revision ArgoCD now compares
+// against. Empty revisions stand for a payload where ArgoCD reported neither.
+func notSyncedApp(phase, message, applied, compared string) Application {
+	application := Application{}
+	application.Status.Sync.Status = "OutOfSync"
+	application.Status.Sync.Revision = compared
+	application.Status.OperationState.Phase = phase
+	application.Status.OperationState.Message = message
+	application.Status.OperationState.SyncResult.Revision = applied
+	return application
 }
 
 // treeNode spares call sites the anonymous struct literal for the Health field.

--- a/internal/models/testdata/out-of-sync-deployment.json
+++ b/internal/models/testdata/out-of-sync-deployment.json
@@ -1,4 +1,11 @@
 {
+  "spec": {
+    "syncPolicy": {
+      "automated": {
+        "prune": true
+      }
+    }
+  },
   "status": {
     "health": {
       "status": "Healthy"
@@ -17,6 +24,7 @@
       "phase": "Succeeded",
       "message": "successfully synced (all tasks run)",
       "syncResult": {
+        "revision": "b6a9f1c4e2d8a7b5c3f1e9d7c5b3a1f9e7d5c3b1",
         "resources": [
           {
             "hookPhase": "Running",
@@ -39,6 +47,13 @@
         "status": "OutOfSync"
       },
       {
+        "kind": "ConfigMap",
+        "name": "product-catalog-legacy",
+        "namespace": "app",
+        "status": "OutOfSync",
+        "requiresPruning": true
+      },
+      {
         "kind": "Service",
         "name": "product-catalog",
         "namespace": "app",
@@ -56,7 +71,8 @@
       ]
     },
     "sync": {
-      "status": "OutOfSync"
+      "status": "OutOfSync",
+      "revision": "d4c2b0a8f6e4d2c0b8a6f4e2d0c8b6a4f2e0d8c6"
     }
   }
 }

--- a/internal/models/testdata/out-of-sync-multi-source.json
+++ b/internal/models/testdata/out-of-sync-multi-source.json
@@ -1,0 +1,46 @@
+{
+  "spec": {
+    "syncPolicy": {
+      "automated": {
+        "prune": true,
+        "selfHeal": true,
+        "enabled": false
+      }
+    }
+  },
+  "status": {
+    "health": {
+      "status": "Healthy"
+    },
+    "operationState": {
+      "phase": "Succeeded",
+      "message": "successfully synced (all tasks run)",
+      "syncResult": {
+        "revisions": [
+          "b6a9f1c4e2d8a7b5c3f1e9d7c5b3a1f9e7d5c3b1",
+          "1.14.2"
+        ]
+      }
+    },
+    "resources": [
+      {
+        "kind": "Deployment",
+        "name": "product-catalog",
+        "namespace": "app",
+        "status": "OutOfSync"
+      }
+    ],
+    "summary": {
+      "images": [
+        "product-catalog:v0.0.2"
+      ]
+    },
+    "sync": {
+      "status": "OutOfSync",
+      "revisions": [
+        "b6a9f1c4e2d8a7b5c3f1e9d7c5b3a1f9e7d5c3b1",
+        "1.15.0"
+      ]
+    }
+  }
+}

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -126,7 +126,7 @@ scenario_unvalidated_not_available() {
 # the old tag, the expected image is "not available", and the failure diagnostics carry the hook.
 scenario_failed_presync_hook() {
   echo "task={\"app\":\"app3\",\"author\":\"e2e\",\"project\":\"lab\",\"timeout\":90,\"images\":[{\"image\":\"${IMAGE}\",\"tag\":\"v0.0.0-hookfail\"}]}"
-  echo "expect=Failed hooks:"
+  echo "expect=Failed resources:"
   echo "expect=PreSync Failed"
   echo "setup=setup_failed_presync_hook"
   echo "teardown=teardown_failed_presync_hook"

--- a/test/e2e/scripts/failure-fixture.sh
+++ b/test/e2e/scripts/failure-fixture.sh
@@ -6,7 +6,7 @@
 #
 # Actions:
 #   hook      a failing PreSync hook Job. The hook aborts the sync before the main wave, so the
-#             app keeps its old image and the failure surfaces under "Failed hooks:".
+#             app keeps its old image and the failure surfaces under "Failed resources:".
 #   degraded  a failing PLAIN Job (no hook annotations). It applies in the same wave as the
 #             Deployment, so the new image DOES roll out while the Job exhausts its backoff
 #             limit: the app settles Synced + Degraded, the terminal-degraded rollout.


### PR DESCRIPTION
The not-synced failure report led with the last sync operation, which routinely reads Succeeded / "successfully synced (all tasks run)" while the application is still OutOfSync, so the report contradicted its own headline. It also listed every sync-result resource: ArgoCD reports a successful apply as hook phase "Running" with kubectl's "configured" message, so resources that worked appeared among the failures.

The report now leads with ArgoCD's sync status and the time waited, then compares the revision the last sync applied against the one ArgoCD compares against — a different one means the desired state moved, the same one means applying it did not converge — and states whether auto-sync will act on the drift. Resources that only reach Synced by being deleted are flagged as requiring pruning, and the sync operation closes the report as context.

The sync-result listing keeps only entries that failed, and each line names the outcome that describes it rather than always the hook phase, so a resource whose live object went unhealthy mid-sync no longer reads "Synced". The section is renamed "Failed resources:" because non-hook SyncFailed entries land there too, which also affects the not-available, not-healthy and degraded reports.

No revision ordering is claimed: a rollback, a revert or a retargeted branch leaves the comparison pointing at an older revision.