### PR TITLE
feat(observability)!: record deployment outcomes as deployments_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deleted while it was still being finished. Such a task is collected by a later sweep,
   once its lease lapses. The setting applies to `STATE_TYPE=postgres` only; with the
   in-memory backend it is inert and the server says so at startup.
+- Deployment outcomes are now measurable. The new `deployments_total` counter is
+  incremented once per deployment when it ends, labelled with the application and the
+  terminal status it reached — `deployed`, `failed`, `aborted`, `app not found` or
+  `cancelled` — so `sum by (result) (increase(deployments_total[1h]))` gives a real
+  breakdown and a success rate over any window. Until now nothing answered that question:
+  the only counter of finished deployments counted successes, while `failed_deployment` is
+  a gauge reset to zero on the next success, so any ratio built from the pair drifted
+  toward 100% success the longer the process ran.
+
+  Only deployments whose application Argo CD confirmed are counted, on the same rule as
+  the other per-app metrics; the rest stay on `unconfirmed_deployment_failures`. The label
+  set is bounded by the task statuses, so there is no cardinality risk. The bundled Grafana
+  dashboard gains a **Deployment Outcomes** panel, and `docs/operations/observability.md`
+  carries the success-rate query.
 
 ### Changed
 
@@ -101,14 +115,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not a hook), and each line names the outcome that describes it instead of always the hook
   phase, so a resource whose live object went unhealthy mid-sync no longer reads `Synced`.
 - Deployment metrics are now labelled with an application only once Argo CD has confirmed
-  that application exists. `processed_deployments{app}` is recorded when the deployment's
-  first status check succeeds rather than when the task is accepted, and a deployment that
-  fails before that — a misspelled or renamed application, Argo CD unreachable, or a task
-  picked up from a lost replica after its window elapsed — is counted by the new
-  `unconfirmed_deployment_failures` counter instead of `failed_deployment{app}`. Total
-  submissions are counted by the new `accepted_deployments`. Both new counters carry no
-  labels: task submission accepts any application name without a credential, so nothing
-  from a submission may become a label value.
+  that application exists. A deployment is labelled from the moment its first status check
+  succeeds rather than when the task is accepted, and one that fails before that — a
+  misspelled or renamed application, Argo CD unreachable, or a task picked up from a lost
+  replica after its window elapsed — is counted by the new `unconfirmed_deployment_failures`
+  counter instead of `failed_deployment{app}`. Total submissions are counted by the new
+  `accepted_deployments`. Both new counters carry no labels: task submission accepts any
+  application name without a credential, so nothing from a submission may become a label
+  value.
 
   This is a breaking change for alerts and dashboards. On an instance whose clients deploy
   without a credential, deployment metrics no longer collapse into `app="unknown"` — they
@@ -118,6 +132,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anything alerting on failures should add `unconfirmed_deployment_failures` to keep seeing
   the failures that never reached Argo CD. `unauthenticated_reads` is unchanged and still
   uses `app="unknown"` for a read that did not resolve to a task.
+
+### Removed
+
+- The `processed_deployments` counter is gone, replaced by `deployments_total`. It counted
+  the same deployments, so `sum without (result) (deployments_total)` is the direct
+  substitute — with one difference worth knowing before swapping it into a dashboard: the
+  new counter is incremented when a deployment ends rather than when Argo CD confirms the
+  application, so a deployment in flight is not counted until it finishes. Use
+  `in_progress_tasks` for the live view. The bundled dashboard is already updated.
 
 ### Fixed
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -27,6 +27,8 @@ Argo Watcher watches the Argo CD application for the images the pipeline just bu
 | `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure — under `failed_deployment` when Argo CD had already confirmed the application, under `unconfirmed_deployment_failures` when it never did; `argocd_unavailable` tells you whether Argo CD was the reason. |
 | `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure. |
 
+Every terminal status also increments `deployments_total{app,result}` once the deployment ends, provided Argo CD confirmed the application — see [Observability](../operations/observability.md#metrics).
+
 Two rules keep supersession from cancelling unrelated work: only in-progress tasks that share an image with the new deployment are cancelled, and a deployment can only cancel one that presented no more authority than itself — a task submitted without a credential never cancels one submitted with a valid deploy token or JWT.
 
 ## Deployment locking

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -16,7 +16,7 @@ Fourteen metrics, all defined in [`internal/prometheus/metrics.go`](https://gith
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `failed_deployment` | gauge | `app` | Failed deployments of a confirmed application since its last success; reset to 0 on success. Includes deployments aborted because Argo CD became unreachable mid-rollout. |
-| `processed_deployments` | counter | `app` | Deployments taken into monitoring, counted once Argo CD confirmed the application exists. |
+| `deployments_total` | counter | `app`, `result` | Deployments of a confirmed application by the terminal status they reached (`deployed`, `failed`, `aborted`, `app not found`, `cancelled`). Counted once, when the deployment ends. |
 | `accepted_deployments` | counter | | Deployments accepted, counted at submission — before Argo CD is asked anything. |
 | `unconfirmed_deployment_failures` | counter | | Deployments that failed before Argo CD confirmed the application: a missing or misspelled name, Argo CD unreachable, or a resumed task whose window had already elapsed. |
 | `in_progress_tasks` | gauge | | Tasks between submission and a terminal state. |
@@ -31,7 +31,7 @@ Fourteen metrics, all defined in [`internal/prometheus/metrics.go`](https://gith
 | `unauthenticated_reads` | counter | `path`, `app` | Reads served without a credential on the endpoints left open while OIDC is enabled (currently `GET /api/v1/tasks/{id}`). |
 
 !!! note "Why some deployments are counted without an `app` label"
-    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so nothing may become a label value until Argo CD has answered for that application. A deployment is therefore counted twice on its way through: once in `accepted_deployments` at submission, and once in `processed_deployments{app}` when Argo CD confirms the app. The gap between the two is mostly deployments naming an application Argo CD never confirmed — read it as an upper bound, since a deployment superseded before its first check, or one whose replica died before it, widens the gap as well. `unconfirmed_deployment_failures` counts the failures on that side of the confirmation, `unauthenticated_reads` still labels a read that did not resolve to a task as `app="unknown"`.
+    `POST /api/v1/tasks` accepts a task without a credential, and the application name is free text — so nothing may become a label value until Argo CD has answered for that application. A deployment is therefore counted twice on its way through: once in `accepted_deployments` at submission, and once in `deployments_total{app,result}` when it ends. The gap between the two is mostly deployments naming an application Argo CD never confirmed — read it as an upper bound, since deployments still in flight, one superseded before its first check, or one whose replica died before it widen the gap as well. `unconfirmed_deployment_failures` counts the failures on that side of the confirmation, `unauthenticated_reads` still labels a read that did not resolve to a task as `app="unknown"`.
 
     The same openness means anyone who can reach the endpoint and knows a managed application's name can raise `gitops_writeback_skipped_unvalidated`. Treat a rise as "investigate", not automatically "our pipeline regressed".
 
@@ -164,12 +164,18 @@ The **Git Write-back Duration** and **Git Lock Wait Duration** panels only fill 
 ```promql
 sum(in_progress_tasks)                          # live workload
 topk(5, max by (app) (failed_deployment))       # which apps need attention
-sum(rate(processed_deployments[1h])) by (app)    # deployment frequency per app
+sum by (result) (increase(deployments_total[1h]))   # outcome breakdown
+sum by (app) (increase(deployments_total[1h]))      # deployment frequency per app
+
+# Success rate over the window. Cancelled deployments are excluded from the
+# denominator: superseding one deployment with another is routine, not a failure.
+sum(increase(deployments_total{result="deployed"}[1h]))
+  / sum(increase(deployments_total{result!="cancelled"}[1h]))
 
 # Upper bound on submissions that never reached an Argo CD application — typos and
-# renamed apps, plus deployments superseded before the first check or left behind by
-# a replica that died.
-sum(increase(accepted_deployments[1h])) - sum(increase(processed_deployments[1h]))
+# renamed apps, plus deployments still in flight, superseded before the first check,
+# or left behind by a replica that died.
+sum(increase(accepted_deployments[1h])) - sum(increase(deployments_total[1h]))
 ```
 
 ## Tracking the read-auth migration

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -159,7 +159,7 @@ func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool,
 	// about the claim alone.
 	abandoned := func() bool { return lease.Lost() || draining() }
 
-	application, waited, confirmed, err := updater.waitForApplicationDeployment(task, resumed, abandoned)
+	application, waited, confirmed, err := updater.waitForApplicationDeployment(task, abandoned)
 
 	// Re-checked here because only the poll loop and the write-back consult the
 	// predicate themselves. Every other way out — a failed fetch, a write-back error,
@@ -210,6 +210,12 @@ func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool,
 		updater.monitor.ProcessDeploymentResult(&task, application, waited)
 	}
 
+	// Counted once: the branches that return early leave the outcome to the replica that
+	// resumes the task. Only for an application ArgoCD confirmed (issue #552).
+	if confirmed {
+		updater.monitor.CountDeploymentOutcome(task.App, task.Status)
+	}
+
 	// Only the deployed state is timed: a failure/abort/supersession is not a completed
 	// deployment and its wall-clock is dominated by the timeout, so it would distort
 	// the histogram.
@@ -236,7 +242,7 @@ func (updater *ArgoStatusUpdater) abortedWriteBackCause(taskId string, abandoned
 // waitForApplicationDeployment fetches the application, writes the image tag back when it is
 // managed, and polls the rollout. The returned bool reports whether ArgoCD confirmed the
 // application: every metric carrying the app name waits for that (issue #552).
-func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, resumed bool, abandoned func() bool) (*models.Application, time.Duration, bool, error) {
+func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task, abandoned func() bool) (*models.Application, time.Duration, bool, error) {
 	if updater.monitor.taskSuperseded(task.Id) {
 		return nil, 0, false, errTaskSuperseded
 	}
@@ -246,14 +252,6 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task,
 	app, err := updater.monitor.ConfirmApplication(context.Background(), task.App, updater.monitor.resolveRefresh(task))
 	if err != nil {
 		return nil, 0, false, err
-	}
-
-	// ArgoCD answered for the application, so the name is no longer merely what the
-	// submission claimed and may label the deployment. Only the replica that accepted the
-	// deployment counts it: a handover monitors the same deployment over again, and
-	// counting it per replica would inflate the deployment count of a rolled replica's apps.
-	if !resumed {
-		updater.monitor.CountProcessedDeployment(task.App)
 	}
 
 	if err := updater.monitor.StoreInitialAppStatus(&task, app); err != nil {

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -157,7 +157,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -204,7 +204,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&unhealthyApp, nil).MinTimes(1).MaxTimes(2)
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&healthyApp, nil).Times(1)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -243,7 +243,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(2).MaxTimes(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 		metricsMock.EXPECT().RemoveInProgressTask()
@@ -284,7 +284,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
@@ -407,7 +407,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage,
@@ -452,7 +452,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		// The headline names ArgoCD's own sync status, and with no revisions, drifted resources or
@@ -506,7 +506,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).Times(3)
 		metricsMock.EXPECT().AddInProgressTask()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 		metricsMock.EXPECT().RemoveInProgressTask()
 		// This fixture app declares no resources, so no resource listing is appended: the reason
@@ -775,7 +775,7 @@ func TestArgoStatusUpdaterDegradedReportsRolloutDiagnostics(t *testing.T) {
 
 	var capturedReason string
 	metrics.EXPECT().AddInProgressTask()
-	metrics.EXPECT().AddProcessedDeployment(task.App)
+	metrics.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 	metrics.EXPECT().AddFailedDeployment(task.App)
 	metrics.EXPECT().RemoveInProgressTask()
 	state.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
@@ -839,7 +839,7 @@ func TestArgoStatusUpdaterSupersededAfterSuccessfulPollWritesNoStatus(t *testing
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
-	metricsMock.EXPECT().AddProcessedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusCancelledMessage)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// No SetTaskStatus and no failed-deployment metric are expected, so gomock fails the test
 	// if the superseded task is mistaken for a reportable rollout state.
@@ -890,7 +890,7 @@ func TestArgoStatusUpdaterAbortsWhenArgoBecomesUnreachableMidPoll(t *testing.T) 
 
 	var capturedReason string
 	metricsMock.EXPECT().AddInProgressTask()
-	metricsMock.EXPECT().AddProcessedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusAborted)
 	metricsMock.EXPECT().AddFailedDeployment(task.App)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, gomock.Any()).
@@ -1319,16 +1319,14 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 
 	t.Run("failsWhenFetchFails", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, errors.New("network")).Times(1)
-		// No AddProcessedDeployment: ArgoCD never confirmed the application.
-		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 		assert.False(t, confirmed)
 	})
 
 	t.Run("failsWhenApplicationNil", func(t *testing.T) {
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(nil, nil).Times(1)
-		metrics.EXPECT().AddProcessedDeployment(task.App)
-		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 		assert.True(t, confirmed)
 	})
@@ -1338,9 +1336,8 @@ func TestArgoStatusUpdaterWaitForApplicationDeploymentErrors(t *testing.T) {
 		app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
 		app.Spec.Source.RepoURL = ""
 		api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(app, nil).Times(1)
-		metrics.EXPECT().AddProcessedDeployment(task.App)
 
-		_, _, confirmed, err := updater.waitForApplicationDeployment(task, false, neverLost)
+		_, _, confirmed, err := updater.waitForApplicationDeployment(task, neverLost)
 		assert.Error(t, err)
 		assert.True(t, confirmed)
 	})
@@ -1391,7 +1388,7 @@ func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
 
 	var capturedReason string
 	metrics.EXPECT().AddInProgressTask()
-	metrics.EXPECT().AddProcessedDeployment(task.App)
+	metrics.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
 	metrics.EXPECT().RemoveInProgressTask()
 	metrics.EXPECT().AddFailedDeployment(task.App)
 	state.EXPECT().
@@ -1672,7 +1669,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
-	metricsMock.EXPECT().AddProcessedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusCancelledMessage)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// No SetTaskStatus and no failed-deployment metric: a superseded rollout is not
 	// a failure and its status must not be overwritten.
@@ -1722,7 +1719,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 	)
 
 	metricsMock.EXPECT().AddInProgressTask()
-	metricsMock.EXPECT().AddProcessedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusAppNotFoundMessage)
 	metricsMock.EXPECT().RemoveInProgressTask()
 	metricsMock.EXPECT().AddFailedDeployment(task.App)
 	stateMock.EXPECT().SetTaskStatus(
@@ -1768,7 +1765,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	stateMock.EXPECT().GetTask(task.Id).Return(nil, errors.New("db unavailable")).AnyTimes()
 	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(&application, nil).MinTimes(1)
 	metricsMock.EXPECT().AddInProgressTask()
-	metricsMock.EXPECT().AddProcessedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
 	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	metricsMock.EXPECT().RemoveInProgressTask()
@@ -2407,16 +2404,10 @@ func TestArgoStatusUpdaterLostLeaseWritesNoStatus(t *testing.T) {
 					return &application, nil
 				}).AnyTimes()
 
-			// Only the in-flight gauge may move. No SetTaskStatus and no failure metric are
-			// declared, so gomock fails the test if this replica reports on a task it lost.
+			// Only the in-flight gauge may move. No SetTaskStatus and no deployment metric
+			// are declared, so gomock fails the test if this replica reports on a task it
+			// lost — the outcome belongs to the replica that took the claim.
 			metricsMock.EXPECT().AddInProgressTask()
-			// A confirmed application is counted exactly once, and the arm whose fetch
-			// fails never confirms one — counting there would be the pre-#552 behaviour.
-			processed := 1
-			if tt.fetchFails {
-				processed = 0
-			}
-			metricsMock.EXPECT().AddProcessedDeployment("test-app").Times(processed)
 			metricsMock.EXPECT().RemoveInProgressTask()
 
 			updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
@@ -2509,15 +2500,7 @@ func TestWaitForApplicationDeploymentStopPredicates(t *testing.T) {
 				Timeout: 15,
 				Images:  []models.Image{{Image: "demo", Tag: "v1"}},
 			}
-			// A task found cancelled is never taken to ArgoCD, so it is never counted;
-			// the takeover arm confirms the app first and counts it exactly once.
-			processed := 1
-			if tt.superseded {
-				processed = 0
-			}
-			metricsMock.EXPECT().AddProcessedDeployment(task.App).Times(processed)
-
-			_, _, _, err := updater.waitForApplicationDeployment(task, false, func() bool { return tt.leaseLost })
+			_, _, _, err := updater.waitForApplicationDeployment(task, func() bool { return tt.leaseLost })
 
 			assert.ErrorIs(t, err, tt.wantErr)
 		})
@@ -2666,7 +2649,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 		updater, apiMock, metricsMock := newUpdater(t)
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(deployedApp(), nil).AnyTimes()
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 
@@ -2678,7 +2661,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 			Return(nil, fmt.Errorf("applications.argoproj.io %q not found", task.App))
-		// Neither AddProcessedDeployment nor AddFailedDeployment is expected: the
+		// Neither AddDeploymentOutcome nor AddFailedDeployment is expected: the
 		// controller fails the test if the unconfirmed name reaches either.
 		metricsMock.EXPECT().AddUnconfirmedFailure()
 
@@ -2693,17 +2676,17 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 			apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).
 				Return(nil, fmt.Errorf("applications.argoproj.io %q not found", task.App)),
 		)
-		metricsMock.EXPECT().AddProcessedDeployment(task.App)
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusAppNotFoundMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 
 		updater.WaitForRollout(task, false)
 	})
 
-	t.Run("a resumed deployment is not counted again", func(t *testing.T) {
+	t.Run("a resumed deployment is counted by the replica that finishes it", func(t *testing.T) {
 		updater, apiMock, metricsMock := newUpdater(t)
 
 		apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(deployedApp(), nil).AnyTimes()
-		// No AddProcessedDeployment: the replica that accepted the deployment counted it.
+		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -166,9 +166,10 @@ func (monitor *DeploymentMonitor) ConfirmApplication(ctx context.Context, appNam
 	return app, nil
 }
 
-// CountProcessedDeployment records a deployment whose application ArgoCD confirmed.
-func (monitor *DeploymentMonitor) CountProcessedDeployment(app string) {
-	monitor.argo.metrics.AddProcessedDeployment(app)
+// CountDeploymentOutcome records the terminal state a deployment reached, once per
+// deployment and only for an application ArgoCD confirmed.
+func (monitor *DeploymentMonitor) CountDeploymentOutcome(app, result string) {
+	monitor.argo.metrics.AddDeploymentOutcome(app, result)
 }
 
 // StoreInitialAppStatus caches the initial rollout status for comparison during monitoring.

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
@@ -287,6 +288,53 @@ func TestWaitRolloutSkipsValidationWithoutRefresh(t *testing.T) {
 	// No GetManagedResources expectation: any call is a failure.
 	_, _, err := monitor.WaitRollout(task, neverLost)
 	require.NoError(t, err)
+}
+
+// TestWaitForRolloutCountsImageNotPartOfAppAsFailed drives issue #519's fail-fast through
+// the whole rollout: it is the one terminal branch whose outcome nothing else exercises
+// end to end, and the counter reads the status the branch leaves behind.
+func TestWaitForRolloutCountsImageNotPartOfAppAsFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	task := models.Task{
+		Id:      "task-id",
+		App:     "demo",
+		Timeout: 600,
+		Images:  []models.Image{{Image: "ghcr.io/shini4i/typo", Tag: "v1"}},
+	}
+
+	api := mocks.NewMockArgoApiInterface(ctrl)
+	api.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	api.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(settledApp(), nil).MinTimes(1)
+	api.EXPECT().GetManagedResources(gomock.Any(), task.App).Return(
+		managedResources(deploymentWith("ghcr.io/shini4i/app:v1")), nil).Times(1)
+
+	metrics := refreshMetrics(ctrl)
+	state := notSupersededState(ctrl)
+	argo := &Argo{}
+	argo.Init(state, api, metrics)
+
+	cfg := newUpdaterTestConfig(lock.NewInMemoryLocker())
+	cfg.WebhookConfig = nil
+	cfg.RefreshApp = true
+	updater := initTestUpdater(t, cfg, argo)
+
+	var capturedReason string
+	metrics.EXPECT().AddInProgressTask()
+	metrics.EXPECT().RemoveInProgressTask()
+	metrics.EXPECT().AddFailedDeployment(task.App)
+	metrics.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage).Times(1)
+	state.EXPECT().
+		SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).
+		DoAndReturn(func(_ string, _ string, reason string) error {
+			capturedReason = reason
+			return nil
+		})
+
+	updater.WaitForRollout(task, false)
+
+	assert.Contains(t, capturedReason, "is not part of application")
 }
 
 func TestHandleImageNotPartOfApp(t *testing.T) {

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -206,6 +206,7 @@ func TestResumeRollout_KeepsTheOriginalDeadline(t *testing.T) {
 	metricsMock.EXPECT().AddInProgressTask()
 	metricsMock.EXPECT().RemoveInProgressTask()
 	metricsMock.EXPECT().ResetFailedDeployment(task.App)
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusDeployedMessage)
 	metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 

--- a/internal/prometheus/metrics.go
+++ b/internal/prometheus/metrics.go
@@ -8,7 +8,7 @@ import (
 // for dependency injection and mocking in tests.
 type MetricsInterface interface {
 	AddAcceptedDeployment()
-	AddProcessedDeployment(app string)
+	AddDeploymentOutcome(app, result string)
 	AddUnconfirmedFailure()
 	AddFailedDeployment(app string)
 	ResetFailedDeployment(app string)
@@ -27,7 +27,7 @@ type MetricsInterface interface {
 
 type Metrics struct {
 	FailedDeployment     *prometheus.GaugeVec
-	ProcessedDeployments *prometheus.CounterVec
+	DeploymentsTotal     *prometheus.CounterVec
 	AcceptedDeployments  prometheus.Counter
 	UnconfirmedFailures  prometheus.Counter
 	ArgocdUnavailable    prometheus.Gauge
@@ -52,17 +52,12 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "failed_deployment",
 			Help: "Per application failed deployment count before first success.",
 		}, []string{"app"}),
-		// ProcessedDeployments is only incremented once ArgoCD has answered for the
-		// application, which is what makes the app name safe as a label: task submission
-		// takes an arbitrary name without a credential (issue #552). Counted by the replica
-		// that accepted the deployment, so a handover does not count it twice. Its gap to
-		// AcceptedDeployments is dominated by deployments naming an application ArgoCD
-		// never confirmed, but a deployment superseded before its first fetch — or one
-		// whose accepting replica died before reaching it — widens the gap too.
-		ProcessedDeployments: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "processed_deployments",
-			Help: "Deployments taken into monitoring, counted once ArgoCD confirmed the application exists.",
-		}, []string{"app"}),
+		// Counted once per deployment, only for an application ArgoCD confirmed — which is
+		// what makes the app name safe as a label (issue #552). See UnconfirmedFailures.
+		DeploymentsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "deployments_total",
+			Help: "Deployments that reached a terminal state for an application ArgoCD confirmed, by outcome.",
+		}, []string{"app", "result"}),
 		// AcceptedDeployments counts every deployment accepted, recorded when the task is
 		// created and therefore before ArgoCD is asked anything. It carries no app label
 		// because at that point the name is only what the submission claimed, and labelling
@@ -158,15 +153,15 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		}, []string{"app"}),
 	}
 
-	reg.MustRegister(m.FailedDeployment, m.ProcessedDeployments, m.AcceptedDeployments, m.UnconfirmedFailures, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize, m.UnauthenticatedReads, m.SkippedWritebacks)
+	reg.MustRegister(m.FailedDeployment, m.DeploymentsTotal, m.AcceptedDeployments, m.UnconfirmedFailures, m.ArgocdUnavailable, m.StateUnavailable, m.InProgressTasks, m.RefreshDuration, m.GitWritebackDuration, m.GitLockWaitDuration, m.DeploymentDuration, m.GitBatchSize, m.UnauthenticatedReads, m.SkippedWritebacks)
 
 	return m
 }
 
-// AddProcessedDeployment increments ProcessedDeployments for app. Callers must have had
-// the application confirmed by ArgoCD first; see that field.
-func (m *Metrics) AddProcessedDeployment(app string) {
-	m.ProcessedDeployments.WithLabelValues(app).Inc()
+// AddDeploymentOutcome increments DeploymentsTotal for app under the terminal status
+// result. Call once per deployment, and only for a confirmed application; see that field.
+func (m *Metrics) AddDeploymentOutcome(app, result string) {
+	m.DeploymentsTotal.WithLabelValues(app, result).Inc()
 }
 
 // AddAcceptedDeployment increments AcceptedDeployments; see that field for why it carries

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -9,21 +9,42 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-func TestMetrics_AddProcessedDeployment(t *testing.T) {
+// The result strings are spelled out rather than taken from models.Status*: they are a
+// contract read outside Go — the documented PromQL, the Grafana dashboard's byName
+// overrides, and the e2e metric gates — so a renamed constant must fail here.
+func TestMetrics_AddDeploymentOutcome(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg)
 	expectedMetric := `
-		# HELP processed_deployments Deployments taken into monitoring, counted once ArgoCD confirmed the application exists.
-		# TYPE processed_deployments counter
-		processed_deployments{app="test-app"} 1
+		# HELP deployments_total Deployments that reached a terminal state for an application ArgoCD confirmed, by outcome.
+		# TYPE deployments_total counter
+		deployments_total{app="test-app",result="aborted"} 1
+		deployments_total{app="test-app",result="app not found"} 1
+		deployments_total{app="test-app",result="cancelled"} 1
+		deployments_total{app="test-app",result="deployed"} 2
+		deployments_total{app="test-app",result="failed"} 1
 	`
 
-	m.AddProcessedDeployment("test-app")
+	for _, result := range []string{"deployed", "deployed", "failed", "aborted", "app not found", "cancelled"} {
+		m.AddDeploymentOutcome("test-app", result)
+	}
 
-	err := testutil.CollectAndCompare(m.ProcessedDeployments, strings.NewReader(expectedMetric))
+	err := testutil.CollectAndCompare(reg, strings.NewReader(expectedMetric), "deployments_total")
 	assert.NoError(t, err)
+}
+
+// The label values above are only a contract if they are what the rollout actually
+// records, which is what these constants are.
+func TestTerminalStatusConstantsMatchResultLabels(t *testing.T) {
+	assert.Equal(t, "deployed", models.StatusDeployedMessage)
+	assert.Equal(t, "failed", models.StatusFailedMessage)
+	assert.Equal(t, "aborted", models.StatusAborted)
+	assert.Equal(t, "app not found", models.StatusAppNotFoundMessage)
+	assert.Equal(t, "cancelled", models.StatusCancelledMessage)
 }
 
 func TestMetrics_AddFailedDeployment(t *testing.T) {

--- a/monitoring/grafana/dashboards/argo-watcher.json
+++ b/monitoring/grafana/dashboards/argo-watcher.json
@@ -25,7 +25,7 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(processed_deployments{job=\"argo-watcher\"}, app)",
+        "definition": "label_values(deployments_total{job=\"argo-watcher\"}, app)",
         "includeAll": true,
         "allValue": ".*",
         "label": "Application",
@@ -34,7 +34,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(processed_deployments{job=\"argo-watcher\"}, app)",
+          "query": "label_values(deployments_total{job=\"argo-watcher\"}, app)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -142,7 +142,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Deployments Argo CD confirmed and argo-watcher then monitored, since startup (processed_deployments counter, summed over all apps). Submissions that never reached a confirmed application are not here — see accepted_deployments.",
+      "description": "Deployments that reached an outcome, since startup (deployments_total, summed over every app and result). Submissions that never reached a confirmed application are not here — see accepted_deployments.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -169,11 +169,11 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(processed_deployments)",
+          "expr": "sum(deployments_total)",
           "refId": "A"
         }
       ],
-      "title": "Total Processed Deployments",
+      "title": "Total Deployments",
       "type": "stat"
     },
     {
@@ -218,7 +218,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Deployments processed per application within the selected time range (increase of processed_deployments). Sort or filter by column. An application idle in the window reads 0 — widen the range to include its activity. argo-watcher is event-driven, so this is a small integer count, not a per-second rate.",
+      "description": "Deployments per application within the selected time range (increase of deployments_total, every outcome). Sort or filter by column. An application idle in the window reads 0 — widen the range to include its activity. argo-watcher is event-driven, so this is a small integer count, not a per-second rate.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "continuous-GrYlRd" },
@@ -252,7 +252,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "round(sum by (app) (increase(processed_deployments[$__range])))",
+          "expr": "round(sum by (app) (increase(deployments_total[$__range])))",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -369,7 +369,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Deployments per application over time (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
+      "description": "Deployments per application over time (increase of deployments_total per interval). Each bar is the number of deployments in that interval.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -403,7 +403,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (app) (increase(processed_deployments[$__rate_interval]))",
+          "expr": "sum by (app) (increase(deployments_total[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
         }
@@ -412,8 +412,73 @@
       "type": "timeseries"
     },
     {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "How deployments ended within the selected time range (increase of deployments_total by result). \"cancelled\" is a deployment superseded by a newer one for the same application, not a fault. Failures before Argo CD confirmed the application are not here — see unconfirmed_deployment_failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "deployed" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "aborted" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "app not found" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "purple", "mode": "fixed" } } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "cancelled" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "text", "mode": "fixed" } } ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 21 },
+      "id": 15,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.3.8",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (result) (increase(deployments_total[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Deployment Outcomes",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
       "id": 101,
       "panels": [],
       "title": "Per-Application Breakdown — $app",
@@ -421,7 +486,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Deployments over time for the selected application(s) (increase of processed_deployments per interval). Each bar is the number of deployments in that interval.",
+      "description": "Deployments over time for the selected application(s) (increase of deployments_total per interval). Each bar is the number of deployments in that interval.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -445,7 +510,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
       "id": 9,
       "options": {
         "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -455,7 +520,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (app) (increase(processed_deployments{app=~\"$app\"}[$__rate_interval]))",
+          "expr": "sum by (app) (increase(deployments_total{app=~\"$app\"}[$__rate_interval]))",
           "legendFormat": "{{app}}",
           "refId": "A"
         }
@@ -489,7 +554,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
       "id": 10,
       "options": {
         "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -533,7 +598,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 30 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 38 },
       "id": 11,
       "options": {
         "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -589,7 +654,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 30 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 38 },
       "id": 12,
       "options": {
         "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -645,7 +710,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 30 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 38 },
       "id": 13,
       "options": {
         "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -701,7 +766,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 38 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 46 },
       "id": 14,
       "options": {
         "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -114,7 +114,7 @@ again instead of re-establishing a forward.
 | `fixtures/nodeports/` | fixed NodePort Services for the four components phases talk to from the host (one per file, matching `fixtures/postgres/`) |
 | `phases.bats` | the per-release phase suite: one test per phase, with the ordering constraints |
 | `ports.bats` | offline assertions on the kind-config ↔ nodeports port coupling |
-| `scripts/lib.sh` | shared phase helpers: endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`, `helm_apply_aw`, `ok`/`bad`/`phase_end` |
+| `scripts/lib.sh` | shared phase helpers: endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`/`metric_label_sum`, `helm_apply_aw`, `ok`/`bad`/`phase_end` |
 | `scripts/lib.bats` | unit tests for lib.sh's pure text-processing helpers (no cluster needed) |
 | `scripts/soak.sh` | the git-conflict soak: competitor + concurrent deploys, then the `collect.sh` gates |
 | `scripts/verify.sh` | post-`up` gate: readyz 200 and `argocd_unavailable` 0 |

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -3,7 +3,8 @@
 #   - any DATA RACE in an argo-watcher pod log
 #   - failed_deployment or unconfirmed_deployment_failures != 0
 #   - argocd_unavailable != 0
-#   - processed_deployments == 0 (no work was actually processed)
+#   - deployments_total records no outcome at all, or fewer "deployed" than the soak
+#     actually deployed
 #   - accepted_deployments == 0 (no deployment was even submitted)
 #   - in_progress_tasks does not drain back to 0 (leaked/stuck task tracking)
 #   - any of the duration histograms recorded 0 observations, i.e. the
@@ -36,10 +37,15 @@ done
 echo "=== metrics ==="
 metrics="$(curl -s -m 10 "${AW_URL}/metrics")"
 fd=$(metric_sum failed_deployment "$metrics")
-pd=$(metric_sum processed_deployments "$metrics")
+dt=$(metric_sum deployments_total "$metrics")
+# "At least this soak's successes", not an exact tally or a zero-failures gate: the
+# counter is cumulative over a process that earlier phases shared, and unlike the
+# failed_deployment gauge above it never resets when a later deploy recovers.
+ok_dep=$(metric_label_sum deployments_total result deployed "$metrics")
+want_dep=$(jq -r '.deployed' "$SUMMARY")
 # The soak deploys real applications, so every submission must reach Argo CD
-# confirmation: accepted_deployments counts them on submission, processed_deployments
-# once Argo CD answered for the app, and a failure before that lands in
+# confirmation: accepted_deployments counts them on submission, deployments_total
+# once the deployment ends, and a failure before confirmation lands in
 # unconfirmed_deployment_failures — which a green soak never records.
 ad=$(metric_sum accepted_deployments "$metrics")
 # metric_raw, not metric_sum: this counter is unlabelled and always exported, so an
@@ -78,7 +84,7 @@ drained() {
 }
 retry 15 1 drained
 
-echo "  failed_deployment=${fd} processed_deployments=${pd} argocd_unavailable=${au:-?} in_progress_tasks=${ip:-?}"
+echo "  failed_deployment=${fd} deployments_total=${dt} (deployed=${ok_dep}, soak deployed ${want_dep}) argocd_unavailable=${au:-?} in_progress_tasks=${ip:-?}"
 echo "  accepted_deployments=${ad} unconfirmed_deployment_failures=${uf}"
 echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc} deployment_count=${dc}"
 [[ "${fd:-0}" == "0" ]]  || bad "failed_deployment=${fd}"
@@ -87,7 +93,15 @@ echo "  refresh_count=${rc} writeback_count=${wc} lock_wait_count=${lc} deployme
 # the renamed/unregistered case these gates exist to catch.
 [[ "${uf:-absent}" == "0" ]] || bad "unconfirmed_deployment_failures=${uf:-<absent>}"
 [[ "${au:-absent}" == "0" ]] || bad "argocd_unavailable=${au:-<absent>}"
-[[ "${pd:-0}" -gt 0 ]]   || bad "processed_deployments=${pd} (expected > 0)"
+[[ "${dt:-0}" -gt 0 ]] || bad "deployments_total=${dt} (expected > 0)"
+# Checked as text first: jq prints "null" for a missing key, and arithmetic evaluation
+# resolves that to 0, which would satisfy the gate for any counter value.
+if [[ "${want_dep}" =~ ^[0-9]+$ ]]; then
+  [[ "${ok_dep:-0}" -ge "${want_dep}" ]] \
+    || bad "deployments_total{result=deployed}=${ok_dep} < the soak's ${want_dep} deployed task(s)"
+else
+  bad "driver summary has no numeric .deployed (got '${want_dep}')"
+fi
 [[ "${ad:-0}" -gt 0 ]]   || bad "accepted_deployments=${ad} (expected > 0)"
 [[ "${ip:-1}" == "0" ]]  || bad "in_progress_tasks=${ip:-<absent>} did not drain to 0"
 [[ "${rc:-0}" -gt 0 ]]   || bad "argocd_refresh_duration_seconds_count=${rc} (expected > 0)"

--- a/test/e2e/scripts/failure-diagnostics.sh
+++ b/test/e2e/scripts/failure-diagnostics.sh
@@ -268,6 +268,11 @@ SCENARIOS=(
   scenario_image_not_part_of_app
 )
 
+# Every scenario below drives a real deployment to the "failed" status, so the counter
+# must rise by one per scenario. A delta, because it is cumulative across the phases
+# sharing this release.
+failed_before=$(metric_label_sum deployments_total result failed)
+
 # --- runner -----------------------------------------------------------------
 for scenario in "${SCENARIOS[@]}"; do
   echo "=== ${scenario#scenario_} ==="
@@ -307,5 +312,13 @@ for scenario in "${SCENARIOS[@]}"; do
 
   [[ -n "$teardown" ]] && { echo "  teardown: $teardown"; "$teardown"; }
 done
+
+failed_after=$(metric_label_sum deployments_total result failed)
+want_failed=$(( failed_before + ${#SCENARIOS[@]} ))
+if [[ "$failed_after" -ge "$want_failed" ]]; then
+  ok "deployments_total{result=failed} rose to ${failed_after} (>= ${want_failed})"
+else
+  bad "deployments_total{result=failed}=${failed_after}, expected >= ${want_failed} after ${#SCENARIOS[@]} failing deployments"
+fi
 
 phase_end FAILURE-DIAGNOSTICS

--- a/test/e2e/scripts/lib.bats
+++ b/test/e2e/scripts/lib.bats
@@ -131,8 +131,13 @@ metrics_fixture() {
 # HELP failed_deployment Failed deployments
 failed_deployment{app="app1"} 2
 failed_deployment{app="app2"} 3
-processed_deployments 7
-processed_deployments_created 1.7e+09
+accepted_deployments 7
+accepted_deployments_created 1.7e+09
+deployments_total{app="app1",result="deployed"} 4
+deployments_total{app="app2",result="deployed"} 6
+deployments_total{app="app1",result="failed"} 1
+deployments_total{app="app1",result="app not found"} 2
+deployments_total_created{app="app1",result="deployed"} 1.7e+09
 argocd_unavailable 0
 gitops_writeback_duration_seconds_bucket{le="0.5"} 11
 gitops_writeback_duration_seconds_sum 4.2
@@ -147,7 +152,7 @@ PROM
 }
 
 @test "metric_sum reads an unlabelled series" {
-  run metric_sum processed_deployments "$(metrics_fixture)"
+  run metric_sum accepted_deployments "$(metrics_fixture)"
   assert_output "7"
 }
 
@@ -162,10 +167,33 @@ PROM
 }
 
 @test "metric_sum does not capture the _created sibling" {
-  # A bare prefix match would fold processed_deployments_created (a unix timestamp)
-  # into processed_deployments.
-  run metric_sum processed_deployments "$(metrics_fixture)"
+  # A bare prefix match would fold accepted_deployments_created (a unix timestamp)
+  # into accepted_deployments.
+  run metric_sum accepted_deployments "$(metrics_fixture)"
   assert_output "7"
+}
+
+@test "metric_label_sum sums only the matching label value" {
+  run metric_label_sum deployments_total result deployed "$(metrics_fixture)"
+  assert_output "10"
+}
+
+@test "metric_label_sum yields 0 when no series carries the value" {
+  run metric_label_sum deployments_total result aborted "$(metrics_fixture)"
+  assert_output "0"
+}
+
+@test "metric_label_sum does not capture the _created sibling" {
+  # deployments_total_created carries the same labels, so an unanchored match would
+  # fold a unix timestamp into the count and the collect.sh gate would pass vacuously.
+  run metric_label_sum deployments_total result deployed "$(metrics_fixture)"
+  assert_output "10"
+}
+
+@test "metric_label_sum matches a value containing spaces" {
+  # "app not found" is a real result value, and the sum reads the last column.
+  run metric_label_sum deployments_total result "app not found" "$(metrics_fixture)"
+  assert_output "2"
 }
 
 @test "metric_sum histogram _count excludes _bucket and _sum" {
@@ -194,7 +222,7 @@ PROM
 @test "metric_raw does not match a longer metric name by prefix" {
   # The trailing space in the pattern is what keeps in_progress_tasks from also
   # matching an in_progress_tasks_total, and argocd_unavailable from a _created.
-  run metric_raw processed_deployments "$(metrics_fixture)"
+  run metric_raw accepted_deployments "$(metrics_fixture)"
   assert_output "7"
 }
 

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -203,13 +203,22 @@ post_task() {
 
 # metric_sum <metric> [metrics-text]: sum the value column across every series of
 # <metric>, scraping /metrics if no text is given. The `[ {]` guard anchors on the
-# exact metric name, so `processed_deployments` never captures
-# `processed_deployments_created` and a histogram's `_count` never pulls in its
+# exact metric name, so `accepted_deployments` never captures
+# `accepted_deployments_created` and a histogram's `_count` never pulls in its
 # `_bucket` / `_sum` siblings.
 metric_sum() {
   local metric="$1" text="${2-}"
   [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
   awk -v k="^${metric}[ {]" '$0 ~ k {s+=$NF} END{print s+0}' <<<"$text"
+  return
+}
+
+# metric_label_sum <metric> <label> <value> [metrics-text]: metric_sum restricted to
+# the series carrying <label>="<value>".
+metric_label_sum() {
+  local metric="$1" label="$2" value="$3" text="${4-}"
+  [[ -n "$text" ]] || text="$(curl -s -m 10 "${AW_URL}/metrics")"
+  awk -v k="^${metric}[{].*${label}=\"${value}\"" '$0 ~ k {s+=$NF} END{print s+0}' <<<"$text"
   return
 }
 

--- a/test/e2e/scripts/race-supersede.sh
+++ b/test/e2e/scripts/race-supersede.sh
@@ -79,6 +79,10 @@ SECONDS_TOTAL="$COMPETITOR_SECONDS" INTERVAL="$COMPETITOR_INTERVAL" \
   "${here}/competitor.sh" & comp_pid=$!
 sleep 5
 
+# Read as a delta around the race: the counter is cumulative and shared with every
+# other phase running against this release.
+cancelled_before=$(metric_label_sum deployments_total result cancelled)
+
 # 3) Race: fire OLD then NEW; NEW must supersede the still-retrying OLD.
 echo "race: ${APP} <- OLD ${OLD_TAG} then NEW ${NEW_TAG} (competitor forces write-back retries)"
 deploy "$OLD_TAG" "$old_out" & old_pid=$!
@@ -108,6 +112,9 @@ grep -qiE "supersed|cancel" "$old_out" \
   || bad "OLD client output did not report the deploy was superseded/cancelled"
 [[ "$committed" == "$NEW_TAG" ]] \
   || bad "committed tag ${committed:-<none>} is not the newer ${NEW_TAG} (superseded task may have clobbered the winner)"
+cancelled_after=$(metric_label_sum deployments_total result cancelled)
+[[ "$cancelled_after" -gt "$cancelled_before" ]] \
+  || bad "deployments_total{result=cancelled} did not rise (${cancelled_before} -> ${cancelled_after})"
 
 if [[ "$E2E_FAILS" -eq 0 ]]; then
   echo "race OK: newer tag ${NEW_TAG} won; older ${OLD_TAG} was superseded and did not clobber it"


### PR DESCRIPTION
Closes #554.

Replaces `processed_deployments{app}` with `deployments_total{app,result}`, counted once per deployment under the terminal status it reached, so `sum by (result) (increase(deployments_total[1h]))` gives a real outcome breakdown and a success rate.

Counting at the outcome rather than at ArgoCD confirmation leaves a single call site, which is what makes it exactly once across a replica handover. `cancelled` is counted so the sum still equals what `processed_deployments` counted.

**Breaking:** `processed_deployments` is removed. `sum without (result) (deployments_total)` is the substitute, with one difference: it increments when a deployment ends, not when ArgoCD confirms the app, so one in flight is not counted until it finishes — use `in_progress_tasks` for the live view. The bundled dashboard is already updated.