### PR TITLE
fix(observability)!: label deployment metrics only once ArgoCD confirms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section is now headed `Failed resources:` rather than `Failed hooks:` (a failed apply is
   not a hook), and each line names the outcome that describes it instead of always the hook
   phase, so a resource whose live object went unhealthy mid-sync no longer reads `Synced`.
+- Deployment metrics are now labelled with an application only once Argo CD has confirmed
+  that application exists. `processed_deployments{app}` is recorded when the deployment's
+  first status check succeeds rather than when the task is accepted, and a deployment that
+  fails before that — a misspelled or renamed application, Argo CD unreachable, or a task
+  picked up from a lost replica after its window elapsed — is counted by the new
+  `unconfirmed_deployment_failures` counter instead of `failed_deployment{app}`. Total
+  submissions are counted by the new `accepted_deployments`. Both new counters carry no
+  labels: task submission accepts any application name without a credential, so nothing
+  from a submission may become a label value.
+
+  This is a breaking change for alerts and dashboards. On an instance whose clients deploy
+  without a credential, deployment metrics no longer collapse into `app="unknown"` — they
+  name the real application — and the `app="unknown"` series for `failed_deployment`, which
+  could never be reset because the reset used the real name, is gone. Anything counting
+  submissions off `processed_deployments` should move to `accepted_deployments`, and
+  anything alerting on failures should add `unconfirmed_deployment_failures` to keep seeing
+  the failures that never reached Argo CD. `unauthenticated_reads` is unchanged and still
+  uses `app="unknown"` for a read that did not resolve to a task.
 
 ### Fixed
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -23,8 +23,8 @@ Argo Watcher watches the Argo CD application for the images the pipeline just bu
 | `in progress` | Waiting for the requested images to be running, synced, and healthy. |
 | `deployed` | The application is synced and healthy with the requested images. |
 | `failed` | Argo CD reported a health or sync failure, `DEPLOYMENT_TIMEOUT` elapsed, or the application finished rolling out without ever declaring the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)). |
-| `app not found` | Argo CD has no application with that name, or the token cannot see it. |
-| `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure (`failed_deployment`); `argocd_unavailable` tells you whether Argo CD was the reason. |
+| `app not found` | Argo CD has no application with that name, or the token cannot see it. Counted under `unconfirmed_deployment_failures`, or under `failed_deployment` in the rarer case where an application that was already confirmed disappeared mid-rollout. |
+| `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure — under `failed_deployment` when Argo CD had already confirmed the application, under `unconfirmed_deployment_failures` when it never did; `argocd_unavailable` tells you whether Argo CD was the reason. |
 | `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure. |
 
 Two rules keep supersession from cancelling unrelated work: only in-progress tasks that share an image with the new deployment are cancelled, and a deployment can only cancel one that presented no more authority than itself — a task submitted without a credential never cancels one submitted with a valid deploy token or JWT.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -11,25 +11,27 @@ scrape_configs:
 
 ## Metrics
 
-Twelve metrics, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go), plus the standard Go runtime ones (`go_*`, `process_*`).
+Fourteen metrics, all defined in [`internal/prometheus/metrics.go`](https://github.com/shini4i/argo-watcher/blob/main/internal/prometheus/metrics.go), plus the standard Go runtime ones (`go_*`, `process_*`).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `failed_deployment` | gauge | `app` | Failed deployments since that application's last success; reset to 0 on success. Includes deployments aborted because Argo CD was unreachable. |
-| `processed_deployments` | counter | `app` | Deployments processed since startup. |
+| `failed_deployment` | gauge | `app` | Failed deployments of a confirmed application since its last success; reset to 0 on success. Includes deployments aborted because Argo CD became unreachable mid-rollout. |
+| `processed_deployments` | counter | `app` | Deployments taken into monitoring, counted once Argo CD confirmed the application exists. |
+| `accepted_deployments` | counter | | Deployments accepted, counted at submission — before Argo CD is asked anything. |
+| `unconfirmed_deployment_failures` | counter | | Deployments that failed before Argo CD confirmed the application: a missing or misspelled name, Argo CD unreachable, or a resumed task whose window had already elapsed. |
 | `in_progress_tasks` | gauge | | Tasks between submission and a terminal state. |
 | `argocd_unavailable` | gauge | | `1` while the Argo CD API is unreachable. |
 | `state_unavailable` | gauge | | `1` while the state backend (database) is unreachable. |
 | `deployment_duration_seconds` | histogram | `app` | End-to-end time of a **successful** deployment, from the start of monitoring to `deployed`. Failures are excluded: their duration is just the timeout. |
-| `argocd_refresh_duration_seconds` | histogram | `app` | Argo CD application refresh requests. Recorded only when the status check asks for a refresh. |
+| `argocd_refresh_duration_seconds` | histogram | `app` | Argo CD application refresh requests. Recorded only when the status check asks for a refresh, and — for a deployment's first request — only when it succeeded. |
 | `gitops_writeback_duration_seconds` | histogram | `app` | Time the write-back held the per-repo lock: clone, commit, push, retries and backoff. |
 | `gitops_lock_wait_duration_seconds` | histogram | `app` | Time spent waiting for that lock. High values mean write-backs are queued behind each other. |
 | `gitops_batch_size` | histogram | | Applications coalesced into one batch flush. Only with `GIT_BATCH_WRITEBACK`; clustered at `1` means no contention to collapse. |
 | `gitops_writeback_skipped_unvalidated` | counter | `app` | Deployments of a `argo-watcher/managed` application whose task carried no valid credential, so the tag was never committed. Any non-zero value is a misconfiguration. |
 | `unauthenticated_reads` | counter | `path`, `app` | Reads served without a credential on the endpoints left open while OIDC is enabled (currently `GET /api/v1/tasks/{id}`). |
 
-!!! note "Why some series say `app="unknown"`"
-    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so a name arriving that way is labelled `unknown` rather than becoming its own series, which would let anyone reaching the endpoint create unbounded series. This affects `processed_deployments`, `unauthenticated_reads`, and `failed_deployment` when the failure precedes Argo CD confirming the application exists. Deployments submitted with a credential are labelled with their real application throughout.
+!!! note "Why some deployments are counted without an `app` label"
+    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so nothing may become a label value until Argo CD has answered for that application. A deployment is therefore counted twice on its way through: once in `accepted_deployments` at submission, and once in `processed_deployments{app}` when Argo CD confirms the app. The gap between the two is mostly deployments naming an application Argo CD never confirmed — read it as an upper bound, since a deployment superseded before its first check, or one whose replica died before it, widens the gap as well. `unconfirmed_deployment_failures` counts the failures on that side of the confirmation, `unauthenticated_reads` still labels a read that did not resolve to a task as `app="unknown"`.
 
     The same openness means anyone who can reach the endpoint and knows a managed application's name can raise `gitops_writeback_skipped_unvalidated`. Treat a rise as "investigate", not automatically "our pipeline regressed".
 
@@ -80,6 +82,20 @@ groups:
           summary: "{{ $labels.app }} has failed {{ $value }} times in a row"
           description: Check the most recent task in the Web UI for the failure reason.
 
+      - alert: ArgoWatcherUnconfirmedDeployments
+        expr: increase(unconfirmed_deployment_failures[1h]) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Deployments are failing before Argo CD confirms the application
+          description: |
+            The app name resolves to no Argo CD application (a typo, or a renamed
+            app a pipeline still deploys), Argo CD was unreachable when the
+            deployment started, or a deployment was picked up from a dead replica
+            after its window had elapsed. The counter names no app by design — the
+            failed tasks in the Web UI do.
+
       - alert: ArgoWatcherTaskBacklog
         expr: sum(in_progress_tasks) > 50
         for: 15m
@@ -129,7 +145,7 @@ groups:
 
 ## Example dashboard
 
-A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size` and `state_unavailable` have no panel yet.
+A ready-made Grafana dashboard lives at [`monitoring/grafana/dashboards/argo-watcher.json`](https://github.com/shini4i/argo-watcher/blob/main/monitoring/grafana/dashboards/argo-watcher.json). Its **Overview** row covers availability, in-progress tasks, deployment counts and failing apps; the **Per-Application Breakdown** row is driven by an `Application` template variable and shows that app's deployment counts, failures, end-to-end duration, and the refresh / write-back / lock-wait percentiles. `gitops_batch_size`, `state_unavailable`, `accepted_deployments` and `unconfirmed_deployment_failures` have no panel yet.
 
 Import it through **Dashboards → New → Import**, or run it next to the dev server:
 
@@ -149,6 +165,11 @@ The **Git Write-back Duration** and **Git Lock Wait Duration** panels only fill 
 sum(in_progress_tasks)                          # live workload
 topk(5, max by (app) (failed_deployment))       # which apps need attention
 sum(rate(processed_deployments[1h])) by (app)    # deployment frequency per app
+
+# Upper bound on submissions that never reached an Argo CD application — typos and
+# renamed apps, plus deployments superseded before the first check or left behind by
+# a replica that died.
+sum(increase(accepted_deployments[1h])) - sum(increase(processed_deployments[1h]))
 ```
 
 ## Tracking the read-auth migration

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -225,7 +225,7 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 		slog.Info("Task image expecting tag", "index", index, "tag", value.Tag, "app", task.App, "id", newTask.Id)
 	}
 
-	argo.metrics.AddProcessedDeployment(task.MetricApp())
+	argo.metrics.AddAcceptedDeployment()
 	return newTask, nil
 }
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -159,7 +159,7 @@ func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool,
 	// about the claim alone.
 	abandoned := func() bool { return lease.Lost() || draining() }
 
-	application, waited, err := updater.waitForApplicationDeployment(task, abandoned)
+	application, waited, confirmed, err := updater.waitForApplicationDeployment(task, resumed, abandoned)
 
 	// Re-checked here because only the poll loop and the write-back consult the
 	// predicate themselves. Every other way out — a failed fetch, a write-back error,
@@ -205,7 +205,7 @@ func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool,
 		slog.Info("Deployment superseded by a newer deployment for the same app; stopping.", "id", task.Id)
 		task.Status = models.StatusCancelledMessage
 	case err != nil:
-		updater.monitor.HandleArgoAPIFailure(&task, err)
+		updater.monitor.HandleArgoAPIFailure(&task, err, confirmed)
 	default:
 		updater.monitor.ProcessDeploymentResult(&task, application, waited)
 	}
@@ -233,20 +233,31 @@ func (updater *ArgoStatusUpdater) abortedWriteBackCause(taskId string, abandoned
 	return errTaskSuperseded
 }
 
-func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, abandoned func() bool) (*models.Application, time.Duration, error) {
+// waitForApplicationDeployment fetches the application, writes the image tag back when it is
+// managed, and polls the rollout. The returned bool reports whether ArgoCD confirmed the
+// application: every metric carrying the app name waits for that (issue #552).
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, resumed bool, abandoned func() bool) (*models.Application, time.Duration, bool, error) {
 	if updater.monitor.taskSuperseded(task.Id) {
-		return nil, 0, errTaskSuperseded
+		return nil, 0, false, errTaskSuperseded
 	}
 
 	// The initial fetch happens before the timed polling loop, so it is bounded only by
 	// the HTTP client's per-request timeout rather than the rollout deadline.
-	app, err := updater.monitor.FetchApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
+	app, err := updater.monitor.ConfirmApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
+	}
+
+	// ArgoCD answered for the application, so the name is no longer merely what the
+	// submission claimed and may label the deployment. Only the replica that accepted the
+	// deployment counts it: a handover monitors the same deployment over again, and
+	// counting it per replica would inflate the deployment count of a rolled replica's apps.
+	if !resumed {
+		updater.monitor.CountProcessedDeployment(task.App)
 	}
 
 	if err := updater.monitor.StoreInitialAppStatus(&task, app); err != nil {
-		return nil, 0, err
+		return nil, 0, true, err
 	}
 
 	// The stop predicate is re-checked inside the write-back retry loop so a task
@@ -258,12 +269,13 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task,
 		return updater.monitor.taskSuperseded(task.Id) || abandoned()
 	}); err != nil {
 		if errors.Is(err, ErrDeploymentSuperseded) {
-			return nil, 0, updater.abortedWriteBackCause(task.Id, abandoned())
+			return nil, 0, true, updater.abortedWriteBackCause(task.Id, abandoned())
 		}
-		return nil, 0, err
+		return nil, 0, true, err
 	}
 
-	return updater.monitor.WaitRollout(task, abandoned)
+	application, waited, err := updater.monitor.WaitRollout(task, abandoned)
+	return application, waited, true, err
 }
 
 func sendNotification(task models.Task, notifier *notifications.Notifier) {

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -157,6 +157,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -203,6 +204,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -241,6 +243,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -281,6 +284,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
@@ -315,7 +319,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("applications.argoproj.io \"test-app\" not found"))
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddFailedDeployment(task.App)
+		metricsMock.EXPECT().AddUnconfirmedFailure()
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAppNotFoundMessage, "ArgoCD API Error: applications.argoproj.io \"test-app\" not found")
 
@@ -342,7 +346,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		unavailableErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, unavailableErr)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddFailedDeployment(task.App)
+		metricsMock.EXPECT().AddUnconfirmedFailure()
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
@@ -368,7 +372,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, fmt.Errorf("unexpected failure"))
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddFailedDeployment(task.App)
+		metricsMock.EXPECT().AddUnconfirmedFailure()
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: unexpected failure")
 
@@ -403,6 +407,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
@@ -447,6 +452,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		// The headline names ArgoCD's own sync status, and with no revisions, drifted resources or
@@ -500,6 +506,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		// This fixture app declares no resources, so no resource listing is appended: the reason
@@ -768,6 +775,7 @@ func TestArgoStatusUpdaterDegradedReportsRolloutDiagnostics(t *testing.T) {
 
 	var capturedReason string
 	metrics.EXPECT().AddInProgressTask()
+	metrics.EXPECT().AddProcessedDeployment(task.App)
 	metrics.EXPECT().AddFailedDeployment(task.App)
 	metrics.EXPECT().RemoveInProgressTask()
 	state.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
@@ -831,6 +839,7 @@ func TestArgoStatusUpdaterSupersededAfterSuccessfulPollWritesNoStatus(t *testing
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().AddProcessedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// No SetTaskStatus and no failed-deployment metric are expected, so gomock fails the test
 	// if the superseded task is mistaken for a reportable rollout state.
@@ -881,6 +890,7 @@ func TestArgoStatusUpdaterAbortsWhenArgoBecomesUnreachableMidPoll(t *testing.T) 
 
 	var capturedReason string
 	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().AddProcessedDeployment(task.App)
 	metricsMock.EXPECT().AddFailedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, gomock.Any()).
@@ -913,7 +923,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureHandlesStateError(t *testing.T) {
 		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
 		Return(errors.New("persist failed"))
 
-	monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"))
+	monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"), true)
 }
 
 // TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure verifies that an
@@ -936,7 +946,7 @@ func TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure(t *testing.T)
 	metrics.EXPECT().AddFailedDeployment(task.App)
 	state.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, gomock.Any())
 
-	monitor.HandleArgoAPIFailure(&task, context.DeadlineExceeded)
+	monitor.HandleArgoAPIFailure(&task, context.DeadlineExceeded, true)
 	assert.Equal(t, models.StatusAborted, task.Status)
 }
 
@@ -1309,14 +1319,18 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errors.New("network")).Times(1)
-		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
+		// No AddProcessedDeployment: ArgoCD never confirmed the application.
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
 		assert.Error(t, err)
+		assert.False(t, confirmed)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, nil).Times(1)
-		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
+		metrics.EXPECT().AddProcessedDeployment(task.App)
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
 		assert.Error(t, err)
+		assert.True(t, confirmed)
 	})
 
 	t.Run("failsWhenGitUpdateFails", func(t *testing.T) {
@@ -1324,9 +1338,11 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
 		app.Spec.Source.RepoURL = ""
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
+		metrics.EXPECT().AddProcessedDeployment(task.App)
 
-		_, _, err := updater.waitForApplicationDeployment(task, neverLost)
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
 		assert.Error(t, err)
+		assert.True(t, confirmed)
 	})
 }
 
@@ -1375,6 +1391,7 @@ func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
 
 	var capturedReason string
 	metrics.EXPECT().AddInProgressTask()
+	metrics.EXPECT().AddProcessedDeployment(task.App)
 	metrics.EXPECT().RemoveInProgressTask()
 	metrics.EXPECT().AddFailedDeployment(task.App)
 	state.EXPECT().
@@ -1655,6 +1672,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().AddProcessedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// No SetTaskStatus and no failed-deployment metric: a superseded rollout is not
 	// a failure and its status must not be overwritten.
@@ -1704,6 +1722,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().AddProcessedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	metricsMock.EXPECT().AddFailedDeployment(task.App)
 	stateMock.EXPECT().SetTaskStatus(
@@ -1749,6 +1768,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	stateMock.EXPECT().GetTask(task.Id).Return(nil, errors.New("db unavailable")).AnyTimes()
 	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(1)
 	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().AddProcessedDeployment(task.App)
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
 	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	metricsMock.EXPECT().RemoveInProgressTask()
@@ -1950,24 +1970,24 @@ func TestArgoStatusUpdater_handleArgoAPIFailure(t *testing.T) {
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any())
 
-		updater.monitor.HandleArgoAPIFailure(&task, err)
+		updater.monitor.HandleArgoAPIFailure(&task, err, true)
 
 		// The resolved terminal status must be reflected back onto the task so the
 		// result notification does not report a stale "in progress" for a failure.
 		assert.Equal(t, models.StatusFailedMessage, task.Status)
 	})
 
-	t.Run("handleArgoAPIFailure - an unvalidated task does not name the app", func(t *testing.T) {
+	t.Run("handleArgoAPIFailure - an unconfirmed application does not name the app", func(t *testing.T) {
 		// This path runs before ArgoCD confirms the app exists, and is the one an
 		// app name that never existed reaches. Labelling it would let an
 		// uncredentialed caller mint a permanent series per submission.
 		task := models.Task{Id: "test-id", App: "attacker-controlled-name"}
 		err := fmt.Errorf("applications.argoproj.io \"attacker-controlled-name\" not found")
 
-		metricsMock.EXPECT().AddFailedDeployment(models.UnknownApp)
+		metricsMock.EXPECT().AddUnconfirmedFailure()
 		stateMock.EXPECT().SetTaskStatus(task.Id, gomock.Any(), gomock.Any())
 
-		updater.monitor.HandleArgoAPIFailure(&task, err)
+		updater.monitor.HandleArgoAPIFailure(&task, err, false)
 	})
 }
 
@@ -2390,6 +2410,13 @@ func TestArgoStatusUpdaterLostLeaseWritesNoStatus(t *testing.T) {
 			// Only the in-flight gauge may move. No SetTaskStatus and no failure metric are
 			// declared, so gomock fails the test if this replica reports on a task it lost.
 			metricsMock.EXPECT().AddInProgressTask()
+			// A confirmed application is counted exactly once, and the arm whose fetch
+			// fails never confirms one — counting there would be the pre-#552 behaviour.
+			processed := 1
+			if tt.fetchFails {
+				processed = 0
+			}
+			metricsMock.EXPECT().AddProcessedDeployment("test-app").Times(processed)
 			metricsMock.EXPECT().RemoveInProgressTask()
 
 			updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
@@ -2482,7 +2509,15 @@ func TestWaitForApplicationDeploymentStopPredicates(t *testing.T) {
 				Timeout: 15,
 				Images:  []models.Image{{Image: "demo", Tag: "v1"}},
 			}
-			_, _, err := updater.waitForApplicationDeployment(task, func() bool { return tt.leaseLost })
+			// A task found cancelled is never taken to ArgoCD, so it is never counted;
+			// the takeover arm confirms the app first and counts it exactly once.
+			processed := 1
+			if tt.superseded {
+				processed = 0
+			}
+			metricsMock.EXPECT().AddProcessedDeployment(task.App).Times(processed)
+
+			_, _, _, err := updater.waitForApplicationDeployment(task, false, func() bool { return tt.leaseLost })
 
 			assert.ErrorIs(t, err, tt.wantErr)
 		})
@@ -2587,4 +2622,129 @@ func TestAbortedWriteBackCause(t *testing.T) {
 			assert.ErrorIs(t, updater.abortedWriteBackCause("task-id", tt.abandoned), tt.want)
 		})
 	}
+}
+
+// TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation pins where the app name is
+// allowed to become a Prometheus label (issue #552): only once ArgoCD has answered for
+// the application. Until then the deployment is counted by the labelless counters, since
+// task submission takes an arbitrary app name without a credential.
+func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
+	newUpdater := func(t *testing.T) (*ArgoStatusUpdater, *mocks.MockArgoApiInterface, *mocks.MockMetricsInterface) {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		apiMock := newArgoApiMock(ctrl)
+		metricsMock := mocks.NewMockMetricsInterface(ctrl)
+		stateMock := notSupersededState(ctrl)
+
+		argo := &Argo{}
+		argo.Init(stateMock, apiMock, metricsMock)
+
+		metricsMock.EXPECT().AddInProgressTask()
+		metricsMock.EXPECT().RemoveInProgressTask()
+		stateMock.EXPECT().SetTaskStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+		return initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo), apiMock, metricsMock
+	}
+
+	// An unvalidated task carries a caller-chosen name, yet after this point it is the
+	// name ArgoCD answered for, so the real app is labelled rather than "unknown".
+	task := models.Task{
+		Id:     "test-id",
+		App:    "test-app",
+		Images: []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	deployedApp := func() *models.Application {
+		application := &models.Application{}
+		application.Status.Summary.Images = []string{"app:v1"}
+		application.Status.Sync.Status = "Synced"
+		application.Status.Health.Status = "Healthy"
+		return application
+	}
+
+	t.Run("confirmed application is counted under its own name", func(t *testing.T) {
+		updater, apiMock, metricsMock := newUpdater(t)
+
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(deployedApp(), nil).AnyTimes()
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().ResetFailedDeployment(task.App)
+		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
+
+		updater.WaitForRollout(task, false)
+	})
+
+	t.Run("an application ArgoCD never confirmed is counted without a label", func(t *testing.T) {
+		updater, apiMock, metricsMock := newUpdater(t)
+
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+			Return(nil, fmt.Errorf("applications.argoproj.io %q not found", task.App))
+		// Neither AddProcessedDeployment nor AddFailedDeployment is expected: the
+		// controller fails the test if the unconfirmed name reaches either.
+		metricsMock.EXPECT().AddUnconfirmedFailure()
+
+		updater.WaitForRollout(task, false)
+	})
+
+	t.Run("a failure after confirmation names the app", func(t *testing.T) {
+		updater, apiMock, metricsMock := newUpdater(t)
+
+		gomock.InOrder(
+			apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(deployedApp(), nil),
+			apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
+				Return(nil, fmt.Errorf("applications.argoproj.io %q not found", task.App)),
+		)
+		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddFailedDeployment(task.App)
+
+		updater.WaitForRollout(task, false)
+	})
+
+	t.Run("a resumed deployment is not counted again", func(t *testing.T) {
+		updater, apiMock, metricsMock := newUpdater(t)
+
+		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(deployedApp(), nil).AnyTimes()
+		// No AddProcessedDeployment: the replica that accepted the deployment counted it.
+		metricsMock.EXPECT().ResetFailedDeployment(task.App)
+		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
+
+		updater.WaitForRollout(task, true)
+	})
+}
+
+// TestDeploymentMonitorConfirmApplicationRefreshDuration pins that a task's first fetch
+// records the refresh duration only once ArgoCD answered for the application: a failed
+// confirmation would otherwise mint an argocd_refresh_duration_seconds series under a name
+// nothing has vouched for (issue #552).
+func TestDeploymentMonitorConfirmApplicationRefreshDuration(t *testing.T) {
+	t.Run("recorded once the application is confirmed", func(t *testing.T) {
+		monitor, api, metrics := newFetchTestMonitor(t)
+		wantApp := &models.Application{}
+		api.EXPECT().GetApplication(gomock.Any(), "demo", true).Return(wantApp, nil)
+		metrics.EXPECT().ObserveRefreshDuration("demo", gomock.Any())
+
+		app, err := monitor.ConfirmApplication(context.Background(), "demo", true)
+		require.NoError(t, err)
+		assert.Same(t, wantApp, app)
+	})
+
+	t.Run("not recorded when the application is not confirmed", func(t *testing.T) {
+		monitor, api, _ := newFetchTestMonitor(t)
+		// No ObserveRefreshDuration expectation: the mock controller fails the test if it is called.
+		api.EXPECT().GetApplication(gomock.Any(), "demo", true).Return(nil, errors.New("not found"))
+
+		app, err := monitor.ConfirmApplication(context.Background(), "demo", true)
+		require.Error(t, err)
+		assert.Nil(t, app)
+	})
+
+	t.Run("not recorded when no refresh was asked for", func(t *testing.T) {
+		monitor, api, _ := newFetchTestMonitor(t)
+		wantApp := &models.Application{}
+		// No ObserveRefreshDuration expectation: the histogram covers refreshes only.
+		api.EXPECT().GetApplication(gomock.Any(), "demo", false).Return(wantApp, nil)
+
+		app, err := monitor.ConfirmApplication(context.Background(), "demo", false)
+		require.NoError(t, err)
+		assert.Same(t, wantApp, app)
+	})
 }

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -286,14 +286,11 @@ func TestArgoAddTask(t *testing.T) {
 			metrics := mocks.NewMockMetricsInterface(ctrl)
 			state := newTaskRepositoryMock(ctrl)
 
-			// mock calls. Only a validated task names the app: submission is open and
-			// the name is free text, so an uncredentialed caller must not be able to
-			// choose a label value.
-			expectedApp := models.UnknownApp
-			if validated {
-				expectedApp = "test-app"
-			}
-			metrics.EXPECT().AddProcessedDeployment(expectedApp)
+			// Acceptance is counted without naming the app: submission is open and the
+			// name is free text, so nothing here may become a label value (issue #552).
+			// The app is named only once ArgoCD confirms it, which happens in the
+			// monitoring path.
+			metrics.EXPECT().AddAcceptedDeployment()
 
 			task := models.Task{
 				App: "test-app",
@@ -339,7 +336,7 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := newTaskRepositoryMock(ctrl)
 
-		metrics.EXPECT().AddProcessedDeployment("test-app")
+		metrics.EXPECT().AddAcceptedDeployment()
 
 		task := models.Task{App: "test-app", Images: []models.Image{{Tag: taskImageTag}}, Validated: true}
 		newTask := models.Task{Id: uuid.NewString(), App: "test-app", Images: []models.Image{{Tag: taskImageTag}}}
@@ -361,7 +358,7 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := newTaskRepositoryMock(ctrl)
 
-		metrics.EXPECT().AddProcessedDeployment(models.UnknownApp)
+		metrics.EXPECT().AddAcceptedDeployment()
 
 		// History ordered created DESC: current is v2, an earlier task (target) ran v1.
 		deployed := []models.Task{
@@ -392,7 +389,7 @@ func TestArgoAddTask(t *testing.T) {
 		metrics := mocks.NewMockMetricsInterface(ctrl)
 		state := newTaskRepositoryMock(ctrl)
 
-		metrics.EXPECT().AddProcessedDeployment(models.UnknownApp)
+		metrics.EXPECT().AddAcceptedDeployment()
 
 		deployed := []models.Task{
 			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
@@ -654,7 +651,7 @@ func TestArgoAddTaskClaimsTheTask(t *testing.T) {
 			Return(int64(0), nil).AnyTimes()
 		stateMock.EXPECT().AddTask(gomock.Any()).Return(&models.Task{Id: "new-id", App: task.App}, nil)
 		stateMock.EXPECT().ClaimTask("new-id").Return(nil).Times(1)
-		metricsMock.EXPECT().AddProcessedDeployment(gomock.Any())
+		metricsMock.EXPECT().AddAcceptedDeployment()
 
 		created, err := argo.AddTask(task)
 		require.NoError(t, err)
@@ -677,7 +674,7 @@ func TestArgoAddTaskClaimsTheTask(t *testing.T) {
 			Return(int64(0), nil).AnyTimes()
 		stateMock.EXPECT().AddTask(gomock.Any()).Return(&models.Task{Id: "new-id", App: task.App}, nil)
 		stateMock.EXPECT().ClaimTask("new-id").Return(errors.New("database unreachable"))
-		metricsMock.EXPECT().AddProcessedDeployment(gomock.Any())
+		metricsMock.EXPECT().AddAcceptedDeployment()
 
 		created, err := argo.AddTask(task)
 		require.NoError(t, err, "the claim is best-effort; a sweep picks the task up instead")

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -132,6 +132,9 @@ func (monitor *DeploymentMonitor) resolveRefresh(task models.Task) bool {
 // When a refresh is requested, the call is timed and its duration recorded (argocd_refresh_duration_seconds)
 // so slow or stuck refreshes are diagnosable. A stuck refresh is avoided operationally, not here: set the
 // per-task Refresh override (or ARGO_REFRESH_APP) to false for apps that never settle (issue #334).
+//
+// The duration is recorded under the app name, so this is for an application ArgoCD has
+// already confirmed. A task's first fetch goes through ConfirmApplication instead.
 func (monitor *DeploymentMonitor) FetchApplication(ctx context.Context, appName string, refresh bool) (*models.Application, error) {
 	if !refresh {
 		return monitor.argo.api.GetApplication(ctx, appName, false)
@@ -141,6 +144,31 @@ func (monitor *DeploymentMonitor) FetchApplication(ctx context.Context, appName 
 	app, err := monitor.argo.api.GetApplication(ctx, appName, true)
 	monitor.argo.metrics.ObserveRefreshDuration(appName, time.Since(start).Seconds())
 	return app, err
+}
+
+// ConfirmApplication performs a task's first fetch — the call that decides whether ArgoCD
+// has the application at all. A requested refresh is timed as in FetchApplication, but the
+// duration is recorded only once the call succeeded: an app name ArgoCD never answered for
+// is only what the submission claimed, and submission takes any name without a credential,
+// so recording it would mint a series per bad request (issue #552).
+func (monitor *DeploymentMonitor) ConfirmApplication(ctx context.Context, appName string, refresh bool) (*models.Application, error) {
+	start := time.Now()
+
+	app, err := monitor.argo.api.GetApplication(ctx, appName, refresh)
+	if err != nil {
+		return nil, err
+	}
+
+	if refresh {
+		monitor.argo.metrics.ObserveRefreshDuration(appName, time.Since(start).Seconds())
+	}
+
+	return app, nil
+}
+
+// CountProcessedDeployment records a deployment whose application ArgoCD confirmed.
+func (monitor *DeploymentMonitor) CountProcessedDeployment(app string) {
+	monitor.argo.metrics.AddProcessedDeployment(app)
 }
 
 // StoreInitialAppStatus caches the initial rollout status for comparison during monitoring.
@@ -353,10 +381,17 @@ func (monitor *DeploymentMonitor) taskSuperseded(id string) bool {
 // task is taken by pointer so the resolved terminal status is reflected back to
 // the caller, keeping the outgoing failure notification in sync with the stored
 // status (mirroring handleDeploymentSuccess/handleDeploymentFailure).
-func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error) {
-	// Reached before ArgoCD confirms the app exists — most often because it does not —
-	// so the name is only as trustworthy as the submission that supplied it.
-	monitor.argo.metrics.AddFailedDeployment(task.MetricApp())
+//
+// confirmed reports whether ArgoCD had answered for the application before the failure.
+// Only then may the app name label a metric: without a confirmation the name is only as
+// trustworthy as the submission that supplied it, so the failure is counted under no app
+// at all (issue #552).
+func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error, confirmed bool) {
+	if confirmed {
+		monitor.argo.metrics.AddFailedDeployment(task.App)
+	} else {
+		monitor.argo.metrics.AddUnconfirmedFailure()
+	}
 	finalStatus := determineFailureStatus(*task, err)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
 	slog.Warn("Deployment not completed", "status", finalStatus, "reason", reason, "id", task.Id)

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -70,9 +70,12 @@ func (monitor *DeploymentMonitor) remainingWindow(task models.Task, now time.Tim
 }
 
 // abortStaleTask records the terminal status for a task that outlived its
-// rollout window while unattended.
+// rollout window while unattended. The outcome is counted without an app label:
+// this replica never asked ArgoCD about the application, and whether the replica
+// that accepted the deployment got that far cannot be known here, so the name is
+// only as trustworthy as the submission that supplied it (issue #552).
 func (monitor *DeploymentMonitor) abortStaleTask(task *models.Task) {
-	monitor.argo.metrics.AddFailedDeployment(task.MetricApp())
+	monitor.argo.metrics.AddUnconfirmedFailure()
 
 	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason); err != nil {
 		slog.Error("Failed to change task status", "error", err, "id", task.Id)

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -146,7 +146,7 @@ func TestResumeRollout_AbortsAnElapsedWindow(t *testing.T) {
 		Images:    []models.Image{{Image: "app", Tag: "v1"}},
 	}
 
-	metricsMock.EXPECT().AddFailedDeployment(task.App)
+	metricsMock.EXPECT().AddUnconfirmedFailure()
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason)
 	// No GetApplication expectation: polling a deployment past its deadline would
 	// only end in the same abort.

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -7,7 +7,9 @@ import (
 // MetricsInterface defines the interface for the metrics service. This is required
 // for dependency injection and mocking in tests.
 type MetricsInterface interface {
+	AddAcceptedDeployment()
 	AddProcessedDeployment(app string)
+	AddUnconfirmedFailure()
 	AddFailedDeployment(app string)
 	ResetFailedDeployment(app string)
 	SetArgoUnavailable(unavailable bool)
@@ -26,6 +28,8 @@ type MetricsInterface interface {
 type Metrics struct {
 	FailedDeployment     *prometheus.GaugeVec
 	ProcessedDeployments *prometheus.CounterVec
+	AcceptedDeployments  prometheus.Counter
+	UnconfirmedFailures  prometheus.Counter
 	ArgocdUnavailable    prometheus.Gauge
 	StateUnavailable     prometheus.Gauge
 	InProgressTasks      prometheus.Gauge
@@ -41,14 +45,40 @@ type Metrics struct {
 // NewMetrics registers the collectors with the provided Registerer.
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	m := &Metrics{
+		// FailedDeployment records failures of an application ArgoCD confirmed; a deployment
+		// that failed before that is counted by UnconfirmedFailures instead, so the gauge is
+		// only ever raised under a name a later success can reset.
 		FailedDeployment: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "failed_deployment",
 			Help: "Per application failed deployment count before first success.",
 		}, []string{"app"}),
+		// ProcessedDeployments is only incremented once ArgoCD has answered for the
+		// application, which is what makes the app name safe as a label: task submission
+		// takes an arbitrary name without a credential (issue #552). Counted by the replica
+		// that accepted the deployment, so a handover does not count it twice. Its gap to
+		// AcceptedDeployments is dominated by deployments naming an application ArgoCD
+		// never confirmed, but a deployment superseded before its first fetch — or one
+		// whose accepting replica died before reaching it — widens the gap too.
 		ProcessedDeployments: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "processed_deployments",
-			Help: "The amount of deployment processed since startup.",
+			Help: "Deployments taken into monitoring, counted once ArgoCD confirmed the application exists.",
 		}, []string{"app"}),
+		// AcceptedDeployments counts every deployment accepted, recorded when the task is
+		// created and therefore before ArgoCD is asked anything. It carries no app label
+		// because at that point the name is only what the submission claimed, and labelling
+		// it would let anyone reaching the endpoint mint a permanent series.
+		AcceptedDeployments: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "accepted_deployments",
+			Help: "Deployments accepted for processing, counted before ArgoCD is asked about the application.",
+		}),
+		// UnconfirmedFailures counts deployments that ended before ArgoCD confirmed the
+		// application — a missing or misspelled name, or ArgoCD unreachable — and resumed
+		// tasks whose window had already elapsed. Labelless for the same reason as
+		// AcceptedDeployments; the per-app counterpart is FailedDeployment.
+		UnconfirmedFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "unconfirmed_deployment_failures",
+			Help: "Deployments that failed before ArgoCD confirmed the application exists.",
+		}),
 		ArgocdUnavailable: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "argocd_unavailable",
 			Help: "Whether the ArgoCD API is unreachable (1) or reachable (0) for argo-watcher. Independent of the state backend (see state_unavailable).",
@@ -128,13 +158,27 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		}, []string{"app"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize, m.UnauthenticatedReads, m.SkippedWritebacks)
+	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.AcceptedDeployments, m.UnconfirmedFailures, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize, m.UnauthenticatedReads, m.SkippedWritebacks)
 
 	return m
 }
 
+// AddProcessedDeployment increments ProcessedDeployments for app. Callers must have had
+// the application confirmed by ArgoCD first; see that field.
 func (m *Metrics) AddProcessedDeployment(app string) {
 	m.ProcessedDeployments.WithLabelValues(app).Inc()
+}
+
+// AddAcceptedDeployment increments AcceptedDeployments; see that field for why it carries
+// no app label.
+func (m *Metrics) AddAcceptedDeployment() {
+	m.AcceptedDeployments.Inc()
+}
+
+// AddUnconfirmedFailure increments UnconfirmedFailures; see that field for which failures
+// belong here rather than in FailedDeployment.
+func (m *Metrics) AddUnconfirmedFailure() {
+	m.UnconfirmedFailures.Inc()
 }
 
 func (m *Metrics) AddFailedDeployment(app string) {

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -15,7 +15,7 @@ func TestMetrics_AddProcessedDeployment(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 	expectedMetric := `
-		# HELP processed_deployments The amount of deployment processed since startup.
+		# HELP processed_deployments Deployments taken into monitoring, counted once ArgoCD confirmed the application exists.
 		# TYPE processed_deployments counter
 		processed_deployments{app="test-app"} 1
 	`
@@ -188,4 +188,58 @@ func TestMetrics_InProgressTasks(t *testing.T) {
 
 	m.RemoveInProgressTask()
 	assert.Equal(t, float64(0), testutil.ToFloat64(m.InProgressTasks))
+}
+
+func TestMetrics_AddAcceptedDeployment(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+	expectedMetric := `
+		# HELP accepted_deployments Deployments accepted for processing, counted before ArgoCD is asked about the application.
+		# TYPE accepted_deployments counter
+		accepted_deployments 1
+	`
+
+	m.AddAcceptedDeployment()
+
+	// Collected through the registry so this also fails if the collector was never
+	// handed to MustRegister, in which case it would never be scraped.
+	err := testutil.CollectAndCompare(reg, strings.NewReader(expectedMetric), "accepted_deployments")
+	assert.NoError(t, err)
+}
+
+func TestMetrics_AddUnconfirmedFailure(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+	expectedMetric := `
+		# HELP unconfirmed_deployment_failures Deployments that failed before ArgoCD confirmed the application exists.
+		# TYPE unconfirmed_deployment_failures counter
+		unconfirmed_deployment_failures 1
+	`
+
+	m.AddUnconfirmedFailure()
+
+	err := testutil.CollectAndCompare(reg, strings.NewReader(expectedMetric), "unconfirmed_deployment_failures")
+	assert.NoError(t, err)
+}
+
+// TestMetrics_LabellessCountersStartAtZero pins that both labelless counters are
+// exported before anything increments them. The e2e soak gates on the absence of
+// unconfirmed_deployment_failures to catch a rename or a dropped registration
+// (test/e2e/scripts/collect.sh), which only works while a fresh process scrapes it
+// as an explicit 0.
+func TestMetrics_LabellessCountersStartAtZero(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	NewMetrics(reg)
+	expectedMetric := `
+		# HELP accepted_deployments Deployments accepted for processing, counted before ArgoCD is asked about the application.
+		# TYPE accepted_deployments counter
+		accepted_deployments 0
+		# HELP unconfirmed_deployment_failures Deployments that failed before ArgoCD confirmed the application exists.
+		# TYPE unconfirmed_deployment_failures counter
+		unconfirmed_deployment_failures 0
+	`
+
+	err := testutil.CollectAndCompare(reg, strings.NewReader(expectedMetric),
+		"accepted_deployments", "unconfirmed_deployment_failures")
+	assert.NoError(t, err)
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -72,7 +72,7 @@ func newArgoAPI(ctrl *gomock.Controller) *mocks.MockArgoApiInterface {
 
 func newMetrics(ctrl *gomock.Controller) *mocks.MockMetricsInterface {
 	metrics := mocks.NewMockMetricsInterface(ctrl)
-	metrics.EXPECT().AddProcessedDeployment(gomock.Any()).AnyTimes()
+	metrics.EXPECT().AddAcceptedDeployment().AnyTimes()
 	metrics.EXPECT().AddFailedDeployment(gomock.Any()).AnyTimes()
 	metrics.EXPECT().ResetFailedDeployment(gomock.Any()).AnyTimes()
 	metrics.EXPECT().SetArgoUnavailable(gomock.Any()).AnyTimes()
@@ -2503,7 +2503,7 @@ func TestAddTaskResolvesTheDeploymentWindow(t *testing.T) {
 			stateMock.EXPECT().CancelInProgressTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(int64(0), nil).AnyTimes()
 			stateMock.EXPECT().ClaimTask(gomock.Any()).Return(nil).AnyTimes()
-			metricsMock.EXPECT().AddProcessedDeployment(gomock.Any()).AnyTimes()
+			metricsMock.EXPECT().AddAcceptedDeployment().AnyTimes()
 
 			var stored models.Task
 			stateMock.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -142,7 +142,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Total deployments processed since startup (processed_deployments counter, summed over all apps).",
+      "description": "Deployments Argo CD confirmed and argo-watcher then monitored, since startup (processed_deployments counter, summed over all apps). Submissions that never reached a confirmed application are not here — see accepted_deployments.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Collect + assert soak signals. Fails (exit 1) if any gate trips:
 #   - any DATA RACE in an argo-watcher pod log
-#   - failed_deployment metric != 0
+#   - failed_deployment or unconfirmed_deployment_failures != 0
 #   - argocd_unavailable != 0
 #   - processed_deployments == 0 (no work was actually processed)
+#   - accepted_deployments == 0 (no deployment was even submitted)
 #   - in_progress_tasks does not drain back to 0 (leaked/stuck task tracking)
 #   - any of the duration histograms recorded 0 observations, i.e. the
 #     refresh / git-writeback / lock-wait / deployment-duration code path never
@@ -36,6 +37,15 @@ echo "=== metrics ==="
 metrics="$(curl -s -m 10 "${AW_URL}/metrics")"
 fd=$(metric_sum failed_deployment "$metrics")
 pd=$(metric_sum processed_deployments "$metrics")
+# The soak deploys real applications, so every submission must reach Argo CD
+# confirmation: accepted_deployments counts them on submission, processed_deployments
+# once Argo CD answered for the app, and a failure before that lands in
+# unconfirmed_deployment_failures — which a green soak never records.
+ad=$(metric_sum accepted_deployments "$metrics")
+# metric_raw, not metric_sum: this counter is unlabelled and always exported, so an
+# absent one means it was renamed or never registered — that must trip the gate
+# rather than read as 0 (see metric_raw in lib.sh).
+uf=$(metric_raw unconfirmed_deployment_failures "$metrics")
 # Histogram observation counts. The soak drives many authenticated deploys, each of
 # which refreshes ArgoCD (ARGO_REFRESH_APP defaults true) and takes the per-repo
 # write-back lock — so all three counts MUST be > 0. A zero means the instrumented
@@ -69,10 +79,16 @@ drained() {
 retry 15 1 drained
 
 echo "  failed_deployment=${fd} processed_deployments=${pd} argocd_unavailable=${au:-?} in_progress_tasks=${ip:-?}"
+echo "  accepted_deployments=${ad} unconfirmed_deployment_failures=${uf}"
 echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc} deployment_count=${dc}"
 [[ "${fd:-0}" == "0" ]]  || bad "failed_deployment=${fd}"
-[[ "${au:-0}" == "0" ]]  || bad "argocd_unavailable=${au}"
+# The two metric_raw gates default to a non-zero sentinel, not 0: an absent metric
+# yields an empty value, and substituting 0 there would pass the gate vacuously —
+# the renamed/unregistered case these gates exist to catch.
+[[ "${uf:-absent}" == "0" ]] || bad "unconfirmed_deployment_failures=${uf:-<absent>}"
+[[ "${au:-absent}" == "0" ]] || bad "argocd_unavailable=${au:-<absent>}"
 [[ "${pd:-0}" -gt 0 ]]   || bad "processed_deployments=${pd} (expected > 0)"
+[[ "${ad:-0}" -gt 0 ]]   || bad "accepted_deployments=${ad} (expected > 0)"
 [[ "${ip:-1}" == "0" ]]  || bad "in_progress_tasks=${ip:-<absent>} did not drain to 0"
 [[ "${rc:-0}" -gt 0 ]]   || bad "argocd_refresh_duration_seconds_count=${rc} (expected > 0)"
 [[ "${dc:-0}" -gt 0 ]]   || bad "deployment_duration_seconds_count=${dc} (expected > 0)"


### PR DESCRIPTION
Per-application metric labels are now written only after Argo CD confirms the application exists. `processed_deployments{app}` moves from task acceptance to the first successful status check; a failure before that point is counted by the new labelless `unconfirmed_deployment_failures` instead of `failed_deployment{app}`, and submissions are counted by the new labelless `accepted_deployments`. Task submission accepts any application name without a credential, so nothing from a submission can become a label value.

Breaking for existing alerts and dashboards: deployment metrics no longer collapse into `app="unknown"` for uncredentialed submissions, and the `failed_deployment{app="unknown"}` series that could never be reset is gone. Alerts counting submissions off `processed_deployments` should move to `accepted_deployments`, and failure alerts should add `unconfirmed_deployment_failures`.

Closes #552