### PR TITLE
fix(web): stop shipping source maps, repair the swagger page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cluster — and offers a retry rather than heading back to the provider that just failed.
   Deployments without OIDC are untouched, as is a configuration request that merely fails
   while the server restarts.
+- The `/swagger/` page renders the API specification again. Its stylesheet and both Swagger
+  UI bundles were copied one directory deeper than the page loads them from, so since
+  v0.11.0 every release image answered those three requests with the Web UI shell and the
+  page stayed blank.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`crypto/tls`), `GO-2026-6089` and `GO-2026-5026` (`net/http`), `GO-2026-6088`
   (`encoding/xml`) and `GO-2026-5972` (`encoding/asn1`). The `go` directive stays at
   `1.26.5`, so the minimum language version required to build is unchanged.
+- Release images no longer ship the frontend source maps. The production build emitted an
+  `index-*.js.map` with the full source of the web UI inlined, and the server served it to
+  anyone who asked, so the application's own sources were readable from a deployed
+  instance. The bundle itself is unchanged; only the map is gone, and `web/dist` drops from
+  8.2 MB to 3.2 MB.
 
 ## [0.15.0] - 2026-08-11
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,6 +157,17 @@ tasks:
     cmds:
       - echo "===> Building React-admin UI"
       - npm run build
+      # dist/ is copied into the release image and served publicly, so a source map here
+      # would expose the UI's own sources. Fail the build instead of shipping it. Only
+      # dist/assets is scanned for the comment: swagger-ui.css ships one for a map that
+      # is not copied.
+      - |
+        found=$(find dist -name '*.map'; grep -rl sourceMappingURL dist/assets || true)
+        if [ -n "$found" ]; then
+          echo "===> ERROR: source maps in web/dist (check build.sourcemap in vite.config.ts):"
+          echo "$found"
+          exit 1
+        fi
       - echo "===> Done"
     sources:
       - src/**/*.ts

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,6 +161,7 @@ tasks:
     sources:
       - src/**/*.ts
       - src/**/*.tsx
+      - vite.config.ts
     # Without this, an unchanged src plus a deleted or partial dist/ is reported
     # up to date and the build is skipped — leaving the consumers of web/dist
     # (the images, the Playwright suite) pointed at nothing.

--- a/web/README.md
+++ b/web/README.md
@@ -18,7 +18,7 @@ The Go API must be running (`task bootstrap` from the repo root, or `go run ./cm
 | Command | Description |
 |---|---|
 | `npm run dev` | Dev server with proxy and HMR |
-| `npm run build` | Production build with sourcemaps into `dist/` |
+| `npm run build` | Production build into `dist/` |
 | `npm run preview` | Serve `dist/` with production routing |
 | `npm run lint` | oxlint (see `.oxlintrc.json`) |
 | `npm run test` | Vitest once, with text + LCOV coverage |

--- a/web/e2e/no-auth/swagger.spec.ts
+++ b/web/e2e/no-auth/swagger.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * `/swagger/` is served straight out of `web/dist/swagger`, and a request that
+ * names no file there falls back to the SPA — so a bundle copied to the wrong
+ * path answers with the Web UI at status 200 instead of failing. Only a browser
+ * that actually renders the spec proves the page's own assets resolved.
+ */
+test('the swagger page renders the API specification', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.goto('/swagger/');
+
+  await expect(page.getByRole('heading', { name: 'Argo-Watcher API' })).toBeVisible();
+  // The spec drives the rendered operations, so one endpoint proves swagger.json
+  // was fetched and parsed rather than the shell merely loading.
+  await expect(page.getByRole('button', { name: /\/api\/v1\/tasks/ }).first()).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -22,16 +22,12 @@ export default defineConfig(({ command }) => {
       viteStaticCopy({
         targets: [
           {
-            src: 'node_modules/swagger-ui-dist/swagger-ui-bundle.js',
+            src: 'node_modules/swagger-ui-dist/{swagger-ui.css,swagger-ui-bundle.js,swagger-ui-standalone-preset.js}',
             dest: 'swagger',
-          },
-          {
-            src: 'node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js',
-            dest: 'swagger',
-          },
-          {
-            src: 'node_modules/swagger-ui-dist/swagger-ui.css',
-            dest: 'swagger',
+            // The plugin preserves the source directory structure, so without this the
+            // files land in dist/swagger/node_modules/swagger-ui-dist/ and the swagger
+            // page, which loads them by bare name, gets the SPA fallback instead.
+            rename: { stripBase: true },
           },
         ],
       }),

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -52,7 +52,8 @@ export default defineConfig(({ command }) => {
     },
     build: {
       outDir: 'dist',
-      sourcemap: true,
+      // dist/ is served publicly by the Go server, so maps would expose the app's sources.
+      sourcemap: false,
     },
   };
 });


### PR DESCRIPTION
Closes #561.

The Vite production build set `sourcemap: true`, so every release image carried a 5.3 MB `index-*.js.map` with `sourcesContent` populated — and since `Dockerfile.server` copies `web/dist` into `./static`, the server served it. Nothing consumed it: there is no error-tracking integration in `web/`. `dist/` goes from 8.2 MB to 3.2 MB; the bundle itself is byte-identical apart from the dropped `sourceMappingURL` comment. `task build-ui` now fails on a `.map` under `dist` or a `sourceMappingURL` comment in `dist/assets`, so a config flip cannot quietly reship them, and `vite.config.ts` joins the task's fingerprint so a config-only change invalidates a stale `dist`.

Writing that assertion turned up a second bug, fixed here as well: `vite-plugin-static-copy` v4 preserves the source directory structure, so the swagger-ui-dist files have been landing in `dist/swagger/node_modules/swagger-ui-dist/` since the v3→v4 bump in 6514c05 (released in v0.11.0), while `public/swagger/index.html` loads them by bare name. The server answers a `/swagger` path naming no file with the SPA shell, so all three requests returned HTML at status 200 and `/swagger/` rendered blank in every release image. `rename: { stripBase: true }` flattens the copy, and a new Playwright spec asserts the page renders the specification — the only check that catches this while the fallback answers 200.

`sourcemap: 'hidden'` was not an option for the first part: it drops the comment but still writes the file into `dist/`.