### PR TITLE
feat(server): prune deployment history past a retention window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the client was pointed at. A client from this release on also logs one warning naming
   both hosts when that happens, rather than dropping the credential silently.
 
+- Deployment history in PostgreSQL can now be pruned automatically. Setting
+  `TASK_RETENTION_ENABLED=true` deletes finished tasks created longer ago than
+  `TASK_RETENTION_DAYS` (365 by default, accepted between 1 and 36500); a window outside
+  that range fails startup naming the setting rather than erroring once an hour inside
+  the sweep. Until now every task was kept forever and trimming the table meant doing it
+  by hand, so the feature is off by default and deletion is irreversible — take a dump
+  before the first sweep if the history is an audit record.
+
+  The purge runs with the existing hourly obsolete-task sweep and needs no migration, so
+  replicas on either version coexist during a rolling upgrade. Rows go in batches of
+  1 000, which keeps the first pass over years of history off the table's locks. A task
+  still in progress when the delete runs is never removed — one may be actively monitored
+  by a replica — though the same pass first marks in-progress tasks older than an hour as
+  aborted, which makes a long-abandoned rollout eligible within that pass. The setting
+  applies to `STATE_TYPE=postgres` only; with the in-memory backend it is inert and the
+  server says so at startup.
+
 ### Changed
 
 - The HTTP server now routes with `chi` instead of `gin`. Endpoints, status codes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The purge runs with the existing hourly obsolete-task sweep and needs no migration, so
   replicas on either version coexist during a rolling upgrade. Rows go in batches of
   1 000, which keeps the first pass over years of history off the table's locks. A task
-  still in progress when the delete runs is never removed — one may be actively monitored
-  by a replica — though the same pass first marks in-progress tasks older than an hour as
-  aborted, which makes a long-abandoned rollout eligible within that pass. The setting
-  applies to `STATE_TYPE=postgres` only; with the in-memory backend it is inert and the
-  server says so at startup.
+  still in progress is never removed, nor is one under an unexpired lease whatever its
+  status: the same pass marks in-progress tasks older than an hour as aborted, and without
+  that second guard a rollout a replica claimed and resumed after an outage would be
+  deleted while it was still being finished. Such a task is collected by a later sweep,
+  once its lease lapses. The setting applies to `STATE_TYPE=postgres` only; with the
+  in-memory backend it is inert and the server says so at startup.
 
 ### Changed
 

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -97,7 +97,7 @@ The `tasks` table grows linearly with the number of deployments. Each row is sma
 
 By default every task is kept forever. Setting `TASK_RETENTION_ENABLED=true` turns on a sweep that deletes finished tasks created longer ago than `TASK_RETENTION_DAYS` (365 by default, between 1 and 36500). It runs with the hourly obsolete-task sweep, in batches of 1 000 rows, so enabling it on a table holding years of history does not lock the table for the duration.
 
-A task that is still in progress when the sweep runs is never deleted — one may be actively monitored by a replica. Note that the same pass first marks in-progress tasks older than an hour as `aborted`, so a rollout abandoned long enough is aborted and then removed by the one sweep. The setting only applies to `STATE_TYPE=postgres`; with the in-memory backend it is inert and the server logs a warning at startup.
+Two kinds of task are never deleted, however old. One still in progress, since a replica may be monitoring it. And one under an unexpired lease, whatever its status — the same pass first marks in-progress tasks older than an hour as `aborted`, so without that guard a rollout a replica claimed and resumed after an outage would be deleted while it was still being finished. Such a task is collected by a later sweep, once its lease lapses. The setting only applies to `STATE_TYPE=postgres`; with the in-memory backend it is inert and the server logs a warning at startup.
 
 !!! warning
     Deleted history is gone: the rows back the Web UI's task list and any audit trail you keep. Take a dump before the first sweep, and if the deployment history is an audit record, set the window to match your retention policy rather than leaving the default.

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -93,7 +93,14 @@ The `tasks` table grows linearly with the number of deployments. Each row is sma
 | 1 000 | ~365 K | ~200 MB |
 | 10 000 | ~3.7 M | ~2 GB |
 
-If the table grows past a few million rows and the Web UI feels slow, consider archiving rows older than your retention window into a separate table. There is no built-in retention job today.
+## Retention
+
+By default every task is kept forever. Setting `TASK_RETENTION_ENABLED=true` turns on a sweep that deletes finished tasks created longer ago than `TASK_RETENTION_DAYS` (365 by default, between 1 and 36500). It runs with the hourly obsolete-task sweep, in batches of 1 000 rows, so enabling it on a table holding years of history does not lock the table for the duration.
+
+A task that is still in progress when the sweep runs is never deleted — one may be actively monitored by a replica. Note that the same pass first marks in-progress tasks older than an hour as `aborted`, so a rollout abandoned long enough is aborted and then removed by the one sweep. The setting only applies to `STATE_TYPE=postgres`; with the in-memory backend it is inert and the server logs a warning at startup.
+
+!!! warning
+    Deleted history is gone: the rows back the Web UI's task list and any audit trail you keep. Take a dump before the first sweep, and if the deployment history is an audit record, set the window to match your retention policy rather than leaving the default.
 
 ## Where to look next
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -3,6 +3,6 @@
 Maintain and troubleshoot Argo Watcher in production.
 
 - **[Observability](observability.md)** — Prometheus metrics, suggested alerts, and an example Grafana dashboard.
-- **[Database](database.md)** — Schema, migrations, backups, and sizing guidance.
+- **[Database](database.md)** — Schema, migrations, backups, sizing, and retention.
 - **[High Availability](high-availability.md)** — Running multiple replicas: what is shared, how a deployment is handed over when a replica stops, and the known limits.
 - **[Troubleshooting](troubleshooting.md)** — Symptom-driven runbook for common issues.

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -58,8 +58,12 @@ Enabling OIDC also makes the Web UI's read endpoints require a credential — se
 | `LOCKDOWN_SCHEDULE` | Recurring deploy freeze, e.g. `Fri 20:00 - Mon 08:00` | | No |
 | `WEBHOOK_ENABLED` | Enable webhook notifications | `false` | No |
 | `MATTERMOST_ENABLED` | Enable Mattermost notifications | `false` | No |
+| `TASK_RETENTION_ENABLED` | Delete finished tasks older than the retention window | `false` | No |
+| `TASK_RETENTION_DAYS` | Retention window in days (1–36500) | `365` | No |
 
 The remaining `WEBHOOK_*` and `MATTERMOST_*` variables are documented in [Notifications](../guides/notifications.md); the schedule format in [Deployment Lock](../guides/deployment-lock.md).
+
+Retention deletes deployment history permanently and only applies to `STATE_TYPE=postgres` — see [Retention](../operations/database.md#retention).
 
 ## Database
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,12 @@ import (
 	"github.com/shini4i/argo-watcher/internal/helpers"
 )
 
+// maxTaskRetentionDays is the longest accepted retention window, a century. It
+// exists to reject a mistyped value at startup: a window long enough to push the
+// cutoff outside the timestamp range Postgres can represent fails inside the
+// sweep instead, once an hour, without naming the setting at fault.
+const maxTaskRetentionDays = 36500
+
 // OIDCConfig holds the settings for the generic OIDC authentication provider.
 // IssuerURL is the provider's issuer (e.g. "https://kc/realms/foo" for Keycloak
 // or "https://authentik/application/o/argo-watcher/" for Authentik); the backend
@@ -103,6 +109,12 @@ type ServerConfig struct {
 	DevEnvironment     bool             `env:"DEV_ENVIRONMENT" envDefault:"false" json:"devEnvironment"` // Whether a set of dev specific setting should be turned on, do not touch unless you know what you are doing
 	ArgoApiRetries     uint             `env:"ARGO_API_RETRIES" envDefault:"3" json:"argo_api_retries"`  // Total attempts (including initial); passed to retry.Attempts()
 	RepoCachePath      string           `env:"REPO_CACHE_PATH" envDefault:"/data" json:"-"`
+	// TaskRetentionEnabled turns on the periodic removal of finished tasks older
+	// than TaskRetentionDays, and TaskRetentionDays is that window in days. Both
+	// only apply to the postgres state; in-memory tasks live no longer than the
+	// process. Deleting deployment history is irreversible, so it is opt-in.
+	TaskRetentionEnabled bool `env:"TASK_RETENTION_ENABLED" envDefault:"false" json:"-"`
+	TaskRetentionDays    int  `env:"TASK_RETENTION_DAYS" envDefault:"365" json:"-"`
 }
 
 // MarshalJSON emits the OIDC block under both the canonical "oidc" key and a
@@ -244,6 +256,12 @@ func NewServerConfig() (*ServerConfig, error) {
 		return nil, err
 	}
 
+	// Retention prunes rows from the tasks table, which the in-memory state does
+	// not have. Warning beats failing: the setting is inert, not contradictory.
+	if config.TaskRetentionEnabled && config.StateType != "postgres" {
+		slog.Warn("TASK_RETENTION_ENABLED has no effect with STATE_TYPE=in-memory; task history is only persisted by the postgres state.")
+	}
+
 	// Enforce the connect timeout even when DB_DSN is supplied explicitly (which
 	// bypasses the default template), so an unreachable Postgres always fails fast
 	// instead of blocking on the OS TCP timeout.
@@ -303,6 +321,14 @@ func validateServerConfig(config *ServerConfig) error {
 	// reads as though it were closed.
 	if config.OIDC.RequireTaskReadAuth && !config.OIDC.Enabled {
 		problems = append(problems, "  - OIDC.RequireTaskReadAuth: OIDC_REQUIRE_TASK_READ_AUTH requires OIDC_ENABLED=true; with OIDC disabled no read endpoint is protected")
+	}
+	// A non-positive window puts the cutoff at or after now, so the first sweep
+	// would delete the entire deployment history. Beyond a century the cutoff
+	// falls outside the range Postgres can represent and every sweep fails, which
+	// would surface as an hourly error rather than as a bad setting. Only checked
+	// when retention is on: with the toggle off the value is inert.
+	if config.TaskRetentionEnabled && (config.TaskRetentionDays < 1 || config.TaskRetentionDays > maxTaskRetentionDays) {
+		problems = append(problems, fmt.Sprintf("  - TaskRetentionDays: must be between 1 and %d days, got %d", maxTaskRetentionDays, config.TaskRetentionDays))
 	}
 
 	if len(problems) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,6 +288,23 @@ func ensureConnectTimeout(dsn string, timeout int) string {
 	return fmt.Sprintf("%s connect_timeout=%d", dsn, timeout)
 }
 
+// taskRetentionProblems reports what makes the retention window unusable, or
+// nothing when retention is off — with the toggle disabled the window is inert.
+//
+// A non-positive window puts the cutoff at or after now, so the first sweep
+// would delete the entire deployment history. Beyond a century the cutoff falls
+// outside the range Postgres can represent and every sweep fails, which would
+// surface as an hourly error rather than as a bad setting.
+func taskRetentionProblems(config *ServerConfig) []string {
+	if !config.TaskRetentionEnabled {
+		return nil
+	}
+	if config.TaskRetentionDays < 1 || config.TaskRetentionDays > maxTaskRetentionDays {
+		return []string{fmt.Sprintf("  - TaskRetentionDays: must be between 1 and %d days, got %d", maxTaskRetentionDays, config.TaskRetentionDays)}
+	}
+	return nil
+}
+
 // validateServerConfig checks the semantic rules that env parsing cannot
 // express (allowed enum values, numeric ranges). It reports every violation in
 // one grouped message — mirroring helpers.PrettifyEnvError — so an operator can
@@ -322,14 +339,7 @@ func validateServerConfig(config *ServerConfig) error {
 	if config.OIDC.RequireTaskReadAuth && !config.OIDC.Enabled {
 		problems = append(problems, "  - OIDC.RequireTaskReadAuth: OIDC_REQUIRE_TASK_READ_AUTH requires OIDC_ENABLED=true; with OIDC disabled no read endpoint is protected")
 	}
-	// A non-positive window puts the cutoff at or after now, so the first sweep
-	// would delete the entire deployment history. Beyond a century the cutoff
-	// falls outside the range Postgres can represent and every sweep fails, which
-	// would surface as an hourly error rather than as a bad setting. Only checked
-	// when retention is on: with the toggle off the value is inert.
-	if config.TaskRetentionEnabled && (config.TaskRetentionDays < 1 || config.TaskRetentionDays > maxTaskRetentionDays) {
-		problems = append(problems, fmt.Sprintf("  - TaskRetentionDays: must be between 1 and %d days, got %d", maxTaskRetentionDays, config.TaskRetentionDays))
-	}
+	problems = append(problems, taskRetentionProblems(config)...)
 
 	if len(problems) == 0 {
 		return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -533,4 +534,117 @@ func TestServerConfig_DefaultValidationInterval(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 300000, cfg.OIDC.TokenValidationInterval)
+}
+
+func TestNewServerConfig_TaskRetention(t *testing.T) {
+	baseEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+	}
+
+	t.Run("defaults to off with a one year window", func(t *testing.T) {
+		baseEnv(t)
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.False(t, cfg.TaskRetentionEnabled)
+		assert.Equal(t, 365, cfg.TaskRetentionDays)
+	})
+
+	t.Run("custom window accepted", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("TASK_RETENTION_ENABLED", "true")
+		t.Setenv("TASK_RETENTION_DAYS", "30")
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.True(t, cfg.TaskRetentionEnabled)
+		assert.Equal(t, 30, cfg.TaskRetentionDays)
+	})
+
+	// A zero or negative window would put the cutoff at or after now, deleting the
+	// entire deployment history on the next sweep.
+	t.Run("non-positive window rejected when enabled", func(t *testing.T) {
+		for _, days := range []string{"0", "-1"} {
+			t.Run(days, func(t *testing.T) {
+				baseEnv(t)
+				t.Setenv("TASK_RETENTION_ENABLED", "true")
+				t.Setenv("TASK_RETENTION_DAYS", days)
+
+				_, err := NewServerConfig()
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "TaskRetentionDays")
+				assert.Contains(t, err.Error(), "must be between 1 and 36500 days")
+			})
+		}
+	})
+
+	// A window long enough to push the cutoff outside the range Postgres can
+	// represent fails inside the hourly sweep, where it names no setting.
+	t.Run("window beyond a century rejected when enabled", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("TASK_RETENTION_ENABLED", "true")
+		t.Setenv("TASK_RETENTION_DAYS", "36501")
+
+		_, err := NewServerConfig()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TaskRetentionDays")
+		assert.Contains(t, err.Error(), "got 36501")
+	})
+
+	t.Run("a century is accepted", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("TASK_RETENTION_ENABLED", "true")
+		t.Setenv("TASK_RETENTION_DAYS", "36500")
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.Equal(t, 36500, cfg.TaskRetentionDays)
+	})
+
+	// With the toggle off nothing is ever deleted, so the window is inert and must
+	// not keep a server from starting.
+	t.Run("non-positive window ignored when disabled", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("TASK_RETENTION_DAYS", "0")
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.False(t, cfg.TaskRetentionEnabled)
+	})
+
+	// In-memory tasks die with the process, so retention has nothing to do there.
+	// It is inert rather than contradictory, so it warns instead of failing startup.
+	t.Run("accepted with in-memory state", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("STATE_TYPE", "in-memory")
+		t.Setenv("TASK_RETENTION_ENABLED", "true")
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.True(t, cfg.TaskRetentionEnabled)
+	})
+}
+
+// The retention settings are server-side only: /api/v1/config is unauthenticated
+// and no consumer reads them. Dropping the json:"-" tags would expose them under
+// a Go-derived key such as TaskRetentionDays, so the check is by key substring
+// and by value rather than by the snake_case name they would never carry.
+func TestServerConfig_TaskRetentionNotExposed(t *testing.T) {
+	cfg := &ServerConfig{TaskRetentionEnabled: true, TaskRetentionDays: 4242}
+
+	jsonBytes, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.NotContains(t, strings.ToLower(string(jsonBytes)), "retention")
+	assert.NotContains(t, string(jsonBytes), "4242", "the window must not leak under a renamed key either")
 }

--- a/internal/state/lease_postgres_test.go
+++ b/internal/state/lease_postgres_test.go
@@ -18,7 +18,15 @@ func (env *postgresTestEnv) secondReplica(t *testing.T) *PostgresState {
 	ownerId, err := newOwnerId()
 	require.NoError(t, err)
 
-	return &PostgresState{orm: env.state.orm, ownerId: ownerId}
+	// Retention is copied from the environment: replicas of one deployment run the
+	// same configuration, and a second replica left with it off would let a
+	// concurrency test pass without ever sweeping.
+	return &PostgresState{
+		orm:              env.state.orm,
+		ownerId:          ownerId,
+		retentionEnabled: env.state.retentionEnabled,
+		retentionDays:    env.state.retentionDays,
+	}
 }
 
 // expireLease backdates a task's lease so a sweep treats it as abandoned,

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -313,7 +313,10 @@ func (state *PostgresState) deleteExpiredTasks() error {
 				FOR UPDATE SKIP LOCKED
 			)`, state.retentionDays, models.StatusInProgressMessage, retentionDeleteBatchSize)
 		if result.Error != nil {
-			return result.Error
+			// Named because the sweep runs three steps and reports their failures
+			// through one log line, where a bare driver error says nothing about which
+			// step produced it.
+			return fmt.Errorf("deleting tasks past the %d day retention window: %w", state.retentionDays, result.Error)
 		}
 
 		deleted += result.RowsAffected

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -21,11 +21,20 @@ import (
 
 const whereStatusEquals = "status = ?"
 
+// retentionDeleteBatchSize is how many expired tasks one DELETE removes. It
+// keeps each statement short enough not to hold locks or grow a transaction for
+// long, while still draining a large backlog in few enough round trips.
+const retentionDeleteBatchSize = 1000
+
 type PostgresState struct {
 	orm *gorm.DB
 	// ownerId identifies this process as the holder of task leases. It is unique
 	// per process, so a restarted pod never inherits its predecessor's claims.
 	ownerId string
+	// retentionEnabled and retentionDays configure the removal of finished tasks
+	// older than the window, performed by the obsolete-task sweep.
+	retentionEnabled bool
+	retentionDays    int
 }
 
 var _ TaskRepository = (*PostgresState)(nil)
@@ -48,6 +57,12 @@ func (state *PostgresState) Connect(serverConfig *config.ServerConfig) error {
 	}
 	state.ownerId = ownerId
 	slog.Debug("Task lease owner id assigned", "owner_id", ownerId)
+
+	state.retentionEnabled = serverConfig.TaskRetentionEnabled
+	state.retentionDays = serverConfig.TaskRetentionDays
+	if state.retentionEnabled {
+		slog.Info("Task retention is enabled", "retention_days", state.retentionDays)
+	}
 
 	return nil
 }
@@ -255,6 +270,60 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 		StatusReason: sql.NullString{String: StaleTaskAbortReason, Valid: true},
 	}).Error; err != nil {
 		return err
+	}
+
+	// Runs last so a task this same pass aborted for staleness is already eligible,
+	// which only matters for a retention window short enough to overlap it.
+	if err := state.deleteExpiredTasks(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deleteExpiredTasks removes finished tasks created longer ago than the
+// retention window, and does nothing when retention is disabled.
+//
+// Rows are deleted in batches instead of one statement: the first sweep after
+// enabling retention can face a table holding every deployment ever made, and a
+// single DELETE over it would hold row locks and bloat one transaction for as
+// long as it ran. SKIP LOCKED lets replicas sweeping concurrently step over each
+// other's batches rather than queue behind them.
+//
+// In-progress tasks are never deleted, whatever their age: one may be claimed
+// and actively monitored by a replica, which would then write a status for a row
+// that no longer exists.
+func (state *PostgresState) deleteExpiredTasks() error {
+	if !state.retentionEnabled {
+		return nil
+	}
+
+	slog.Debug("Removing tasks older than the retention window...", "retention_days", state.retentionDays)
+
+	var deleted int64
+	for {
+		result := state.orm.Exec(`
+			DELETE FROM tasks
+			WHERE id IN (
+				SELECT id FROM tasks
+				WHERE created < now() - make_interval(days => ?)
+					AND status <> ?
+				ORDER BY created
+				LIMIT ?
+				FOR UPDATE SKIP LOCKED
+			)`, state.retentionDays, models.StatusInProgressMessage, retentionDeleteBatchSize)
+		if result.Error != nil {
+			return result.Error
+		}
+
+		deleted += result.RowsAffected
+		if result.RowsAffected < retentionDeleteBatchSize {
+			break
+		}
+	}
+
+	if deleted > 0 {
+		slog.Info("Removed tasks older than the retention window", "count", deleted, "retention_days", state.retentionDays)
 	}
 
 	return nil

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -290,9 +290,14 @@ func (state *PostgresState) doProcessPostgresObsoleteTasks() error {
 // long as it ran. SKIP LOCKED lets replicas sweeping concurrently step over each
 // other's batches rather than queue behind them.
 //
-// In-progress tasks are never deleted, whatever their age: one may be claimed
-// and actively monitored by a replica, which would then write a status for a row
-// that no longer exists.
+// Two kinds of row are spared whatever their age. In-progress tasks, because one
+// may be claimed and actively monitored by a replica, which would then write a
+// status for a row that no longer exists. And any task still under an unexpired
+// lease, whatever its status: the sweep marks in-progress tasks older than an
+// hour as aborted before this step runs, so a rollout a replica claimed and
+// resumed after an outage — its creation timestamp old, its lease live — would
+// otherwise be aborted and deleted out from under the replica finishing it. Once
+// the lease lapses the row is collected by a later sweep.
 func (state *PostgresState) deleteExpiredTasks() error {
 	if !state.retentionEnabled {
 		return nil
@@ -308,6 +313,7 @@ func (state *PostgresState) deleteExpiredTasks() error {
 				SELECT id FROM tasks
 				WHERE created < now() - make_interval(days => ?)
 					AND status <> ?
+					AND (lease_expires_at IS NULL OR lease_expires_at <= now())
 				ORDER BY created
 				LIMIT ?
 				FOR UPDATE SKIP LOCKED

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"os"
 	"sync"
 	"testing"
@@ -647,4 +648,24 @@ func TestPostgresState_TaskRetentionConcurrentSweeps(t *testing.T) {
 	// A row one sweeper skipped was locked by another that deletes it before
 	// returning, so nothing survives all four.
 	assert.Zero(t, env.taskCount(t), "concurrent sweeps must between them remove every expired task")
+}
+
+// The sweep funnels three steps into one "Couldn't process obsolete tasks" log
+// line, so the prefix is how an operator tells a failed retention pass from the
+// app-not-found delete or the stale-abort update. Only the prefix is asserted:
+// the driver's own wording is internal to database/sql and has no stable
+// sentinel to match on.
+func TestPostgresState_TaskRetentionSweepErrorNamesTheStep(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+	env.addAgedTask(t, "Expired", models.StatusDeployedMessage, 31*day)
+
+	sqlDB, err := env.state.orm.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	err = env.state.deleteExpiredTasks()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "deleting tasks past the 30 day retention window")
+	assert.NotNil(t, errors.Unwrap(err), "the driver cause must stay wrapped with %w")
 }

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,8 +19,10 @@ type postgresTestEnv struct {
 	state *PostgresState
 }
 
-// Skips the test automatically when no Postgres configuration is present.
-func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
+// Skips the test automatically when no Postgres configuration is present. Each
+// option adjusts the server config the state connects with, so settings the
+// state reads at connection time are exercised the way the server sets them.
+func newPostgresTestEnv(t *testing.T, opts ...func(*config.ServerConfig)) *postgresTestEnv {
 	t.Helper()
 
 	if os.Getenv("DB_DSN") == "" && os.Getenv("DB_HOST") == "" {
@@ -32,6 +35,9 @@ func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
 	testConfig := &config.ServerConfig{
 		StateType: "postgres",
 		Db:        databaseConfig,
+	}
+	for _, opt := range opts {
+		opt(testConfig)
 	}
 
 	env := &postgresTestEnv{state: &PostgresState{}}
@@ -457,4 +463,188 @@ func TestPostgresState_ResumptionFieldsPersist(t *testing.T) {
 		assert.False(t, stored.OwnerId.Valid)
 		assert.False(t, stored.LeaseExpiresAt.Valid)
 	})
+}
+
+// withRetention configures the task retention window for a test environment.
+func withRetention(days int) func(*config.ServerConfig) {
+	return func(cfg *config.ServerConfig) {
+		cfg.TaskRetentionEnabled = true
+		cfg.TaskRetentionDays = days
+	}
+}
+
+// addAgedTask stores a task and backdates it to the given age with the given
+// status. Both columns are set by the database on insert, so a test that needs
+// history has to rewrite them.
+func (env *postgresTestEnv) addAgedTask(t *testing.T, app, status string, age time.Duration) *models.Task {
+	t.Helper()
+	task := env.addTask(t, sampleTask(app))
+	require.NoError(t, env.state.orm.Exec(
+		"UPDATE tasks SET status = ?, created = now() - make_interval(secs => ?) WHERE id = ?",
+		status, age.Seconds(), task.Id).Error)
+	return task
+}
+
+func (env *postgresTestEnv) taskExists(t *testing.T, id string) bool {
+	t.Helper()
+	var count int64
+	require.NoError(t, env.state.orm.Model(&state_models.TaskModel{}).Where("id = ?", id).Count(&count).Error)
+	return count > 0
+}
+
+func (env *postgresTestEnv) taskCount(t *testing.T) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, env.state.orm.Model(&state_models.TaskModel{}).Count(&count).Error)
+	return count
+}
+
+const day = 24 * time.Hour
+
+// Deleting deployment history is irreversible, so nothing may be removed unless
+// the operator turned retention on.
+func TestPostgresState_TaskRetentionDisabled(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	ancient := env.addAgedTask(t, "Ancient", models.StatusDeployedMessage, 3650*day)
+
+	require.NoError(t, env.state.deleteExpiredTasks())
+
+	assert.True(t, env.taskExists(t, ancient.Id),
+		"retention is off, so no task may be deleted regardless of age")
+}
+
+func TestPostgresState_TaskRetention(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	expired := env.addAgedTask(t, "Expired", models.StatusDeployedMessage, 31*day)
+	expiredFailed := env.addAgedTask(t, "ExpiredFailed", models.StatusFailedMessage, 400*day)
+	recent := env.addAgedTask(t, "Recent", models.StatusDeployedMessage, 29*day)
+	// An in-progress task may be claimed and actively monitored by a replica,
+	// which would then write a status for a row that no longer exists.
+	stuck := env.addAgedTask(t, "Stuck", models.StatusInProgressMessage, 400*day)
+
+	require.NoError(t, env.state.deleteExpiredTasks())
+
+	assert.False(t, env.taskExists(t, expired.Id))
+	assert.False(t, env.taskExists(t, expiredFailed.Id))
+	assert.True(t, env.taskExists(t, recent.Id), "a task inside the window must be kept")
+	assert.True(t, env.taskExists(t, stuck.Id), "an in-progress task must never be deleted")
+}
+
+// The first sweep after enabling retention can face a table holding every
+// deployment ever made, which is deleted in batches rather than one statement.
+func TestPostgresState_TaskRetentionDrainsBacklogLargerThanOneBatch(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	backlog := retentionDeleteBatchSize + 500
+	require.NoError(t, env.state.orm.Exec(`
+		INSERT INTO tasks (created, updated, images, status, app, author, project)
+		SELECT now() - make_interval(days => 400), now(), '[]'::jsonb, ?, 'Backlog', 'author', 'project'
+		FROM generate_series(1, ?)`, models.StatusDeployedMessage, backlog).Error)
+	require.Equal(t, int64(backlog), env.taskCount(t))
+
+	require.NoError(t, env.state.deleteExpiredTasks())
+
+	assert.Zero(t, env.taskCount(t), "every expired task must be removed, not just the first batch")
+}
+
+// Retention is driven by the hourly obsolete-task sweep, not by a loop of its own.
+func TestPostgresState_TaskRetentionRunsWithinObsoleteSweep(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	expired := env.addAgedTask(t, "Expired", models.StatusDeployedMessage, 400*day)
+	recent := env.addAgedTask(t, "Recent", models.StatusDeployedMessage, time.Hour)
+
+	env.state.ProcessObsoleteTasks(1)
+
+	assert.False(t, env.taskExists(t, expired.Id))
+	assert.True(t, env.taskExists(t, recent.Id))
+}
+
+// The window is the one piece of arithmetic that decides what is destroyed, so
+// it is pinned at the tightest legal setting rather than a day either side of a
+// month, where an off-by-one would land within microseconds of the boundary.
+func TestPostgresState_TaskRetentionWindowBoundary(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(1))
+
+	past := env.addAgedTask(t, "JustPast", models.StatusDeployedMessage, 24*time.Hour+time.Minute)
+	inside := env.addAgedTask(t, "JustInside", models.StatusDeployedMessage, 24*time.Hour-time.Minute)
+
+	require.NoError(t, env.state.deleteExpiredTasks())
+
+	assert.False(t, env.taskExists(t, past.Id), "a task one minute past the window is removed")
+	assert.True(t, env.taskExists(t, inside.Id), "a task one minute inside the window is kept")
+}
+
+// The sweep aborts in-progress tasks older than an hour before deleting expired
+// ones, so a rollout abandoned for longer than the retention window is aborted
+// and removed by the same pass. Only a task still in progress when the delete
+// runs is protected.
+func TestPostgresState_TaskRetentionRemovesTaskAbortedByTheSamePass(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	abandoned := env.addAgedTask(t, "Abandoned", models.StatusInProgressMessage, 400*day)
+	require.NoError(t, env.state.ClaimTask(abandoned.Id))
+
+	env.state.ProcessObsoleteTasks(1)
+
+	assert.False(t, env.taskExists(t, abandoned.Id),
+		"a task aborted for staleness by this pass is past the window and removed by it")
+
+	// The replica that was monitoring it must learn it no longer holds the task
+	// rather than fail: RenewLease reports ownership, and a row that is gone is a
+	// task this instance no longer owns.
+	held, err := env.state.RenewLease(abandoned.Id)
+	require.NoError(t, err)
+	assert.False(t, held)
+}
+
+// Every replica runs the sweep, so sweeps contend for the same rows — something
+// sequential tests never show. What is pinned here is the outcome: no sweep
+// fails, deadlocks, or double-counts, and between them they leave nothing
+// behind. Whether SKIP LOCKED made them step over each other or merely queue is
+// deliberately not asserted; both drain the backlog, and only the first is
+// observable under load a test cannot reproduce.
+func TestPostgresState_TaskRetentionConcurrentSweeps(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	const expired = 2500
+	require.NoError(t, env.state.orm.Exec(`
+		INSERT INTO tasks (created, updated, images, status, app, author, project)
+		SELECT now() - make_interval(days => 400), now(), '[]'::jsonb, ?, 'Raced', 'author', 'project'
+		FROM generate_series(1, ?)`, models.StatusDeployedMessage, expired).Error)
+	require.Equal(t, int64(expired), env.taskCount(t))
+
+	const sweepers = 4
+	var (
+		start = make(chan struct{})
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		errs  []error
+	)
+
+	for range sweepers {
+		replica := env.secondReplica(t)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := replica.deleteExpiredTasks()
+
+			mu.Lock()
+			defer mu.Unlock()
+			errs = append(errs, err)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err, "a sweep must not fail because another was running")
+	}
+	// A row one sweeper skipped was locked by another that deletes it before
+	// returning, so nothing survives all four.
+	assert.Zero(t, env.taskCount(t), "concurrent sweeps must between them remove every expired task")
 }

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -578,27 +578,35 @@ func TestPostgresState_TaskRetentionWindowBoundary(t *testing.T) {
 	assert.True(t, env.taskExists(t, inside.Id), "a task one minute inside the window is kept")
 }
 
-// The sweep aborts in-progress tasks older than an hour before deleting expired
-// ones, so a rollout abandoned for longer than the retention window is aborted
-// and removed by the same pass. Only a task still in progress when the delete
-// runs is protected.
-func TestPostgresState_TaskRetentionRemovesTaskAbortedByTheSamePass(t *testing.T) {
+// A task the sweep aborts for staleness is past the window and collected by the
+// same pass — unless a replica still holds it. This pins the lease guard: the
+// two paths differ only in whether the claim is live.
+func TestPostgresState_TaskRetentionSparesTaskUnderActiveLease(t *testing.T) {
 	env := newPostgresTestEnv(t, withRetention(30))
 
-	abandoned := env.addAgedTask(t, "Abandoned", models.StatusInProgressMessage, 400*day)
-	require.NoError(t, env.state.ClaimTask(abandoned.Id))
+	// The HA case: a replica returning after an outage claims a rollout abandoned
+	// long ago and resumes monitoring it. Its creation timestamp is past the
+	// window and the sweep's earlier step marks it aborted for staleness, so
+	// without the lease guard this pass would delete the row the replica is still
+	// working on — leaving it unable to record the outcome.
+	resumed := env.addAgedTask(t, "Resumed", models.StatusInProgressMessage, 400*day)
+	require.NoError(t, env.state.ClaimTask(resumed.Id))
 
 	env.state.ProcessObsoleteTasks(1)
 
-	assert.False(t, env.taskExists(t, abandoned.Id),
-		"a task aborted for staleness by this pass is past the window and removed by it")
+	require.True(t, env.taskExists(t, resumed.Id),
+		"a task under an unexpired lease must survive, however old it is")
 
-	// The replica that was monitoring it must learn it no longer holds the task
-	// rather than fail: RenewLease reports ownership, and a row that is gone is a
-	// task this instance no longer owns.
-	held, err := env.state.RenewLease(abandoned.Id)
+	held, err := env.state.RenewLease(resumed.Id)
 	require.NoError(t, err)
-	assert.False(t, held)
+	assert.True(t, held, "the replica monitoring it must still hold its claim")
+
+	// Once the claim lapses the row is nobody's, and the next sweep collects it.
+	env.expireLease(t, resumed.Id)
+	require.NoError(t, env.state.deleteExpiredTasks())
+
+	assert.False(t, env.taskExists(t, resumed.Id),
+		"a lapsed lease no longer protects a task past the window")
 }
 
 // Every replica runs the sweep, so sweeps contend for the same rows — something
@@ -668,4 +676,18 @@ func TestPostgresState_TaskRetentionSweepErrorNamesTheStep(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "deleting tasks past the 30 day retention window")
 	assert.NotNil(t, errors.Unwrap(err), "the driver cause must stay wrapped with %w")
+}
+
+// The other half of the lease guard: an abandoned rollout nobody claimed is
+// aborted for staleness and collected by that same pass, which is what the
+// retention step running last buys. Only a live claim defers it.
+func TestPostgresState_TaskRetentionCollectsUnleasedTaskAbortedByTheSamePass(t *testing.T) {
+	env := newPostgresTestEnv(t, withRetention(30))
+
+	unclaimed := env.addAgedTask(t, "Unclaimed", models.StatusInProgressMessage, 400*day)
+
+	env.state.ProcessObsoleteTasks(1)
+
+	assert.False(t, env.taskExists(t, unclaimed.Id),
+		"with no replica holding it, a stale task is aborted and removed by the one sweep")
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,7 +172,7 @@ plugins:
         Operations:
           - operations/index.md: Index of operational guides.
           - operations/observability.md: Prometheus metrics, suggested alerts, and an example Grafana dashboard.
-          - operations/database.md: Schema, migrations, backups, and sizing.
+          - operations/database.md: Schema, migrations, backups, sizing, and retention.
           - operations/troubleshooting.md: Diagnosing common problems.
         Contributing:
           - contributing/index.md: How to contribute.


### PR DESCRIPTION
Adds opt-in retention for the `tasks` table: `TASK_RETENTION_ENABLED=true` deletes finished tasks older than `TASK_RETENTION_DAYS` (default 365, accepted 1–36500).

The purge runs as a step of the existing hourly obsolete-task sweep and ships no migration. A task still in progress when it runs is never deleted.