### PR TITLE
fix(observability): make the example dashboard importable and readable

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -31,6 +31,10 @@ Twelve metrics, all defined in [`internal/prometheus/metrics.go`](https://github
 !!! note "Why some series say `app="unknown"`"
     `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so a name arriving that way is labelled `unknown` rather than becoming its own series, which would let anyone reaching the endpoint create unbounded series. This affects `processed_deployments`, `unauthenticated_reads`, and `failed_deployment` when the failure precedes Argo CD confirming the application exists. Deployments submitted with a credential are labelled with their real application throughout.
 
+    A task labelled `unknown` is still attributable, because the collapse applies only at submission. Once Argo CD confirms the application exists the real name is safe to use, so `deployment_duration_seconds`, `argocd_refresh_duration_seconds` and the `gitops_*` histograms carry it whether or not the task was validated. The dashboard therefore counts per-application deployments from `deployment_duration_seconds_count`, not `processed_deployments` — the trade-off is that only deployments reaching the deployed state are counted.
+
+    An instance where most series say `unknown` is not misconfigured metrics: it means the clients posting those tasks send no credential at all. A *wrong* token is rejected with 401 and never becomes a task, so `unknown` always means "none sent". Set `ARGO_WATCHER_DEPLOY_TOKEN` (or `BEARER_TOKEN`) on the clients to get real names on `processed_deployments` too.
+
     The same openness means anyone who can reach the endpoint and knows a managed application's name can raise `gitops_writeback_skipped_unvalidated`. Treat a rise as "investigate", not automatically "our pipeline regressed".
 
 !!! note "Aggregate the gauges across replicas"

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -133,7 +133,7 @@ groups:
 
 ## Example dashboard
 
-A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps, plus two donuts splitting the selected range by outcome and by whether the submitting client was credentialled; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
+A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps, plus a donut splitting processed deployments by whether the submitting client was credentialled; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
 
 Import it through **Dashboards → New → Import** — a **Data source** picker at the top of the dashboard selects which Prometheus to query, so no datasource UID has to match. Or run it next to the dev server:
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -131,7 +131,7 @@ groups:
 
 A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
 
-Import it through **Dashboards → New → Import**, or run it next to the dev server:
+Import it through **Dashboards → New → Import** — a **Data source** picker at the top of the dashboard selects which Prometheus to query, so no datasource UID has to match. Or run it next to the dev server:
 
 ```bash
 docker compose --profile monitoring up

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -133,7 +133,7 @@ groups:
 
 ## Example dashboard
 
-A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
+A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps, plus two donuts splitting the selected range by outcome and by whether the submitting client was credentialled; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
 
 Import it through **Dashboards → New → Import** — a **Data source** picker at the top of the dashboard selects which Prometheus to query, so no datasource UID has to match. Or run it next to the dev server:
 

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -24,7 +24,21 @@
     "list": [
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
         "definition": "label_values(processed_deployments{job=\"argo-watcher\"}, app)",
         "includeAll": true,
         "allValue": ".*",
@@ -61,7 +75,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Whether ArgoCD is reachable by argo-watcher (argocd_unavailable gauge).",
       "fieldConfig": {
         "defaults": {
@@ -93,7 +107,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "max(argocd_unavailable)",
           "instant": true,
           "refId": "A"
@@ -103,7 +117,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Tasks argo-watcher is currently processing (in_progress_tasks gauge).",
       "fieldConfig": {
         "defaults": {
@@ -132,7 +146,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(in_progress_tasks)",
           "refId": "A"
         }
@@ -141,7 +155,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Total deployments processed since startup (processed_deployments counter, summed over all apps).",
       "fieldConfig": {
         "defaults": {
@@ -159,7 +173,7 @@
       "id": 3,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
@@ -168,7 +182,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(processed_deployments)",
           "refId": "A"
         }
@@ -177,7 +191,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Number of applications currently reporting one or more failed deployments before their first success (failed_deployment gauge > 0).",
       "fieldConfig": {
         "defaults": {
@@ -207,7 +221,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "count(failed_deployment > 0) or vector(0)",
           "instant": true,
           "refId": "A"
@@ -217,7 +231,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Deployments processed per application within the selected time range (increase of processed_deployments). Sort or filter by column. An application idle in the window reads 0 — widen the range to include its activity. argo-watcher is event-driven, so this is a small integer count, not a per-second rate.",
       "fieldConfig": {
         "defaults": {
@@ -251,7 +265,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "round(sum by (app) (increase(processed_deployments[$__range])))",
           "format": "table",
           "instant": true,
@@ -271,7 +285,7 @@
       "type": "table"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "In-progress tasks over time (in_progress_tasks gauge).",
       "fieldConfig": {
         "defaults": {
@@ -305,7 +319,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(in_progress_tasks)",
           "legendFormat": "in progress",
           "refId": "A"
@@ -315,7 +329,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Applications currently reporting failed deployments before first success.",
       "fieldConfig": {
         "defaults": {
@@ -348,7 +362,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "failed_deployment > 0",
           "format": "table",
           "instant": true,
@@ -368,7 +382,7 @@
       "type": "table"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Deployments per application over time (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
       "fieldConfig": {
         "defaults": {
@@ -402,7 +416,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (app) (increase(processed_deployments[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
@@ -420,7 +434,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Deployments over time for the selected application(s) (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
       "fieldConfig": {
         "defaults": {
@@ -454,7 +468,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (app) (increase(processed_deployments{app=~\"$app\"}[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
@@ -464,7 +478,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Failed deployments before first success for the selected application(s) (failed_deployment gauge).",
       "fieldConfig": {
         "defaults": {
@@ -498,7 +512,7 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "failed_deployment{app=~\"$app\"}",
           "legendFormat": "{{app}}",
           "refId": "A"
@@ -508,7 +522,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "ArgoCD application refresh latency for the selected application(s) (argocd_refresh_duration_seconds histogram quantiles).",
       "fieldConfig": {
         "defaults": {
@@ -542,19 +556,19 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.50, sum(rate(argocd_refresh_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum(rate(argocd_refresh_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.99, sum(rate(argocd_refresh_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99",
           "refId": "C"
@@ -564,7 +578,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Time the git write-back held the per-repo lock (clone/commit/push plus retries) for the selected application(s) (gitops_writeback_duration_seconds histogram quantiles). Populated only for applications using GitOps write-back (argo-watcher/managed); empty otherwise.",
       "fieldConfig": {
         "defaults": {
@@ -598,19 +612,19 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.50, sum(rate(gitops_writeback_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum(rate(gitops_writeback_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.99, sum(rate(gitops_writeback_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99",
           "refId": "C"
@@ -620,7 +634,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Time spent waiting to acquire the per-repository git write-back lock for the selected application(s) (gitops_lock_wait_duration_seconds histogram quantiles). Populated only for applications using GitOps write-back (argo-watcher/managed); empty otherwise.",
       "fieldConfig": {
         "defaults": {
@@ -654,19 +668,19 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.50, sum(rate(gitops_lock_wait_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum(rate(gitops_lock_wait_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.99, sum(rate(gitops_lock_wait_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99",
           "refId": "C"
@@ -676,7 +690,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "End-to-end duration of successful deployments for the selected application(s): from the start of rollout monitoring until the app reached the deployed state (deployment_duration_seconds histogram quantiles). Failed/aborted deployments are not counted.",
       "fieldConfig": {
         "defaults": {
@@ -710,19 +724,19 @@
       "pluginVersion": "12.3.8",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.50, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.99, sum(rate(deployment_duration_seconds_bucket{app=~\"$app\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99",
           "refId": "C"

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -372,7 +372,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Applications currently reporting failed deployments before first success. The gauge is per replica and each deployment is monitored by one of them, so this aggregates with max by (app) — the same aggregation the suggested alert rules use — rather than summing replicas that never handled the application.",
+      "description": "Applications currently reporting failed deployments before first success. The gauge is per replica and each deployment is monitored by one of them, so this aggregates with max by (app) — the same aggregation the suggested alert rules use — rather than summing replicas that never handled the application. With several replicas a recovered application can keep its row: each replica clears only its own gauge, and only when it handles a later success for that application, so a row can outlive the failure until that pod restarts.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -222,7 +222,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "count(failed_deployment > 0) or vector(0)",
+          "expr": "count(sum by (app) (failed_deployment) > 0) or vector(0)",
           "instant": true,
           "refId": "A"
         }
@@ -273,10 +273,10 @@
         }
       ],
       "transformations": [
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["app", "Value"] } } },
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "job": true, "instance": true, "__name__": true },
             "renameByName": { "app": "Application", "Value": "Deployments" }
           }
         }
@@ -363,17 +363,17 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "failed_deployment > 0",
+          "expr": "sum by (app) (failed_deployment) > 0",
           "format": "table",
           "instant": true,
           "refId": "A"
         }
       ],
       "transformations": [
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["app", "Value"] } } },
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "job": true, "instance": true, "__name__": true },
             "renameByName": { "app": "Application", "Value": "Failures" }
           }
         }
@@ -383,47 +383,53 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Deployments that reached the deployed state per application over time. Each bar is the number of successful deployments in that interval. This counts deployment_duration_seconds_count rather than processed_deployments, because that is the per-app series that carries the real application name whether or not the task was submitted with a credential.",
+      "description": "How the deployments submitted in the selected time range ended up. Both slices are increases of counters over the same window, so the ratio is meaningful: \"succeeded\" is deployment_duration_seconds_count, which only observes a deployment reaching the deployed state, and \"did not succeed\" is the rest of processed_deployments. That remainder is not only failures — it also holds aborted, cancelled and superseded tasks, plus any deployment still in flight when the window ended, so expect a small non-zero slice on a healthy instance. There is no counter of failed deployments to chart instead; failed_deployment is a gauge that resets on success.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 60,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
-          },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "succeeded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "did not succeed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
       },
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 13 },
-      "id": 8,
+      "id": 103,
       "options": {
-        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "displayLabels": ["name", "value", "percent"],
+        "legend": { "showLegend": false },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "tooltip": { "hideZeros": false, "mode": "single", "sort": "none" }
       },
       "pluginVersion": "12.3.8",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (app) (increase(deployment_duration_seconds_count[$__rate_interval]))",
-          "legendFormat": "{{app}}",
+          "expr": "round(sum(increase(deployment_duration_seconds_count[$__range])))",
+          "instant": true,
+          "legendFormat": "succeeded",
           "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "clamp_min(round(sum(increase(processed_deployments[$__range]))) - round(sum(increase(deployment_duration_seconds_count[$__range]))), 0)",
+          "instant": true,
+          "legendFormat": "did not succeed",
+          "refId": "B"
         }
       ],
-      "title": "Successful Deployment Activity (by app)",
-      "type": "timeseries"
+      "title": "Deployment Outcomes (selected range)",
+      "type": "piechart"
     },
     {
       "collapsed": false,
@@ -760,8 +766,8 @@
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 13 },
       "id": 102,
       "options": {
-        "displayLabels": ["percent"],
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "values": ["value"] },
+        "displayLabels": ["name", "value", "percent"],
+        "legend": { "showLegend": false },
         "pieType": "donut",
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "tooltip": { "hideZeros": false, "mode": "single", "sort": "none" }

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -39,7 +39,7 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
-        "definition": "label_values(processed_deployments{job=\"argo-watcher\"}, app)",
+        "definition": "label_values({__name__=~\"deployment_duration_seconds_count|failed_deployment\", job=\"argo-watcher\"}, app)",
         "includeAll": true,
         "allValue": ".*",
         "label": "Application",
@@ -48,7 +48,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(processed_deployments{job=\"argo-watcher\"}, app)",
+          "query": "label_values({__name__=~\"deployment_duration_seconds_count|failed_deployment\", job=\"argo-watcher\"}, app)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -232,7 +232,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Deployments processed per application within the selected time range (increase of processed_deployments). Sort or filter by column. An application idle in the window reads 0 — widen the range to include its activity. argo-watcher is event-driven, so this is a small integer count, not a per-second rate.",
+      "description": "Deployments that reached the deployed state per application within the selected time range (increase of deployment_duration_seconds_count). Sort or filter by column. An application idle in the window reads 0 — widen the range to include its activity. argo-watcher is event-driven, so this is a small integer count, not a per-second rate. Deployments that failed are not counted here; see Failing Applications.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "continuous-GrYlRd" },
@@ -266,7 +266,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "round(sum by (app) (increase(processed_deployments[$__range])))",
+          "expr": "round(sum by (app) (increase(deployment_duration_seconds_count[$__range])))",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -281,7 +281,7 @@
           }
         }
       ],
-      "title": "Deployments by Application (selected range)",
+      "title": "Successful Deployments by Application (selected range)",
       "type": "table"
     },
     {
@@ -330,7 +330,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Applications currently reporting failed deployments before first success.",
+      "description": "Applications currently reporting failed deployments before first success. A row for app=\"unknown\" is not one application: it aggregates failures raised before Argo CD confirmed the application exists, whose task was submitted without a credential. That bucket also never resets — a success clears the counter under the real application name, not under unknown — so treat its value as a running total, not a current count.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -351,7 +351,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 13 },
       "id": 7,
       "options": {
         "cellHeight": "sm",
@@ -383,7 +383,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Deployments per application over time (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
+      "description": "Deployments that reached the deployed state per application over time. Each bar is the number of successful deployments in that interval. This counts deployment_duration_seconds_count rather than processed_deployments, because that is the per-app series that carries the real application name whether or not the task was submitted with a credential.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -407,7 +407,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 13 },
       "id": 8,
       "options": {
         "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -417,12 +417,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (app) (increase(processed_deployments[$__rate_interval]))",
+          "expr": "sum by (app) (increase(deployment_duration_seconds_count[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
         }
       ],
-      "title": "Deployment Activity (by app)",
+      "title": "Successful Deployment Activity (by app)",
       "type": "timeseries"
     },
     {
@@ -435,7 +435,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Deployments over time for the selected application(s) (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
+      "description": "Successful deployments over time for the selected application(s). Each bar is the number in that interval.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -469,12 +469,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (app) (increase(processed_deployments{app=~\"$app\"}[$__rate_interval]))",
+          "expr": "sum by (app) (increase(deployment_duration_seconds_count{app=~\"$app\"}[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
         }
       ],
-      "title": "Deployment Activity — $app",
+      "title": "Successful Deployment Activity — $app",
       "type": "timeseries"
     },
     {
@@ -744,6 +744,45 @@
       ],
       "title": "Deployment Duration — $app",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Share of processed deployments whose task was submitted with a valid credential. A task submitted without one is still accepted, but its application name is not trusted as a metric label, so it is counted under app=\"unknown\" — which is why an unvalidated deployment cannot be attributed to an application anywhere in this dashboard. A large unvalidated share means the clients posting those tasks send no ARGO_WATCHER_DEPLOY_TOKEN (or BEARER_TOKEN); a wrong token is rejected outright and never reaches this metric.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 13 },
+      "id": 102,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "values": ["value"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "tooltip": { "hideZeros": false, "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "12.3.8",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(processed_deployments{app!=\"unknown\"})",
+          "legendFormat": "validated",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(processed_deployments{app=\"unknown\"}) or vector(0)",
+          "legendFormat": "unvalidated",
+          "refId": "B"
+        }
+      ],
+      "title": "Validated vs Unvalidated Submissions",
+      "type": "piechart"
     }
   ]
 }

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -351,7 +351,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 13 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
       "id": 7,
       "options": {
         "cellHeight": "sm",
@@ -380,56 +380,6 @@
       ],
       "title": "Failing Applications",
       "type": "table"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "How the deployments submitted in the selected time range ended up. Both slices are increases of counters over the same window, so the ratio is meaningful: \"succeeded\" is deployment_duration_seconds_count, which only observes a deployment reaching the deployed state, and \"did not succeed\" is the rest of processed_deployments. That remainder is not only failures — it also holds aborted, cancelled and superseded tasks, plus any deployment still in flight when the window ended, so expect a small non-zero slice on a healthy instance. There is no counter of failed deployments to chart instead; failed_deployment is a gauge that resets on success.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "succeeded" },
-            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
-          },
-          {
-            "matcher": { "id": "byName", "options": "did not succeed" },
-            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
-          }
-        ]
-      },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 13 },
-      "id": 103,
-      "options": {
-        "displayLabels": ["name", "value", "percent"],
-        "legend": { "showLegend": false },
-        "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "hideZeros": false, "mode": "single", "sort": "none" }
-      },
-      "pluginVersion": "12.3.8",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "round(sum(increase(deployment_duration_seconds_count[$__range])))",
-          "instant": true,
-          "legendFormat": "succeeded",
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "clamp_min(round(sum(increase(processed_deployments[$__range]))) - round(sum(increase(deployment_duration_seconds_count[$__range]))), 0)",
-          "instant": true,
-          "legendFormat": "did not succeed",
-          "refId": "B"
-        }
-      ],
-      "title": "Deployment Outcomes (selected range)",
-      "type": "piechart"
     },
     {
       "collapsed": false,
@@ -763,7 +713,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 13 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
       "id": 102,
       "options": {
         "displayLabels": ["name", "value", "percent"],

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -5,7 +5,5 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
-    # Fixed uid so the provisioned dashboard can reference this datasource by uid.
-    uid: prometheus
     isDefault: true
     editable: false


### PR DESCRIPTION
The dashboard referenced its datasource by the uid `prometheus`, which only exists in the bundled compose stack, so importing it anywhere else broke every panel. A datasource template variable now selects the Prometheus to query.

Per-application panels read `processed_deployments`, the one per-app series that collapses to `app="unknown"` for uncredentialled submissions — they now count `deployment_duration_seconds_count`, which keeps the real name either way. A donut charts the validated/unvalidated split that `unknown` used to imply.

Tables now keep columns by allowlist, so kube scrape labels (`pod`, `namespace`, …) cannot leak in, and the failure panels aggregate by app so replicas do not each report a row.

No outcome or success-rate panel: deriving one by subtraction counts cancelled and aborted tasks as failures. Needs #554. `Failing Applications` still shows an `unknown` row — see #552.