### PR TITLE
feat(server): hand deployments over between replicas via task leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Argo Watcher can now run with more than one replica when `STATE_TYPE=postgres`. Each
+  in-progress deployment is owned by exactly one replica, recorded as a lease on the task
+  row. A replica that stops mid-rollout — crash, eviction, or a rolling update — has its
+  deployments claimed and finished by another replica instead of leaving them stuck in
+  progress until the hourly stale sweep marked them aborted. Takeover happens within about
+  15 seconds of a graceful shutdown, or 45 seconds of a crash.
+
+  A resumed deployment keeps the window it was accepted with, measured from its creation,
+  so passing between replicas cannot extend how long it polls; one whose window elapsed
+  while unattended is recorded as `aborted` with a reason naming that cause. There are no
+  new environment variables and no API changes, and `STATE_TYPE=in-memory` is unaffected —
+  it remains single-replica only. The new High Availability page in the documentation
+  covers what is shared between replicas and what is not.
+
+  Note for the upgrade itself: deployments already in flight when the first new replica
+  starts carry no lease, so for the duration of the rollout one of them may briefly be
+  watched by both an old and a new replica and reported twice. No duplicate commit results
+  — a write-back whose tag is already committed is skipped.
+
 - A new `gitops_writeback_skipped_unvalidated` counter (labelled by `app`) reports
   deployments of an application annotated `argo-watcher/managed: "true"` whose task
   presented no valid credential, so the image tag was never committed. Any non-zero value

--- a/db/migrations/000008_task_leases.down.sql
+++ b/db/migrations/000008_task_leases.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_tasks_claimable;
+
+ALTER TABLE tasks
+    DROP COLUMN IF EXISTS owner_id,
+    DROP COLUMN IF EXISTS lease_expires_at,
+    DROP COLUMN IF EXISTS timeout,
+    DROP COLUMN IF EXISTS refresh;

--- a/db/migrations/000008_task_leases.up.sql
+++ b/db/migrations/000008_task_leases.up.sql
@@ -1,0 +1,24 @@
+-- Task ownership for HA. A task is monitored by exactly one replica at a time:
+-- owner_id names it and lease_expires_at is the instant its claim lapses. A row
+-- whose lease has lapsed (or was never taken) is available for another replica
+-- to claim and resume, so a deployment survives losing the pod that accepted it.
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS owner_id         TEXT,
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ,
+    -- The per-task rollout deadline and refresh override arrive on the request and
+    -- until now lived only in the accepting process. A resumed task must keep the
+    -- settings it was accepted with rather than inheriting the new owner's defaults.
+    ADD COLUMN IF NOT EXISTS timeout          INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS refresh          BOOLEAN;
+
+-- Only in-progress rows are ever claimed, so the partial index keeps each claim
+-- scan proportional to the number of live deployments rather than to the whole
+-- task history. NULL leases are indexed too: an unowned row is claimable.
+--
+-- Built without CONCURRENTLY, which blocks writes to tasks until it completes.
+-- The migrator runs each file in a transaction, where CONCURRENTLY is not
+-- allowed, and the build scans a table holding one row per deployment ever made:
+-- brief at any realistic history size, and it runs in the pre-upgrade hook while
+-- the previous version is still serving.
+CREATE INDEX IF NOT EXISTS idx_tasks_claimable
+    ON tasks (lease_expires_at) WHERE status = 'in progress';

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -17,6 +17,10 @@ There are two tables. `tasks` stores every deployment task and its status; index
 | `is_rollback` | `boolean NOT NULL DEFAULT false` | `true` when this task's image set was previously deployed for the app. |
 | `rollback_target_id` | `text NOT NULL DEFAULT ''` | ID of the earlier task this deployment rolls back to; empty when not a rollback. |
 | `validated` | `boolean NOT NULL DEFAULT false` | `true` when the request that created the task presented a valid credential. Gates the git write-back and what the task may supersede; never exposed through the API. |
+| `timeout` | `int NOT NULL DEFAULT 0` | Per-task rollout deadline in seconds; `0` when the client did not override `DEPLOYMENT_TIMEOUT`. |
+| `refresh` | `boolean` | Per-task override of `ARGO_REFRESH_APP`; `NULL` when the client omitted it, which is distinct from an explicit `false`. |
+| `owner_id` | `text` | The replica currently monitoring the rollout; `NULL` when unclaimed. See [High Availability](high-availability.md#task-ownership). |
+| `lease_expires_at` | `timestamptz` | When that claim lapses. A lapsed claim on an in-progress task is taken over by another replica; indexed for that sweep via the partial index `idx_tasks_claimable`. |
 | `app` | `varchar(255) NOT NULL` | Argo CD application name. |
 | `author` | `varchar(255) NOT NULL` | Deployment author identifier. |
 | `project` | `varchar(255) NOT NULL` | Business project identifier. |

--- a/docs/operations/high-availability.md
+++ b/docs/operations/high-availability.md
@@ -54,9 +54,12 @@ its claims, rather than leaving them to lapse.
 
 A resumed deployment keeps the window it was accepted with: the remaining time
 is measured from when the task was created, not from when it was taken over.
-A deployment cannot outlive its `DEPLOYMENT_TIMEOUT` (or its per-task
-`TASK_TIMEOUT`) by being passed between replicas. One whose window already
-elapsed while unattended is marked `aborted` rather than resumed.
+The window is a whole number of poll intervals, so a rollout ends at most one
+interval past its `DEPLOYMENT_TIMEOUT` (or its per-task `TASK_TIMEOUT`), and a
+resumed one at most two — the remainder it is handed is rounded up to whole polls
+again. That overshoot does not grow with further handovers, because every
+takeover measures what is left from the moment the task was accepted. One whose
+window already elapsed while unattended is marked `aborted` rather than resumed.
 
 ## What is shared, and what is not
 

--- a/docs/operations/high-availability.md
+++ b/docs/operations/high-availability.md
@@ -1,0 +1,86 @@
+# High Availability
+
+Argo Watcher runs with more than one replica when `STATE_TYPE=postgres`. All
+replicas are equal — there is no leader and no election. They share the task
+table, the deploy lock, and the write-back serialization, and each deployment is
+monitored by exactly one replica at a time.
+
+!!! warning "Postgres is required"
+    With `STATE_TYPE=in-memory` every replica has its own private task list, its
+    own deploy lock, and no way to take a deployment over. It is correct for a
+    single replica only. The Helm chart requires Postgres above `replicaCount: 1`.
+
+## What each replica does
+
+Any replica can accept a deployment. The one that accepts it also monitors it:
+it polls Argo CD for the rollout, performs the git write-back, and records the
+outcome. The others take no part in that deployment unless the owner stops.
+
+Reads are served by whichever replica the request lands on, from the shared
+table, so the task list and task details are identical everywhere.
+
+## Task ownership
+
+Accepting a task claims it. The claim is a lease held in the `tasks` row:
+`owner_id` names the replica and `lease_expires_at` is when the claim lapses.
+The owner extends it every 10 seconds for as long as it is watching the rollout.
+
+Every replica sweeps for lapsed leases on a 15-second timer and takes over what
+it finds. A lease is lapsed when its owner stopped renewing it — because the pod
+crashed, was evicted, lost its database connection for long enough, or shut
+down. The new owner starts monitoring the rollout from where it stands: it
+re-reads the application, re-runs the write-back if the target tag is not
+committed yet, and records the outcome.
+
+Two properties make that safe to run everywhere at once. Claims are taken with
+`FOR UPDATE SKIP LOCKED`, so simultaneous sweeps partition the abandoned tasks
+instead of handing the same one to two replicas. And a replica that lost its
+claim discovers this on its next renewal and stops without writing a status, so
+it cannot clobber the outcome the new owner records.
+
+### How long a deployment is unattended
+
+| Event | Time before another replica resumes it |
+|---|---|
+| Graceful shutdown (rolling update, scale-down) | Up to 15s — one sweep |
+| Crash, eviction, `SIGKILL` | Up to 45s — the 30s lease plus one sweep |
+
+A graceful shutdown is faster because the last thing a replica does is release
+its claims, rather than leaving them to lapse.
+
+### The deadline does not restart
+
+A resumed deployment keeps the window it was accepted with: the remaining time
+is measured from when the task was created, not from when it was taken over.
+A deployment cannot outlive its `DEPLOYMENT_TIMEOUT` (or its per-task
+`TASK_TIMEOUT`) by being passed between replicas. One whose window already
+elapsed while unattended is marked `aborted` rather than resumed.
+
+## What is shared, and what is not
+
+| Behaviour | Across replicas |
+|---|---|
+| Task history and status | Shared — one Postgres table. |
+| Deploy lock and its schedule override | Shared. See [Deployment Lock](../guides/deployment-lock.md#multiple-replicas). |
+| Superseding an in-flight deployment | Shared — a new deployment cancels the older one even when another replica is watching it. |
+| Git write-back | Serialized by a Postgres advisory lock, so concurrent write-backs to one repository queue rather than collide. |
+| Rollout monitoring | Owned by one replica at a time, handed over as described above. |
+| Web UI banners (deploy lock, Argo CD reachability) | Each replica polls the shared state, so clients see a change within a few seconds regardless of which replica they are connected to. |
+
+### Known limits
+
+- **Mattermost threading.** The link between a start post and its result is held
+  in the memory of the replica that posted it. A deployment finished by a
+  different replica posts its result as a channel message instead of a threaded
+  reply. See [Notifications](../guides/notifications.md).
+- **Per-replica metrics.** `failed_deployment` and `in_progress_tasks` are
+  per-process gauges. Aggregate across pods when alerting — `max by (app)` for
+  the former, `sum` for the latter — or a rollout watched by one replica will
+  look absent on the others. See [Observability](observability.md).
+
+## Sizing
+
+Replicas exist for availability, not throughput: a single one comfortably
+handles the polling load of a normal deployment fleet. Two is the useful number
+— it survives a node failure and makes rolling updates transparent. More than
+that mainly adds sweeps against the same database.

--- a/docs/operations/high-availability.md
+++ b/docs/operations/high-availability.md
@@ -34,9 +34,11 @@ committed yet, and records the outcome.
 
 Two properties make that safe to run everywhere at once. Claims are taken with
 `FOR UPDATE SKIP LOCKED`, so simultaneous sweeps partition the abandoned tasks
-instead of handing the same one to two replicas. And a replica that lost its
-claim discovers this on its next renewal and stops without writing a status, so
-it cannot clobber the outcome the new owner records.
+instead of handing the same one to two replicas. And a replica stops watching a
+rollout as soon as it is no longer the one to finish it — because it lost its
+claim, which it discovers on its next renewal, or because it has begun shutting
+down and is about to release the claim itself. Either way it stops without
+writing a status, so it cannot clobber the outcome the new owner records.
 
 ### How long a deployment is unattended
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -4,4 +4,5 @@ Maintain and troubleshoot Argo Watcher in production.
 
 - **[Observability](observability.md)** — Prometheus metrics, suggested alerts, and an example Grafana dashboard.
 - **[Database](database.md)** — Schema, migrations, backups, and sizing guidance.
+- **[High Availability](high-availability.md)** — Running multiple replicas: what is shared, how a deployment is handed over when a replica stops, and the known limits.
 - **[Troubleshooting](troubleshooting.md)** — Symptom-driven runbook for common issues.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -33,6 +33,14 @@ Twelve metrics, all defined in [`internal/prometheus/metrics.go`](https://github
 
     The same openness means anyone who can reach the endpoint and knows a managed application's name can raise `gitops_writeback_skipped_unvalidated`. Treat a rise as "investigate", not automatically "our pipeline regressed".
 
+!!! note "Aggregate the gauges across replicas"
+    `failed_deployment` and `in_progress_tasks` count what one process saw. Each
+    deployment is monitored by a single replica, so a failing application reads as
+    healthy on every replica that did not handle it, and the backlog on any one pod
+    is only its own share. Aggregate before alerting — `max by (app)` for the former,
+    `sum` for the latter, as the examples below do. The aggregation is harmless on a
+    single replica. See [High Availability](high-availability.md#known-limits).
+
 The cached reachability behind `argocd_unavailable` and `state_unavailable` is also readable at `GET /api/v1/reachability`, which returns `{"available":bool,"reason":"argocd"|"database"|"both"}` (`reason` omitted when available). The Web UI's banner uses `reason` to name what is down.
 
 ## Suggested alerts
@@ -64,7 +72,7 @@ groups:
             rejected as locked because the lock state cannot be read.
 
       - alert: ArgoWatcherFailingDeployments
-        expr: failed_deployment > 3
+        expr: max by (app) (failed_deployment) > 3
         for: 10m
         labels:
           severity: warning
@@ -73,7 +81,7 @@ groups:
           description: Check the most recent task in the Web UI for the failure reason.
 
       - alert: ArgoWatcherTaskBacklog
-        expr: in_progress_tasks > 50
+        expr: sum(in_progress_tasks) > 50
         for: 15m
         labels:
           severity: warning
@@ -139,7 +147,7 @@ The **Git Write-back Duration** and **Git Lock Wait Duration** panels only fill 
 
 ```promql
 sum(in_progress_tasks)                          # live workload
-topk(5, failed_deployment)                      # which apps need attention
+topk(5, max by (app) (failed_deployment))       # which apps need attention
 sum(rate(processed_deployments[1h])) by (app)    # deployment frequency per app
 ```
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -156,22 +156,36 @@ metadata:
 
 **Symptom:** after a rolling restart or eviction, tasks that were deploying stay `in progress` and are later marked `aborted`, even though Argo CD shows the deployment succeeded.
 
-**Cause:** a deployment being tracked when the process exits is not handed to another replica, and nothing waits for the tracker to persist a final status. The row is later reaped by the obsolete-task sweep, which marks `in progress` rows older than an hour as `aborted` — bookkeeping only, so the recorded status can disagree with what really happened.
+**Cause with `STATE_TYPE=postgres`:** normally none — a deployment whose replica stops is claimed by another one and monitored through to its real outcome, within about 15 seconds of a graceful shutdown or 45 seconds of a crash. See [High Availability](high-availability.md#task-ownership).
 
-This is expected on any restart and is **not** fixed by tuning the shutdown budget: a graceful shutdown protects the git commit, not the task status. Until task ownership survives a pod replacement, treat the GitOps repository and Argo CD as the record of what happened.
+A task that still ends up `aborted` means its rollout window elapsed while no replica was watching it. The window is measured from when the deployment was accepted and is not restarted by a handover, so a restart late in a long rollout can exhaust it. The recorded reason names this case specifically:
+`Deployment window elapsed while the task was unattended; marked aborted by argo-watcher.`
+
+The other possibility is that no replica was left to take it over: with a single replica, nothing claims the task until that pod is back.
+
+**Cause with `STATE_TYPE=in-memory`:** the task lives only in the process that accepted it, so it cannot be handed over at all. The row is later reaped by the obsolete-task sweep, which marks `in progress` rows older than an hour as `aborted` — bookkeeping only, so the recorded status can disagree with what really happened. This is expected, and is **not** fixed by tuning the shutdown budget: a graceful shutdown protects the git commit, not the task status. Treat the GitOps repository and Argo CD as the record of what happened, or move to Postgres.
 
 **How to verify**
 
 ```bash
+# Which replica owns the task, and when its claim lapses
+psql -c "SELECT id, status, owner_id, lease_expires_at FROM tasks WHERE status = 'in progress'"
+
+# The takeover, on the replica that picked the deployment up
+kubectl logs <pod> | grep -i "abandoned by another replica"
+
 kubectl logs <pod> --previous | grep -i shutdown
 ```
+
+An `owner_id` of `NULL` on an in-progress task means it is waiting to be claimed; a `lease_expires_at` in the past means the same. Either should resolve within one sweep.
 
 `git write-back batch drain did not finish before the shutdown deadline` means queued commits were abandoned mid-flush — that part *is* tunable.
 
 **Fix**
 
-1. Check the GitOps repository for the commit. If it is missing, re-run the pipeline job — an interrupted write-back is not resumed.
+1. Check the GitOps repository for the commit. A resumed deployment re-runs the write-back, and skips it when the tag is already committed, so a missing commit means no replica ever got that far: re-run the pipeline job.
 2. Graceful shutdown needs up to 25s: raise `terminationGracePeriodSeconds` if it is below the Kubernetes default of 30s, and keep `GIT_OP_TIMEOUT` under the shutdown budget so an in-flight attempt can finish.
+3. If tasks are consistently aborted with the unattended-window reason, the rollout window is too tight for how long your pods take to be replaced. Raise `DEPLOYMENT_TIMEOUT`, or run at least two replicas so a handover does not wait for a restart.
 
 ## Web UI is not accessible
 

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -206,6 +206,15 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 		return nil, err
 	}
 
+	// This replica is about to start monitoring the rollout, so it claims the task
+	// before any sweep can offer it to another replica. Best-effort: an unclaimed
+	// task is dropped by this replica at its first renewal, which finds no claim to
+	// extend, and taken up by the next sweep instead — a failed claim costs a reap
+	// interval, not the deployment.
+	if err := argo.State.ClaimTask(newTask.Id); err != nil {
+		slog.Warn("Failed to claim the new task for this replica", "error", err, "id", newTask.Id)
+	}
+
 	slog.Info("A new task was triggered", "id", newTask.Id)
 	for index, value := range newTask.Images {
 		slog.Info("Task image expecting tag", "index", index, "tag", value.Tag, "app", task.App, "id", newTask.Id)

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -207,10 +207,15 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	}
 
 	// This replica is about to start monitoring the rollout, so it claims the task
-	// before any sweep can offer it to another replica. Best-effort: an unclaimed
-	// task is dropped by this replica at its first renewal, which finds no claim to
-	// extend, and taken up by the next sweep instead — a failed claim costs a reap
-	// interval, not the deployment.
+	// before any sweep can offer it to another replica.
+	//
+	// Best-effort on purpose: a claim that cannot be written is a database blip, and
+	// refusing the deployment over it would be a worse outcome than proceeding. An
+	// unclaimed task is nobody else's to take for a full lease — the sweep leaves
+	// rows that young alone — so this replica monitors it unopposed, discovers at
+	// its first renewal that it holds no claim, and stops without writing a status.
+	// A sweep then picks the task up and resumes it, re-running the write-back
+	// idempotently. The cost is a delayed deployment, not a lost or duplicated one.
 	if err := argo.State.ClaimTask(newTask.Id); err != nil {
 		slog.Warn("Failed to claim the new task for this replica", "error", err, "id", newTask.Id)
 	}

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/notifications"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 // ArgoStatusUpdater handles the monitoring and updating of ArgoCD application deployments
@@ -21,6 +22,11 @@ type ArgoStatusUpdater struct {
 	monitor    *DeploymentMonitor
 	gitUpdater *GitUpdater
 	notifier   *notifications.Notifier
+	// leaseRenewInterval and leaseTTL parameterize the claim a monitored rollout
+	// holds. They are fields rather than constants so tests can drive a takeover
+	// without waiting out a real lease.
+	leaseRenewInterval time.Duration
+	leaseTTL           time.Duration
 }
 
 // ArgoStatusUpdaterConfig groups the dependencies required to bootstrap an ArgoStatusUpdater.
@@ -50,6 +56,9 @@ func (updater *ArgoStatusUpdater) Init(argo Argo, cfg ArgoStatusUpdaterConfig) e
 	if cfg.Locker == nil {
 		return fmt.Errorf("locker cannot be nil")
 	}
+
+	updater.leaseRenewInterval = state.TaskLeaseRenewInterval
+	updater.leaseTTL = state.TaskLeaseTTL
 
 	updater.monitor = NewDeploymentMonitor(argo, cfg.RegistryProxyURL, retryOptions, cfg.AcceptSuspended, cfg.RetryDelay)
 	updater.monitor.defaultAttempts = cfg.RetryAttempts
@@ -105,12 +114,23 @@ func (updater *ArgoStatusUpdater) Close(ctx context.Context) {
 
 // WaitForRollout monitors the application until it reaches a final state (deployed
 // or failed), or stops early if a newer deployment for the same app supersedes it
-// (issue #353).
-func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
+// (issue #353), or if another replica takes the task over.
+//
+// resumed marks a task picked up from another replica: its start notification was
+// already sent by the replica that accepted it, so sending a second one would
+// announce the same deployment twice.
+func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
 
-	sendNotification(task, updater.notifier)
+	// Renewing the claim for as long as this replica polls the rollout is what keeps
+	// a sweep on another replica from taking over a deployment that is being watched.
+	lease := newLeaseGuard(updater.monitor.argo.State, task.Id, updater.leaseRenewInterval, updater.leaseTTL)
+	defer lease.Stop()
+
+	if !resumed {
+		sendNotification(task, updater.notifier)
+	}
 
 	// start bounds the deployment-duration metric: a monotonic in-process clock over the whole
 	// deployment, write-back included. It is taken after the start notification so a slow
@@ -119,11 +139,25 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	// reports waited instead, which covers the rollout polling alone.
 	start := time.Now()
 
-	application, waited, err := updater.waitForApplicationDeployment(task)
+	application, waited, err := updater.waitForApplicationDeployment(task, lease.Lost)
+
+	// Re-checked here because only the poll loop and the write-back consult the
+	// lease themselves. Every other way out — a failed fetch, a write-back error,
+	// or an ordinary success — would otherwise write a status and notify on a task
+	// this replica lost during the last poll interval.
+	if lease.Lost() {
+		err = errLeaseLost
+	}
 
 	var imageErr *ImageNotPartOfAppError
 
 	switch {
+	case errors.Is(err, errLeaseLost):
+		// Another replica owns this task now and is monitoring the same rollout.
+		// Writing a status here would clobber the outcome it is about to record, and
+		// notifying would announce a result this replica no longer decides.
+		slog.Info("Stopped monitoring a deployment taken over by another replica.", "id", task.Id)
+		return
 	case errors.As(err, &imageErr):
 		updater.monitor.HandleImageNotPartOfApp(&task, imageErr)
 	case errors.Is(err, errTaskSuperseded):
@@ -148,7 +182,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task) {
 	sendNotification(task, updater.notifier)
 }
 
-func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task) (*models.Application, time.Duration, error) {
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, leaseLost func() bool) (*models.Application, time.Duration, error) {
 	if updater.monitor.taskSuperseded(task.Id) {
 		return nil, 0, errTaskSuperseded
 	}
@@ -164,20 +198,24 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task)
 		return nil, 0, err
 	}
 
-	// The supersede predicate is re-checked inside the write-back retry loop so a
-	// task that keeps retrying under
-	// contention aborts (rather than overwriting a newer deployment) the moment a
-	// newer one supersedes it.
+	// The stop predicate is re-checked inside the write-back retry loop so a task
+	// that keeps retrying under contention aborts the moment a newer deployment
+	// supersedes it — rather than overwriting that deployment — or the moment
+	// another replica takes it over, which would otherwise have two replicas
+	// pushing the same write-back.
 	if err := updater.gitUpdater.UpdateIfNeeded(app, task, func() bool {
-		return updater.monitor.taskSuperseded(task.Id)
+		return updater.monitor.taskSuperseded(task.Id) || leaseLost()
 	}); err != nil {
 		if errors.Is(err, ErrDeploymentSuperseded) {
+			if leaseLost() {
+				return nil, 0, errLeaseLost
+			}
 			return nil, 0, errTaskSuperseded
 		}
 		return nil, 0, err
 	}
 
-	return updater.monitor.WaitRollout(task)
+	return updater.monitor.WaitRollout(task, leaseLost)
 }
 
 func sendNotification(task models.Task, notifier *notifications.Notifier) {

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -120,6 +120,20 @@ func (updater *ArgoStatusUpdater) Close(ctx context.Context) {
 // already sent by the replica that accepted it, so sending a second one would
 // announce the same deployment twice.
 func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool) {
+	updater.waitForRollout(task, resumed, neverDraining)
+}
+
+// neverDraining is the abandon predicate for a rollout monitored by the replica
+// that accepted the deployment. Such a task has nowhere to be handed back to:
+// nothing else holds its claim, so it is watched until it finishes or until the
+// process ends with it.
+func neverDraining() bool { return false }
+
+// waitForRollout is WaitForRollout with the condition under which this replica
+// gives the rollout up: draining reports that shutdown has begun, which ends the
+// monitoring as a takeover would — without a status, so the replica that resumes
+// the task records the outcome instead.
+func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool, draining func() bool) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
 
@@ -139,19 +153,43 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool)
 	// reports waited instead, which covers the rollout polling alone.
 	start := time.Now()
 
-	application, waited, err := updater.waitForApplicationDeployment(task, lease.Lost)
+	// Both conditions end the rollout the same way, so the poll loop and the
+	// write-back are given one predicate: stop at the next boundary, without a
+	// status. Composing them here rather than inside the lease guard keeps the guard
+	// about the claim alone.
+	abandoned := func() bool { return lease.Lost() || draining() }
+
+	application, waited, err := updater.waitForApplicationDeployment(task, abandoned)
 
 	// Re-checked here because only the poll loop and the write-back consult the
-	// lease themselves. Every other way out — a failed fetch, a write-back error,
+	// predicate themselves. Every other way out — a failed fetch, a write-back error,
 	// or an ordinary success — would otherwise write a status and notify on a task
-	// this replica lost during the last poll interval.
-	if lease.Lost() {
+	// this replica lost during the last poll interval, or no longer finishes.
+	switch {
+	case lease.Lost():
+		// Whatever the rollout ended as, the replica that took the claim is monitoring
+		// it too and reaches the same outcome — a supersession included. Reporting it
+		// here as well would announce one deployment twice.
 		err = errLeaseLost
+	case errors.Is(err, errTaskSuperseded):
+		// Left as it is even while draining: the cancellation is already persisted by
+		// the deployment that caused it, and a cancelled task is never re-claimed by a
+		// sweep — so this replica is the last one able to announce it.
+	case draining():
+		err = errReplicaDraining
 	}
 
 	var imageErr *ImageNotPartOfAppError
 
 	switch {
+	case errors.Is(err, errReplicaDraining):
+		// This replica finishes nothing from here on: its claims are released in the
+		// last shutdown phase and another replica resumes the deployment. A status
+		// written now would be decided by a monitor that is about to disappear — and
+		// once the write-back batcher is closed, it would be a failure for a rollout
+		// that is otherwise healthy.
+		slog.Info("Stopped monitoring a deployment while shutting down; another replica will resume it.", "id", task.Id)
+		return
 	case errors.Is(err, errLeaseLost):
 		// Another replica owns this task now and is monitoring the same rollout.
 		// Writing a status here would clobber the outcome it is about to record, and
@@ -182,7 +220,20 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool)
 	sendNotification(task, updater.notifier)
 }
 
-func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, leaseLost func() bool) (*models.Application, time.Duration, error) {
+// abortedWriteBackCause names why a write-back gave up. Both of its stop conditions
+// surface as ErrDeploymentSuperseded, so the shared state decides which one is
+// reported: a task cancelled there is reported as superseded even when this replica
+// is also giving the rollout up, because a cancelled task is never re-claimed by a
+// sweep and no successor could announce it.
+func (updater *ArgoStatusUpdater) abortedWriteBackCause(taskId string, abandoned bool) error {
+	if abandoned && !updater.monitor.taskSuperseded(taskId) {
+		return errLeaseLost
+	}
+
+	return errTaskSuperseded
+}
+
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, abandoned func() bool) (*models.Application, time.Duration, error) {
 	if updater.monitor.taskSuperseded(task.Id) {
 		return nil, 0, errTaskSuperseded
 	}
@@ -200,22 +251,19 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task,
 
 	// The stop predicate is re-checked inside the write-back retry loop so a task
 	// that keeps retrying under contention aborts the moment a newer deployment
-	// supersedes it — rather than overwriting that deployment — or the moment
-	// another replica takes it over, which would otherwise have two replicas
-	// pushing the same write-back.
+	// supersedes it — rather than overwriting that deployment — or the moment this
+	// replica gives the rollout up, which would otherwise have two replicas pushing
+	// the same write-back, or push after the batcher was drained.
 	if err := updater.gitUpdater.UpdateIfNeeded(app, task, func() bool {
-		return updater.monitor.taskSuperseded(task.Id) || leaseLost()
+		return updater.monitor.taskSuperseded(task.Id) || abandoned()
 	}); err != nil {
 		if errors.Is(err, ErrDeploymentSuperseded) {
-			if leaseLost() {
-				return nil, 0, errLeaseLost
-			}
-			return nil, 0, errTaskSuperseded
+			return nil, 0, updater.abortedWriteBackCause(task.Id, abandoned())
 		}
 		return nil, 0, err
 	}
 
-	return updater.monitor.WaitRollout(task, leaseLost)
+	return updater.monitor.WaitRollout(task, abandoned)
 }
 
 func sendNotification(task models.Task, notifier *notifications.Notifier) {

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -89,7 +89,7 @@ func newArgoApiMock(ctrl *gomock.Controller) *mocks.MockArgoApiInterface {
 // in-progress task, so the poll loop's supersession check never fires. Use it when
 // a test exercises rollout polling but is not about cancellation.
 func notSupersededState(ctrl *gomock.Controller) *mocks.MockTaskRepository {
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	state.EXPECT().GetTask(gomock.Any()).Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
 	return state
 }
@@ -128,7 +128,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 	t.Run("Status Updater - Application deployed", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -162,13 +162,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application deployed with Retry", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -208,13 +208,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application deployed with Registry proxy", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -246,13 +246,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application deployed without Registry proxy", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -290,13 +290,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application not found", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -319,13 +319,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAppNotFoundMessage, "ArgoCD API Error: applications.argoproj.io \"test-app\" not found")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - ArgoCD unavailable", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -346,13 +346,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application API error", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -372,13 +372,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: unexpected failure")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application not available", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -412,13 +412,13 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 
 	t.Run("Status Updater - Application out of Sync", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -463,7 +463,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				return nil
 			})
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 
 		assert.True(t, strings.HasPrefix(capturedReason, "Deployment failed: ArgoCD reports sync status Syncing"),
 			"unexpected headline: %s", capturedReason)
@@ -473,7 +473,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 	t.Run("Status Updater - Application not healthy", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(stateMock, apiMock, metricsMock)
@@ -509,7 +509,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"App sync status \"Synced\"\n"+
 				"App health status \"NotHealthy\"")
 
-		updater.WaitForRollout(task)
+		updater.WaitForRollout(task, false)
 	})
 }
 
@@ -525,7 +525,7 @@ func TestDeploymentMonitorHandleDeploymentSuccessHandlesStateError(t *testing.T)
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
 		metrics: metrics,
@@ -546,7 +546,7 @@ func TestDeploymentMonitorHandleDeploymentFailureHandlesStateError(t *testing.T)
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	api := newArgoApiMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
@@ -583,7 +583,7 @@ func TestDeploymentMonitorHandleDeploymentFailureEnrichesReasonFromResourceTree(
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	api := mocks.NewMockArgoApiInterface(ctrl)
 
 	podNode := models.ApplicationTreeNode{Kind: "Pod", Name: "app-xyz", Namespace: "demo"}
@@ -630,7 +630,7 @@ func TestDeploymentMonitorProcessDeploymentResultReportsTimeWaited(t *testing.T)
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	api := newArgoApiMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
@@ -676,7 +676,7 @@ func TestDeploymentMonitorHandleDeploymentFailureResourceTreeErrorIsNonFatal(t *
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	api := mocks.NewMockArgoApiInterface(ctrl)
 	api.EXPECT().GetResourceTree(gomock.Any(), "demo").Return(nil, errors.New("resource-tree unavailable"))
 
@@ -776,7 +776,7 @@ func TestArgoStatusUpdaterDegradedReportsRolloutDiagnostics(t *testing.T) {
 			return nil
 		})
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 
 	assert.NotContains(t, capturedReason, "ArgoCD API Error")
 	assert.Contains(t, capturedReason, "Application deployment failed. Rollout status is degraded")
@@ -797,7 +797,7 @@ func TestArgoStatusUpdaterSupersededAfterSuccessfulPollWritesNoStatus(t *testing
 
 	apiMock := newArgoApiMock(ctrl)
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
@@ -835,7 +835,7 @@ func TestArgoStatusUpdaterSupersededAfterSuccessfulPollWritesNoStatus(t *testing
 	// No SetTaskStatus and no failed-deployment metric are expected, so gomock fails the test
 	// if the superseded task is mistaken for a reportable rollout state.
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 
 	require.NotEmpty(t, capture.sent)
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
@@ -889,7 +889,7 @@ func TestArgoStatusUpdaterAbortsWhenArgoBecomesUnreachableMidPoll(t *testing.T) 
 			return nil
 		})
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 
 	assert.Contains(t, capturedReason, "connection refused")
 }
@@ -899,7 +899,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
 		metrics: metrics,
@@ -924,7 +924,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure(t *testing.T)
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{
 		metrics: metrics,
@@ -1292,7 +1292,7 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 	api := newArgoApiMock(ctrl)
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	locker := lock.NewInMemoryLocker()
 
 	argo := &Argo{}
@@ -1309,13 +1309,13 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errors.New("network")).Times(1)
-		_, _, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, nil).Times(1)
-		_, _, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 	})
 
@@ -1325,7 +1325,7 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app.Spec.Source.RepoURL = ""
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
-		_, _, err := updater.waitForApplicationDeployment(task)
+		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 	})
 }
@@ -1340,7 +1340,7 @@ func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
 
 	api := newArgoApiMock(ctrl)
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(state, api, metrics)
@@ -1384,7 +1384,7 @@ func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
 			return nil
 		})
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 
 	assert.Equal(t,
 		"Deployment failed: ArgoCD reports sync status OutOfSync.\n\n"+
@@ -1413,7 +1413,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 		app.Metadata.Annotations = map[string]string{"argo-watcher/fire-and-forget": "true"}
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
 
-		received, _, err := monitor.WaitRollout(task)
+		received, _, err := monitor.WaitRollout(task, neverLost)
 		require.NoError(t, err)
 		assert.Equal(t, app, received)
 	})
@@ -1422,7 +1422,7 @@ func TestDeploymentMonitorWaitRollout(t *testing.T) {
 		errNotFound := fmt.Errorf("applications.argoproj.io %q not found", task.App)
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errNotFound).Times(1)
 
-		_, _, err := monitor.WaitRollout(task)
+		_, _, err := monitor.WaitRollout(task, neverLost)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), errNotFound.Error())
 	})
@@ -1462,7 +1462,7 @@ func TestDeploymentMonitorWaitRolloutRespectsDeadline(t *testing.T) {
 		}).MinTimes(1).MaxTimes(3)
 
 	start := time.Now()
-	received, _, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task, neverLost)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err, "deadline expiry while polling must be swallowed so the caller reports the real status")
@@ -1506,7 +1506,7 @@ func TestDeploymentMonitorWaitRolloutReportsLastGoodStatusOnDeadline(t *testing.
 			return nil, ctx.Err()
 		}).MinTimes(2).MaxTimes(3)
 
-	received, _, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task, neverLost)
 	require.NoError(t, err)
 	assert.Equal(t, goodApp, received, "should report the last successfully-fetched application, not nil")
 }
@@ -1533,7 +1533,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesErrorWhenNoFetchSucceeds(t *testing
 	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 		Return(nil, unavailableErr).MinTimes(1)
 
-	received, _, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task, neverLost)
 	require.Error(t, err)
 	assert.Nil(t, received)
 	assert.ErrorIs(t, err, unavailableErr,
@@ -1562,7 +1562,7 @@ func TestDeploymentMonitorWaitRolloutSurfacesArgoAPIError(t *testing.T) {
 	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 		Return(nil, apiErr).MinTimes(1)
 
-	received, _, err := monitor.WaitRollout(task)
+	received, _, err := monitor.WaitRollout(task, neverLost)
 	require.Error(t, err)
 	assert.Nil(t, received)
 
@@ -1584,7 +1584,7 @@ func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
@@ -1610,7 +1610,7 @@ func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
 	// "cancelled" status the newer deployment already wrote untouched. Any
 	// GetApplication or SetTaskStatus call would be unexpected and fail the test.
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 
 	require.NotEmpty(t, capture.sent)
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
@@ -1626,7 +1626,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
@@ -1659,7 +1659,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	// No SetTaskStatus and no failed-deployment metric: a superseded rollout is not
 	// a failure and its status must not be overwritten.
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 }
 
 // TestArgoStatusUpdaterAppDisappearsMidRollout is the regression guard for issue #387:
@@ -1674,7 +1674,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
@@ -1712,7 +1712,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 		fmt.Sprintf(ArgoAPIErrorTemplate, notFound.Error()),
 	)
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 }
 
 // TestArgoStatusUpdaterProceedsWhenStatusReadFails verifies that a transient
@@ -1726,7 +1726,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 
 	argo := &Argo{}
 	argo.Init(stateMock, apiMock, metricsMock)
@@ -1754,7 +1754,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	metricsMock.EXPECT().RemoveInProgressTask()
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-	updater.WaitForRollout(task)
+	updater.WaitForRollout(task, false)
 }
 
 func TestHandleApplicationFetchError(t *testing.T) {
@@ -1851,7 +1851,7 @@ func TestArgoStatusUpdater_processDeploymentResult(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 	mockLocker := lock.NewInMemoryLocker()
 
 	argo := &Argo{}
@@ -1934,7 +1934,7 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 	apiMock := newArgoApiMock(ctrl)
 
 	metricsMock := mocks.NewMockMetricsInterface(ctrl)
-	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
 	mockLocker := lock.NewInMemoryLocker()
 
 	argo := &Argo{}
@@ -2321,6 +2321,170 @@ func TestDetermineFailureStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, determineFailureStatus(task, tt.err))
+		})
+	}
+}
+
+// TestArgoStatusUpdaterLostLeaseWritesNoStatus fences the property the whole
+// multi-replica design rests on: once another replica owns the task, this one
+// must record nothing. A status written here would clobber the outcome the new
+// owner is about to write, and a notification would announce a result this
+// replica no longer decides.
+//
+// The two cases cover the two independent guards. "while polling" exercises the
+// check inside the poll loop; "while the initial fetch fails" takes a path that
+// never consults the lease at all and would otherwise write "aborted", which is
+// what the re-check after the rollout returns exists to stop.
+func TestArgoStatusUpdaterLostLeaseWritesNoStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		fetchFails bool
+	}{
+		{name: "taken over while polling the rollout"},
+		{name: "taken over while the initial fetch was failing", fetchFails: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := mocks.NewMockTaskRepository(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+
+			// Never superseded: the lease, not the supersession check, must stop this.
+			stateMock.EXPECT().GetTask(gomock.Any()).
+				Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+			// Closed by the renewal that reports the claim lost, so the rollout below can
+			// wait for the takeover instead of racing it.
+			takenOver := make(chan struct{})
+			var once sync.Once
+			stateMock.EXPECT().RenewLease(gomock.Any()).DoAndReturn(func(string) (bool, error) {
+				once.Do(func() { close(takenOver) })
+				return false, nil
+			}).AnyTimes()
+
+			application := models.Application{}
+			application.Status.Summary.Images = []string{"ghcr.io/shini4i/argo-watcher:dev"}
+			application.Status.Sync.Status = "Synced"
+			application.Status.Health.Status = "Progressing"
+
+			apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(context.Context, string, bool) (*models.Application, error) {
+					<-takenOver
+					// The signal is sent from inside the renewal, a few instructions before the
+					// guard records the loss. Yielding here lets it land, so the rollout below
+					// observes a lost claim rather than racing the goroutine that sets it.
+					time.Sleep(20 * time.Millisecond)
+					if tt.fetchFails {
+						return nil, errors.New("argocd unreachable")
+					}
+					return &application, nil
+				}).AnyTimes()
+
+			// Only the in-flight gauge may move. No SetTaskStatus and no failure metric are
+			// declared, so gomock fails the test if this replica reports on a task it lost.
+			metricsMock.EXPECT().AddInProgressTask()
+			metricsMock.EXPECT().RemoveInProgressTask()
+
+			updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+			updater.leaseRenewInterval = time.Millisecond
+			updater.leaseTTL = time.Hour
+			capture := &capturingStrategy{}
+			updater.notifier = notifications.NewNotifier(capture)
+
+			// Status as AddTask returns it, so a terminal status in the capture below can
+			// only have come from this replica reporting on a task it no longer owns.
+			task := models.Task{
+				Id:      "leased-id",
+				App:     "test-app",
+				Status:  models.StatusInProgressMessage,
+				Timeout: 15,
+				Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
+			}
+
+			updater.WaitForRollout(task, false)
+
+			for _, sent := range capture.sent {
+				assert.Equal(t, models.StatusInProgressMessage, sent.Status,
+					"only the start notification may be sent; the new owner announces the result")
+			}
+		})
+	}
+}
+
+// TestWaitForApplicationDeploymentStopPredicates pins how the two stop reasons
+// are told apart. Both end the rollout without writing a status, so a regression
+// that collapsed one into the other would look identical in outcome — but a
+// deployment cancelled by a newer one and a deployment handed to another replica
+// are different events, and only the supersession arm may report the task as
+// cancelled.
+func TestWaitForApplicationDeploymentStopPredicates(t *testing.T) {
+	tests := []struct {
+		name       string
+		superseded bool
+		leaseLost  bool
+		wantErr    error
+	}{
+		{name: "a newer deployment superseded it", superseded: true, wantErr: errTaskSuperseded},
+		{name: "another replica took it over", leaseLost: true, wantErr: errLeaseLost},
+		{
+			// Supersession is checked before the rollout starts and wins here. The
+			// takeover still has the final say: WaitForRollout re-checks the lease after
+			// this returns, and neither arm writes a status, so the ordering only decides
+			// which one is logged.
+			name:       "both at once report the supersession checked first",
+			superseded: true,
+			leaseLost:  true,
+			wantErr:    errTaskSuperseded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := newTaskRepositoryMock(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+
+			status := models.StatusInProgressMessage
+			if tt.superseded {
+				status = models.StatusCancelledMessage
+			}
+			stateMock.EXPECT().GetTask(gomock.Any()).
+				Return(&models.Task{Status: status}, nil).AnyTimes()
+
+			// Not managed by the watcher, so the write-back is skipped and the rollout
+			// reaches the poll loop, where the lease is checked once per iteration.
+			app := &models.Application{}
+			app.Status.Summary.Images = []string{"demo:v1"}
+			app.Status.Sync.Status = "Synced"
+			app.Status.Health.Status = "Progressing"
+			apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(app, nil).AnyTimes()
+
+			cfg := newUpdaterTestConfig(lock.NewInMemoryLocker())
+			cfg.WebhookConfig = nil
+			updater := initTestUpdater(t, cfg, argo)
+
+			task := models.Task{
+				Id:      "task-id",
+				App:     "demo",
+				Timeout: 15,
+				Images:  []models.Image{{Image: "demo", Tag: "v1"}},
+			}
+			_, _, err := updater.waitForApplicationDeployment(task, func() bool { return tt.leaseLost })
+
+			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -2488,3 +2488,103 @@ func TestWaitForApplicationDeploymentStopPredicates(t *testing.T) {
 		})
 	}
 }
+
+// A supersession that lands after the claim was taken over is the new owner's to
+// announce: it monitors the same rollout and hits the same check, so announcing it
+// here as well reports one deployment twice. Only a replica that is shutting down
+// still owes that announcement — a cancelled task is never re-claimed, so nobody
+// else would ever make it.
+func TestWaitForRollout_LeavesASupersessionItLostToTheNewOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	// Closed by the renewal that reports the claim lost, so the supersession below is
+	// observed after the takeover rather than racing it.
+	takenOver := make(chan struct{})
+	var once sync.Once
+	stateMock.EXPECT().RenewLease(gomock.Any()).DoAndReturn(func(string) (bool, error) {
+		once.Do(func() { close(takenOver) })
+		return false, nil
+	}).AnyTimes()
+
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		DoAndReturn(func(string) (*models.Task, error) {
+			<-takenOver
+			// The signal is sent from inside the renewal, a few instructions before the
+			// guard records the loss; yielding lets it land.
+			time.Sleep(20 * time.Millisecond)
+			return &models.Task{Status: models.StatusCancelledMessage}, nil
+		}).AnyTimes()
+
+	// Only the in-flight gauge may move: no SetTaskStatus is declared, so gomock fails
+	// the test if this replica records anything for a task it no longer owns.
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	updater.leaseRenewInterval = time.Millisecond
+	updater.leaseTTL = time.Hour
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := models.Task{
+		Id:      "lost-and-superseded",
+		App:     "test-app",
+		Status:  models.StatusInProgressMessage,
+		Timeout: 15,
+		Images:  []models.Image{{Image: "demo", Tag: "v1"}},
+	}
+
+	updater.WaitForRollout(task, false)
+
+	for _, sent := range capture.sent {
+		assert.Equal(t, models.StatusInProgressMessage, sent.Status,
+			"only the start notification may be sent; the new owner announces the cancellation")
+	}
+}
+
+// The write-back reports both of its stop conditions as one error, so the cause has
+// to be recovered from the shared state. Guessing it from the predicate loses a
+// cancellation whenever both conditions hold at once, and a cancelled task is never
+// re-claimed, so nothing else would announce it.
+func TestAbortedWriteBackCause(t *testing.T) {
+	tests := []struct {
+		name      string
+		cancelled bool
+		abandoned bool
+		want      error
+	}{
+		{name: "cancelled by a newer deployment", cancelled: true, want: errTaskSuperseded},
+		{name: "given up by this replica", abandoned: true, want: errLeaseLost},
+		{name: "cancelled and given up at once reports the cancellation", cancelled: true, abandoned: true, want: errTaskSuperseded},
+		{name: "neither, so the abort was the supersede check racing itself", want: errTaskSuperseded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			stateMock := newTaskRepositoryMock(ctrl)
+			status := models.StatusInProgressMessage
+			if tt.cancelled {
+				status = models.StatusCancelledMessage
+			}
+			stateMock.EXPECT().GetTask(gomock.Any()).
+				Return(&models.Task{Status: status}, nil).AnyTimes()
+
+			argo := &Argo{}
+			argo.Init(stateMock, newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+			updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+
+			assert.ErrorIs(t, updater.abortedWriteBackCause("task-id", tt.abandoned), tt.want)
+		})
+	}
+}

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -24,7 +26,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Up", func(t *testing.T) {
 		apiMock := newArgoApiMock(ctrl)
 		metricsMock := mocks.NewMockMetricsInterface(ctrl)
-		stateMock := mocks.NewMockTaskRepository(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
 
 		stateMock.EXPECT().Check().Return(true)
 		testUserInfo := &models.Userinfo{
@@ -46,7 +48,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Down - Cannot connect to State manager", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		state.EXPECT().Check().Return(false)
 		testUserInfo := &models.Userinfo{
@@ -69,7 +71,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Down - Cannot login", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		state.EXPECT().Check().Return(true)
 		testUserInfo := &models.Userinfo{
@@ -92,7 +94,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Down - Unexpected login failure", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		state.EXPECT().Check().Return(true)
 		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("unexpected login error"))
@@ -111,7 +113,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Down - Both ArgoCD and state backend unreachable", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		state.EXPECT().Check().Return(false)
 		api.EXPECT().GetUserInfo().Return(nil, fmt.Errorf("unexpected login error"))
@@ -131,7 +133,7 @@ func TestArgoCheck(t *testing.T) {
 	t.Run("Argo Watcher - Down - Both, ArgoCD login rejected", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		// State backend down AND ArgoCD reachable-but-not-logged-in (the other
 		// ArgoCD-down branch): the combined error must carry the login-rejected
@@ -158,7 +160,7 @@ func TestArgoIsAvailable(t *testing.T) {
 
 	t.Run("defaults to available after Init", func(t *testing.T) {
 		argo := &Argo{}
-		argo.Init(mocks.NewMockTaskRepository(ctrl), newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+		argo.Init(newTaskRepositoryMock(ctrl), newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
 		// Optimistic default avoids a spurious "unreachable" banner before the
 		// first liveness probe runs.
 		assert.True(t, argo.IsAvailable())
@@ -167,7 +169,7 @@ func TestArgoIsAvailable(t *testing.T) {
 	t.Run("Check flips the cached state and mirrors the gauge", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		// A failing Check must mark ArgoCD unavailable (gauge 1 / cache false),
 		// a passing one must restore it (gauge 0 / cache true). setReason sets the
@@ -204,7 +206,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo Unavailable", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
@@ -222,7 +224,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - Image not passed", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
@@ -236,7 +238,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - App not passed", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
@@ -254,7 +256,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - State add failed", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		stateError := fmt.Errorf("database error")
 		state.EXPECT().GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, gomock.Any(), gomock.Any()).Return([]models.Task{}, int64(0))
@@ -282,7 +284,7 @@ func TestArgoAddTask(t *testing.T) {
 		t.Run(fmt.Sprintf("Argo - Task added (validated=%t)", validated), func(t *testing.T) {
 			api := newArgoApiMock(ctrl)
 			metrics := mocks.NewMockMetricsInterface(ctrl)
-			state := mocks.NewMockTaskRepository(ctrl)
+			state := newTaskRepositoryMock(ctrl)
 
 			// mock calls. Only a validated task names the app: submission is open and
 			// the name is free text, so an uncredentialed caller must not be able to
@@ -335,7 +337,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - Cancel failure does not block new deployment", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		metrics.EXPECT().AddProcessedDeployment("test-app")
 
@@ -357,7 +359,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - Rollback fields are computed and persisted", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		metrics.EXPECT().AddProcessedDeployment(models.UnknownApp)
 
@@ -388,7 +390,7 @@ func TestArgoAddTask(t *testing.T) {
 	t.Run("Argo - Client-supplied rollback fields are overwritten from history", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		metrics.EXPECT().AddProcessedDeployment(models.UnknownApp)
 
@@ -509,7 +511,7 @@ func TestArgoDetectRollback(t *testing.T) {
 				})
 			}
 
-			state := mocks.NewMockTaskRepository(ctrl)
+			state := newTaskRepositoryMock(ctrl)
 			state.EXPECT().
 				GetTasks(gomock.Any(), gomock.Any(), "test-app", models.StatusDeployedMessage, rollbackHistoryWindow, 0).
 				Return(deployed, int64(len(deployed)))
@@ -532,7 +534,7 @@ func TestArgoGetTasks(t *testing.T) {
 	t.Run("readsFromStateWithoutCheckingArgoCD", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		start := 10.0
 		end := 20.0
@@ -561,7 +563,7 @@ func TestArgoGetTasks(t *testing.T) {
 	t.Run("makesNoArgoCDCallsRegardlessOfInput", func(t *testing.T) {
 		api := newArgoApiMock(ctrl)
 		metrics := mocks.NewMockMetricsInterface(ctrl)
-		state := mocks.NewMockTaskRepository(ctrl)
+		state := newTaskRepositoryMock(ctrl)
 
 		expectedTasks := []models.Task{
 			{Id: "task-1", App: "demo"},
@@ -585,7 +587,7 @@ func TestArgoStartLivenessProbe(t *testing.T) {
 
 	api := newArgoApiMock(ctrl)
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	// Cancel before starting: the immediate probe still runs Check() exactly
 	// once (refreshing the metric), then the loop returns on ctx.Done() without
@@ -619,11 +621,66 @@ func TestArgoSimpleHealthCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 	state.EXPECT().Check().Return(true)
 
 	argo := &Argo{}
 	argo.Init(state, nil, nil)
 
 	assert.True(t, argo.SimpleHealthCheck())
+}
+
+// TestArgoAddTaskClaimsTheTask pins claim-on-accept. The shared repository mock
+// permits ClaimTask any number of times, so without this the claim could be
+// removed from AddTask entirely and every other test would still pass — leaving
+// each new task unowned until a sweep noticed it a reap interval later.
+func TestArgoAddTaskClaimsTheTask(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("the accepting replica claims what it accepted", func(t *testing.T) {
+		stateMock := mocks.NewMockTaskRepository(ctrl)
+		metricsMock := mocks.NewMockMetricsInterface(ctrl)
+
+		argo := &Argo{}
+		argo.Init(stateMock, newArgoApiMock(ctrl), metricsMock)
+
+		task := models.Task{App: "test-app", Author: "author", Project: "project", Validated: true,
+			Images: []models.Image{{Image: "app", Tag: "v1"}}}
+
+		stateMock.EXPECT().GetTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]models.Task{}, int64(0)).AnyTimes()
+		stateMock.EXPECT().CancelInProgressTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(int64(0), nil).AnyTimes()
+		stateMock.EXPECT().AddTask(gomock.Any()).Return(&models.Task{Id: "new-id", App: task.App}, nil)
+		stateMock.EXPECT().ClaimTask("new-id").Return(nil).Times(1)
+		metricsMock.EXPECT().AddProcessedDeployment(gomock.Any())
+
+		created, err := argo.AddTask(task)
+		require.NoError(t, err)
+		assert.Equal(t, "new-id", created.Id)
+	})
+
+	t.Run("a claim that fails does not reject the deployment", func(t *testing.T) {
+		stateMock := mocks.NewMockTaskRepository(ctrl)
+		metricsMock := mocks.NewMockMetricsInterface(ctrl)
+
+		argo := &Argo{}
+		argo.Init(stateMock, newArgoApiMock(ctrl), metricsMock)
+
+		task := models.Task{App: "test-app", Author: "author", Project: "project", Validated: true,
+			Images: []models.Image{{Image: "app", Tag: "v1"}}}
+
+		stateMock.EXPECT().GetTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]models.Task{}, int64(0)).AnyTimes()
+		stateMock.EXPECT().CancelInProgressTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(int64(0), nil).AnyTimes()
+		stateMock.EXPECT().AddTask(gomock.Any()).Return(&models.Task{Id: "new-id", App: task.App}, nil)
+		stateMock.EXPECT().ClaimTask("new-id").Return(errors.New("database unreachable"))
+		metricsMock.EXPECT().AddProcessedDeployment(gomock.Any())
+
+		created, err := argo.AddTask(task)
+		require.NoError(t, err, "the claim is best-effort; a sweep picks the task up instead")
+		assert.Equal(t, "new-id", created.Id)
+	})
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -39,6 +39,11 @@ var errAppDegraded = errors.New("application has degraded")
 // without overwriting the "cancelled" status the newer deployment already wrote.
 var errTaskSuperseded = errors.New("task superseded by a newer deployment")
 
+// errLeaseLost is an internal sentinel returned when another replica claimed the
+// task while this one was monitoring it. Like errTaskSuperseded it stops the
+// rollout without writing a status: the new owner records the outcome.
+var errLeaseLost = errors.New("task taken over by another replica")
+
 // ImageNotPartOfAppError reports that a task expects an image the application's desired
 // state never declares, so waiting for it to appear is pointless (issue #519).
 // Image is a repository name without tag or digest, as are DesiredImages.
@@ -166,7 +171,7 @@ func (monitor *DeploymentMonitor) StoreInitialAppStatus(task *models.Task, appli
 // time the deployment waited. It covers this loop alone: the initial fetch, the status write and
 // the git write-back all precede it, and counting them would report a rollout that failed on the
 // first poll as one that waited out a slow write-back.
-func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Application, time.Duration, error) {
+func (monitor *DeploymentMonitor) WaitRollout(task models.Task, leaseLost func() bool) (*models.Application, time.Duration, error) {
 	// application holds the most recent successfully-fetched state. It is deliberately assigned only
 	// inside the success branch so that a fetch aborted by the deadline (which returns a nil application)
 	// cannot clobber the last-known-good status we want to report on timeout.
@@ -196,6 +201,12 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task) (*models.Applica
 		// is accepted (issue #353) to avoid a status-conditional write.
 		if monitor.taskSuperseded(task.Id) {
 			return retry.Unrecoverable(errTaskSuperseded)
+		}
+
+		// Checked alongside supersession so a takeover stops the polling within one
+		// iteration instead of at the deadline, leaving only the new owner watching.
+		if leaseLost() {
+			return retry.Unrecoverable(errLeaseLost)
 		}
 
 		app, fetchErr := monitor.FetchApplication(ctx, task.App, refresh)
@@ -249,20 +260,13 @@ func rolloutStateAlreadyObserved(err error) bool {
 func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]retry.Option, time.Duration) {
 	retryOptions := append([]retry.Option{}, monitor.retryOptions...)
 
-	delay := monitor.retryDelay
-	if delay <= 0 {
-		delay = ArgoSyncRetryDelay
-	}
+	delay := monitor.resolvedDelay()
 
 	retryOptions = append(retryOptions, retry.Delay(delay))
 
 	delaySeconds := helpers.CeilDivDuration(delay, time.Second)
 
-	defaultAttempts := monitor.defaultAttempts
-	if defaultAttempts == 0 {
-		fallbackWindow := time.Duration(legacyRetryIntervals) * ArgoSyncRetryDelay
-		defaultAttempts = helpers.SafeIntToUint(helpers.CeilDivDuration(fallbackWindow, delay))
-	}
+	defaultAttempts := monitor.resolvedDefaultAttempts(delay)
 
 	if task.Timeout <= 0 {
 		// A zero timeout is the norm: the field is omitted whenever a client leaves
@@ -484,4 +488,27 @@ func isArgoUnavailable(err error) bool {
 	// ArgoCD responded with a server error: the app state is unknown.
 	var apiErr *ArgoAPIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode >= 500
+}
+
+// resolvedDelay is the interval between rollout polls, falling back to the
+// package default when the instance was configured without one.
+func (monitor *DeploymentMonitor) resolvedDelay() time.Duration {
+	if monitor.retryDelay <= 0 {
+		return ArgoSyncRetryDelay
+	}
+
+	return monitor.retryDelay
+}
+
+// resolvedDefaultAttempts is how many polls a task without its own timeout is
+// given, falling back to whatever reproduces the historical retry window at the
+// supplied delay.
+func (monitor *DeploymentMonitor) resolvedDefaultAttempts(delay time.Duration) uint {
+	if monitor.defaultAttempts != 0 {
+		return monitor.defaultAttempts
+	}
+
+	fallbackWindow := time.Duration(legacyRetryIntervals) * ArgoSyncRetryDelay
+
+	return helpers.SafeIntToUint(helpers.CeilDivDuration(fallbackWindow, delay))
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -44,6 +44,12 @@ var errTaskSuperseded = errors.New("task superseded by a newer deployment")
 // rollout without writing a status: the new owner records the outcome.
 var errLeaseLost = errors.New("task taken over by another replica")
 
+// errReplicaDraining is an internal sentinel returned when this replica began
+// shutting down while it was monitoring a resumed rollout. It stops the rollout
+// without writing a status, like errLeaseLost: the claim is released at the end of
+// shutdown and the replica that resumes the task records the outcome.
+var errReplicaDraining = errors.New("replica is shutting down")
+
 // ImageNotPartOfAppError reports that a task expects an image the application's desired
 // state never declares, so waiting for it to appear is pointless (issue #519).
 // Image is a repository name without tag or digest, as are DesiredImages.
@@ -171,7 +177,7 @@ func (monitor *DeploymentMonitor) StoreInitialAppStatus(task *models.Task, appli
 // time the deployment waited. It covers this loop alone: the initial fetch, the status write and
 // the git write-back all precede it, and counting them would report a rollout that failed on the
 // first poll as one that waited out a slow write-back.
-func (monitor *DeploymentMonitor) WaitRollout(task models.Task, leaseLost func() bool) (*models.Application, time.Duration, error) {
+func (monitor *DeploymentMonitor) WaitRollout(task models.Task, abandoned func() bool) (*models.Application, time.Duration, error) {
 	// application holds the most recent successfully-fetched state. It is deliberately assigned only
 	// inside the success branch so that a fetch aborted by the deadline (which returns a nil application)
 	// cannot clobber the last-known-good status we want to report on timeout.
@@ -203,9 +209,10 @@ func (monitor *DeploymentMonitor) WaitRollout(task models.Task, leaseLost func()
 			return retry.Unrecoverable(errTaskSuperseded)
 		}
 
-		// Checked alongside supersession so a takeover stops the polling within one
-		// iteration instead of at the deadline, leaving only the new owner watching.
-		if leaseLost() {
+		// Checked alongside supersession so a rollout this replica gave up — taken over,
+		// or left behind by a shutdown — stops polling within one iteration instead of at
+		// the deadline, leaving only its next owner watching.
+		if abandoned() {
 			return retry.Unrecoverable(errLeaseLost)
 		}
 

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -289,11 +289,35 @@ func (monitor *DeploymentMonitor) configureRetryOptions(task models.Task) ([]ret
 		return append(retryOptions, retry.Attempts(defaultAttempts)), helpers.MulDurationSaturating(defaultAttempts, delay)
 	}
 
-	attempts := helpers.SafeIntToUint(int64(task.Timeout)/delaySeconds + 1)
+	attempts := monitor.rolloutAttempts(task, delay)
 
 	slog.Debug("Overriding task timeout", "timeout_seconds", task.Timeout, "retry_delay", delay, "delay_step_seconds", delaySeconds, "attempts", attempts, "id", task.Id)
 
 	return append(retryOptions, retry.Attempts(attempts)), helpers.MulDurationSaturating(attempts, delay)
+}
+
+// rolloutAttempts is how many polls a task is given: its timeout in whole delay steps
+// plus the poll that lands on the deadline itself, or this instance's default when the
+// task carries no timeout of its own.
+func (monitor *DeploymentMonitor) rolloutAttempts(task models.Task, delay time.Duration) uint {
+	if task.Timeout <= 0 {
+		return monitor.resolvedDefaultAttempts(delay)
+	}
+
+	return helpers.SafeIntToUint(int64(task.Timeout)/helpers.CeilDivDuration(delay, time.Second) + 1)
+}
+
+// rolloutWindow is the wall-clock span the poll loop is given for task, which is the
+// attempts it is configured with times the delay between them — a whole number of
+// polls, so it is the task's timeout rounded up rather than the timeout itself.
+//
+// remainingWindow measures a handover against this, so a resumed rollout is judged by
+// the same budget the replica that accepted it was polling under; measuring against
+// the raw timeout would abort a handover that lands in the final poll interval.
+func (monitor *DeploymentMonitor) rolloutWindow(task models.Task) time.Duration {
+	delay := monitor.resolvedDelay()
+
+	return helpers.MulDurationSaturating(monitor.rolloutAttempts(task, delay), delay)
 }
 
 // ProcessDeploymentResult determines if the deployment was successful and updates the appropriate

--- a/internal/argocd/git_writeback.go
+++ b/internal/argocd/git_writeback.go
@@ -145,7 +145,7 @@ func runGitUpdateWithRetry(parentCtx context.Context, repo *updater.GitRepo, app
 	var lastErr error
 	for attempt := uint(1); attempt <= maxAttempts; attempt++ {
 		if isSuperseded != nil && isSuperseded() {
-			slog.Info("Git update aborted: task superseded by a newer deployment", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
+			slog.Info("Git update aborted: the task was superseded, taken over, or this replica is shutting down", "attempt", attempt, "max_attempts", maxAttempts, "id", task.Id)
 			return ErrDeploymentSuperseded
 		}
 

--- a/internal/argocd/git_writeback_batch.go
+++ b/internal/argocd/git_writeback_batch.go
@@ -158,10 +158,10 @@ func runBatchAttempt(parentCtx context.Context, repo *updater.GitRepo, opTimeout
 // request is left unresolved so the next attempt retries it — mirroring the single-app
 // path, where a commit failure is also retriable rather than fatal.
 func applyRequest(repo *updater.GitRepo, req *batchWriteRequest, outcomes, commitErrs map[*batchWriteRequest]error) bool {
-	// Re-check supersede every attempt so a task that keeps retrying under
-	// contention aborts the moment a newer deployment for the same app wins.
+	// Re-check the stop predicate every attempt so a task that keeps retrying under
+	// contention aborts the moment this replica stops being the one to write it back.
 	if req.isSuperseded != nil && req.isSuperseded() {
-		slog.Info("Git update aborted: task superseded by a newer deployment", "id", req.task.Id)
+		slog.Info("Git update aborted: the task was superseded, taken over, or this replica is shutting down", "id", req.task.Id)
 		outcomes[req] = ErrDeploymentSuperseded
 		return false
 	}

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -220,7 +220,7 @@ func TestWaitRolloutFailsFastOnImageNotPartOfApp(t *testing.T) {
 	)
 	monitor.refreshApp = true
 
-	_, _, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task, neverLost)
 
 	var imageErr *ImageNotPartOfAppError
 	require.ErrorAs(t, err, &imageErr)
@@ -253,7 +253,7 @@ func TestWaitRolloutValidatesDesiredImagesOnce(t *testing.T) {
 	)
 	monitor.refreshApp = true
 
-	_, _, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task, neverLost)
 	require.NoError(t, err)
 }
 
@@ -285,7 +285,7 @@ func TestWaitRolloutSkipsValidationWithoutRefresh(t *testing.T) {
 	)
 
 	// No GetManagedResources expectation: any call is a failure.
-	_, _, err := monitor.WaitRollout(task)
+	_, _, err := monitor.WaitRollout(task, neverLost)
 	require.NoError(t, err)
 }
 
@@ -294,7 +294,7 @@ func TestHandleImageNotPartOfApp(t *testing.T) {
 	defer ctrl.Finish()
 
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	state := mocks.NewMockTaskRepository(ctrl)
+	state := newTaskRepositoryMock(ctrl)
 
 	monitor := NewDeploymentMonitor(Argo{metrics: metrics, State: state}, "", nil, false, time.Millisecond)
 	task := models.Task{Id: "task-id", App: "demo"}

--- a/internal/argocd/lease_guard.go
+++ b/internal/argocd/lease_guard.go
@@ -1,0 +1,110 @@
+package argocd
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/shini4i/argo-watcher/internal/state"
+)
+
+// leaseGuard keeps this replica's claim on a task alive for as long as it is
+// monitoring the rollout, and reports when the claim has been lost to another
+// replica. Losing it is not an error to report to the user: the new owner is
+// monitoring the same rollout and will record its outcome.
+type leaseGuard struct {
+	lost atomic.Bool
+	// lastRenewed is when the most recent renewal was issued, as Unix nanoseconds.
+	// Lost is derived from it as well as from the flag, so a claim that has aged
+	// out is reported even if the renewing goroutine is wedged and never set the
+	// flag itself.
+	lastRenewed atomic.Int64
+	interval    time.Duration
+	ttl         time.Duration
+	stop        chan struct{}
+	stopOnce    sync.Once
+	done        chan struct{}
+}
+
+// newLeaseGuard starts renewing the task's claim every interval until Stop is
+// called. A renewal that fails to reach the store leaves the claim held: the
+// lease outlives several intervals, so a blip must not abandon a rollout this
+// replica still owns.
+//
+// That tolerance is bounded by the lease itself, and the bound is measured
+// rather than inferred from a renewal returning. Once the claim is within one
+// interval of ageing out it is given up, because past that point any sweep may
+// take the task over — including a sweep in this very process, which would
+// re-claim the row under the same owner id and so stay invisible to a renewal
+// that only compares owners. Giving up early is safe: it costs a handover, while
+// holding on too long costs two monitors writing two outcomes for one rollout.
+func newLeaseGuard(repository state.TaskRepository, id string, interval, leaseTTL time.Duration) *leaseGuard {
+	guard := &leaseGuard{
+		interval: interval,
+		ttl:      leaseTTL,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	guard.lastRenewed.Store(time.Now().UnixNano())
+
+	go func() {
+		defer close(guard.done)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-guard.stop:
+				return
+			case <-ticker.C:
+				if guard.aged() {
+					slog.Info("Giving up a claim that could not be kept alive within its lease", "id", id)
+					guard.lost.Store(true)
+					return
+				}
+
+				// Stamped before the statement, never after, so this replica's idea of the
+				// deadline can only be earlier than the one Postgres recorded.
+				issued := time.Now()
+				held, err := repository.RenewLease(id)
+				if err != nil {
+					slog.Warn("Could not renew the claim on this deployment", "error", err, "id", id)
+					continue
+				}
+				if !held {
+					slog.Info("Another replica took this deployment over", "id", id)
+					guard.lost.Store(true)
+					return
+				}
+
+				guard.lastRenewed.Store(issued.UnixNano())
+			}
+		}
+	}()
+
+	return guard
+}
+
+// Lost reports whether this replica has stopped holding the task — because
+// another replica took it over, or because the claim has aged far enough that it
+// is about to become claimable by anyone.
+func (guard *leaseGuard) Lost() bool {
+	return guard.lost.Load() || guard.aged()
+}
+
+// aged reports whether the claim is within one renewal interval of lapsing,
+// which is the last moment it can be given up before a sweep could take the task.
+func (guard *leaseGuard) aged() bool {
+	since := time.Since(time.Unix(0, guard.lastRenewed.Load()))
+
+	return since+guard.interval >= guard.ttl
+}
+
+// Stop ends the renewals and waits for the goroutine to finish. It is safe to
+// call more than once.
+func (guard *leaseGuard) Stop() {
+	guard.stopOnce.Do(func() { close(guard.stop) })
+	<-guard.done
+}

--- a/internal/argocd/lease_guard_test.go
+++ b/internal/argocd/lease_guard_test.go
@@ -1,0 +1,185 @@
+package argocd
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/mocks"
+)
+
+// waitFor polls until condition holds, failing the test if it never does. It
+// keeps the lease tests free of fixed sleeps sized to the renewal interval.
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	require.Eventually(t, condition, time.Second, time.Millisecond)
+}
+
+func TestLeaseGuard_HoldsTheClaimWhileMonitoring(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	renewed := make(chan struct{}, 1)
+	stateMock.EXPECT().RenewLease("task-id").DoAndReturn(func(string) (bool, error) {
+		select {
+		case renewed <- struct{}{}:
+		default:
+		}
+		return true, nil
+	}).MinTimes(1)
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, time.Hour)
+	defer guard.Stop()
+
+	<-renewed
+	assert.False(t, guard.Lost(), "a renewed claim is still held")
+}
+
+func TestLeaseGuard_ReportsATakenOverTask(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().RenewLease("task-id").Return(false, nil).MinTimes(1)
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, time.Hour)
+	defer guard.Stop()
+
+	waitFor(t, guard.Lost)
+}
+
+// A failed renewal is not a lost claim: the lease outlives several renewal
+// intervals, so a blip must not abandon a rollout this replica still owns.
+func TestLeaseGuard_KeepsGoingWhenARenewalFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	attempts := make(chan struct{}, 8)
+	stateMock.EXPECT().RenewLease("task-id").DoAndReturn(func(string) (bool, error) {
+		select {
+		case attempts <- struct{}{}:
+		default:
+		}
+		return false, errors.New("database unreachable")
+	}).MinTimes(2)
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, time.Hour)
+	defer guard.Stop()
+
+	<-attempts
+	<-attempts
+	assert.False(t, guard.Lost(), "an unreadable lease state is not proof of a takeover")
+}
+
+func TestLeaseGuard_StopsRenewing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var renewals atomic.Int32
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().RenewLease("task-id").DoAndReturn(func(string) (bool, error) {
+		renewals.Add(1)
+		return true, nil
+	}).AnyTimes()
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, time.Hour)
+	require.Eventually(t, func() bool { return renewals.Load() > 0 }, time.Second, time.Millisecond)
+
+	guard.Stop()
+	settled := renewals.Load()
+
+	// Stop waits for the goroutine, so nothing may renew after it returns — a leaked
+	// guard would keep a finished rollout's claim alive for as long as the process runs.
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, settled, renewals.Load())
+
+	guard.Stop() // idempotent: the deferred stop must survive an early one
+}
+
+// neverLost is the lease predicate for tests that are not about takeover: this
+// replica keeps the task for the whole rollout.
+func neverLost() bool { return false }
+
+// newTaskRepositoryMock returns a task repository mock that already allows the
+// lease calls every monitored rollout makes, so each test declares only the
+// expectations it is actually about. Tests asserting on the lease itself build
+// the mock directly instead.
+func newTaskRepositoryMock(ctrl *gomock.Controller) *mocks.MockTaskRepository {
+	repository := mocks.NewMockTaskRepository(ctrl)
+	repository.EXPECT().ClaimTask(gomock.Any()).Return(nil).AnyTimes()
+	repository.EXPECT().RenewLease(gomock.Any()).Return(true, nil).AnyTimes()
+	return repository
+}
+
+// A renewal outage that outlasts the lease means the claim is gone whether or not
+// this replica noticed. Holding on regardless is what would let this very process
+// re-claim the task in a sweep — under the same owner id, so every later renewal
+// still reports "held" — and monitor the same rollout twice.
+func TestLeaseGuard_GivesUpAClaimThatOutlivedItsLease(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().RenewLease("task-id").Return(false, errors.New("database unreachable")).MinTimes(1)
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, 10*time.Millisecond)
+	defer guard.Stop()
+
+	waitFor(t, guard.Lost)
+}
+
+// The bound is measured from the last SUCCESSFUL renewal, so intermittent errors
+// between good renewals must not accumulate toward it.
+func TestLeaseGuard_FailuresBetweenSuccessesDoNotExpireTheClaim(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var calls atomic.Int32
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().RenewLease("task-id").DoAndReturn(func(string) (bool, error) {
+		// Alternate failure, success, failure, success...
+		if calls.Add(1)%2 == 0 {
+			return true, nil
+		}
+		return false, errors.New("transient blip")
+	}).MinTimes(6)
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, 20*time.Millisecond)
+	defer guard.Stop()
+
+	require.Eventually(t, func() bool { return calls.Load() >= 6 }, time.Second, time.Millisecond)
+	assert.False(t, guard.Lost(), "a claim renewed between blips is still held")
+}
+
+// A renewal that never returns is the case the error-branch bound cannot see: no
+// tick completes, so nothing sets the flag, while the claim ages out in the
+// database and a sweep hands the rollout to someone else. Lost must become true
+// on the clock alone.
+func TestLeaseGuard_ReportsALapsedClaimWhileRenewalIsStuck(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	release := make(chan struct{})
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().RenewLease("task-id").DoAndReturn(func(string) (bool, error) {
+		<-release
+		return true, nil
+	}).AnyTimes()
+
+	guard := newLeaseGuard(stateMock, "task-id", time.Millisecond, 20*time.Millisecond)
+
+	waitFor(t, guard.Lost)
+
+	// Released before stopping, because Stop waits for the renewing goroutine. In
+	// production the same wait is bounded by RenewLease's own statement timeout.
+	close(release)
+	guard.Stop()
+}

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -21,7 +21,12 @@ const StaleResumedTaskReason = "Deployment window elapsed while the task was una
 // deployment polls. A task whose window has already elapsed is aborted here
 // instead of being resumed, which is the outcome it would reach on the first
 // poll anyway.
-func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task) {
+//
+// draining reports that this replica has begun shutting down. A rollout resumed
+// shortly before shutdown is given up as soon as that happens: the claim is
+// released in the last shutdown phase, so the next replica to sweep resumes the
+// deployment and records its outcome.
+func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task, draining func() bool) {
 	remaining, resumable := updater.monitor.remainingWindow(task, time.Now())
 	if !resumable {
 		slog.Info("Not resuming a deployment whose window already elapsed", "id", task.Id, "app", task.App)
@@ -37,7 +42,7 @@ func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task) {
 		"id", task.Id, "app", task.App, "remaining", remaining)
 
 	task.Timeout = int(remaining.Seconds())
-	updater.WaitForRollout(task, true)
+	updater.waitForRollout(task, true, draining)
 }
 
 // remainingWindow returns how much of the task's rollout window is left at now,

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
 
@@ -17,10 +16,13 @@ const StaleResumedTaskReason = "Deployment window elapsed while the task was una
 // watches the rollout through to its outcome.
 //
 // The task keeps the deadline it was accepted with rather than starting a fresh
-// one, so passing through any number of replicas cannot extend how long a
-// deployment polls. A task whose window has already elapsed is aborted here
-// instead of being resumed, which is the outcome it would reach on the first
-// poll anyway.
+// one, so no number of replicas can restart the clock. The remainder is handed on
+// as a whole-second timeout and rounded up to whole poll attempts again, which is
+// the one way a handover extends anything: a resumed rollout can end up to one
+// poll interval past the window it would have had. That bound does not grow with
+// further handovers, since each one measures what is left from the task's
+// creation. A task whose window has already elapsed is aborted here instead of
+// being resumed, which is the outcome it would reach on the first poll anyway.
 //
 // draining reports that this replica has begun shutting down. A rollout resumed
 // shortly before shutdown is given up as soon as that happens: the claim is
@@ -46,20 +48,16 @@ func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task, draining func(
 }
 
 // remainingWindow returns how much of the task's rollout window is left at now,
-// and whether enough remains to be worth resuming. The window is the per-task
-// timeout when the client set one, and this instance's default otherwise; it is
-// measured from the task's creation, which is the instant the deployment was
-// accepted.
+// and whether enough remains to be worth resuming. The window is the span the poll
+// loop is given for this task (see rolloutWindow), measured from the task's
+// creation, which is the instant the deployment was accepted.
 //
 // Unlike the lease deadlines, which Postgres computes so replica clock skew
 // cannot alter them, this compares the resuming replica's clock against a
 // creation timestamp written by whichever replica accepted the task. Hosts kept
 // in sync leave that difference far below the granularity that matters here.
 func (monitor *DeploymentMonitor) remainingWindow(task models.Task, now time.Time) (time.Duration, bool) {
-	window := monitor.defaultWindow()
-	if task.Timeout > 0 {
-		window = time.Duration(task.Timeout) * time.Second
-	}
+	window := monitor.rolloutWindow(task)
 
 	elapsed := now.Sub(time.Unix(int64(task.Created), 0))
 	remaining := window - elapsed
@@ -69,16 +67,6 @@ func (monitor *DeploymentMonitor) remainingWindow(task models.Task, now time.Tim
 	// down to zero — which reads as "no per-task timeout" and would hand the task a
 	// fresh instance-default window, the very thing this bound exists to prevent.
 	return remaining, remaining >= time.Second
-}
-
-// defaultWindow is how long this instance polls a rollout when the task carries
-// no timeout of its own. It shares resolvedDelay and resolvedDefaultAttempts with
-// configureRetryOptions so a resumed task is measured against the same window the
-// rollout would actually be given.
-func (monitor *DeploymentMonitor) defaultWindow() time.Duration {
-	delay := monitor.resolvedDelay()
-
-	return helpers.MulDurationSaturating(monitor.resolvedDefaultAttempts(delay), delay)
 }
 
 // abortStaleTask records the terminal status for a task that outlived its

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -1,0 +1,88 @@
+package argocd
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/shini4i/argo-watcher/internal/helpers"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// StaleResumedTaskReason is the status reason recorded for a task whose rollout
+// window ran out while no replica was monitoring it.
+const StaleResumedTaskReason = "Deployment window elapsed while the task was unattended; marked aborted by argo-watcher."
+
+// ResumeRollout takes over a task claimed from a replica that stopped monitoring
+// it — one that crashed, was rolled, or released its claim on shutdown — and
+// watches the rollout through to its outcome.
+//
+// The task keeps the deadline it was accepted with rather than starting a fresh
+// one, so passing through any number of replicas cannot extend how long a
+// deployment polls. A task whose window has already elapsed is aborted here
+// instead of being resumed, which is the outcome it would reach on the first
+// poll anyway.
+func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task) {
+	remaining, resumable := updater.monitor.remainingWindow(task, time.Now())
+	if !resumable {
+		slog.Info("Not resuming a deployment whose window already elapsed", "id", task.Id, "app", task.App)
+		updater.monitor.abortStaleTask(&task)
+		// The replica that accepted this deployment announced it as started, and this
+		// is where it ends, so the terminal notification is owed here as much as on
+		// any other final status.
+		sendNotification(task, updater.notifier)
+		return
+	}
+
+	slog.Info("Resuming a deployment abandoned by another replica",
+		"id", task.Id, "app", task.App, "remaining", remaining)
+
+	task.Timeout = int(remaining.Seconds())
+	updater.WaitForRollout(task, true)
+}
+
+// remainingWindow returns how much of the task's rollout window is left at now,
+// and whether enough remains to be worth resuming. The window is the per-task
+// timeout when the client set one, and this instance's default otherwise; it is
+// measured from the task's creation, which is the instant the deployment was
+// accepted.
+//
+// Unlike the lease deadlines, which Postgres computes so replica clock skew
+// cannot alter them, this compares the resuming replica's clock against a
+// creation timestamp written by whichever replica accepted the task. Hosts kept
+// in sync leave that difference far below the granularity that matters here.
+func (monitor *DeploymentMonitor) remainingWindow(task models.Task, now time.Time) (time.Duration, bool) {
+	window := monitor.defaultWindow()
+	if task.Timeout > 0 {
+		window = time.Duration(task.Timeout) * time.Second
+	}
+
+	elapsed := now.Sub(time.Unix(int64(task.Created), 0))
+	remaining := window - elapsed
+
+	// Anything under a second is not worth resuming, and must not be: the rollout
+	// deadline is configured in whole seconds, where a sub-second remainder rounds
+	// down to zero — which reads as "no per-task timeout" and would hand the task a
+	// fresh instance-default window, the very thing this bound exists to prevent.
+	return remaining, remaining >= time.Second
+}
+
+// defaultWindow is how long this instance polls a rollout when the task carries
+// no timeout of its own. It shares resolvedDelay and resolvedDefaultAttempts with
+// configureRetryOptions so a resumed task is measured against the same window the
+// rollout would actually be given.
+func (monitor *DeploymentMonitor) defaultWindow() time.Duration {
+	delay := monitor.resolvedDelay()
+
+	return helpers.MulDurationSaturating(monitor.resolvedDefaultAttempts(delay), delay)
+}
+
+// abortStaleTask records the terminal status for a task that outlived its
+// rollout window while unattended.
+func (monitor *DeploymentMonitor) abortStaleTask(task *models.Task) {
+	monitor.argo.metrics.AddFailedDeployment(task.MetricApp())
+
+	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason); err != nil {
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
+	}
+	task.Status = models.StatusAborted
+}

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -1,0 +1,224 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/lock"
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/notifications"
+)
+
+func monitorWithDefaultWindow(window time.Duration) *DeploymentMonitor {
+	return &DeploymentMonitor{
+		retryDelay:      time.Second,
+		defaultAttempts: uint(window / time.Second),
+	}
+}
+
+func TestRemainingWindow(t *testing.T) {
+	now := time.Unix(2000, 0)
+
+	tests := []struct {
+		name          string
+		taskTimeout   int
+		createdAgo    time.Duration
+		defaultWindow time.Duration
+		want          time.Duration
+		wantResumable bool
+	}{
+		{
+			name:          "a task resumed early keeps the rest of its own window",
+			taskTimeout:   600,
+			createdAgo:    100 * time.Second,
+			defaultWindow: 60 * time.Second,
+			want:          500 * time.Second,
+			wantResumable: true,
+		},
+		{
+			name:          "a task without an override is bounded by the instance default",
+			createdAgo:    20 * time.Second,
+			defaultWindow: 60 * time.Second,
+			want:          40 * time.Second,
+			wantResumable: true,
+		},
+		{
+			name:          "a task whose window already elapsed is not resumed",
+			taskTimeout:   60,
+			createdAgo:    90 * time.Second,
+			defaultWindow: 60 * time.Second,
+			wantResumable: false,
+		},
+		{
+			name:          "a task resumed exactly at its deadline is not resumed",
+			taskTimeout:   60,
+			createdAgo:    60 * time.Second,
+			defaultWindow: 60 * time.Second,
+			wantResumable: false,
+		},
+		{
+			// A sub-second remainder rounds down to a zero timeout, which the rollout
+			// reads as "no override" and answers with a full default window — so this
+			// must not be resumable, or the deadline silently restarts.
+			name:          "a task with under a second left is not resumed",
+			taskTimeout:   60,
+			createdAgo:    59500 * time.Millisecond,
+			defaultWindow: 60 * time.Second,
+			wantResumable: false,
+		},
+		{
+			name:          "a task with exactly a second left is still resumed",
+			taskTimeout:   60,
+			createdAgo:    59 * time.Second,
+			defaultWindow: 60 * time.Second,
+			want:          time.Second,
+			wantResumable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monitor := monitorWithDefaultWindow(tt.defaultWindow)
+			task := models.Task{
+				Timeout: tt.taskTimeout,
+				Created: float64(now.Add(-tt.createdAgo).Unix()),
+			}
+
+			remaining, resumable := monitor.remainingWindow(task, now)
+
+			assert.Equal(t, tt.wantResumable, resumable)
+			if tt.wantResumable {
+				assert.Equal(t, tt.want, remaining)
+			}
+		})
+	}
+}
+
+// A handoff must not restart the clock: however many replicas a task passes
+// through, the total time it may poll is the window it was accepted with.
+func TestRemainingWindow_ShrinksAcrossSuccessiveHandoffs(t *testing.T) {
+	monitor := monitorWithDefaultWindow(time.Minute)
+	created := time.Unix(1000, 0)
+	task := models.Task{Timeout: 300, Created: float64(created.Unix())}
+
+	first, resumable := monitor.remainingWindow(task, created.Add(time.Minute))
+	assert.True(t, resumable)
+
+	second, resumable := monitor.remainingWindow(task, created.Add(3*time.Minute))
+	assert.True(t, resumable)
+
+	assert.Less(t, second, first)
+	assert.Equal(t, 2*time.Minute, second)
+}
+
+// TestResumeRollout_AbortsAnElapsedWindow covers the arm remainingWindow only
+// feeds: a deployment whose window ran out while nobody was watching is recorded
+// as aborted here, and — because the replica that accepted it announced it as
+// started — announced as finished too. Argo CD is never called, since there is
+// nothing left to wait for.
+func TestResumeRollout_AbortsAnElapsedWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := models.Task{
+		Id:      "stale-id",
+		App:     "test-app",
+		Timeout: 30,
+		// Accepted well over its own window ago.
+		Created:   float64(time.Now().Add(-10 * time.Minute).Unix()),
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	metricsMock.EXPECT().AddFailedDeployment(task.App)
+	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason)
+	// No GetApplication expectation: polling a deployment past its deadline would
+	// only end in the same abort.
+
+	updater.ResumeRollout(task)
+
+	require.Len(t, capture.sent, 1, "the deployment must still be reported as finished")
+	assert.Equal(t, models.StatusAborted, capture.sent[0].Status)
+}
+
+// TestResumeRollout_KeepsTheOriginalDeadline is the guard against a handover
+// silently restarting the clock: the resumed rollout must be given what is left
+// of the window the deployment was accepted with, never a fresh one.
+func TestResumeRollout_KeepsTheOriginalDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	// 600s window, 590s of it already spent.
+	task := models.Task{
+		Id:        "resumed-id",
+		App:       "test-app",
+		Timeout:   600,
+		Created:   float64(time.Now().Add(-590 * time.Second).Unix()),
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	// The deployment is already done, so the resumed monitor settles on its first poll.
+	application := models.Application{}
+	application.Status.Summary.Images = []string{"app:v1"}
+	application.Status.Sync.Status = "Synced"
+	application.Status.Health.Status = "Healthy"
+	// The initial fetch runs unbounded by design; the polling loop is what carries
+	// the rollout deadline, so that is where the resumed window is observable.
+	var polledWindows []time.Duration
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string, _ bool) (*models.Application, error) {
+			if deadline, ok := ctx.Deadline(); ok {
+				polledWindows = append(polledWindows, time.Until(deadline))
+			}
+			return &application, nil
+		}).AnyTimes()
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().ResetFailedDeployment(task.App)
+	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
+	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
+
+	updater.ResumeRollout(task)
+
+	require.NotEmpty(t, polledWindows, "the resumed rollout must be polled under a deadline")
+	for _, window := range polledWindows {
+		assert.Less(t, window, time.Duration(task.Timeout)*time.Second,
+			"a resumed rollout must get what is left of its window, never a fresh one")
+	}
+
+	require.Len(t, capture.sent, 1,
+		"a resumed deployment was already announced as started by the replica that accepted it")
+	assert.Equal(t, models.StatusDeployedMessage, capture.sent[0].Status)
+}

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -2,6 +2,8 @@ package argocd
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,7 +154,7 @@ func TestResumeRollout_AbortsAnElapsedWindow(t *testing.T) {
 	// No GetApplication expectation: polling a deployment past its deadline would
 	// only end in the same abort.
 
-	updater.ResumeRollout(task)
+	updater.ResumeRollout(task, neverDraining)
 
 	require.Len(t, capture.sent, 1, "the deployment must still be reported as finished")
 	assert.Equal(t, models.StatusAborted, capture.sent[0].Status)
@@ -210,7 +212,7 @@ func TestResumeRollout_KeepsTheOriginalDeadline(t *testing.T) {
 	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-	updater.ResumeRollout(task)
+	updater.ResumeRollout(task, neverDraining)
 
 	require.NotEmpty(t, polledWindows, "the resumed rollout must be polled under a deadline")
 	for _, window := range polledWindows {
@@ -221,4 +223,186 @@ func TestResumeRollout_KeepsTheOriginalDeadline(t *testing.T) {
 	require.Len(t, capture.sent, 1,
 		"a resumed deployment was already announced as started by the replica that accepted it")
 	assert.Equal(t, models.StatusDeployedMessage, capture.sent[0].Status)
+}
+
+// Shutdown can begin after the reaper handed the task over but before the rollout
+// finishes. From that point on this replica finishes nothing: its claim is released
+// in the last shutdown phase and another replica resumes the deployment. Writing a
+// status here would record an outcome for a rollout this replica no longer decides —
+// and once the write-back batcher is closed, that outcome is a failure for a
+// deployment that is otherwise healthy.
+func TestResumeRollout_StopsWhenTheReplicaStartsDraining(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := models.Task{
+		Id:        "draining-id",
+		App:       "test-app",
+		Timeout:   600,
+		Created:   float64(time.Now().Unix()),
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	// The rollout has already succeeded, so a monitor that keeps going records a
+	// terminal status — which is what must not happen here.
+	application := models.Application{}
+	application.Status.Summary.Images = []string{"app:v1"}
+	application.Status.Sync.Status = "Synced"
+	application.Status.Health.Status = "Healthy"
+
+	// The call count is load-bearing: shutdown begins during the fetch that precedes
+	// the polling loop, so the loop must give up on its first check and never reach a
+	// fetch of its own. A second call here means the rollout kept polling ArgoCD for
+	// a deployment this replica had already abandoned.
+	var draining atomic.Bool
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+		DoAndReturn(func(context.Context, string, bool) (*models.Application, error) {
+			draining.Store(true)
+			return &application, nil
+		}).Times(1)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// No SetTaskStatus and no deployment metrics are expected: gomock fails the test
+	// if the abandoned monitor records anything.
+
+	updater.ResumeRollout(task, draining.Load)
+
+	assert.Empty(t, capture.sent,
+		"a deployment left to another replica must not be announced as finished")
+}
+
+// A superseded task is the one outcome a draining replica must still announce. The
+// newer deployment already wrote "cancelled", and a cancelled task is never
+// re-claimed by a sweep — so the replica that resumes nothing here is the last one
+// able to report it, and staying silent loses the notification for good.
+func TestResumeRollout_AnnouncesASupersededTaskEvenWhileDraining(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+	// A newer deployment for the same app already cancelled this task.
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		Return(&models.Task{Status: models.StatusCancelledMessage}, nil).AnyTimes()
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := models.Task{
+		Id:        "superseded-id",
+		App:       "test-app",
+		Timeout:   600,
+		Created:   float64(time.Now().Unix()),
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// No SetTaskStatus: the superseding deployment already recorded "cancelled".
+
+	updater.ResumeRollout(task, func() bool { return true })
+
+	require.Len(t, capture.sent, 1, "the cancellation must still be announced")
+	assert.Equal(t, models.StatusCancelledMessage, capture.sent[0].Status)
+}
+
+// Shutdown is not observed at a single point: the poll loop checks it at the top of
+// an iteration, while the rollout's outcome is decided later in that same iteration.
+// A rollout that finishes — or fails — in that gap reaches the end of monitoring with
+// an ordinary result, and only the re-check that follows keeps this replica from
+// recording it. Both arms are covered: an outcome that would be written as a success,
+// and a fetch failure that would be written as a terminal failure.
+func TestResumeRollout_WritesNothingWhenShutdownBeginsMidPoll(t *testing.T) {
+	tests := []struct {
+		name           string
+		inLoopFetchErr error
+	}{
+		{name: "the rollout succeeded in the same iteration"},
+		{
+			name:           "the fetch failed terminally in the same iteration",
+			inLoopFetchErr: errors.New(`rpc error: code = NotFound desc = applications.argoproj.io "test-app" not found`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := newTaskRepositoryMock(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+			stateMock.EXPECT().GetTask(gomock.Any()).
+				Return(&models.Task{Status: models.StatusInProgressMessage}, nil).AnyTimes()
+
+			updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+			capture := &capturingStrategy{}
+			updater.notifier = notifications.NewNotifier(capture)
+
+			task := models.Task{
+				Id:        "mid-poll-id",
+				App:       "test-app",
+				Timeout:   600,
+				Created:   float64(time.Now().Unix()),
+				Validated: true,
+				Images:    []models.Image{{Image: "app", Tag: "v1"}},
+			}
+
+			application := models.Application{}
+			application.Status.Summary.Images = []string{"app:v1"}
+			application.Status.Sync.Status = "Synced"
+			application.Status.Health.Status = "Healthy"
+
+			// Shutdown begins during the poll loop's own fetch — after the abandon check
+			// that opens the iteration, and before its outcome is classified.
+			var draining atomic.Bool
+			var fetches int
+			apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+				DoAndReturn(func(context.Context, string, bool) (*models.Application, error) {
+					fetches++
+					if fetches == 1 {
+						return &application, nil
+					}
+					draining.Store(true)
+					if tt.inLoopFetchErr != nil {
+						return nil, tt.inLoopFetchErr
+					}
+					return &application, nil
+				}).Times(2)
+
+			metricsMock.EXPECT().AddInProgressTask()
+			metricsMock.EXPECT().RemoveInProgressTask()
+			// Nothing else is declared: gomock fails the test if this replica records a
+			// status, a deployment metric or a failure for a rollout it is abandoning.
+
+			updater.ResumeRollout(task, draining.Load)
+
+			assert.Empty(t, capture.sent,
+				"a rollout left to another replica must not be announced")
+		})
+	}
 }

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -36,11 +36,13 @@ func TestRemainingWindow(t *testing.T) {
 		wantResumable bool
 	}{
 		{
+			// The window is a whole number of polls, so a 600s timeout at a 1s delay is
+			// polled for 601s — and that is what the remainder is measured against.
 			name:          "a task resumed early keeps the rest of its own window",
 			taskTimeout:   600,
 			createdAgo:    100 * time.Second,
 			defaultWindow: 60 * time.Second,
-			want:          500 * time.Second,
+			want:          501 * time.Second,
 			wantResumable: true,
 		},
 		{
@@ -58,11 +60,14 @@ func TestRemainingWindow(t *testing.T) {
 			wantResumable: false,
 		},
 		{
-			name:          "a task resumed exactly at its deadline is not resumed",
+			// The replica that accepted this task would still be polling here: its last
+			// attempt is the one that lands on the configured timeout.
+			name:          "a task at its configured timeout still has its final poll",
 			taskTimeout:   60,
 			createdAgo:    60 * time.Second,
 			defaultWindow: 60 * time.Second,
-			wantResumable: false,
+			want:          time.Second,
+			wantResumable: true,
 		},
 		{
 			// A sub-second remainder rounds down to a zero timeout, which the rollout
@@ -70,17 +75,9 @@ func TestRemainingWindow(t *testing.T) {
 			// must not be resumable, or the deadline silently restarts.
 			name:          "a task with under a second left is not resumed",
 			taskTimeout:   60,
-			createdAgo:    59500 * time.Millisecond,
+			createdAgo:    60500 * time.Millisecond,
 			defaultWindow: 60 * time.Second,
 			wantResumable: false,
-		},
-		{
-			name:          "a task with exactly a second left is still resumed",
-			taskTimeout:   60,
-			createdAgo:    59 * time.Second,
-			defaultWindow: 60 * time.Second,
-			want:          time.Second,
-			wantResumable: true,
 		},
 	}
 
@@ -116,7 +113,7 @@ func TestRemainingWindow_ShrinksAcrossSuccessiveHandoffs(t *testing.T) {
 	assert.True(t, resumable)
 
 	assert.Less(t, second, first)
-	assert.Equal(t, 2*time.Minute, second)
+	assert.Equal(t, 2*time.Minute+time.Second, second)
 }
 
 // TestResumeRollout_AbortsAnElapsedWindow covers the arm remainingWindow only
@@ -405,4 +402,56 @@ func TestResumeRollout_WritesNothingWhenShutdownBeginsMidPoll(t *testing.T) {
 				"a rollout left to another replica must not be announced")
 		})
 	}
+}
+
+// The window a handover is judged against must be the window the rollout is actually
+// given: the poll loop is configured in whole attempts, so a task carrying a timeout
+// polls for that timeout rounded up to the next attempt. Measuring the remainder
+// against the raw timeout instead would abort a handover that lands in the last
+// interval — while the replica that accepted it would still have been polling.
+func TestRemainingWindow_MatchesThePollBudget(t *testing.T) {
+	// 900s at a 15s delay is 61 attempts, so the rollout polls for 915s.
+	monitor := &DeploymentMonitor{retryDelay: 15 * time.Second, defaultAttempts: 61}
+	created := time.Unix(1000, 0)
+	task := models.Task{Timeout: 900, Created: float64(created.Unix())}
+
+	_, deadline := monitor.configureRetryOptions(task)
+	require.Equal(t, 915*time.Second, deadline, "the poll budget is the attempts times the delay")
+
+	remaining, resumable := monitor.remainingWindow(task, created.Add(900*time.Second))
+
+	assert.True(t, resumable, "the accepting replica would still be polling at this age")
+	assert.Equal(t, deadline-900*time.Second, remaining)
+}
+
+// The bound the documentation states: a handover costs at most one extra poll
+// interval, because the remainder is re-expressed in whole attempts, and it does not
+// widen however often the task changes hands. Each handover is measured against the
+// persisted task — ResumeRollout rewrites Timeout on its own copy only — so this
+// walks the real sequence rather than a chain of rewritten tasks.
+func TestRemainingWindow_HandoverOvershootStaysBounded(t *testing.T) {
+	const delay = 15 * time.Second
+	monitor := &DeploymentMonitor{retryDelay: delay, defaultAttempts: 61}
+	created := time.Unix(1000, 0)
+	task := models.Task{Timeout: 900, Created: float64(created.Unix())}
+
+	_, unattended := monitor.configureRetryOptions(task)
+	bound := unattended + delay
+
+	var worst time.Duration
+	for _, handoverAt := range []time.Duration{time.Second, 100 * time.Second, 450 * time.Second, 899 * time.Second, 914 * time.Second} {
+		remaining, resumable := monitor.remainingWindow(task, created.Add(handoverAt))
+		require.True(t, resumable, "a handover at %s is still inside the window", handoverAt)
+
+		resumed := task
+		resumed.Timeout = int(remaining.Seconds())
+		_, deadline := monitor.configureRetryOptions(resumed)
+
+		if end := handoverAt + deadline; end > worst {
+			worst = end
+		}
+	}
+
+	assert.LessOrEqual(t, worst, bound,
+		"a resumed rollout must not poll more than one interval past the un-handed-over budget")
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -92,6 +92,15 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 
 	task.Validated = tokenValid
 
+	// Resolve the rollout window now, while this replica's configuration is the one
+	// that applies. Left at zero it would mean "whatever the default is", and a task
+	// resumed by a replica configured differently — during a rollout that changes
+	// DEPLOYMENT_TIMEOUT, say — would silently be judged against the new value
+	// instead of the one it was accepted under.
+	if task.Timeout <= 0 {
+		task.Timeout = int(env.config.DeploymentTimeout)
+	}
+
 	newTask, err := env.argo.AddTask(task)
 	if err != nil {
 		slog.Error("failed to add task", "error", err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -102,7 +102,7 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go env.updater.WaitForRollout(*newTask)
+	go env.updater.WaitForRollout(*newTask, false)
 
 	writeJSON(w, http.StatusAccepted, models.TaskStatus{
 		Id:     newTask.Id,

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -1742,6 +1743,7 @@ func TestAddTaskEndpoint(t *testing.T) {
 			strategies:    strategies,
 			authenticator: auth.NewAuthenticator(strategies),
 			argo:          argo,
+			config:        &config.ServerConfig{DeploymentTimeout: 900},
 		}
 
 		router := chi.NewRouter()
@@ -1785,6 +1787,7 @@ func TestAddTaskEndpoint(t *testing.T) {
 			strategies:    strategies,
 			authenticator: auth.NewAuthenticator(strategies),
 			argo:          argo,
+			config:        &config.ServerConfig{DeploymentTimeout: 900},
 		}
 
 		router := chi.NewRouter()
@@ -1830,6 +1833,7 @@ func TestAddTaskEndpoint(t *testing.T) {
 			strategies:    strategies,
 			authenticator: auth.NewAuthenticator(strategies),
 			argo:          argo,
+			config:        &config.ServerConfig{DeploymentTimeout: 900},
 		}
 
 		router := chi.NewRouter()
@@ -2457,4 +2461,75 @@ func TestCORSPolicy(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code, "a non-upgrade /ws request is still answered, not refused")
 		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 	})
+}
+
+// TestAddTaskResolvesTheDeploymentWindow pins that a task accepted without an
+// explicit timeout is stored with this replica's configured window rather than
+// with zero. Zero would mean "whatever the default is", and a replica that later
+// resumes the task would apply its own default — so a fleet mid-way through a
+// DEPLOYMENT_TIMEOUT change would judge a deployment against a window it was
+// never accepted under.
+func TestAddTaskResolvesTheDeploymentWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name        string
+		requestJSON string
+		want        int
+	}{
+		{
+			name:        "an omitted timeout is resolved to the instance default",
+			requestJSON: `{"app":"test-app","author":"a","project":"p","images":[{"image":"test","tag":"v1"}]}`,
+			want:        900,
+		},
+		{
+			name:        "an explicit timeout is kept as sent",
+			requestJSON: `{"app":"test-app","author":"a","project":"p","timeout":120,"images":[{"image":"test","tag":"v1"}]}`,
+			want:        120,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stateMock := mocks.NewMockTaskRepository(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+
+			argo := &argocd.Argo{}
+			argo.Init(stateMock, mocks.NewMockArgoApiInterface(ctrl), metricsMock)
+
+			stateMock.EXPECT().GetTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]models.Task{}, int64(0)).AnyTimes()
+			stateMock.EXPECT().CancelInProgressTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(int64(0), nil).AnyTimes()
+			stateMock.EXPECT().ClaimTask(gomock.Any()).Return(nil).AnyTimes()
+			metricsMock.EXPECT().AddProcessedDeployment(gomock.Any()).AnyTimes()
+
+			var stored models.Task
+			stateMock.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+				stored = task
+				// Returning an error stops the handler before it spawns a rollout, which
+				// this test is not about.
+				return nil, errors.New("stop here")
+			})
+
+			lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
+			require.NoError(t, err)
+
+			env := &Env{
+				argo:     argo,
+				lockdown: lockdown,
+				config:   &config.ServerConfig{DeploymentTimeout: 900},
+			}
+
+			router := chi.NewRouter()
+			router.Post("/api/v1/tasks", env.addTask)
+
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(tt.requestJSON))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			assert.Equal(t, tt.want, stored.Timeout)
+		})
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -164,6 +164,11 @@ func (s *Server) Run() {
 	// or hide the "ArgoCD unreachable" banner (issue #498).
 	s.env.StartArgoWatcher()
 
+	// Take over deployments whose replica stopped monitoring them, so losing a pod
+	// mid-rollout costs a few seconds of unattended time rather than the whole
+	// deployment (issue #152).
+	s.env.StartTaskReaper()
+
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("failed to start server", "error", err)
@@ -255,4 +260,11 @@ func (s *Server) shutdown(srv httpShutdowner) {
 	if s.updater != nil {
 		s.updater.Close(shutdownCtx)
 	}
+
+	// Phase 4: hand the rollouts this replica was watching to the others. The
+	// monitoring goroutines are about to die with the process, and without this
+	// their tasks would sit unattended until their leases lapse. Last, so a
+	// surviving replica does not resume a write-back the drain above is still
+	// flushing. No-op with in-memory state, where nothing else can pick them up.
+	s.env.releaseTaskLeases()
 }

--- a/internal/server/task_reaper.go
+++ b/internal/server/task_reaper.go
@@ -61,7 +61,7 @@ func reapAbandonedTasks(stop <-chan struct{}, draining func() bool, interval tim
 			}
 
 			for _, task := range claimed {
-				go resumeSafely(task, resume)
+				go resumeSafely(task, draining, resume)
 			}
 		}
 	}
@@ -92,12 +92,24 @@ func (env *Env) releaseTaskLeases() {
 // A task is only ever abandoned back to the other replicas, so a panic that took
 // the process down would be re-claimed elsewhere and take that replica down too,
 // walking one bad deployment through the whole fleet.
-func resumeSafely(task models.Task, resume func(models.Task)) {
+//
+// Draining is re-checked here because it can begin between the sweep's own check
+// and this goroutine starting. Monitoring a rollout this replica cannot finish is
+// worse than not starting it: once shutdown closes the write-back batcher, the
+// resumed task's write-back fails and records a terminal status for a deployment
+// that is otherwise healthy. Giving up before starting leaves the claim to be
+// released with the rest, so another replica takes it instead.
+func resumeSafely(task models.Task, draining func() bool, resume func(models.Task)) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			slog.Error("Resuming an abandoned deployment panicked", "id", task.Id, "app", task.App, "panic", recovered)
 		}
 	}()
+
+	if draining() {
+		slog.Info("Not resuming a claimed deployment: this replica is shutting down", "id", task.Id, "app", task.App)
+		return
+	}
 
 	resume(task)
 }

--- a/internal/server/task_reaper.go
+++ b/internal/server/task_reaper.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/state"
+)
+
+// StartTaskReaper launches a background goroutine that takes over deployments
+// abandoned by another replica — one that crashed, was rolled, or released its
+// claims on shutdown — and resumes monitoring them here.
+//
+// Without it a deployment whose replica disappeared is watched by nobody: no
+// status is ever written, no git write-back happens, and the task sits in
+// progress until the obsolete-task sweep gives up on it an hour later.
+//
+// With in-memory state there is nothing to take over — the tasks died with the
+// process that held them — so the sweeps simply come back empty. The goroutine is
+// tracked by connWg and stops when the shutdown channel is closed.
+func (env *Env) StartTaskReaper() {
+	env.connWg.Add(1)
+	go func() {
+		defer env.connWg.Done()
+		reapAbandonedTasks(env.shutdownCh, env.isDraining, state.TaskReapInterval, env.argo.State, env.updater.ResumeRollout)
+	}()
+}
+
+// reapAbandonedTasks claims lapsed tasks on every tick and hands each one to
+// resume. A sweep that fails is logged and retried on the next tick: an
+// unreachable database is an outage to ride out, not a reason to stop taking
+// over abandoned deployments. Dependencies are parameters so the loop can be
+// unit-tested. It runs until stop is closed.
+func reapAbandonedTasks(stop <-chan struct{}, draining func() bool, interval time.Duration, repository state.TaskRepository, resume func(models.Task)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			// Draining begins several seconds before the shutdown channel closes.
+			// Claiming in that window takes deployments this replica cannot finish: it
+			// releases them again moments later, and a resume that outlives the
+			// write-back drain fails on the closed batcher and writes a terminal status
+			// no other replica will revisit.
+			if draining() {
+				continue
+			}
+
+			claimed, err := repository.ClaimExpiredTasks(state.TaskReapBatchSize)
+			if err != nil {
+				slog.Error("Failed to look for deployments abandoned by other replicas", "error", err)
+				continue
+			}
+
+			if len(claimed) > 0 {
+				slog.Info("Took over deployments abandoned by another replica", "count", len(claimed))
+			}
+
+			for _, task := range claimed {
+				go resumeSafely(task, resume)
+			}
+		}
+	}
+}
+
+// releaseTaskLeases gives up this replica's claims so the deployments it was
+// monitoring are taken over by another replica on its next sweep, rather than
+// waiting out their leases. It reports the outcome rather than returning it:
+// shutdown proceeds either way, and a claim that could not be released still
+// lapses on its own.
+func (env *Env) releaseTaskLeases() {
+	if env.argo == nil || env.argo.State == nil {
+		return
+	}
+
+	released, err := env.argo.State.ReleaseOwnedLeases()
+	if err != nil {
+		slog.Error("failed to hand over in-flight deployments", "error", err)
+		return
+	}
+
+	if released > 0 {
+		slog.Info("handed in-flight deployments to the other replicas", "count", released)
+	}
+}
+
+// resumeSafely runs resume and contains a panic to the one task that caused it.
+// A task is only ever abandoned back to the other replicas, so a panic that took
+// the process down would be re-claimed elsewhere and take that replica down too,
+// walking one bad deployment through the whole fleet.
+func resumeSafely(task models.Task, resume func(models.Task)) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Error("Resuming an abandoned deployment panicked", "id", task.Id, "app", task.App, "panic", recovered)
+		}
+	}()
+
+	resume(task)
+}

--- a/internal/server/task_reaper.go
+++ b/internal/server/task_reaper.go
@@ -32,7 +32,7 @@ func (env *Env) StartTaskReaper() {
 // unreachable database is an outage to ride out, not a reason to stop taking
 // over abandoned deployments. Dependencies are parameters so the loop can be
 // unit-tested. It runs until stop is closed.
-func reapAbandonedTasks(stop <-chan struct{}, draining func() bool, interval time.Duration, repository state.TaskRepository, resume func(models.Task)) {
+func reapAbandonedTasks(stop <-chan struct{}, draining func() bool, interval time.Duration, repository state.TaskRepository, resume func(models.Task, func() bool)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -99,7 +99,11 @@ func (env *Env) releaseTaskLeases() {
 // resumed task's write-back fails and records a terminal status for a deployment
 // that is otherwise healthy. Giving up before starting leaves the claim to be
 // released with the rest, so another replica takes it instead.
-func resumeSafely(task models.Task, draining func() bool, resume func(models.Task)) {
+//
+// The same predicate is handed to resume, which keeps watching it: shutdown can
+// also begin after a rollout is under way, and that rollout must be given up
+// rather than raced against the teardown.
+func resumeSafely(task models.Task, draining func() bool, resume func(models.Task, func() bool)) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			slog.Error("Resuming an abandoned deployment panicked", "id", task.Id, "app", task.App, "panic", recovered)
@@ -111,5 +115,5 @@ func resumeSafely(task models.Task, draining func() bool, resume func(models.Tas
 		return
 	}
 
-	resume(task)
+	resume(task, draining)
 }

--- a/internal/server/task_reaper_test.go
+++ b/internal/server/task_reaper_test.go
@@ -146,6 +146,19 @@ func TestReapAbandonedTasks_ClaimsNothingWhileDraining(t *testing.T) {
 	assert.Empty(t, recorder.recorded())
 }
 
+// Draining can begin after a sweep has already claimed work, so the check is
+// repeated in the goroutine that would do the monitoring. Starting it anyway
+// means the write-back lands after shutdown closed the batcher, and a healthy
+// deployment gets a terminal failure no other replica will revisit.
+func TestResumeSafely_DoesNotStartWhileDraining(t *testing.T) {
+	resumed := false
+	resumeSafely(models.Task{Id: "claimed"}, func() bool { return true }, func(models.Task) {
+		resumed = true
+	})
+
+	assert.False(t, resumed, "a replica on its way out must leave the claim for another")
+}
+
 // A panic in one resumed deployment must not take the replica down, or the task
 // would be re-claimed elsewhere and walk the crash through the fleet.
 func TestReapAbandonedTasks_ContainsAPanickingResume(t *testing.T) {

--- a/internal/server/task_reaper_test.go
+++ b/internal/server/task_reaper_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// resumeRecorder collects the tasks the reaper handed back for monitoring.
+type resumeRecorder struct {
+	mu     sync.Mutex
+	tasks  []models.Task
+	resume chan struct{}
+}
+
+func newResumeRecorder() *resumeRecorder {
+	return &resumeRecorder{resume: make(chan struct{}, 8)}
+}
+
+func (r *resumeRecorder) record(task models.Task) {
+	r.mu.Lock()
+	r.tasks = append(r.tasks, task)
+	r.mu.Unlock()
+
+	select {
+	case r.resume <- struct{}{}:
+	default:
+	}
+}
+
+func (r *resumeRecorder) recorded() []models.Task {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]models.Task(nil), r.tasks...)
+}
+
+func TestReapAbandonedTasks_ResumesWhatItClaims(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	abandoned := []models.Task{{Id: "first"}, {Id: "second"}}
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().ClaimExpiredTasks(gomock.Any()).Return(abandoned, nil).MinTimes(1)
+
+	recorder := newResumeRecorder()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	go reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, recorder.record)
+
+	// Sweeps keep firing, so assert that both tasks were handed over rather than
+	// on the order or the exact count, which two overlapping sweeps make arbitrary.
+	require.Eventually(t, func() bool {
+		seen := map[string]bool{}
+		for _, task := range recorder.recorded() {
+			seen[task.Id] = true
+		}
+		return seen["first"] && seen["second"]
+	}, time.Second, time.Millisecond)
+}
+
+// A sweep that cannot reach the database is a failed sweep, not a reason to stop
+// sweeping: the next tick tries again once the outage clears.
+func TestReapAbandonedTasks_SurvivesAFailedSweep(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sweeps := make(chan struct{}, 8)
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().ClaimExpiredTasks(gomock.Any()).DoAndReturn(func(int) ([]models.Task, error) {
+		select {
+		case sweeps <- struct{}{}:
+		default:
+		}
+		return nil, errors.New("database unreachable")
+	}).MinTimes(2)
+
+	recorder := newResumeRecorder()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	go reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, recorder.record)
+
+	<-sweeps
+	<-sweeps
+	assert.Empty(t, recorder.recorded())
+}
+
+func TestReapAbandonedTasks_StopsOnShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().ClaimExpiredTasks(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	stop := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, newResumeRecorder().record)
+		close(finished)
+	}()
+
+	close(stop)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("the reaper kept running after shutdown was signalled")
+	}
+}
+
+// notDraining is the drain predicate for tests about sweeping itself: this
+// replica is serving normally and may take on abandoned work.
+func notDraining() bool { return false }
+
+// A replica on its way out must not take on deployments it cannot finish.
+func TestReapAbandonedTasks_ClaimsNothingWhileDraining(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().ClaimExpiredTasks(gomock.Any()).Times(0)
+
+	recorder := newResumeRecorder()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Counting the predicate proves the loop actually ticked and chose not to claim.
+	// A fixed sleep would report success on a loaded runner where no tick ever fired.
+	var checks atomic.Int32
+	go reapAbandonedTasks(stop, func() bool {
+		checks.Add(1)
+		return true
+	}, time.Millisecond, stateMock, recorder.record)
+
+	require.Eventually(t, func() bool { return checks.Load() >= 2 }, time.Second, time.Millisecond)
+	assert.Empty(t, recorder.recorded())
+}
+
+// A panic in one resumed deployment must not take the replica down, or the task
+// would be re-claimed elsewhere and walk the crash through the fleet.
+func TestReapAbandonedTasks_ContainsAPanickingResume(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := mocks.NewMockTaskRepository(ctrl)
+	stateMock.EXPECT().ClaimExpiredTasks(gomock.Any()).Return([]models.Task{{Id: "poison"}}, nil).MinTimes(1)
+
+	var attempts atomic.Int32
+	stop := make(chan struct{})
+	defer close(stop)
+
+	go reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, func(models.Task) {
+		attempts.Add(1)
+		panic("resume blew up")
+	})
+
+	// Sweeping past the first panic is the property: the panic was contained rather
+	// than unwinding the process, and the reaper is still taking on work.
+	require.Eventually(t, func() bool { return attempts.Load() >= 2 }, time.Second, time.Millisecond)
+}

--- a/internal/server/task_reaper_test.go
+++ b/internal/server/task_reaper_test.go
@@ -26,7 +26,7 @@ func newResumeRecorder() *resumeRecorder {
 	return &resumeRecorder{resume: make(chan struct{}, 8)}
 }
 
-func (r *resumeRecorder) record(task models.Task) {
+func (r *resumeRecorder) record(task models.Task, _ func() bool) {
 	r.mu.Lock()
 	r.tasks = append(r.tasks, task)
 	r.mu.Unlock()
@@ -152,7 +152,7 @@ func TestReapAbandonedTasks_ClaimsNothingWhileDraining(t *testing.T) {
 // deployment gets a terminal failure no other replica will revisit.
 func TestResumeSafely_DoesNotStartWhileDraining(t *testing.T) {
 	resumed := false
-	resumeSafely(models.Task{Id: "claimed"}, func() bool { return true }, func(models.Task) {
+	resumeSafely(models.Task{Id: "claimed"}, func() bool { return true }, func(models.Task, func() bool) {
 		resumed = true
 	})
 
@@ -172,7 +172,7 @@ func TestReapAbandonedTasks_ContainsAPanickingResume(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	go reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, func(models.Task) {
+	go reapAbandonedTasks(stop, notDraining, time.Millisecond, stateMock, func(models.Task, func() bool) {
 		attempts.Add(1)
 		panic("resume blew up")
 	})
@@ -180,4 +180,22 @@ func TestReapAbandonedTasks_ContainsAPanickingResume(t *testing.T) {
 	// Sweeping past the first panic is the property: the panic was contained rather
 	// than unwinding the process, and the reaper is still taking on work.
 	require.Eventually(t, func() bool { return attempts.Load() >= 2 }, time.Second, time.Millisecond)
+}
+
+// The check must reach the resumed rollout live, not as a snapshot: shutdown can
+// begin after monitoring started, and from that point the rollout has to be given
+// up rather than raced against the teardown.
+func TestResumeSafely_HandsTheDrainingCheckToResume(t *testing.T) {
+	var draining atomic.Bool
+	var handed func() bool
+
+	resumeSafely(models.Task{Id: "claimed"}, draining.Load, func(_ models.Task, check func() bool) {
+		handed = check
+	})
+
+	require.NotNil(t, handed, "the resumed rollout was given no way to observe shutdown")
+	assert.False(t, handed())
+
+	draining.Store(true)
+	assert.True(t, handed(), "a rollout under way must still see shutdown begin")
 }

--- a/internal/state/lease.go
+++ b/internal/state/lease.go
@@ -1,0 +1,194 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/state/state_models"
+)
+
+const (
+	// TaskLeaseTTL is how long a replica's claim on a task stays valid without
+	// being renewed. It bounds how long a deployment sits unattended after the
+	// replica monitoring it dies, so it is short; it must still comfortably
+	// outlast a garbage-collection pause or a slow ArgoCD call, or a live owner
+	// would lose tasks it is actively monitoring.
+	TaskLeaseTTL = 30 * time.Second
+
+	// TaskLeaseRenewInterval is how often an owner extends its claim. An owner
+	// gives the claim up one interval before it would lapse, so at a fifth of the
+	// TTL three consecutive renewals can fail before a rollout changes hands — a
+	// database blip costs nothing, while a real outage still hands the work over.
+	TaskLeaseRenewInterval = TaskLeaseTTL / 5
+
+	// TaskReapInterval is how often a replica looks for lapsed leases to take
+	// over. Half the TTL keeps the worst-case unattended window at ~1.5x the TTL.
+	TaskReapInterval = TaskLeaseTTL / 2
+
+	// TaskReapBatchSize bounds how many tasks one replica takes over per tick, so
+	// a replica returning after an outage picks up work gradually instead of
+	// claiming every orphaned rollout at once.
+	TaskReapBatchSize = 20
+)
+
+// newOwnerId returns an identifier for this process, used as the owner of task
+// leases. The hostname alone would not do: a restarted pod keeps its name, and
+// would then mistake the leases held by its predecessor for its own.
+func newOwnerId() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("could not determine hostname for the task lease owner id: %w", err)
+	}
+
+	return fmt.Sprintf("%s/%s", hostname, uuid.NewString()), nil
+}
+
+// RenewLease reports whether this instance still holds the task. With in-memory
+// state there is no second replica to lose it to, so it always does.
+func (state *InMemoryState) RenewLease(_ string) (bool, error) {
+	return true, nil
+}
+
+// ReleaseOwnedLeases has nothing to hand over: no other process can pick these
+// tasks up.
+func (state *InMemoryState) ReleaseOwnedLeases() (int64, error) {
+	return 0, nil
+}
+
+// ClaimExpiredTasks never returns anything. In-memory tasks live in the process
+// that accepted them, so a process that stopped monitoring them also lost them.
+func (state *InMemoryState) ClaimExpiredTasks(_ int) ([]models.Task, error) {
+	return nil, nil
+}
+
+// claimQueryTTLSeconds renders the lease TTL for make_interval. Every lease
+// deadline is computed by Postgres rather than by the replica writing it, so
+// clock skew between replicas cannot shorten or extend a claim.
+const claimQueryTTLSeconds = float64(TaskLeaseTTL) / float64(time.Second)
+
+// ClaimTask takes ownership of a task for this instance. It is called right
+// after a task is accepted, so the replica that will monitor it holds the lease
+// from the start rather than from its first renewal.
+func (state *PostgresState) ClaimTask(id string) error {
+	result := state.orm.Exec(`
+		UPDATE tasks
+		SET owner_id = ?, lease_expires_at = now() + make_interval(secs => ?)
+		WHERE id = ?`,
+		state.ownerId, claimQueryTTLSeconds, id)
+
+	return result.Error
+}
+
+// RenewLease extends this instance's claim and reports whether it still holds
+// it. A false return means another replica took the task over — the caller must
+// stop monitoring it without writing a status, or it would clobber the outcome
+// the new owner is about to record.
+//
+// Ownership is the only thing checked. A task cancelled by a newer deployment
+// still belongs to this instance, and is stopped by the supersession check
+// instead, so the two mechanisms never race to end the same rollout.
+func (state *PostgresState) RenewLease(id string) (bool, error) {
+	// Bounded because the DSN sets only connect_timeout, which does not cover a
+	// statement issued on an already-established connection. Without this a stalled
+	// renewal — a failover, a blackholed connection — would block the caller past
+	// the lease it is meant to be extending, and the claim would lapse with nobody
+	// noticing.
+	ctx, cancel := context.WithTimeout(context.Background(), TaskLeaseRenewInterval)
+	defer cancel()
+
+	result := state.orm.WithContext(ctx).Exec(`
+		UPDATE tasks
+		SET lease_expires_at = now() + make_interval(secs => ?)
+		WHERE id = ? AND owner_id = ?`,
+		claimQueryTTLSeconds, id, state.ownerId)
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	return result.RowsAffected == 1, nil
+}
+
+// ReleaseOwnedLeases expires every claim this instance holds and reports how
+// many it gave up, so the tasks it was monitoring are picked up by another
+// replica on its next sweep instead of waiting out the full TTL. It is how a
+// graceful shutdown hands its in-flight rollouts over.
+//
+// The owner is cleared as well as the deadline. Nothing waits for the monitoring
+// goroutines, so one of them can outlive this call by a few instructions; while
+// the row still named this instance, its next renewal would take the claim back
+// and undo the handover. Unowned, that renewal reports the claim lost and the
+// rollout stops without writing a status — which is what a replica on its way out
+// should do.
+func (state *PostgresState) ReleaseOwnedLeases() (int64, error) {
+	result := state.orm.Exec(`
+		UPDATE tasks
+		SET owner_id = NULL, lease_expires_at = now()
+		WHERE owner_id = ? AND status = ?`,
+		state.ownerId, models.StatusInProgressMessage)
+
+	return result.RowsAffected, result.Error
+}
+
+// ClaimExpiredTasks takes over up to limit in-progress tasks whose lease has
+// lapsed — tasks whose previous owner died, was rolled, or released them on
+// shutdown — and returns them ready to be monitored again.
+//
+// FOR UPDATE SKIP LOCKED is what makes this safe to run on every replica at
+// once: concurrent sweeps neither block each other nor hand the same task to two
+// owners.
+//
+// A task that was never claimed is picked up too, but only once it has gone a
+// whole TTL unclaimed. Accepting a task and claiming it are two statements, and
+// treating the gap between them as an abandoned task would let a sweep start a
+// second monitor for a deployment the accepting replica is about to watch. The
+// same grace covers tasks left in progress by a replica running a version from
+// before leases existed: they carry no lease, and are taken over rather than
+// stranded — during that upgrade only, both the old replica and the new owner
+// watch the rollout, so it can be reported twice.
+//
+// That grace is the one deadline here not computed by Postgres: `created` is
+// written by whichever replica accepted the task. Hosts kept in sync leave the
+// difference far below a lease, but a replica whose clock runs badly behind will
+// treat its own fresh rows as claimable.
+func (state *PostgresState) ClaimExpiredTasks(limit int) ([]models.Task, error) {
+	var claimed []state_models.TaskModel
+
+	err := state.orm.Raw(`
+		UPDATE tasks
+		SET owner_id = ?, lease_expires_at = now() + make_interval(secs => ?)
+		WHERE id IN (
+			SELECT id FROM tasks
+			WHERE status = ?
+			  AND (
+			        lease_expires_at < now()
+			     OR (lease_expires_at IS NULL AND created < now() - make_interval(secs => ?))
+			  )
+			ORDER BY created
+			FOR UPDATE SKIP LOCKED
+			LIMIT ?
+		)
+		RETURNING *`,
+		state.ownerId, claimQueryTTLSeconds, models.StatusInProgressMessage, claimQueryTTLSeconds, limit).
+		Scan(&claimed).Error
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]models.Task, len(claimed))
+	for i := range claimed {
+		tasks[i] = *claimed[i].ConvertToResumedTask()
+	}
+
+	return tasks, nil
+}
+
+// ClaimTask is a no-op: the accepting process is the only one that could
+// monitor the task.
+func (state *InMemoryState) ClaimTask(_ string) error {
+	return nil
+}

--- a/internal/state/lease_postgres_test.go
+++ b/internal/state/lease_postgres_test.go
@@ -171,6 +171,31 @@ func TestPostgresState_ClaimExpiredTasks(t *testing.T) {
 		assert.Nil(t, findTask(claimed, inserted.Id))
 	})
 
+	// The scenario this guards: a replica dies mid-rollout, a newer deployment for
+	// the same app lands elsewhere and commits its own tag, and only then does a
+	// sweep notice the abandoned task. Resuming it would re-run its write-back and
+	// commit the superseded tag over the newer one. Superseding marks the old task
+	// cancelled before the new one is even inserted, so it leaves the claimable set
+	// entirely — a lapsed lease on it is irrelevant.
+	t.Run("a superseded task is never reclaimed", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		old := env.addTask(t, sampleTask("Superseded"))
+		require.NoError(t, env.state.ClaimTask(old.Id))
+		env.expireLease(t, old.Id)
+
+		// What accepting a newer deployment for the same app does first.
+		cancelled, err := env.state.CancelInProgressTasks(
+			"Superseded", []models.Image{{Image: "test", Tag: "v0.0.2"}}, "superseded", true)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), cancelled)
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.Nil(t, findTask(claimed, old.Id),
+			"resuming it would commit the tag the newer deployment just replaced")
+	})
+
 	t.Run("a task already claimed is not handed to a second owner", func(t *testing.T) {
 		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
 

--- a/internal/state/lease_postgres_test.go
+++ b/internal/state/lease_postgres_test.go
@@ -1,0 +1,335 @@
+package state
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// secondReplica returns a state sharing the database but identifying as a
+// different process, which is what makes cross-replica takeover observable.
+func (env *postgresTestEnv) secondReplica(t *testing.T) *PostgresState {
+	t.Helper()
+
+	ownerId, err := newOwnerId()
+	require.NoError(t, err)
+
+	return &PostgresState{orm: env.state.orm, ownerId: ownerId}
+}
+
+// expireLease backdates a task's lease so a sweep treats it as abandoned,
+// without making the test wait out the real TTL.
+func (env *postgresTestEnv) expireLease(t *testing.T, id string) {
+	t.Helper()
+	require.NoError(t, env.state.orm.Exec(
+		"UPDATE tasks SET lease_expires_at = now() - interval '1 second' WHERE id = ?", id).Error)
+}
+
+func TestPostgresState_ClaimTask(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	inserted := env.addTask(t, sampleTask("Claimed"))
+	require.NoError(t, env.state.ClaimTask(inserted.Id))
+
+	stored := env.storedModel(t, inserted.Id)
+	require.True(t, stored.OwnerId.Valid)
+	assert.Equal(t, env.state.ownerId, stored.OwnerId.String)
+	require.True(t, stored.LeaseExpiresAt.Valid)
+	assert.True(t, stored.LeaseExpiresAt.Time.After(stored.Created),
+		"the claim must be dated from the database clock, not left at the epoch")
+}
+
+func TestPostgresState_RenewLease(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	t.Run("the owner keeps its claim", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Renewed"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+
+		held, err := env.state.RenewLease(inserted.Id)
+		require.NoError(t, err)
+		assert.True(t, held)
+	})
+
+	t.Run("a replica that lost the task learns it on the next renewal", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Stolen"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+
+		other := env.secondReplica(t)
+		require.NoError(t, other.ClaimTask(inserted.Id))
+
+		held, err := env.state.RenewLease(inserted.Id)
+		require.NoError(t, err)
+		assert.False(t, held,
+			"the previous owner must stop rather than clobber the new owner's outcome")
+	})
+
+	t.Run("a cancelled task still belongs to its owner", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Cancelled"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+		require.NoError(t, env.state.SetTaskStatus(inserted.Id, models.StatusCancelledMessage, "superseded"))
+
+		held, err := env.state.RenewLease(inserted.Id)
+		require.NoError(t, err)
+		assert.True(t, held,
+			"supersession stops the rollout through its own check; the lease must not double as one")
+	})
+}
+
+func TestPostgresState_ClaimExpiredTasks(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	t.Run("a live claim is left alone", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Live"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.NotContains(t, taskIds(claimed), inserted.Id)
+	})
+
+	t.Run("an abandoned task is taken over with everything the rollout needs", func(t *testing.T) {
+		refresh := false
+		task := sampleTask("Abandoned")
+		task.Validated = true
+		task.Timeout = 600
+		task.Refresh = &refresh
+		inserted := env.addTask(t, task)
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+		env.expireLease(t, inserted.Id)
+
+		other := env.secondReplica(t)
+		claimed, err := other.ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+
+		resumed := findTask(claimed, inserted.Id)
+		require.NotNil(t, resumed, "an expired lease must be reclaimable")
+		assert.True(t, resumed.Validated, "a resumed task that loses authority skips its write-back")
+		assert.Equal(t, 600, resumed.Timeout)
+		require.NotNil(t, resumed.Refresh)
+		assert.False(t, *resumed.Refresh)
+
+		held, err := env.state.RenewLease(inserted.Id)
+		require.NoError(t, err)
+		assert.False(t, held, "the abandoning replica must not reclaim what was taken from it")
+	})
+
+	t.Run("a released task is taken over without waiting out the lease", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		inserted := env.addTask(t, sampleTask("Released"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+		released, err := env.state.ReleaseOwnedLeases()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), released)
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.NotNil(t, findTask(claimed, inserted.Id))
+	})
+
+	// A task accepted moments ago has not been abandoned — it is waiting for the
+	// accepting replica's own claim, one statement behind. Claiming it here would
+	// put two monitors on one rollout.
+	t.Run("a just-accepted task is left for the replica that accepted it", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		inserted := env.addTask(t, sampleTask("JustAccepted"))
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.Nil(t, findTask(claimed, inserted.Id),
+			"an unclaimed task is only abandoned once it has gone a whole lease unclaimed")
+	})
+
+	// The other half: a task whose claim never landed must not be stranded.
+	t.Run("a long-unclaimed task is eventually taken over", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		inserted := env.addTask(t, sampleTask("NeverClaimed"))
+		require.NoError(t, env.state.orm.Exec(
+			"UPDATE tasks SET created = now() - make_interval(secs => ?) WHERE id = ?",
+			claimQueryTTLSeconds+1, inserted.Id).Error)
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.NotNil(t, findTask(claimed, inserted.Id))
+	})
+
+	t.Run("a finished task is never reclaimed", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Finished"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+		env.expireLease(t, inserted.Id)
+		require.NoError(t, env.state.SetTaskStatus(inserted.Id, models.StatusDeployedMessage, ""))
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		assert.Nil(t, findTask(claimed, inserted.Id))
+	})
+
+	t.Run("a task already claimed is not handed to a second owner", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		var ids []string
+		for range 6 {
+			inserted := env.addTask(t, sampleTask("Contended"))
+			require.NoError(t, env.state.ClaimTask(inserted.Id))
+			env.expireLease(t, inserted.Id)
+			ids = append(ids, inserted.Id)
+		}
+
+		first, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+		second, err := env.secondReplica(t).ClaimExpiredTasks(TaskReapBatchSize)
+		require.NoError(t, err)
+
+		assert.Len(t, first, len(ids), "the first sweep claims what is available")
+		assert.Empty(t, second, "a task already claimed must not be handed to a second owner")
+	})
+
+	// The property every replica sweeping at once depends on: SKIP LOCKED must
+	// make simultaneous sweeps partition the abandoned tasks rather than block on
+	// each other or hand the same rollout to two owners. Sequential sweeps cannot
+	// show this — they never contend for the same rows.
+	t.Run("simultaneous sweeps partition the abandoned tasks", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		const abandoned = 24
+		for range abandoned {
+			inserted := env.addTask(t, sampleTask("Raced"))
+			require.NoError(t, env.state.ClaimTask(inserted.Id))
+			env.expireLease(t, inserted.Id)
+		}
+
+		const sweepers = 4
+		var (
+			start   = make(chan struct{})
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			claimed []models.Task
+			errs    []error
+		)
+
+		for range sweepers {
+			replica := env.secondReplica(t)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				got, err := replica.ClaimExpiredTasks(abandoned)
+
+				mu.Lock()
+				defer mu.Unlock()
+				claimed = append(claimed, got...)
+				errs = append(errs, err)
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		for _, err := range errs {
+			require.NoError(t, err, "a sweep must not fail because another was running")
+		}
+
+		seen := map[string]int{}
+		for _, task := range claimed {
+			seen[task.Id]++
+		}
+		for id, times := range seen {
+			assert.Equal(t, 1, times, "task %s was handed to more than one owner", id)
+		}
+		assert.Len(t, seen, abandoned, "every abandoned task must be claimed by exactly one sweep")
+	})
+
+	// A bounded sweep must take the oldest first, or a replica returning from an
+	// outage keeps picking up fresh orphans while the ones nearest their deadline
+	// starve and are eventually aborted as stale.
+	t.Run("a bounded sweep takes the oldest abandoned tasks first", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		var ids []string
+		for age := range 3 {
+			inserted := env.addTask(t, sampleTask("Batched"))
+			// Spread creation times so "oldest" is unambiguous.
+			require.NoError(t, env.state.orm.Exec(
+				"UPDATE tasks SET created = now() - make_interval(secs => ?) WHERE id = ?",
+				(3-age)*3600, inserted.Id).Error)
+			env.expireLease(t, inserted.Id)
+			ids = append(ids, inserted.Id)
+		}
+
+		claimed, err := env.secondReplica(t).ClaimExpiredTasks(2)
+		require.NoError(t, err)
+		require.Len(t, claimed, 2)
+		assert.ElementsMatch(t, ids[:2], taskIds(claimed),
+			"the two oldest must be claimed, not an arbitrary two")
+	})
+}
+
+func taskIds(tasks []models.Task) []string {
+	ids := make([]string, len(tasks))
+	for i := range tasks {
+		ids[i] = tasks[i].Id
+	}
+	return ids
+}
+
+func findTask(tasks []models.Task, id string) *models.Task {
+	for i := range tasks {
+		if tasks[i].Id == id {
+			return &tasks[i]
+		}
+	}
+	return nil
+}
+
+// TestPostgresState_ReleaseOwnedLeases pins the half of the handover that the
+// takeover tests cannot see. Expiring the deadline alone is enough for another
+// replica to claim the task, so only these assertions catch the loss of
+// `owner_id = NULL` — and with it the straggler renewal that would silently take
+// the claim back and undo the handover.
+func TestPostgresState_ReleaseOwnedLeases(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	t.Run("the owner is cleared, not just the deadline", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		inserted := env.addTask(t, sampleTask("Handed"))
+		require.NoError(t, env.state.ClaimTask(inserted.Id))
+
+		released, err := env.state.ReleaseOwnedLeases()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), released)
+
+		assert.False(t, env.storedModel(t, inserted.Id).OwnerId.Valid,
+			"a released task must name no owner")
+
+		held, err := env.state.RenewLease(inserted.Id)
+		require.NoError(t, err)
+		assert.False(t, held,
+			"a goroutine still running in the departing replica must not take the claim back")
+	})
+
+	t.Run("only in-progress tasks are handed over", func(t *testing.T) {
+		require.NoError(t, env.state.orm.Exec("TRUNCATE TABLE tasks").Error)
+
+		live := env.addTask(t, sampleTask("Live"))
+		require.NoError(t, env.state.ClaimTask(live.Id))
+
+		finished := env.addTask(t, sampleTask("Finished"))
+		require.NoError(t, env.state.ClaimTask(finished.Id))
+		require.NoError(t, env.state.SetTaskStatus(finished.Id, models.StatusDeployedMessage, ""))
+
+		released, err := env.state.ReleaseOwnedLeases()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), released, "a finished task is not in flight and needs no owner")
+
+		assert.True(t, env.storedModel(t, finished.Id).OwnerId.Valid,
+			"a finished task's row is left untouched")
+	})
+}

--- a/internal/state/lease_test.go
+++ b/internal/state/lease_test.go
@@ -1,0 +1,40 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOwnerId_IsUniquePerProcess(t *testing.T) {
+	first, err := newOwnerId()
+	require.NoError(t, err)
+	second, err := newOwnerId()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, first)
+	assert.NotEqual(t, first, second,
+		"a restarted pod reuses its name, so the id must not be the hostname alone")
+}
+
+// TestInMemoryState_LeasesAreNoOps documents the single-process contract: there
+// is no second replica to lose a claim to, and a crash takes the tasks with it,
+// so nothing is ever reclaimable.
+func TestInMemoryState_LeasesAreNoOps(t *testing.T) {
+	state := &InMemoryState{}
+	task, err := state.AddTask(createTestTask("Leased"))
+	require.NoError(t, err)
+
+	held, err := state.RenewLease(task.Id)
+	require.NoError(t, err)
+	assert.True(t, held, "a single process can never lose its claim")
+
+	released, err := state.ReleaseOwnedLeases()
+	require.NoError(t, err)
+	assert.Zero(t, released)
+
+	reclaimed, err := state.ClaimExpiredTasks(10)
+	require.NoError(t, err)
+	assert.Empty(t, reclaimed)
+}

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -23,6 +23,9 @@ const whereStatusEquals = "status = ?"
 
 type PostgresState struct {
 	orm *gorm.DB
+	// ownerId identifies this process as the holder of task leases. It is unique
+	// per process, so a restarted pod never inherits its predecessor's claims.
+	ownerId string
 }
 
 var _ TaskRepository = (*PostgresState)(nil)
@@ -38,6 +41,14 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 	} else {
 		state.orm = orm
 	}
+
+	ownerId, err := newOwnerId()
+	if err != nil {
+		return err
+	}
+	state.ownerId = ownerId
+	slog.Debug("Task lease owner id assigned", "owner_id", ownerId)
+
 	return nil
 }
 
@@ -52,6 +63,8 @@ func (state *PostgresState) AddTask(task models.Task) (*models.Task, error) {
 		IsRollback:       task.IsRollback,
 		RollbackTargetId: task.RollbackTargetId,
 		Validated:        task.Validated,
+		Timeout:          task.Timeout,
+		Refresh:          nullBoolFromPointer(task.Refresh),
 	}
 
 	if err := state.orm.Create(&ormTask).Error; err != nil {
@@ -250,4 +263,14 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 // GetDB exposes the connection pool so other components can share it.
 func (state *PostgresState) GetDB() *gorm.DB {
 	return state.orm
+}
+
+// nullBoolFromPointer maps an optional override onto its nullable column: an
+// omitted field stays NULL, which is distinct from an explicit false.
+func nullBoolFromPointer(value *bool) sql.NullBool {
+	if value == nil {
+		return sql.NullBool{}
+	}
+
+	return sql.NullBool{Bool: *value, Valid: true}
 }

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -400,3 +400,61 @@ func TestPostgresState_Check(t *testing.T) {
 	env := newPostgresTestEnv(t)
 	assert.True(t, env.state.Check())
 }
+
+// TestPostgresState_ResumptionFieldsPersist locks the storage contract the HA
+// handoff depends on: a replica that claims a task after its owner stopped
+// rebuilds it from the row alone, so the row must carry every setting the
+// rollout acts on. A dropped timeout silently re-deadlines the deployment; a
+// dropped refresh override silently changes how its status is read.
+func TestPostgresState_ResumptionFieldsPersist(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	t.Run("timeout and refresh overrides survive the round trip", func(t *testing.T) {
+		refresh := true
+		task := sampleTask("Overridden")
+		task.Timeout = 900
+		task.Refresh = &refresh
+		task.Validated = true
+		inserted := env.addTask(t, task)
+
+		stored := env.storedModel(t, inserted.Id)
+		assert.Equal(t, 900, stored.Timeout)
+		require.True(t, stored.Refresh.Valid)
+		assert.True(t, stored.Refresh.Bool)
+
+		resumed := stored.ConvertToResumedTask()
+		assert.Equal(t, 900, resumed.Timeout)
+		require.NotNil(t, resumed.Refresh)
+		assert.True(t, *resumed.Refresh)
+		assert.True(t, resumed.Validated)
+	})
+
+	t.Run("an omitted refresh stays null rather than becoming false", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Default"))
+
+		stored := env.storedModel(t, inserted.Id)
+		assert.Equal(t, 0, stored.Timeout)
+		assert.False(t, stored.Refresh.Valid,
+			"NULL means the instance default applies; false would force refresh off")
+		assert.Nil(t, stored.ConvertToResumedTask().Refresh)
+	})
+
+	t.Run("an explicit false is stored as false, not null", func(t *testing.T) {
+		refresh := false
+		task := sampleTask("ExplicitOff")
+		task.Refresh = &refresh
+		inserted := env.addTask(t, task)
+
+		stored := env.storedModel(t, inserted.Id)
+		require.True(t, stored.Refresh.Valid)
+		assert.False(t, stored.Refresh.Bool)
+	})
+
+	t.Run("a fresh task is unowned until a replica claims it", func(t *testing.T) {
+		inserted := env.addTask(t, sampleTask("Unowned"))
+
+		stored := env.storedModel(t, inserted.Id)
+		assert.False(t, stored.OwnerId.Valid)
+		assert.False(t, stored.LeaseExpiresAt.Valid)
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -62,6 +62,23 @@ type TaskRepository interface {
 	CancelInProgressTasks(app string, images []models.Image, reason string, newTaskValidated bool) (int64, error)
 	Check() bool
 	ProcessObsoleteTasks(retryTimes uint)
+
+	// ClaimTask records this instance as the one monitoring the task, for as long
+	// as it keeps renewing the claim.
+	ClaimTask(id string) error
+	// RenewLease extends this instance's claim and reports whether it still holds
+	// it. A false return means another replica took the task over, and the caller
+	// must stop without writing a status.
+	RenewLease(id string) (bool, error)
+	// ReleaseOwnedLeases expires every claim this instance holds, so the tasks it
+	// was monitoring are taken over immediately instead of after the lease lapses,
+	// and reports how many were given up.
+	ReleaseOwnedLeases() (int64, error)
+	// ClaimExpiredTasks takes over up to limit in-progress tasks whose lease has
+	// lapsed, and returns them ready to be monitored again. The returned tasks
+	// carry the authority and overrides the rollout acts on, which the API-facing
+	// tasks deliberately do not.
+	ClaimExpiredTasks(limit int) ([]models.Task, error)
 }
 
 // NewState returns a task repository for the configured StateType, already connected.

--- a/internal/state/state_models/task_model.go
+++ b/internal/state/state_models/task_model.go
@@ -24,17 +24,29 @@ type TaskModel struct {
 	// Validated is persisted because CancelInProgressTasks weighs it against the
 	// superseding task, which may be handled by another replica.
 	Validated bool `gorm:"column:validated;not null;default:false;"`
+	// Timeout is the per-task rollout deadline in seconds, 0 when the client did
+	// not override the instance default. Persisted so a task resumed by another
+	// replica keeps the deadline it was accepted with.
+	Timeout int `gorm:"column:timeout;not null;default:0;"`
+	// Refresh optionally overrides the instance-wide ARGO_REFRESH_APP setting.
+	// NULL means the client omitted it, which is distinct from an explicit false.
+	Refresh sql.NullBool `gorm:"column:refresh;"`
+	// OwnerId names the replica currently monitoring this task, and
+	// LeaseExpiresAt is the instant its claim lapses. A row whose lease has
+	// expired is available for another replica to claim and resume.
+	OwnerId        sql.NullString `gorm:"column:owner_id;"`
+	LeaseExpiresAt sql.NullTime   `gorm:"column:lease_expires_at;"`
 }
 
 func (TaskModel) TableName() string {
 	return "tasks"
 }
 
-// ConvertToExternalTask maps the row onto the API-facing task. Validated is
-// deliberately not mapped: nothing re-reads a task to decide its write-back today
-// (WaitForRollout is fed the in-process task from addTask). A future task-resumption
-// path — HA handoff — MUST map it, or a resumed task reads as uncredentialed and
-// UpdateIfNeeded skips its write-back silently.
+// ConvertToExternalTask maps the row onto the API-facing task. The fields that
+// grant authority or steer the rollout — Validated, Timeout, Refresh — are
+// deliberately left out: this task is served to clients and re-read for status
+// checks, neither of which may act on them. Resuming a rollout needs them, and
+// uses ConvertToResumedTask instead.
 func (ormTask *TaskModel) ConvertToExternalTask() *models.Task {
 	return &models.Task{
 		Id:               ormTask.Id.String(),
@@ -49,4 +61,22 @@ func (ormTask *TaskModel) ConvertToExternalTask() *models.Task {
 		IsRollback:       ormTask.IsRollback,
 		RollbackTargetId: ormTask.RollbackTargetId,
 	}
+}
+
+// ConvertToResumedTask maps the row onto a task ready to be monitored again by a
+// replica that claimed it after its previous owner stopped. Unlike
+// ConvertToExternalTask it carries the fields the rollout acts on: Validated,
+// without which UpdateIfNeeded would silently skip the git write-back; and the
+// Timeout and Refresh overrides the deployment was accepted with, which would
+// otherwise fall back to this replica's defaults.
+func (ormTask *TaskModel) ConvertToResumedTask() *models.Task {
+	task := ormTask.ConvertToExternalTask()
+	task.Validated = ormTask.Validated
+	task.Timeout = ormTask.Timeout
+	if ormTask.Refresh.Valid {
+		refresh := ormTask.Refresh.Bool
+		task.Refresh = &refresh
+	}
+
+	return task
 }

--- a/internal/state/state_models/task_model_test.go
+++ b/internal/state/state_models/task_model_test.go
@@ -1,0 +1,69 @@
+package state_models
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+func storedTask() TaskModel {
+	return TaskModel{
+		Id:              uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+		Created:         time.Unix(1700000000, 0),
+		Updated:         time.Unix(1700000060, 0),
+		Images:          datatypes.NewJSONSlice([]models.Image{{Image: "app", Tag: "v1"}}),
+		Status:          models.StatusInProgressMessage,
+		ApplicationName: sql.NullString{String: "app", Valid: true},
+		Author:          sql.NullString{String: "author", Valid: true},
+		Project:         sql.NullString{String: "project", Valid: true},
+		Validated:       true,
+		Timeout:         900,
+		Refresh:         sql.NullBool{Bool: true, Valid: true},
+	}
+}
+
+func TestConvertToExternalTask_WithholdsAuthority(t *testing.T) {
+	stored := storedTask()
+	external := stored.ConvertToExternalTask()
+
+	assert.False(t, external.Validated,
+		"the API-facing task must not claim authority it cannot prove")
+	// Timeout and Refresh steer the rollout, so folding them into the base
+	// converter would hand them to every re-read and to API clients.
+	assert.Zero(t, external.Timeout)
+	assert.Nil(t, external.Refresh)
+	assert.Equal(t, "app", external.App)
+	assert.Equal(t, models.StatusInProgressMessage, external.Status)
+}
+
+func TestConvertToResumedTask_CarriesEverythingTheRolloutNeeds(t *testing.T) {
+	stored := storedTask()
+	resumed := stored.ConvertToResumedTask()
+
+	require.NotNil(t, resumed)
+	assert.True(t, resumed.Validated,
+		"a resumed task that loses Validated has its git write-back skipped silently")
+	assert.Equal(t, 900, resumed.Timeout,
+		"a resumed task must keep its per-task deadline, not fall back to the instance default")
+	require.NotNil(t, resumed.Refresh)
+	assert.True(t, *resumed.Refresh)
+	assert.Equal(t, "app", resumed.App)
+	assert.Equal(t, []models.Image{{Image: "app", Tag: "v1"}}, []models.Image(resumed.Images))
+}
+
+func TestConvertToResumedTask_OmittedRefreshStaysNil(t *testing.T) {
+	stored := storedTask()
+	stored.Refresh = sql.NullBool{}
+
+	resumed := stored.ConvertToResumedTask()
+
+	assert.Nil(t, resumed.Refresh,
+		"a NULL refresh means the client never overrode it, so the instance default applies")
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
     - Overview: 'operations/index.md'
     - Observability: 'operations/observability.md'
     - Database: 'operations/database.md'
+    - High Availability: 'operations/high-availability.md'
     - Troubleshooting: 'operations/troubleshooting.md'
   - Contributing:
     - Overview: 'contributing/index.md'


### PR DESCRIPTION
Closes #152.

Each in-progress task carries a Postgres lease naming the replica monitoring it. A replica that stops mid-rollout has its deployments claimed and finished by another instead of sitting in progress until the hourly stale sweep aborts them — measured at 11s after a graceful shutdown, 41s after a SIGKILL.

Notable:

- A resumed task keeps the window it was accepted with, measured from creation, so handovers cannot extend how long a deployment polls.
- A monitor gives up its claim after a full lease without a confirmed renewal. Without that, a replica re-claims its own lapsed row under the same owner id and watches one rollout twice.
- `timeout` and `refresh` are now persisted; a resumed rollout would otherwise inherit the new owner's defaults. `ConvertToResumedTask` is the only mapper that reads `validated` back out.
- `STATE_TYPE=in-memory` is unchanged and stays single-replica. No new env vars, no API changes.

On the upgrade itself, deployments already in flight carry no lease, so one may briefly be watched by both an old and a new replica and reported twice. No duplicate commit — a write-back whose tag is already committed is skipped.

Not included, deliberately: the per-instance concurrency cap and a multi-replica e2e lab phase.