### PR TITLE
chore(ci): bump action pins, shrink the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,42 @@
+# Keeps the build context small for test/e2e/Dockerfile.server.race, the only
+# Dockerfile built from the repo root (it does a `COPY . .`). goreleaser builds
+# Dockerfile.server and Dockerfile.client in a context it assembles itself, so
+# this file does not apply there. Docker ignores .gitignore, which is why the
+# generated and developer-local paths are repeated here.
+#
+# Patterns are anchored at the context root; use `**/` to match at any depth.
+
+# Devshell Go caches. The flake points GOPATH and GOMODCACHE inside the repo,
+# so these hold multiple GB and would otherwise be uploaded on every build.
+.go
+.gomod
+
+# direnv, Taskfile and mkdocs caches
+.direnv
+.task
+.cache
+
+# Local dev database volume (owned by the Postgres container's uid)
 db/data
+
+# Node dependencies (web/dist is built on the host before the image build)
+**/node_modules
+
+# Developer-local secrets
+**/.env
+
+# Build, test and scratch output
+site
+dist
+sandbox
+argo-watcher
+**/coverage.*
+**/coverage/
+test/e2e/reports
+web/playwright-report
+web/test-results
+
+# Repository metadata not read by any build
+.git
+.github
+.idea

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -23,15 +23,15 @@ jobs:
       contents: read
       security-events: write # upload SARIF to the code-scanning dashboard
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -42,7 +42,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps
@@ -265,7 +265,7 @@ jobs:
 
       - name: Upload Nuclei SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         # Upload is best-effort: a clean scan may produce no SARIF file, which
         # would otherwise error here.
         continue-on-error: true

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -36,7 +36,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       # bats is absent from the runner image; shellcheck is present but pinned here
       # anyway, because the runner ships 0.9.0 while the flake devshell provides

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,17 +33,17 @@ jobs:
     # runners are slower, so 45 left almost no headroom.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
       # Node + Task + swag mirror the UI build the rest of the automation uses;
       # `task build-race-image` runs `task build-ui` to produce web/dist.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -54,7 +54,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install build dependencies (swag for the UI's swagger step)
         run: task install-deps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write # needed to write releases
       packages: write # needed to push container images to GHCR
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx # dockers_v2 pushes a multi-arch manifest, which needs the docker-container driver (the default docker driver can't)
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           # Matches the setup-go `cache: false` policy below: this release
           # publishes signed artifacts, so don't restore the buildx binary from
@@ -26,7 +26,7 @@ jobs:
           cache-binary: false
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # required for changelog to work properly - https://github.com/goreleaser/goreleaser-action#usage
           submodules: true
@@ -35,13 +35,13 @@ jobs:
           persist-credentials: false
 
       - name: Install NodeJS
-        # zizmor: ignore[cache-poisoning] no `cache:` input is set, so setup-node creates no cache to poison (v6.4.0)
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        # zizmor: ignore[cache-poisoning] no `cache:` input is set, so setup-node creates no cache to poison (v7.0.0)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           # Release publishes signed artifacts. setup-go enables the build/module
@@ -54,7 +54,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps
@@ -69,17 +69,13 @@ jobs:
         run: rm -rf web/node_modules
 
       - name: Install Cosign
-        # Pinned to the v3.x line on purpose: it installs cosign v2.x. The
-        # cosign-installer v4 line installs cosign v3+, which requires a
-        # `--bundle` arg for the `cosign sign-blob` call in .goreleaser.yaml —
-        # bumping the major would break checksum signing until that is reworked.
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Syft for SBOM Generation
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -112,7 +108,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ steps.changelog.outputs.RELEASE_TAG }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Update helm chart
         uses: shini4i/helm-charts-updater@v1 # zizmor: ignore[unpinned-uses] first-party shini4i action; policy permits semver tags

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,21 +34,21 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps
@@ -85,7 +85,7 @@ jobs:
         run: go test -race -count=1 -timeout=5m ./internal/server/...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
@@ -123,20 +123,20 @@ jobs:
           - 12222:12222
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps
@@ -173,11 +173,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -192,7 +192,7 @@ jobs:
         run: npm run test -- --coverage
 
       - name: Upload frontend coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: web/coverage/lcov.info
@@ -205,11 +205,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -218,7 +218,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,11 +19,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -32,7 +32,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         run: task install-deps
@@ -47,7 +47,7 @@ jobs:
       - name: Run Gosec Security Scanner
         id: gosec
         continue-on-error: true
-        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
+        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
         env:
           # The gosec image bundles an older Go with GOTOOLCHAIN=local, so it
           # refuses a go.mod whose toolchain directive names a newer patch. Allow
@@ -63,7 +63,7 @@ jobs:
         id: govulncheck
         continue-on-error: true
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           "$(go env GOPATH)/bin/govulncheck" ./...
 
       - name: Fail if any Go scanner failed
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -102,14 +102,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so the scan can diff the pushed/PR commit range.
           fetch-depth: 0
           persist-credentials: false
 
       - name: Scan for secrets
-        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
+        uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
         with:
           # .trufflehog-exclude skips files holding intentional non-secrets
           # (local dev credentials, SSH key fixtures). Keep it in sync with the

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -51,15 +51,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -70,7 +70,7 @@ jobs:
         with:
           # An exact version skips the unauthenticated go-task tags API
           # lookup, which shares the runner IP 60 req/h anonymous quota.
-          version: 3.52.0
+          version: 3.53.1
 
       - name: Install environment dependencies
         # swag, for the swagger spec that task build-ui requires.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,12 +23,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Audit workflows
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           # Gate on actionable findings (low and above); informational
           # recommendations are surfaced locally without blocking CI.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea
 .run
 
-# database for development (local sqlite volumes created by dev docker-compose)
+# Postgres data directory created by the dev docker-compose stack
 db/data
 
 # static directory artifacts (compiled frontend assets and vendored modules)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,7 +1,6 @@
 FROM alpine:3.24
 
-# TARGETPLATFORM is set by buildx; goreleaser dockers_v2 lays binaries out per
-# platform (e.g. linux/amd64/client) in the build context.
+# Set by buildx; goreleaser lays the binaries out per platform in the context.
 ARG TARGETPLATFORM
 
 COPY $TARGETPLATFORM/client /client

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,8 +2,7 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /app
 
-# TARGETPLATFORM is set by buildx; goreleaser dockers_v2 lays binaries out per
-# platform (e.g. linux/amd64/argo-watcher) in the build context.
+# Set by buildx; goreleaser lays the binaries out per platform in the context.
 ARG TARGETPLATFORM
 
 COPY --chown=nonroot:nonroot $TARGETPLATFORM/argo-watcher /usr/local/bin/argo-watcher

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,21 +167,6 @@ tasks:
     generates:
       - dist/index.html
 
-  kind-upload:
-    desc: Build and upload the argo-watcher image to a kind cluster
-    deps: [build, build-ui]
-    env:
-      CGO_ENABLED: 0
-      GOOS: linux
-      GOARCH: arm64
-    cmds:
-      - echo "===> Building argo-watcher docker image"
-      - docker build -t ghcr.io/shini4i/argo-watcher:dev -f Dockerfile.server .
-      - echo "===> Loading argo-watcher docker image into kind cluster"
-      - kind load docker-image ghcr.io/shini4i/argo-watcher:dev -n disposable-cluster
-      - echo "===> Restarting argo-watcher deployment"
-      - kubectl rollout restart sts argo-watcher -n argo-watcher
-
   bootstrap:
     desc: Bring docker compose setup up
     cmds:

--- a/test/e2e/Dockerfile.server.race
+++ b/test/e2e/Dockerfile.server.race
@@ -1,21 +1,6 @@
-# Lab-only image: argo-watcher built with the Go race detector.
-#
-# This exists ONLY for the per-release e2e lab. It is NOT the shipped image.
-#
-# Why a separate Dockerfile from Dockerfile.server:
-#   `go build -race` forces CGO_ENABLED=1 and produces a binary dynamically
-#   linked against glibc. The production image's base (gcr.io/distroless/static)
-#   ships no libc or dynamic loader, so a race binary cannot run there. This
-#   image therefore uses a glibc-bearing distroless base instead.
-#
-# web/dist is a generated artifact and must exist in the build context before
-# this build. The `build-race-image` task runs `task build-ui` first (the same
-# frontend build the rest of the automation uses), exactly as the production
-# image pipeline does.
-#
-# Build from the repo root so the Go module and web/dist + db assets are in
-# context:
-#   docker build -f test/e2e/Dockerfile.server.race -t argo-watcher:race .
+# Lab-only argo-watcher image built with the Go race detector. Not the shipped
+# image. Build from the repo root: web/dist must already exist there (the
+# build-race-image task runs `task build-ui` first).
 
 FROM golang:1.26.5-bookworm AS build
 
@@ -26,11 +11,11 @@ RUN go mod download
 
 COPY . .
 
-# CGO_ENABLED=1 is mandatory for -race (the detector is a C runtime).
+# CGO_ENABLED=1 is mandatory for -race: the detector is a C runtime.
 RUN CGO_ENABLED=1 go build -race -o /out/argo-watcher ./cmd/argo-watcher
 
-# base-debian12 (unlike static) carries glibc + the dynamic loader the race
-# binary needs, while staying distroless and running as nonroot.
+# base-debian12 carries the glibc and dynamic loader the race binary needs;
+# the production base (distroless/static) has neither.
 FROM gcr.io/distroless/base-debian12:nonroot
 
 WORKDIR /app
@@ -39,8 +24,6 @@ COPY --from=build /out/argo-watcher /usr/local/bin/argo-watcher
 COPY --chown=nonroot:nonroot web/dist ./static
 COPY --chown=nonroot:nonroot db ./db
 
-# The :nonroot base already defaults to uid 65532, but make it explicit so the
-# non-root user is stated in the image, not just implied by the tag.
 USER 65532:65532
 
 CMD ["argo-watcher"]


### PR DESCRIPTION
Closes #559.

`.dockerignore` listed only `db/data`, so a build from the repo root uploaded the devshell's in-repo Go caches (`.gomod` alone is 4.7 GB) along with the docs site, coverage reports and the stale root binary. It is now a denylist covering the generated and developer-local paths docker cannot learn from `.gitignore`, taking the context from 5.9 GB to 3.7 MB.

Alongside that, every action is pinned to its latest release resolved to the tag's peeled commit SHA, the `arduino/setup-task`, `govulncheck` and pre-commit-hooks versions move to current, the release job leaves `ubuntu-22.04` for `ubuntu-latest`, and the pre-release goreleaser step stops reading `steps.changelog.outputs.RELEASE_TAG` (an id no step carries, so it resolved to empty).

Three things worth knowing before merging:

- `securego/gosec@v2.28.0`'s `action.yml` runs the image labelled `2.27.1`, so the tag is not the scanner version — this bump moves the scanner 2.26.1 → 2.27.1.
- `task kind-upload` is deleted rather than repaired. `Dockerfile.server` declares `ARG TARGETPLATFORM`, so its `COPY` resolves to `linux/<arch>/argo-watcher`, a path `task build` never writes, and it loaded into a kind cluster no config in the repo creates.
- Neither image was built while preparing this. The `.dockerignore` patterns were instead replayed through `moby/patternmatcher` over the tree, which confirms nothing the race build needs is dropped, but the first CI run is the real check.