### PR TITLE
feat(web): show the signed-in user in the side panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set is bounded by the task statuses, so there is no cardinality risk. The bundled Grafana
   dashboard gains a **Deployment Outcomes** panel, and `docs/operations/observability.md`
   carries the success-rate query.
+- The workspace side panel now shows an account card for the signed-in user: their avatar,
+  display name and email, a crown when they belong to one of `OIDC_PRIVILEGED_GROUPS`, and
+  a menu holding **Log out** — the first way to end a session from the UI. The avatar comes
+  from the provider's `picture` claim; users whose provider serves none get their initial.
+  The card only appears when OIDC is enabled.
+- `OIDC_GRAVATAR_FALLBACK` (default `false`) lets the account card fall back to Gravatar
+  when the provider serves no `picture` claim. It is opt-in because it sends a hash of the
+  signed-in user's email address to gravatar.com — hashed, but a hash of a known address
+  is trivially reversible. An address with no Gravatar still falls back to the initial.
 
 ### Changed
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -10,6 +10,7 @@ With OIDC disabled (the default) nothing is protected: there is no backend to va
 2. The backend validates the token by calling the provider's **userinfo** endpoint, which it discovers from `<issuer>/.well-known/openid-configuration`. Discovery happens lazily on the first validation, so a provider that is briefly down at boot does not stop Argo Watcher from starting.
 3. Reads the Web UI performs require a credential — being signed in is enough, no group needed.
 4. Users in a **privileged group** additionally get the **Rollback to this version** button on a task, and control of the [deployment lock](deployment-lock.md).
+5. Signed-in users get an account card in the side panel (opened from the logo) showing their avatar, name and email, with **Log out** in its menu.
 
 The browser performs discovery and the code exchange itself, so the issuer must be reachable **from the browser as well as from the server**. When a sign-in cannot complete, the Web UI stops on its loading screen and names the reason instead of bouncing back to the provider — see [Web UI stops on "Sign-in failed"](../operations/troubleshooting.md#web-ui-stops-on-sign-in-failed).
 
@@ -23,8 +24,11 @@ The browser performs discovery and the code exchange itself, so the issuer must 
 | `OIDC_PRIVILEGED_GROUPS` | Comma-separated groups allowed to roll back and to manage the lock | | No |
 | `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
 | `OIDC_REQUIRE_TASK_READ_AUTH` | Also require a credential on `GET /api/v1/tasks/{id}` | `false` | No |
+| `OIDC_GRAVATAR_FALLBACK` | Fall back to Gravatar when the provider sends no `picture` claim | `false` | No |
 
 The server refuses to start with `OIDC_ENABLED=true` and no issuer or client id. Leaving `OIDC_PRIVILEGED_GROUPS` empty is valid — it simply means nobody is privileged.
+
+`OIDC_GRAVATAR_FALLBACK` is off by default because it discloses the signed-in user's email address to gravatar.com. The address is hashed, but a hash of a known address is trivially reversible, so treat it as the address itself. With the setting off, a user whose provider serves no `picture` claim gets an initial instead.
 
 `OIDC_ISSUER_URL` is whatever the provider advertises as its `issuer`:
 
@@ -155,4 +159,4 @@ Earlier releases were Keycloak-specific. The old variables are **deprecated but 
 
 ## Privileged groups
 
-Members of `OIDC_PRIVILEGED_GROUPS` get two things: the **Rollback to this version** button on a task page, which is hidden from everyone else, and the [deployment lock](deployment-lock.md) switch, which others see disabled. Restricting rollback per application is not implemented yet.
+Members of `OIDC_PRIVILEGED_GROUPS` get three things: the **Rollback to this version** button on a task page, which is hidden from everyone else, the [deployment lock](deployment-lock.md) switch, which others see disabled, and a crown on their account card in the side panel. Restricting rollback per application is not implemented yet.

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -46,6 +46,7 @@ The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you 
 | `OIDC_PRIVILEGED_GROUPS` | Groups allowed to roll back a task and manage the deploy lock | | No |
 | `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
 | `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}` too | `false` | No |
+| `OIDC_GRAVATAR_FALLBACK` | Let the account card fall back to Gravatar when the provider sends no `picture` claim | `false` | No |
 
 Enabling OIDC also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The legacy `KEYCLOAK_*` variables are still honored but deprecated ([migration table](../guides/oidc.md#migrating-from-keycloak_)).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ const maxTaskRetentionDays = 36500
 // clients that poll it without a credential. It is opt-in because turning it on
 // fails every deployment driven by such a client; the unauthenticated_reads metric
 // reports how many are left.
+//
+// GravatarFallback lets the UI fall back to gravatar.com for users whose provider
+// serves no picture claim. It is opt-in because it discloses the signed-in user's
+// email address to a third party: the address is hashed, but a hash of a known
+// address is trivially reversible.
 type OIDCConfig struct {
 	Enabled                 bool     `env:"OIDC_ENABLED" json:"enabled"`
 	IssuerURL               string   `env:"OIDC_ISSUER_URL" json:"issuer_url,omitempty"`
@@ -43,6 +48,7 @@ type OIDCConfig struct {
 	TokenValidationInterval int      `env:"OIDC_TOKEN_VALIDATION_INTERVAL" envDefault:"300000" json:"token_validation_interval"`
 	PrivilegedGroups        []string `env:"OIDC_PRIVILEGED_GROUPS" json:"privileged_groups,omitempty"`
 	RequireTaskReadAuth     bool     `env:"OIDC_REQUIRE_TASK_READ_AUTH" json:"-"`
+	GravatarFallback        bool     `env:"OIDC_GRAVATAR_FALLBACK" json:"gravatar_fallback"`
 }
 
 type DatabaseConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,8 @@ const maxTaskRetentionDays = 36500
 // fails every deployment driven by such a client; the unauthenticated_reads metric
 // reports how many are left.
 //
-// GravatarFallback lets the UI fall back to gravatar.com for users whose provider
-// serves no picture claim. It is opt-in because it discloses the signed-in user's
-// email address to a third party: the address is hashed, but a hash of a known
-// address is trivially reversible.
+// GravatarFallback is opt-in because it discloses the user's email address to
+// gravatar.com — hashed, but reversible for any address worth guessing.
 type OIDCConfig struct {
 	Enabled                 bool     `env:"OIDC_ENABLED" json:"enabled"`
 	IssuerURL               string   `env:"OIDC_ISSUER_URL" json:"issuer_url,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -648,3 +648,46 @@ func TestServerConfig_TaskRetentionNotExposed(t *testing.T) {
 	assert.NotContains(t, strings.ToLower(string(jsonBytes)), "retention")
 	assert.NotContains(t, string(jsonBytes), "4242", "the window must not leak under a renamed key either")
 }
+
+// The Gravatar fallback sends a hash of the signed-in user's email to a third party,
+// so it must stay off unless an operator turns it on, and it must reach the UI through
+// /api/v1/config for the browser to act on it.
+func TestNewServerConfig_GravatarFallback(t *testing.T) {
+	baseEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "in-memory")
+	}
+
+	t.Run("defaults to off", func(t *testing.T) {
+		baseEnv(t)
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.False(t, cfg.OIDC.GravatarFallback)
+	})
+
+	t.Run("enabled by the operator", func(t *testing.T) {
+		baseEnv(t)
+		t.Setenv("OIDC_ENABLED", "true")
+		t.Setenv("OIDC_ISSUER_URL", "https://idp.example.com/application/o/aw/")
+		t.Setenv("OIDC_CLIENT_ID", "argo-watcher")
+		t.Setenv("OIDC_GRAVATAR_FALLBACK", "true")
+
+		cfg, err := NewServerConfig()
+
+		require.NoError(t, err)
+		assert.True(t, cfg.OIDC.GravatarFallback)
+	})
+
+	t.Run("is published to the UI", func(t *testing.T) {
+		cfg := &ServerConfig{OIDC: OIDCConfig{Enabled: true, GravatarFallback: true}}
+
+		encoded, err := json.Marshal(cfg)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(encoded), `"gravatar_fallback":true`)
+	})
+}

--- a/web/e2e/auth/logout.spec.ts
+++ b/web/e2e/auth/logout.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { expectAppLoaded, KEYCLOAK_ORIGIN, signIn } from '../helpers';
+
+/**
+ * Signing out has to end the session at the provider, not just in the browser: the
+ * app holds its token in memory only, so a local-only sign-out would be undone by
+ * the next silent SSO login. Only a real provider proves the end-session redirect
+ * happens and that the app comes back unauthenticated.
+ */
+test('the account card signs the user out at the provider', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  await signIn(page);
+  await expectAppLoaded(page);
+
+  await page.getByRole('button', { name: 'Open configuration drawer' }).click();
+  // The account card is the drawer's only menu trigger; its label is the display
+  // name the provider issues, which is not this spec's subject.
+  await page.locator('[aria-haspopup="menu"]').click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
+
+  // Whether the provider asks to confirm depends on the id_token_hint it received,
+  // so accept the prompt when it appears rather than requiring it.
+  await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
+  const confirm = page.getByRole('button', { name: /log ?out/i });
+  if (await confirm.isVisible().catch(() => false)) {
+    await confirm.click();
+  }
+
+  // No session left: the app bounces the returning browser back to the login form.
+  await expect(page.locator('#kc-form-login')).toBeVisible({ timeout: 15_000 });
+});

--- a/web/e2e/auth/logout.spec.ts
+++ b/web/e2e/auth/logout.spec.ts
@@ -2,10 +2,8 @@ import { expect, test } from '@playwright/test';
 import { expectAppLoaded, KEYCLOAK_ORIGIN, signIn } from '../helpers';
 
 /**
- * Signing out has to end the session at the provider, not just in the browser: the
- * app holds its token in memory only, so a local-only sign-out would be undone by
- * the next silent SSO login. Only a real provider proves the end-session redirect
- * happens and that the app comes back unauthenticated.
+ * The token lives in memory only, so a local-only sign-out would be undone by the
+ * next silent SSO login — only a real provider proves the session actually ended.
  */
 test('the account card signs the user out at the provider', async ({ page }) => {
   await page.goto('/');

--- a/web/e2e/auth/privileged-gating.spec.ts
+++ b/web/e2e/auth/privileged-gating.spec.ts
@@ -56,6 +56,10 @@ test.describe('privileged control gating', () => {
     await expect(page.getByRole('button', { name: ROLLBACK_BUTTON })).toBeVisible();
 
     await openConfigDrawer(page);
+    // The realm builds the display name from firstName+lastName; the crown reflects
+    // the same userinfo groups the lock toggle gates on.
+    await expect(page.getByText('Priv User')).toBeVisible();
+    await expect(page.getByRole('img', { name: 'Privileged access' })).toBeVisible();
     await expect(page.getByLabel(LOCK_SWITCH)).toBeEnabled();
 
     const token = await mintToken(request, PRIVILEGED_USER);
@@ -75,6 +79,9 @@ test.describe('privileged control gating', () => {
     await expect(page.getByRole('button', { name: ROLLBACK_BUTTON })).toHaveCount(0);
 
     await openConfigDrawer(page);
+    // The badge still names the user — only the crown is withheld.
+    await expect(page.getByText('Regular User')).toBeVisible();
+    await expect(page.getByRole('img', { name: 'Privileged access' })).toHaveCount(0);
     await expect(page.getByLabel(LOCK_SWITCH)).toBeDisabled();
     await expect(page.getByText('Deploy lock requires privileged access.')).toBeVisible();
 

--- a/web/e2e/no-auth/anonymous-mode.spec.ts
+++ b/web/e2e/no-auth/anonymous-mode.spec.ts
@@ -24,6 +24,10 @@ test('an anonymous deployment renders without a sign-in and hides privileged con
   // The toggle is not merely disabled here: without OIDC there is no identity to
   // authorize, so the control is not offered at all.
   await expect(page.getByLabel('Toggle deploy lock')).toHaveCount(0);
+  // Same reason there is no identity to authorize: there is none to name either.
+  // Keys on the account card's menu trigger, the one element the badge always renders.
+  await expect(page.locator('[aria-haspopup="menu"]')).toHaveCount(0);
+  await expect(page.getByRole('img', { name: 'Privileged access' })).toHaveCount(0);
 
   await page.keyboard.press('Escape');
   await expect(page.getByRole('button', { name: 'Rollback to this version' })).toHaveCount(0);

--- a/web/src/auth/authProvider.test.ts
+++ b/web/src/auth/authProvider.test.ts
@@ -244,6 +244,17 @@ describe('authProvider', () => {
     expect(identity.avatar).toBe('https://idp.example.com/avatar.png');
   });
 
+  it('keeps the identity when the digest fails', async () => {
+    mockConfig(enabledConfig({ gravatar_fallback: true }));
+    userManagerMock.getUser.mockResolvedValue(signedInUser());
+    vi.spyOn(globalThis.crypto.subtle, 'digest').mockRejectedValue(new Error('no digest'));
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.email).toBe('user@example.com');
+    expect(identity.avatar).toBeUndefined();
+  });
+
   it('serves no Gravatar for a user without an email', async () => {
     mockConfig(enabledConfig({ gravatar_fallback: true }));
     userManagerMock.getUser.mockResolvedValue(signedInUser({ email: undefined }));

--- a/web/src/auth/authProvider.test.ts
+++ b/web/src/auth/authProvider.test.ts
@@ -200,6 +200,68 @@ describe('authProvider', () => {
     expect(identity.id).toBe('user-id');
   });
 
+  it('exposes the profile picture as the identity avatar', async () => {
+    mockConfig(enabledConfig());
+    userManagerMock.getUser.mockResolvedValue(
+      signedInUser({ picture: 'https://idp.example.com/avatar.png' }),
+    );
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.fullName).toBe('User Example');
+    expect(identity.avatar).toBe('https://idp.example.com/avatar.png');
+  });
+
+  it('leaves the identity avatar undefined without a picture claim', async () => {
+    mockConfig(enabledConfig());
+    userManagerMock.getUser.mockResolvedValue(signedInUser());
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.avatar).toBeUndefined();
+  });
+
+  it('derives a Gravatar avatar when the provider serves no picture and the fallback is on', async () => {
+    mockConfig(enabledConfig({ gravatar_fallback: true }));
+    userManagerMock.getUser.mockResolvedValue(signedInUser());
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    // sha256('user@example.com'), per the current Gravatar spec.
+    expect(identity.avatar).toBe(
+      'https://www.gravatar.com/avatar/b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514?s=80&d=404',
+    );
+  });
+
+  it('prefers the provider picture over Gravatar', async () => {
+    mockConfig(enabledConfig({ gravatar_fallback: true }));
+    userManagerMock.getUser.mockResolvedValue(
+      signedInUser({ picture: 'https://idp.example.com/avatar.png' }),
+    );
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.avatar).toBe('https://idp.example.com/avatar.png');
+  });
+
+  it('serves no Gravatar for a user without an email', async () => {
+    mockConfig(enabledConfig({ gravatar_fallback: true }));
+    userManagerMock.getUser.mockResolvedValue(signedInUser({ email: undefined }));
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.avatar).toBeUndefined();
+  });
+
+  it('falls back to preferred_username when the name claim is blank', async () => {
+    mockConfig(enabledConfig());
+    userManagerMock.getUser.mockResolvedValue(signedInUser({ name: '' }));
+    const provider = await loadAuthProvider();
+
+    const identity = await provider.getIdentity!();
+    expect(identity.fullName).toBe('user');
+  });
+
   it('reads groups from userinfo (the source the backend enforces on), not the ID token', async () => {
     mockConfig(enabledConfig(), ['admins']);
     userManagerMock.getUser.mockResolvedValue(signedInUser({ groups: [] }));

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -15,6 +15,7 @@ interface OidcConfig {
   issuer_url?: string;
   client_id?: string;
   privileged_groups?: string[];
+  gravatar_fallback?: boolean;
 }
 
 interface ServerConfig {
@@ -355,6 +356,31 @@ export const bootstrapAuth = async ({
   return ensureAuthenticated(manager);
 };
 
+/**
+ * Gravatar URL for an email address, hashed with SHA-256 as the current Gravatar
+ * spec requires. `d=404` makes an address without a Gravatar fail the image load,
+ * which is what lets the badge fall back to the initial instead of showing a
+ * generic silhouette.
+ *
+ * WebCrypto is unavailable outside a secure context, so an installation served over
+ * plain HTTP gets no Gravatar rather than a broken one.
+ *
+ * @returns the avatar URL, or undefined without an email or a usable WebCrypto.
+ */
+const gravatarUrl = async (email?: string): Promise<string | undefined> => {
+  const normalized = email?.trim().toLowerCase();
+  const subtle = globalThis.crypto?.subtle;
+  if (!normalized || !subtle) {
+    return undefined;
+  }
+
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(normalized));
+  const hash = Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `https://www.gravatar.com/avatar/${hash}?s=80&d=404`;
+};
+
 export const authProvider: AuthProvider = {
   async login(params) {
     const manager = await ensureUserManager();
@@ -431,19 +457,24 @@ export const authProvider: AuthProvider = {
     return { groups, privilegedGroups } satisfies Permissions;
   },
 
-  async getIdentity(): Promise<{ id: Identifier; fullName?: string; email?: string }> {
+  async getIdentity(): Promise<{ id: Identifier; fullName?: string; email?: string; avatar?: string }> {
     const manager = await ensureUserManager();
     if (!manager) {
-      return { id: 'anonymous', fullName: 'Anonymous', email: undefined };
+      return { id: 'anonymous', fullName: 'Anonymous', email: undefined, avatar: undefined };
     }
 
     const user = await manager.getUser();
     const profile = user?.profile ?? {};
     const id = (profile.sub as Identifier) ?? 'unknown';
-    const fullName = (profile.name as string) ?? (profile.preferred_username as string) ?? undefined;
-    const email = (profile.email as string) ?? undefined;
+    // || not ??: a provider that concatenates absent given/family names sends an
+    // empty string, which must fall through to the next claim.
+    const fullName = (profile.name as string) || (profile.preferred_username as string) || undefined;
+    const email = (profile.email as string) || undefined;
+    const avatar =
+      (profile.picture as string) ||
+      (serverConfig?.oidc?.gravatar_fallback ? await gravatarUrl(email) : undefined);
 
-    return { id, fullName, email };
+    return { id, fullName, email, avatar };
   },
 };
 

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -368,7 +368,14 @@ const gravatarUrl = async (email?: string): Promise<string | undefined> => {
     return undefined;
   }
 
-  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(normalized));
+  // An optional avatar must never cost the identity it decorates.
+  const digest = await subtle
+    .digest('SHA-256', new TextEncoder().encode(normalized))
+    .catch(() => undefined);
+  if (!digest) {
+    return undefined;
+  }
+
   const hash = Array.from(new Uint8Array(digest))
     .map(byte => byte.toString(16).padStart(2, '0'))
     .join('');

--- a/web/src/auth/authProvider.ts
+++ b/web/src/auth/authProvider.ts
@@ -357,15 +357,9 @@ export const bootstrapAuth = async ({
 };
 
 /**
- * Gravatar URL for an email address, hashed with SHA-256 as the current Gravatar
- * spec requires. `d=404` makes an address without a Gravatar fail the image load,
- * which is what lets the badge fall back to the initial instead of showing a
- * generic silhouette.
- *
- * WebCrypto is unavailable outside a secure context, so an installation served over
- * plain HTTP gets no Gravatar rather than a broken one.
- *
- * @returns the avatar URL, or undefined without an email or a usable WebCrypto.
+ * SHA-256 Gravatar URL, or undefined without an email or WebCrypto (which is
+ * absent outside a secure context). `d=404` so an address with no Gravatar fails
+ * the image load and the badge falls back to the initial.
  */
 const gravatarUrl = async (email?: string): Promise<string | undefined> => {
   const normalized = email?.trim().toLowerCase();

--- a/web/src/layout/components/AppTopBar.test.tsx
+++ b/web/src/layout/components/AppTopBar.test.tsx
@@ -15,6 +15,7 @@ const httpClientMock = vi.fn();
 const notifyMock = vi.fn();
 const permissionsMock = vi.fn();
 const oidcEnabledMock = vi.fn();
+const identityMock = vi.fn();
 
 vi.mock('../../data/httpClient', () => ({
   httpClient: (...args: unknown[]) => httpClientMock(...args),
@@ -38,6 +39,8 @@ vi.mock('react-admin', async () => {
     ...actual,
     useNotify: () => notifyMock,
     usePermissions: () => permissionsMock(),
+    useGetIdentity: () => identityMock(),
+    useLogout: () => vi.fn(),
   };
 });
 
@@ -48,6 +51,11 @@ describe('AppTopBar', () => {
     permissionsMock.mockReset();
     oidcEnabledMock.mockReset();
     oidcEnabledMock.mockReturnValue(true);
+    identityMock.mockReset();
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'Shini4i' },
+      isPending: false,
+    });
     permissionsMock.mockReturnValue({
       permissions: { groups: ['devops'], privilegedGroups: ['devops'] },
       isLoading: false,

--- a/web/src/layout/components/ConfigDrawer.test.tsx
+++ b/web/src/layout/components/ConfigDrawer.test.tsx
@@ -13,6 +13,7 @@ vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 const notifyMock = vi.fn();
 const oidcEnabledMock = vi.fn();
 const permissionsMock = vi.fn();
+const identityMock = vi.fn();
 
 vi.mock('../../features/deployLock/deployLockService', () => ({
   deployLockService: {
@@ -32,6 +33,8 @@ vi.mock('react-admin', async () => {
     ...actual,
     usePermissions: () => permissionsMock(),
     useNotify: () => notifyMock,
+    useGetIdentity: () => identityMock(),
+    useLogout: () => vi.fn(),
   };
 });
 
@@ -61,6 +64,11 @@ describe('ConfigDrawer', () => {
     vi.mocked(deployLockService.subscribe).mockReset();
     oidcEnabledMock.mockReset();
     permissionsMock.mockReset();
+    identityMock.mockReset();
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'Shini4i' },
+      isPending: false,
+    });
     oidcEnabledMock.mockReturnValue(true);
     permissionsMock.mockReturnValue({
       permissions: { groups: ['devops'], privilegedGroups: ['devops'] },
@@ -147,6 +155,40 @@ describe('ConfigDrawer', () => {
 
     expect(deployLockService.releaseLock).toHaveBeenCalled();
     expect(notifyMock).toHaveBeenCalledWith('Deploy lock released.', { type: 'info' });
+  });
+
+  it('shows the signed-in user badge with a crown for privileged users', () => {
+    renderDrawer();
+
+    expect(screen.getByText('Shini4i')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /privileged access/i })).toBeInTheDocument();
+  });
+
+  it('drops the crown for a user outside the privileged groups', () => {
+    permissionsMock.mockReturnValue({
+      permissions: { groups: ['dev'], privilegedGroups: ['devops'] },
+      isLoading: false,
+    });
+    renderDrawer();
+
+    expect(screen.getByText('Shini4i')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: /privileged access/i })).toBeNull();
+  });
+
+  it('hides the user badge when OIDC is disabled', () => {
+    oidcEnabledMock.mockReturnValue(false);
+    renderDrawer();
+
+    expect(screen.queryByText('Shini4i')).toBeNull();
+    expect(screen.queryByRole('img', { name: /privileged access/i })).toBeNull();
+  });
+
+  it('hides the user badge while the OIDC status is unknown', () => {
+    oidcEnabledMock.mockReturnValue(null);
+    renderDrawer();
+
+    expect(screen.queryByText('Shini4i')).toBeNull();
+    expect(screen.queryByRole('img', { name: /privileged access/i })).toBeNull();
   });
 
   it('does not render the backend configuration section', () => {

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -20,6 +20,7 @@ import { useDeployLock } from '../../features/deployLock/DeployLockProvider';
 import { useOidcEnabled } from '../../shared/hooks/useOidcEnabled';
 import { hasPrivilegedAccess } from '../../shared/utils/permissions';
 import { useTimezone } from '../../shared/providers/TimezoneProvider';
+import { UserBadge } from './UserBadge';
 
 interface ConfigDrawerProps {
   open: boolean;
@@ -101,6 +102,8 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
               v{version}
             </Typography>
           </Stack>
+
+          {oidcEnabled === true && <UserBadge privileged={privileged} />}
 
           <Stack spacing={1.5} component="section" aria-labelledby="drawer-appearance">
             <Typography variant="subtitle2" sx={{

--- a/web/src/layout/components/UserBadge.test.tsx
+++ b/web/src/layout/components/UserBadge.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserBadge } from './UserBadge';
+
+const identityMock = vi.fn();
+const logoutMock = vi.fn();
+
+vi.mock('react-admin', async () => {
+  const actual = await vi.importActual<typeof import('react-admin')>('react-admin');
+  return {
+    ...actual,
+    useGetIdentity: () => identityMock(),
+    useLogout: () => logoutMock,
+  };
+});
+
+describe('UserBadge', () => {
+  beforeEach(() => {
+    identityMock.mockReset();
+    logoutMock.mockReset();
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'Shini4i', email: 'user@example.com' },
+      isPending: false,
+    });
+  });
+
+  it('renders the display name', () => {
+    render(<UserBadge privileged={false} />);
+    expect(screen.getByText('Shini4i')).toBeInTheDocument();
+  });
+
+  it('renders the profile picture when the identity carries one', () => {
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'Shini4i', avatar: 'https://idp.example.com/avatar.png' },
+      isPending: false,
+    });
+    const { container } = render(<UserBadge privileged={false} />);
+
+    expect(container.querySelector('img')).toHaveAttribute('src', 'https://idp.example.com/avatar.png');
+  });
+
+  it('falls back to the email when no name is present', () => {
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', email: 'user@example.com' },
+      isPending: false,
+    });
+    render(<UserBadge privileged={false} />);
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+
+  it('marks a privileged user with a crown', () => {
+    render(<UserBadge privileged />);
+    expect(screen.getByRole('img', { name: /privileged access/i })).toBeInTheDocument();
+  });
+
+  it('omits the crown for a regular user', () => {
+    render(<UserBadge privileged={false} />);
+    expect(screen.queryByRole('img', { name: /privileged access/i })).toBeNull();
+  });
+
+  it('signs the user out from the badge menu', async () => {
+    render(<UserBadge privileged={false} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Shini4i/ }));
+    await user.click(await screen.findByRole('menuitem', { name: /log out/i }));
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the menu without signing out when dismissed', async () => {
+    render(<UserBadge privileged={false} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Shini4i/ }));
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).toBeNull());
+    expect(logoutMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the uppercased initial and no image when the provider serves no picture', () => {
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'shini4i', email: 'user@example.com' },
+      isPending: false,
+    });
+    const { container } = render(<UserBadge privileged />);
+
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('shows both the picture and the crown for a privileged user', () => {
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: 'Shini4i', avatar: 'https://idp.example.com/avatar.png' },
+      isPending: false,
+    });
+    const { container } = render(<UserBadge privileged />);
+
+    expect(container.querySelector('img')).toHaveAttribute('src', 'https://idp.example.com/avatar.png');
+    expect(screen.getByRole('img', { name: /privileged access/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the email as the display name when the name claim is blank', () => {
+    identityMock.mockReturnValue({
+      identity: { id: 'user-id', fullName: '', email: 'user@example.com' },
+      isPending: false,
+    });
+    render(<UserBadge privileged={false} />);
+
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+
+  it('still renders a card with a sign-out menu when the provider names nobody', () => {
+    identityMock.mockReturnValue({ identity: { id: 'user-id' }, isPending: false });
+    render(<UserBadge privileged={false} />);
+
+    expect(screen.getByRole('button', { name: /Signed in/ })).toBeInTheDocument();
+  });
+
+  it('renders nothing when the identity lookup fails', () => {
+    identityMock.mockReturnValue({
+      identity: undefined,
+      isPending: false,
+      error: new Error('identity unavailable'),
+    });
+    const { container } = render(<UserBadge privileged={false} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while the identity is loading', () => {
+    identityMock.mockReturnValue({ identity: undefined, isPending: true });
+    const { container } = render(<UserBadge privileged={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/layout/components/UserBadge.tsx
+++ b/web/src/layout/components/UserBadge.tsx
@@ -29,12 +29,8 @@ const CrownIcon = (props: SvgIconProps) => (
 );
 
 /**
- * Account card for the signed-in user: the OIDC profile picture (initial when the
- * provider serves none), the display name with a crown for privileged users, the
- * email, and a menu holding the sign-out action.
- *
- * Renders nothing until an identity resolves, so a session still being established
- * never shows an empty card.
+ * Account card for the signed-in user — picture or initial, name, crown when
+ * privileged, email — with sign-out in its menu. Empty until an identity resolves.
  */
 export const UserBadge = ({ privileged }: UserBadgeProps) => {
   const { identity, isPending } = useGetIdentity();
@@ -44,10 +40,9 @@ export const UserBadge = ({ privileged }: UserBadgeProps) => {
   if (isPending || !identity?.id) {
     return null;
   }
-  // A provider is free to keep every naming claim out of the ID token; the card still
-  // has to render, because its menu is the only way to sign out.
+  // A provider may keep every naming claim out of the ID token; the card must still
+  // render, because its menu is the only way to sign out.
   const name = identity.fullName || identity.email || 'Signed in';
-  // Only a second line when it adds something the name does not already say.
   const secondary = identity?.email && identity.email !== name ? identity.email : undefined;
 
   return (

--- a/web/src/layout/components/UserBadge.tsx
+++ b/web/src/layout/components/UserBadge.tsx
@@ -1,0 +1,135 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import LogoutIcon from '@mui/icons-material/Logout';
+import {
+  Avatar,
+  ButtonBase,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Stack,
+  SvgIcon,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import type { SvgIconProps } from '@mui/material';
+import { useState } from 'react';
+import { useGetIdentity, useLogout } from 'react-admin';
+
+interface UserBadgeProps {
+  /** Whether the signed-in user belongs to one of the configured privileged groups. */
+  readonly privileged: boolean;
+}
+
+/** Crown marking a privileged user; @mui/icons-material ships no crown glyph. */
+const CrownIcon = (props: SvgIconProps) => (
+  <SvgIcon viewBox="0 0 24 24" {...props}>
+    <path d="M3 5l5.5 4L12 3l3.5 6L21 5l-2 12H5L3 5zm2 14h14v2H5v-2z" />
+  </SvgIcon>
+);
+
+/**
+ * Account card for the signed-in user: the OIDC profile picture (initial when the
+ * provider serves none), the display name with a crown for privileged users, the
+ * email, and a menu holding the sign-out action.
+ *
+ * Renders nothing until an identity resolves, so a session still being established
+ * never shows an empty card.
+ */
+export const UserBadge = ({ privileged }: UserBadgeProps) => {
+  const { identity, isPending } = useGetIdentity();
+  const logout = useLogout();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  if (isPending || !identity?.id) {
+    return null;
+  }
+  // A provider is free to keep every naming claim out of the ID token; the card still
+  // has to render, because its menu is the only way to sign out.
+  const name = identity.fullName || identity.email || 'Signed in';
+  // Only a second line when it adds something the name does not already say.
+  const secondary = identity?.email && identity.email !== name ? identity.email : undefined;
+
+  return (
+    <>
+      <ButtonBase
+        onClick={event => setAnchorEl(event.currentTarget)}
+        aria-haspopup="menu"
+        aria-expanded={Boolean(anchorEl)}
+        sx={theme => ({
+          width: '100%',
+          justifyContent: 'flex-start',
+          gap: 1.5,
+          px: 1.5,
+          py: 1,
+          borderRadius: 1,
+          border: `1px solid ${theme.palette.divider}`,
+          backgroundColor: theme.palette.action.hover,
+          '&:hover': { backgroundColor: theme.palette.action.selected },
+        })}
+      >
+        <Avatar
+          src={identity.avatar}
+          alt={name}
+          // Keeps the deployment's hostname out of the request when the avatar is a
+          // Gravatar: the third party has no business learning where it was loaded from.
+          slotProps={{ img: { referrerPolicy: 'no-referrer' } }}
+          sx={theme => ({
+            width: 36,
+            height: 36,
+            fontSize: 15,
+            fontWeight: 700,
+            backgroundColor: theme.palette.primary.main,
+            color: theme.palette.primary.contrastText,
+          })}
+        >
+          {[...name][0].toUpperCase()}
+        </Avatar>
+        <Stack sx={{ minWidth: 0, flexGrow: 1, alignItems: 'flex-start' }}>
+          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', maxWidth: '100%' }}>
+            <Typography variant="body2" sx={{ fontWeight: 600, minWidth: 0 }} noWrap title={name}>
+              {name}
+            </Typography>
+            {privileged && (
+              <Tooltip title="Privileged access">
+                <CrownIcon
+                  titleAccess="Privileged access"
+                  sx={{ fontSize: 16, color: 'warning.main', flexShrink: 0 }}
+                />
+              </Tooltip>
+            )}
+          </Stack>
+          {secondary && (
+            <Typography
+              variant="caption"
+              sx={{ color: 'text.secondary', maxWidth: '100%' }}
+              noWrap
+              title={secondary}
+            >
+              {secondary}
+            </Typography>
+          )}
+        </Stack>
+        <ExpandMoreIcon fontSize="small" sx={{ color: 'text.secondary', flexShrink: 0 }} />
+      </ButtonBase>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        slotProps={{ paper: { sx: { minWidth: 180 } } }}
+      >
+        <MenuItem
+          onClick={() => {
+            setAnchorEl(null);
+            logout();
+          }}
+        >
+          <ListItemIcon>
+            <LogoutIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Log out</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};


### PR DESCRIPTION
The workspace side panel opens with an account card — avatar, display name, email, and a crown for members of `OIDC_PRIVILEGED_GROUPS` — whose menu holds Log out, previously unreachable from the UI.

The avatar comes from the provider's `picture` claim. `OIDC_GRAVATAR_FALLBACK` (default false) lets it fall back to Gravatar for providers that serve none; it is opt-in because it discloses the user's email address to a third party. An address with no Gravatar falls back to the initial, as does an install served over plain HTTP, where WebCrypto cannot hash the address.