### PR TITLE
feat(auth)!: drop the Keycloak backward-compatibility surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,9 +150,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new counter is incremented when a deployment ends rather than when Argo CD confirms the
   application, so a deployment in flight is not counted until it finishes. Use
   `in_progress_tasks` for the live view. The bundled dashboard is already updated.
+- **Breaking:** the `KEYCLOAK_*` environment variables, deprecated since 0.13.0, are gone.
+  Rename them before upgrading: `KEYCLOAK_ENABLED` → `OIDC_ENABLED`, `KEYCLOAK_CLIENT_ID`
+  → `OIDC_CLIENT_ID`, `KEYCLOAK_TOKEN_VALIDATION_INTERVAL` →
+  `OIDC_TOKEN_VALIDATION_INTERVAL`, `KEYCLOAK_PRIVILEGED_GROUPS` →
+  `OIDC_PRIVILEGED_GROUPS`, and `KEYCLOAK_URL` + `KEYCLOAK_REALM` → a single
+  `OIDC_ISSUER_URL` spelled `<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>`.
+
+  The server refuses to start while any of the old names is set, listing each one with its
+  replacement. A missed rename is therefore a failed startup, not a server that comes up
+  with authentication switched off and every read open.
+- **Breaking:** `GET /api/v1/config` no longer mirrors the auth block under a legacy
+  `keycloak` key alongside `oidc`, and the `Keycloak-Authorization` header is no longer
+  accepted — send `Oidc-Authorization` instead. Both date from the Keycloak-only releases.
 
 ### Fixed
 
+- `OIDC_PRIVILEGED_GROUPS` now tolerates spaces around its entries. A value written
+  `"admins, operators"` kept the leading space on every entry after the first, and group
+  names are matched exactly against the provider's claim, so those groups silently got no
+  privileged access at all: no rollback button, no deploy-lock switch, no crown — with
+  nothing in the log to say why. Blank entries from a trailing or doubled comma are
+  dropped too.
 - The example Grafana dashboard now imports into any Grafana. It picks its Prometheus
   through a **Data source** selector at the top instead of referencing a datasource by a
   hardcoded `prometheus` uid, which only ever resolved on the bundled dev stack — anywhere

--- a/docs/guides/deployment-lock.md
+++ b/docs/guides/deployment-lock.md
@@ -40,7 +40,7 @@ Click the **Argo Watcher** logo to open the configuration drawer, then use the s
 
 ### From the API
 
-Both calls need a token from a user in one of the `OIDC_PRIVILEGED_GROUPS`, in the `Oidc-Authorization` header (the legacy `Keycloak-Authorization` name still works):
+Both calls need a token from a user in one of the `OIDC_PRIVILEGED_GROUPS`, in the `Oidc-Authorization` header:
 
 ```bash
 # Hold the lock

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -145,17 +145,17 @@ A read whose credential could not be checked returns **503 Service Unavailable**
 
 ## Migrating from `KEYCLOAK_*`
 
-Earlier releases were Keycloak-specific. The old variables are **deprecated but still honored** — existing deployments keep working — and are mapped automatically when their `OIDC_*` counterparts are unset, with a one-time deprecation warning in the log.
+Earlier releases were Keycloak-specific. Those variables were **removed in 1.0.0**, and the server refuses to start while any of them is set, naming each one and its replacement. Rename them:
 
-| Deprecated | Replacement |
+| Removed | Replacement |
 |---|---|
 | `KEYCLOAK_ENABLED` | `OIDC_ENABLED` |
-| `KEYCLOAK_URL` + `KEYCLOAK_REALM` | `OIDC_ISSUER_URL` (synthesized as `<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>`) |
+| `KEYCLOAK_URL` + `KEYCLOAK_REALM` | `OIDC_ISSUER_URL`, set to `<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>` |
 | `KEYCLOAK_CLIENT_ID` | `OIDC_CLIENT_ID` |
 | `KEYCLOAK_TOKEN_VALIDATION_INTERVAL` | `OIDC_TOKEN_VALIDATION_INTERVAL` |
 | `KEYCLOAK_PRIVILEGED_GROUPS` | `OIDC_PRIVILEGED_GROUPS` |
 
-`OIDC_*` wins when both are set. `GET /api/v1/config` still mirrors the auth block under a legacy `keycloak` key alongside the new `oidc` one, and both the `Oidc-Authorization` and `Keycloak-Authorization` headers are accepted.
+Two other Keycloak-era surfaces went with them. `GET /api/v1/config` no longer mirrors the auth block under a legacy `keycloak` key, and the `Keycloak-Authorization` header is no longer accepted — send `Oidc-Authorization` instead.
 
 ## Privileged groups
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -18,7 +18,7 @@ A credential does two things: it authorizes the [GitOps updater](../guides/gitop
 |---|---|
 | Deploy token | `ARGO_WATCHER_DEPLOY_TOKEN: <token>` |
 | JWT | `Authorization: <token>` (raw; `Bearer <token>` also accepted) |
-| OIDC session | `Oidc-Authorization: <access token>` (legacy `Keycloak-Authorization` also accepted) |
+| OIDC session | `Oidc-Authorization: <access token>` |
 
 ### Reads
 

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -48,7 +48,7 @@ The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you 
 | `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}` too | `false` | No |
 | `OIDC_GRAVATAR_FALLBACK` | Let the account card fall back to Gravatar when the provider sends no `picture` claim | `false` | No |
 
-Enabling OIDC also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The legacy `KEYCLOAK_*` variables are still honored but deprecated ([migration table](../guides/oidc.md#migrating-from-keycloak_)).
+Enabling OIDC also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The `KEYCLOAK_*` variables were removed in 1.0.0 and now fail startup ([migration table](../guides/oidc.md#migrating-from-keycloak_)).
 
 `OIDC_REQUIRE_TASK_READ_AUTH` fails every deployment driven by a client that sends no credential on reads, which includes **every client older than v0.15.0**. It also requires `OIDC_ENABLED=true`; the server refuses to start otherwise. Check `unauthenticated_reads` first — see [Closing the task lookup](../guides/oidc.md#closing-the-task-lookup).
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -388,9 +388,9 @@ func TestAuthenticatorValidateStrategy(t *testing.T) {
 
 		request, err := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 		assert.NoError(t, err)
-		request.Header.Set("Keycloak-Authorization", "token")
+		request.Header.Set("X-Unregistered-Auth", "token")
 
-		valid, validateErr := authenticator.ValidateStrategy(request, "Keycloak-Authorization")
+		valid, validateErr := authenticator.ValidateStrategy(request, "X-Unregistered-Auth")
 		assert.False(t, valid)
 		assert.NoError(t, validateErr)
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,12 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 
 	envConfig "github.com/caarlos0/env/v11"
@@ -25,8 +23,7 @@ const maxTaskRetentionDays = 36500
 // OIDCConfig holds the settings for the generic OIDC authentication provider.
 // IssuerURL is the provider's issuer (e.g. "https://kc/realms/foo" for Keycloak
 // or "https://authentik/application/o/argo-watcher/" for Authentik); the backend
-// discovers the userinfo endpoint from it at runtime. The deprecated KEYCLOAK_*
-// variables are mapped onto these fields by applyKeycloakCompat.
+// discovers the userinfo endpoint from it at runtime.
 //
 // TokenValidationInterval (milliseconds) bounds how stale a read authorization can be,
 // capped per token by that token's own expiry. Zero revalidates every request, which
@@ -121,115 +118,46 @@ type ServerConfig struct {
 	TaskRetentionDays    int  `env:"TASK_RETENTION_DAYS" envDefault:"365" json:"-"`
 }
 
-// MarshalJSON emits the OIDC block under both the canonical "oidc" key and a
-// legacy "keycloak" key with identical content. The mirror preserves backward
-// compatibility for older API consumers (and the e2e api-surface check) that
-// still read config.keycloak.* after the rename from Keycloak-only auth. The
-// `type alias` indirection drops ServerConfig's own MarshalJSON to avoid
-// infinite recursion while keeping every field's json tag intact.
-func (config ServerConfig) MarshalJSON() ([]byte, error) {
-	type alias ServerConfig
-	return json.Marshal(struct {
-		alias
-		Keycloak OIDCConfig `json:"keycloak"`
-	}{
-		alias:    alias(config),
-		Keycloak: config.OIDC,
-	})
+// removedKeycloakVars pairs each KEYCLOAK_* variable removed in 1.0.0 with the
+// OIDC_* setting that replaces it.
+var removedKeycloakVars = []struct{ legacy, replacement string }{
+	{"KEYCLOAK_ENABLED", "OIDC_ENABLED"},
+	{"KEYCLOAK_URL", "OIDC_ISSUER_URL (as <KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>)"},
+	{"KEYCLOAK_REALM", "OIDC_ISSUER_URL (as <KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>)"},
+	{"KEYCLOAK_CLIENT_ID", "OIDC_CLIENT_ID"},
+	{"KEYCLOAK_TOKEN_VALIDATION_INTERVAL", "OIDC_TOKEN_VALIDATION_INTERVAL"},
+	{"KEYCLOAK_PRIVILEGED_GROUPS", "OIDC_PRIVILEGED_GROUPS"},
 }
 
-// applyKeycloakCompat maps the deprecated KEYCLOAK_* environment variables onto
-// the generic OIDC config whenever their OIDC_* counterparts are unset, so
-// existing Keycloak deployments keep working unchanged after the rename. A
-// single deprecation warning is logged when any KEYCLOAK_* variable is present.
-//
-// The Keycloak issuer is synthesized as "<KEYCLOAK_URL>/realms/<KEYCLOAK_REALM>"
-// — exactly the issuer a Keycloak realm advertises — so OIDC discovery against
-// it resolves the same userinfo endpoint the Keycloak-specific code targeted
-// before.
-func applyKeycloakCompat(cfg *ServerConfig) error {
-	if !anyKeycloakVarSet() {
+// trimEntries strips surrounding whitespace from each entry and drops the blanks a
+// trailing or doubled separator leaves behind.
+func trimEntries(values []string) []string {
+	var trimmed []string
+	for _, v := range values {
+		if entry := strings.TrimSpace(v); entry != "" {
+			trimmed = append(trimmed, entry)
+		}
+	}
+	return trimmed
+}
+
+// rejectRemovedKeycloakVars fails startup when any KEYCLOAK_* variable is still set,
+// naming each one and its OIDC_* replacement. Ignoring them would be fail-open: a
+// deployment carrying only KEYCLOAK_ENABLED=true would boot with authentication off,
+// serving every read to anyone, with nothing in the log naming the cause.
+func rejectRemovedKeycloakVars() error {
+	var problems []string
+	for _, v := range removedKeycloakVars {
+		if _, ok := os.LookupEnv(v.legacy); ok {
+			problems = append(problems, fmt.Sprintf("  - %s: removed in 1.0.0, use %s", v.legacy, v.replacement))
+		}
+	}
+
+	if len(problems) == 0 {
 		return nil
 	}
-
-	slog.Warn("KEYCLOAK_* environment variables are deprecated; use OIDC_* instead " +
-		"(see docs/reference/server-env.md). They remain honored for backward compatibility.")
-
-	if val, ok := legacyValue("OIDC_ENABLED", "KEYCLOAK_ENABLED"); ok {
-		// A malformed legacy value must fail startup rather than silently leave
-		// auth disabled — a typo must never quietly drop the protected routes.
-		parsed, err := strconv.ParseBool(strings.TrimSpace(val))
-		if err != nil {
-			return fmt.Errorf("invalid KEYCLOAK_ENABLED value %q: must be a boolean", val)
-		}
-		cfg.OIDC.Enabled = parsed
-	}
-
-	if _, ok := os.LookupEnv("OIDC_ISSUER_URL"); !ok {
-		if issuer := keycloakIssuer(); issuer != "" {
-			cfg.OIDC.IssuerURL = issuer
-		}
-	}
-
-	if val, ok := legacyValue("OIDC_CLIENT_ID", "KEYCLOAK_CLIENT_ID"); ok {
-		cfg.OIDC.ClientId = val
-	}
-
-	if val, ok := legacyValue("OIDC_TOKEN_VALIDATION_INTERVAL", "KEYCLOAK_TOKEN_VALIDATION_INTERVAL"); ok {
-		parsed, err := strconv.Atoi(strings.TrimSpace(val))
-		if err != nil {
-			return fmt.Errorf("invalid KEYCLOAK_TOKEN_VALIDATION_INTERVAL value %q: must be an integer", val)
-		}
-		cfg.OIDC.TokenValidationInterval = parsed
-	}
-
-	if val, ok := legacyValue("OIDC_PRIVILEGED_GROUPS", "KEYCLOAK_PRIVILEGED_GROUPS"); ok {
-		cfg.OIDC.PrivilegedGroups = splitGroups(val)
-	}
-
-	return nil
-}
-
-func anyKeycloakVarSet() bool {
-	for _, v := range []string{
-		"KEYCLOAK_ENABLED", "KEYCLOAK_URL", "KEYCLOAK_REALM", "KEYCLOAK_CLIENT_ID",
-		"KEYCLOAK_TOKEN_VALIDATION_INTERVAL", "KEYCLOAK_PRIVILEGED_GROUPS",
-	} {
-		if _, ok := os.LookupEnv(v); ok {
-			return true
-		}
-	}
-	return false
-}
-
-// legacyValue returns the deprecated legacyKey's value, but only when the
-// canonical primaryKey is unset — the OIDC_* variable always wins.
-func legacyValue(primaryKey, legacyKey string) (string, bool) {
-	if _, ok := os.LookupEnv(primaryKey); ok {
-		return "", false
-	}
-	return os.LookupEnv(legacyKey)
-}
-
-// keycloakIssuer synthesizes the issuer a Keycloak realm advertises from the deprecated
-// KEYCLOAK_URL + KEYCLOAK_REALM pair, or "" if either is missing.
-func keycloakIssuer() string {
-	url := strings.TrimSpace(os.Getenv("KEYCLOAK_URL"))
-	realm := strings.TrimSpace(os.Getenv("KEYCLOAK_REALM"))
-	if url == "" || realm == "" {
-		return ""
-	}
-	return strings.TrimRight(url, "/") + "/realms/" + realm
-}
-
-func splitGroups(val string) []string {
-	var groups []string
-	for _, g := range strings.Split(val, ",") {
-		if trimmed := strings.TrimSpace(g); trimmed != "" {
-			groups = append(groups, trimmed)
-		}
-	}
-	return groups
+	return errors.New("invalid argo-watcher server configuration:\nremoved variables:\n" +
+		strings.Join(problems, "\n"))
 }
 
 // NewServerConfig parses the server configuration from environment variables.
@@ -248,12 +176,12 @@ func NewServerConfig() (*ServerConfig, error) {
 	config.DeployToken = strings.TrimSpace(config.DeployToken)
 	config.JWTSecret = strings.TrimSpace(config.JWTSecret)
 	config.Mattermost.Token = strings.TrimSpace(config.Mattermost.Token)
+	// Group membership is matched exactly against the provider's claim, so a spaced
+	// list entry would silently deny every privileged action to that group.
+	config.OIDC.PrivilegedGroups = trimEntries(config.OIDC.PrivilegedGroups)
 
-	// Map deprecated KEYCLOAK_* vars onto the generic OIDC config before
-	// validation, so a synthesized Keycloak issuer is validated like any other.
-	// A malformed legacy value fails startup rather than silently disabling auth.
-	if err := applyKeycloakCompat(&config); err != nil {
-		return nil, fmt.Errorf("invalid argo-watcher server configuration: %w", err)
+	if err := rejectRemovedKeycloakVars(); err != nil {
+		return nil, err
 	}
 
 	if err := validateServerConfig(&config); err != nil {
@@ -331,10 +259,10 @@ func validateServerConfig(config *ServerConfig) error {
 	// and the login redirect cannot proceed without them.
 	if config.OIDC.Enabled {
 		if strings.TrimSpace(config.OIDC.IssuerURL) == "" {
-			problems = append(problems, "  - OIDC.IssuerURL: must be set when OIDC auth is enabled (OIDC_ISSUER_URL, or legacy KEYCLOAK_URL + KEYCLOAK_REALM)")
+			problems = append(problems, "  - OIDC.IssuerURL: must be set when OIDC auth is enabled (OIDC_ISSUER_URL)")
 		}
 		if strings.TrimSpace(config.OIDC.ClientId) == "" {
-			problems = append(problems, "  - OIDC.ClientId: must be set when OIDC auth is enabled (OIDC_CLIENT_ID, or legacy KEYCLOAK_CLIENT_ID)")
+			problems = append(problems, "  - OIDC.ClientId: must be set when OIDC auth is enabled (OIDC_CLIENT_ID)")
 		}
 	}
 	// Rejected rather than ignored: with OIDC disabled no read is protected, so

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -247,116 +247,114 @@ func TestNewServerConfig_ArgoApiRetriesTooHighRejected(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// The deprecated KEYCLOAK_* variables map onto the generic OIDC config, with the issuer
-// synthesized from KEYCLOAK_URL + KEYCLOAK_REALM, so existing Keycloak deployments keep
-// working after the rename without any config change.
-func TestNewServerConfig_OIDCKeycloakFallback(t *testing.T) {
-	t.Setenv("ARGO_URL", "https://example.com")
-	t.Setenv("ARGO_TOKEN", "secret-token")
-	t.Setenv("STATE_TYPE", "in-memory")
-	t.Setenv("KEYCLOAK_ENABLED", "true")
-	t.Setenv("KEYCLOAK_URL", "https://kc.example.com/")
-	t.Setenv("KEYCLOAK_REALM", "argo-watcher")
-	t.Setenv("KEYCLOAK_CLIENT_ID", "argo-watcher")
-	t.Setenv("KEYCLOAK_TOKEN_VALIDATION_INTERVAL", "5000")
-	t.Setenv("KEYCLOAK_PRIVILEGED_GROUPS", "admins, operators")
+// The KEYCLOAK_* variables were removed in 1.0.0, and a leftover one must fail
+// startup naming its OIDC_* replacement. Ignoring them instead would boot an
+// upgraded server with KEYCLOAK_ENABLED=true and authentication off — every read
+// open, and the operator told nothing.
+func TestNewServerConfig_KeycloakVariablesRejected(t *testing.T) {
+	cases := map[string]struct {
+		env      map[string]string
+		mentions []string
+		excludes []string
+	}{
+		"enable flag": {
+			env:      map[string]string{"KEYCLOAK_ENABLED": "true"},
+			mentions: []string{"KEYCLOAK_ENABLED", "OIDC_ENABLED"},
+		},
+		"issuer pair": {
+			env:      map[string]string{"KEYCLOAK_URL": "https://kc.example.com", "KEYCLOAK_REALM": "argo-watcher"},
+			mentions: []string{"KEYCLOAK_URL", "KEYCLOAK_REALM", "OIDC_ISSUER_URL"},
+		},
+		"client and groups": {
+			env: map[string]string{
+				"KEYCLOAK_CLIENT_ID":                 "argo-watcher",
+				"KEYCLOAK_TOKEN_VALIDATION_INTERVAL": "5000",
+				"KEYCLOAK_PRIVILEGED_GROUPS":         "admins,operators",
+			},
+			mentions: []string{
+				"KEYCLOAK_CLIENT_ID", "OIDC_CLIENT_ID",
+				"KEYCLOAK_TOKEN_VALIDATION_INTERVAL", "OIDC_TOKEN_VALIDATION_INTERVAL",
+				"KEYCLOAK_PRIVILEGED_GROUPS", "OIDC_PRIVILEGED_GROUPS",
+			},
+		},
+		// A leftover legacy variable is rejected even when the OIDC_* settings are
+		// complete: dead config that once controlled authentication must be removed,
+		// not silently shadowed.
+		"alongside a complete OIDC config": {
+			env: map[string]string{
+				"OIDC_ENABLED":       "true",
+				"OIDC_ISSUER_URL":    "https://authentik.example.com/application/o/aw/",
+				"OIDC_CLIENT_ID":     "aw-oidc",
+				"KEYCLOAK_CLIENT_ID": "legacy-client",
+			},
+			mentions: []string{"KEYCLOAK_CLIENT_ID", "OIDC_CLIENT_ID"},
+		},
+		// A chart that still renders the variable with no value must fail too: the
+		// leftover has to be deleted, not blanked.
+		"set but empty": {
+			env:      map[string]string{"KEYCLOAK_ENABLED": ""},
+			mentions: []string{"KEYCLOAK_ENABLED", "OIDC_ENABLED"},
+		},
+		// This case would ALSO fail validation, for a missing issuer. The rename must
+		// win: told only "OIDC.IssuerURL must be set", an operator has no idea the
+		// KEYCLOAK_URL they did set is the reason it is empty.
+		"rename beats the downstream validation error": {
+			env: map[string]string{
+				"OIDC_ENABLED":   "true",
+				"KEYCLOAK_URL":   "https://kc.example.com",
+				"KEYCLOAK_REALM": "argo-watcher",
+			},
+			mentions: []string{"KEYCLOAK_URL", "KEYCLOAK_REALM", "OIDC_ISSUER_URL"},
+			excludes: []string{"OIDC.IssuerURL"},
+		},
+	}
 
-	cfg, err := NewServerConfig()
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("ARGO_URL", "https://example.com")
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
 
-	require.NoError(t, err)
-	assert.True(t, cfg.OIDC.Enabled)
-	assert.Equal(t, "https://kc.example.com/realms/argo-watcher", cfg.OIDC.IssuerURL)
-	assert.Equal(t, "argo-watcher", cfg.OIDC.ClientId)
-	assert.Equal(t, 5000, cfg.OIDC.TokenValidationInterval)
-	assert.Equal(t, []string{"admins", "operators"}, cfg.OIDC.PrivilegedGroups)
+			_, err := NewServerConfig()
+
+			require.Error(t, err)
+			for _, want := range tc.mentions {
+				assert.Contains(t, err.Error(), want)
+			}
+			for _, unwanted := range tc.excludes {
+				assert.NotContains(t, err.Error(), unwanted)
+			}
+		})
+	}
 }
 
-// The per-field fallback a real upgrade hits: an operator sets the new OIDC_ISSUER_URL
-// but still relies on the deprecated KEYCLOAK_CLIENT_ID / KEYCLOAK_PRIVILEGED_GROUPS.
-// Each field must resolve independently.
-func TestNewServerConfig_OIDCMixedFallback(t *testing.T) {
+// PrivilegedGroups is the OIDC field that fails silently when parsing is wrong: an entry
+// carrying a stray space never matches the claim, so the crown, rollback and deploy-lock
+// switch simply never appear. Operators rename a spaced KEYCLOAK_PRIVILEGED_GROUPS list
+// verbatim, so entries are trimmed and blanks dropped.
+func TestNewServerConfig_OIDCFieldsParse(t *testing.T) {
 	t.Setenv("ARGO_URL", "https://example.com")
 	t.Setenv("ARGO_TOKEN", "secret-token")
 	t.Setenv("STATE_TYPE", "in-memory")
 	t.Setenv("OIDC_ENABLED", "true")
 	t.Setenv("OIDC_ISSUER_URL", "https://authentik.example.com/application/o/aw/")
-	t.Setenv("KEYCLOAK_CLIENT_ID", "legacy-client")
-	t.Setenv("KEYCLOAK_PRIVILEGED_GROUPS", "admins,operators")
+	t.Setenv("OIDC_CLIENT_ID", "argo-watcher")
+	t.Setenv("OIDC_TOKEN_VALIDATION_INTERVAL", "5000")
+	// "Release Managers" carries an internal space, as AD and Entra group names do:
+	// only the edges are trimmed, never the name itself.
+	t.Setenv("OIDC_PRIVILEGED_GROUPS", "admins, operators ,,   Release Managers  ")
 
 	cfg, err := NewServerConfig()
 
 	require.NoError(t, err)
+	assert.True(t, cfg.OIDC.Enabled)
 	assert.Equal(t, "https://authentik.example.com/application/o/aw/", cfg.OIDC.IssuerURL)
-	assert.Equal(t, "legacy-client", cfg.OIDC.ClientId)
-	assert.Equal(t, []string{"admins", "operators"}, cfg.OIDC.PrivilegedGroups)
-}
-
-// A half-configured legacy Keycloak (URL without realm) must not synthesize a
-// malformed issuer.
-func TestNewServerConfig_KeycloakPartialIssuer(t *testing.T) {
-	t.Setenv("ARGO_URL", "https://example.com")
-	t.Setenv("ARGO_TOKEN", "secret-token")
-	t.Setenv("STATE_TYPE", "in-memory")
-	t.Setenv("KEYCLOAK_ENABLED", "true")
-	t.Setenv("KEYCLOAK_URL", "https://kc.example.com")
-	// KEYCLOAK_REALM intentionally unset.
-	t.Setenv("KEYCLOAK_CLIENT_ID", "argo-watcher")
-
-	_, err := NewServerConfig()
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "OIDC.IssuerURL")
-}
-
-// A malformed deprecated value must fail startup rather than silently disable auth: a typo like
-// KEYCLOAK_ENABLED=yes must never quietly drop the protected OIDC routes from an
-// otherwise healthy deployment (fail closed, not open).
-func TestNewServerConfig_KeycloakMalformedValuesRejected(t *testing.T) {
-	t.Run("malformed KEYCLOAK_ENABLED", func(t *testing.T) {
-		t.Setenv("ARGO_URL", "https://example.com")
-		t.Setenv("ARGO_TOKEN", "secret-token")
-		t.Setenv("STATE_TYPE", "in-memory")
-		t.Setenv("KEYCLOAK_ENABLED", "yes")
-
-		_, err := NewServerConfig()
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "KEYCLOAK_ENABLED")
-	})
-
-	t.Run("malformed KEYCLOAK_TOKEN_VALIDATION_INTERVAL", func(t *testing.T) {
-		t.Setenv("ARGO_URL", "https://example.com")
-		t.Setenv("ARGO_TOKEN", "secret-token")
-		t.Setenv("STATE_TYPE", "in-memory")
-		t.Setenv("KEYCLOAK_ENABLED", "true")
-		t.Setenv("KEYCLOAK_URL", "https://kc.example.com")
-		t.Setenv("KEYCLOAK_REALM", "demo")
-		t.Setenv("KEYCLOAK_CLIENT_ID", "argo-watcher")
-		t.Setenv("KEYCLOAK_TOKEN_VALIDATION_INTERVAL", "soon")
-
-		_, err := NewServerConfig()
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "KEYCLOAK_TOKEN_VALIDATION_INTERVAL")
-	})
-}
-
-func TestNewServerConfig_OIDCPrecedence(t *testing.T) {
-	t.Setenv("ARGO_URL", "https://example.com")
-	t.Setenv("ARGO_TOKEN", "secret-token")
-	t.Setenv("STATE_TYPE", "in-memory")
-	t.Setenv("OIDC_ENABLED", "true")
-	t.Setenv("OIDC_ISSUER_URL", "https://authentik.example.com/application/o/argo-watcher/")
-	t.Setenv("OIDC_CLIENT_ID", "aw-oidc")
-	t.Setenv("KEYCLOAK_URL", "https://kc.example.com")
-	t.Setenv("KEYCLOAK_REALM", "legacy")
-	t.Setenv("KEYCLOAK_CLIENT_ID", "legacy-client")
-
-	cfg, err := NewServerConfig()
-
-	require.NoError(t, err)
-	assert.Equal(t, "https://authentik.example.com/application/o/argo-watcher/", cfg.OIDC.IssuerURL)
-	assert.Equal(t, "aw-oidc", cfg.OIDC.ClientId)
+	assert.Equal(t, "argo-watcher", cfg.OIDC.ClientId)
+	assert.Equal(t, 5000, cfg.OIDC.TokenValidationInterval)
+	assert.Equal(t, []string{"admins", "operators", "Release Managers"}, cfg.OIDC.PrivilegedGroups)
 }
 
 func TestNewServerConfig_OIDCValidation(t *testing.T) {
@@ -415,28 +413,11 @@ func TestNewServerConfig_RequireTaskReadAuth(t *testing.T) {
 		assert.Contains(t, err.Error(), "OIDC.RequireTaskReadAuth")
 		assert.Contains(t, err.Error(), "OIDC_ENABLED")
 	})
-
-	t.Run("accepted when OIDC is enabled through the legacy KEYCLOAK_* variables", func(t *testing.T) {
-		// The guard reads OIDC.Enabled, which a legacy deployment only sets via
-		// applyKeycloakCompat. Checking it before that mapping would refuse to start
-		// every Keycloak-configured server, naming a variable its operator never set.
-		baseEnv(t)
-		t.Setenv("KEYCLOAK_ENABLED", "true")
-		t.Setenv("KEYCLOAK_URL", "https://kc.example.com")
-		t.Setenv("KEYCLOAK_REALM", "argo-watcher")
-		t.Setenv("KEYCLOAK_CLIENT_ID", "argo-watcher")
-		t.Setenv("OIDC_REQUIRE_TASK_READ_AUTH", "true")
-
-		cfg, err := NewServerConfig()
-
-		require.NoError(t, err)
-		assert.True(t, cfg.OIDC.RequireTaskReadAuth)
-	})
 }
 
-// /api/v1/config exposes the OIDC block under both the canonical "oidc" key and the
-// legacy "keycloak" mirror, preserving backward compatibility for old consumers.
-func TestServerConfig_JSONDualKey(t *testing.T) {
+// /api/v1/config exposes the OIDC block under the single canonical "oidc" key. The
+// legacy "keycloak" mirror was removed in 1.0.0, so its absence is asserted here.
+func TestServerConfig_JSONOIDCKey(t *testing.T) {
 	cfg := &ServerConfig{
 		OIDC: OIDCConfig{
 			Enabled:   true,
@@ -452,10 +433,8 @@ func TestServerConfig_JSONDualKey(t *testing.T) {
 	require.NoError(t, json.Unmarshal(jsonBytes, &decoded))
 
 	oidcRaw, hasOIDC := decoded["oidc"]
-	kcRaw, hasKeycloak := decoded["keycloak"]
 	require.True(t, hasOIDC, "expected an oidc block")
-	require.True(t, hasKeycloak, "expected a legacy keycloak mirror block")
-	assert.JSONEq(t, string(oidcRaw), string(kcRaw), "keycloak mirror must match the oidc block")
+	assert.NotContains(t, decoded, "keycloak", "the legacy keycloak mirror must be gone")
 	assert.Contains(t, string(oidcRaw), `"issuer_url":"https://kc.example.com/realms/argo-watcher"`)
 
 	// /api/v1/config is readable without a credential, and read policy is the

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -210,11 +210,7 @@ func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prome
 		if oidcErr != nil {
 			return nil, fmt.Errorf("failed to initialize OIDC auth: %w", oidcErr)
 		}
-		// Register the same strategy under both the canonical header and the
-		// deprecated Keycloak header, so existing clients that still send
-		// Keycloak-Authorization keep working.
 		env.strategies[oidcHeader] = oidcService
-		env.strategies[legacyKeycloakHeader] = oidcService
 	}
 
 	if env.config.JWTSecret != "" {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -24,11 +24,9 @@ const maxTaskListLimit = 1000
 
 const (
 	unauthorizedMessage = "You are not authorized to perform this action"
-	// oidcHeader is the canonical header carrying the OIDC bearer token for
-	// privileged (deploy-lock/rollback) requests. legacyKeycloakHeader is the
-	// deprecated alias still accepted for backward compatibility.
-	oidcHeader           = "Oidc-Authorization"
-	legacyKeycloakHeader = "Keycloak-Authorization"
+	// oidcHeader carries the OIDC bearer token for privileged
+	// (deploy-lock/rollback) requests.
+	oidcHeader = "Oidc-Authorization"
 )
 
 // getVersion godoc
@@ -273,10 +271,9 @@ func (env *Env) getConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, env.config)
 }
 
-// requireOIDCAuth validates the OIDC token when OIDC auth is enabled. It returns
-// true if validation passes (or OIDC is disabled). The canonical Oidc-Authorization
-// header is tried first, then the deprecated Keycloak-Authorization alias. On
-// failure the response distinguishes:
+// requireOIDCAuth validates the OIDC token from the Oidc-Authorization header when
+// OIDC auth is enabled. It returns true if validation passes (or OIDC is disabled).
+// On failure the response distinguishes:
 //   - 401 with "authentication required" when no auth header was sent.
 //   - 401 with the strategy's reason when the token was rejected.
 //   - 503 when the provider could not be consulted at all, so that a provider
@@ -287,32 +284,29 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
-	for _, header := range []string{oidcHeader, legacyKeycloakHeader} {
-		valid, err := env.validateToken(r, header)
-		if valid {
-			return true
-		}
-		if errors.Is(err, auth.ErrProviderUnavailable) {
-			slog.Error("rejecting request: authentication provider unavailable",
-				"method", r.Method, "url", r.URL, "error", err)
-			writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-				Status: "authentication provider unavailable",
-				Error:  err.Error(),
-			})
-			return false
-		}
-		if err != nil {
-			slog.Warn("rejected request with invalid token",
-				"method", r.Method, "url", r.URL, "error", err)
-			writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-				Status: unauthorizedMessage,
-				Error:  err.Error(),
-			})
-			return false
-		}
+	valid, err := env.validateToken(r, oidcHeader)
+	if valid {
+		return true
+	}
+	if errors.Is(err, auth.ErrProviderUnavailable) {
+		slog.Error("rejecting request: authentication provider unavailable",
+			"method", r.Method, "url", r.URL, "error", err)
+		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
+			Status: "authentication provider unavailable",
+			Error:  err.Error(),
+		})
+		return false
+	}
+	if err != nil {
+		slog.Warn("rejected request with invalid token",
+			"method", r.Method, "url", r.URL, "error", err)
+		writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
+			Status: unauthorizedMessage,
+			Error:  err.Error(),
+		})
+		return false
 	}
 
-	// No auth header sent on either the canonical or the legacy name.
 	slog.Warn("rejected unauthenticated request", "method", r.Method, "url", r.URL)
 	writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
 		Status: unauthorizedMessage,

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -84,11 +84,10 @@ func keycloakToken(t *testing.T, username, password string) string {
 	return out.AccessToken
 }
 
-// newKeycloakEnv builds an Env wired with the real OIDC auth strategy pointed at
-// the live Keycloak. The issuer is synthesized as "<url>/realms/<realm>" — exactly
-// what the KEYCLOAK_* backward-compat shim produces — so this test also proves
-// that OIDC discovery against a real Keycloak resolves the same userinfo endpoint
-// the pre-refactor code targeted directly.
+// newKeycloakEnv builds an Env wired with the real OIDC auth strategy pointed at the
+// live Keycloak, with the issuer set to "<url>/realms/<realm>" — the issuer a Keycloak
+// realm advertises — so this test also proves OIDC discovery against a real Keycloak
+// resolves the userinfo endpoint.
 func newKeycloakEnv(t *testing.T) *Env {
 	t.Helper()
 	// TokenValidationInterval is left at zero on purpose: every request then
@@ -110,10 +109,8 @@ func newKeycloakEnv(t *testing.T) *Env {
 	lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
 	require.NoError(t, err)
 
-	// Register under both headers, mirroring production wiring (NewEnv).
 	strategies := map[string]auth.AuthStrategy{
-		oidcHeader:           oidcService,
-		legacyKeycloakHeader: oidcService,
+		oidcHeader: oidcService,
 	}
 
 	return &Env{
@@ -140,14 +137,13 @@ func deployLockServer(t *testing.T, env *Env) *httptest.Server {
 }
 
 // callDeployLock issues a deploy-lock request, optionally carrying a token in the
-// deprecated Keycloak-Authorization header — proving the legacy header still
-// authenticates end to end — and returns the HTTP status code.
+// Oidc-Authorization header, and returns the HTTP status code.
 func callDeployLock(t *testing.T, srv *httptest.Server, method, token string) int {
 	t.Helper()
 	req, err := http.NewRequest(method, srv.URL+"/api/v1/deploy-lock", nil)
 	require.NoError(t, err)
 	if token != "" {
-		req.Header.Set(legacyKeycloakHeader, "Bearer "+token)
+		req.Header.Set(oidcHeader, "Bearer "+token)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -160,14 +160,13 @@ func TestReadAuthProtectedEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("accepts the legacy Keycloak header", func(t *testing.T) {
+	t.Run("rejects the removed Keycloak header", func(t *testing.T) {
 		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
-			oidcHeader:           oidcLikeStrategy{authenticated: true},
-			legacyKeycloakHeader: oidcLikeStrategy{authenticated: true},
+			oidcHeader: oidcLikeStrategy{authenticated: true},
 		})
 
-		assert.Equal(t, http.StatusOK,
-			getWith(t, env, "/api/v1/tasks?from_timestamp=0", legacyKeycloakHeader, "Bearer token").Code)
+		assert.Equal(t, http.StatusUnauthorized,
+			getWith(t, env, "/api/v1/tasks?from_timestamp=0", "Keycloak-Authorization", "Bearer token").Code)
 	})
 
 	t.Run("accepts a deploy token so a pipeline can read", func(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -284,7 +284,7 @@ func isSameOrigin(origin, host string) bool {
 func (env *Env) corsOptions() cors.Options {
 	options := cors.Options{
 		AllowedMethods:       []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
-		AllowedHeaders:       []string{"Origin", "Content-Type", "Accept", "Authorization", oidcHeader, legacyKeycloakHeader, "ARGO_WATCHER_DEPLOY_TOKEN"},
+		AllowedHeaders:       []string{"Origin", "Content-Type", "Accept", "Authorization", oidcHeader, "ARGO_WATCHER_DEPLOY_TOKEN"},
 		ExposedHeaders:       []string{"Content-Length"},
 		MaxAge:               int((12 * time.Hour).Seconds()),
 		OptionsSuccessStatus: http.StatusNoContent,

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -295,13 +295,10 @@ func TestNewEnv(t *testing.T) {
 	expectedOIDC, oidcErr := auth.NewOIDCAuthService(serverConfig)
 	assert.NoError(t, oidcErr)
 
-	// The OIDC strategy is registered under both the canonical and the legacy
-	// Keycloak header for backward compatibility.
 	expectedStrategies := map[string]auth.AuthStrategy{
 		"ARGO_WATCHER_DEPLOY_TOKEN": auth.NewDeployTokenAuthService(serverConfig.DeployToken),
 		"Authorization":             auth.NewJWTAuthService(serverConfig.JWTSecret),
 		oidcHeader:                  expectedOIDC,
-		legacyKeycloakHeader:        expectedOIDC,
 	}
 
 	assert.Equal(t, expectedStrategies, env.strategies)
@@ -1627,7 +1624,7 @@ func TestValidateTokenWithStrategies(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, "/test", nil)
 		req.Header.Set("Authorization", "Bearer test-token")
 
-		valid, err := env.validateToken(req, "Keycloak-Authorization")
+		valid, err := env.validateToken(req, "X-Unregistered-Auth")
 		assert.False(t, valid)
 		assert.NoError(t, err)
 	})
@@ -1997,14 +1994,13 @@ func TestDeployLockStoreFailure(t *testing.T) {
 	}
 }
 
-// TestSetDeployLockAcceptsLegacyKeycloakHeader verifies backward compatibility:
-// a client still sending the deprecated Keycloak-Authorization header (instead of
-// the canonical Oidc-Authorization) is authenticated exactly as before.
-func TestSetDeployLockAcceptsLegacyKeycloakHeader(t *testing.T) {
-
+// The Keycloak-Authorization header was removed in 1.0.0. A client still sending
+// it must be rejected, and the privileged write it carried must not take effect.
+func TestSetDeployLockRejectsLegacyKeycloakHeader(t *testing.T) {
 	lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
-	strategies := make(map[string]auth.AuthStrategy)
-	strategies[legacyKeycloakHeader] = newAuthStrategy(t, true, nil)
+	strategies := map[string]auth.AuthStrategy{
+		oidcHeader: newAuthStrategy(t, true, nil),
+	}
 
 	env := &Env{
 		lockdown:      lockdown,
@@ -2019,69 +2015,12 @@ func TestSetDeployLockAcceptsLegacyKeycloakHeader(t *testing.T) {
 	router.Post("/api/v1/deploy-lock", env.SetDeployLock)
 
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/deploy-lock", nil)
-	req.Header.Set(legacyKeycloakHeader, "Bearer valid-token")
+	req.Header.Set("Keycloak-Authorization", "Bearer valid-token")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.True(t, lockdown.IsLocked())
-}
-
-// TestRequireOIDCAuthHeaderPrecedence pins the two-header loop semantics in
-// requireOIDCAuth: the legacy header is a full alias (invalid tokens on it still
-// surface a 401 with the reason), and a rejected canonical header returns
-// immediately without falling through to the legacy header.
-func TestRequireOIDCAuthHeaderPrecedence(t *testing.T) {
-
-	t.Run("invalid token on the legacy header surfaces the reason as 401", func(t *testing.T) {
-		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
-		strategies := map[string]auth.AuthStrategy{
-			legacyKeycloakHeader: newAuthStrategy(t, false, fmt.Errorf("token expired")),
-		}
-		env := &Env{
-			lockdown:      lockdown,
-			strategies:    strategies,
-			authenticator: auth.NewAuthenticator(strategies),
-			config:        &config.ServerConfig{OIDC: config.OIDCConfig{Enabled: true}},
-		}
-		router := chi.NewRouter()
-		router.Post("/api/v1/deploy-lock", env.SetDeployLock)
-
-		req, _ := http.NewRequest(http.MethodPost, "/api/v1/deploy-lock", nil)
-		req.Header.Set(legacyKeycloakHeader, "Bearer invalid-token")
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
-		assert.Contains(t, w.Body.String(), "token expired")
-	})
-
-	t.Run("a rejected canonical header does not fall through to the legacy header", func(t *testing.T) {
-		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
-		legacy := mocks.NewMockAuthStrategy(gomock.NewController(t))
-		legacy.EXPECT().Validate(gomock.Any()).Times(0)
-		strategies := map[string]auth.AuthStrategy{
-			oidcHeader:           newAuthStrategy(t, false, fmt.Errorf("canonical rejected")),
-			legacyKeycloakHeader: legacy,
-		}
-		env := &Env{
-			lockdown:      lockdown,
-			strategies:    strategies,
-			authenticator: auth.NewAuthenticator(strategies),
-			config:        &config.ServerConfig{OIDC: config.OIDCConfig{Enabled: true}},
-		}
-		router := chi.NewRouter()
-		router.Post("/api/v1/deploy-lock", env.SetDeployLock)
-
-		req, _ := http.NewRequest(http.MethodPost, "/api/v1/deploy-lock", nil)
-		req.Header.Set(oidcHeader, "Bearer bad")
-		req.Header.Set(legacyKeycloakHeader, "Bearer also-bad")
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
-		assert.Contains(t, w.Body.String(), "canonical rejected")
-	})
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.False(t, lockdown.IsLocked())
 }
 
 func TestReleaseDeployLockWithKeycloak(t *testing.T) {
@@ -2393,7 +2332,7 @@ func TestCORSPolicy(t *testing.T) {
 		// dropping a header from corsOptions would break browser deploys silently.
 		router := newRouter(t, true)
 
-		for _, header := range []string{oidcHeader, legacyKeycloakHeader, "ARGO_WATCHER_DEPLOY_TOKEN", "Authorization", "Content-Type", "Accept"} {
+		for _, header := range []string{oidcHeader, "ARGO_WATCHER_DEPLOY_TOKEN", "Authorization", "Content-Type", "Accept"} {
 			t.Run(header, func(t *testing.T) {
 				w := do(router, http.MethodOptions, "/api/v1/tasks", map[string]string{
 					"Origin":                         allowedOrigin,
@@ -2407,6 +2346,23 @@ func TestCORSPolicy(t *testing.T) {
 				assert.Contains(t, strings.ToLower(w.Header().Get("Access-Control-Allow-Headers")), strings.ToLower(header))
 			})
 		}
+	})
+
+	t.Run("the removed Keycloak header is refused by a preflight", func(t *testing.T) {
+		// The counterpart of the subtest above: rs/cors signals refusal by omitting
+		// Access-Control-Allow-Origin, so this pins that the alias stays out of
+		// corsOptions once the strategy behind it is gone.
+		router := newRouter(t, true)
+
+		w := do(router, http.MethodOptions, "/api/v1/tasks", map[string]string{
+			"Origin":                         allowedOrigin,
+			"Access-Control-Request-Method":  http.MethodPost,
+			"Access-Control-Request-Headers": "keycloak-authorization",
+		})
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"),
+			"an allow-origin here means the removed alias is allowlisted again")
+		assert.NotContains(t, strings.ToLower(w.Header().Get("Access-Control-Allow-Headers")), "keycloak-authorization")
 	})
 
 	t.Run("production preflight never pairs the wildcard with credentials", func(t *testing.T) {

--- a/internal/server/ws_auth_test.go
+++ b/internal/server/ws_auth_test.go
@@ -103,7 +103,6 @@ func TestAuthorizeWebSocket(t *testing.T) {
 
 	strategies := map[string]auth.AuthStrategy{
 		oidcHeader:                  oidcLikeStrategy{authenticated: true},
-		legacyKeycloakHeader:        oidcLikeStrategy{authenticated: true},
 		"ARGO_WATCHER_DEPLOY_TOKEN": auth.NewDeployTokenAuthService("deploy-token"),
 	}
 
@@ -114,11 +113,11 @@ func TestAuthorizeWebSocket(t *testing.T) {
 		want        bool
 		wantStatus  int
 	}{
-		"canonical OIDC header":  {header: oidcHeader, value: "Bearer token", want: true},
-		"legacy Keycloak header": {header: legacyKeycloakHeader, value: "Bearer token", want: true},
-		"deploy token":           {header: "ARGO_WATCHER_DEPLOY_TOKEN", value: "deploy-token", want: true},
-		"subprotocol token":      {subprotocol: wsTokenSubprotocolPrefix + "token", want: true},
-		"no credential":          {want: false, wantStatus: http.StatusUnauthorized},
+		"canonical OIDC header":   {header: oidcHeader, value: "Bearer token", want: true},
+		"removed Keycloak header": {header: "Keycloak-Authorization", value: "Bearer token", want: false, wantStatus: http.StatusUnauthorized},
+		"deploy token":            {header: "ARGO_WATCHER_DEPLOY_TOKEN", value: "deploy-token", want: true},
+		"subprotocol token":       {subprotocol: wsTokenSubprotocolPrefix + "token", want: true},
+		"no credential":           {want: false, wantStatus: http.StatusUnauthorized},
 		"wrong deploy token": {
 			header:     "ARGO_WATCHER_DEPLOY_TOKEN",
 			value:      "nope",

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -4,8 +4,9 @@
 # nothing (safe to run before the soak). Covers the endpoints the UI, client, and
 # operators depend on that no other phase exercises:
 #   - GET  /api/v1/version              -> 200, non-empty JSON string
-#   - GET  /api/v1/config               -> 200; Keycloak reported disabled; the
-#                                          deploy-token secret is redacted (json:"-");
+#   - GET  /api/v1/config               -> 200; OIDC reported disabled, no legacy
+#                                          keycloak mirror; the deploy-token secret is
+#                                          redacted (json:"-");
 #                                          notification targets absent but their
 #                                          `enabled` flags kept — the endpoint is
 #                                          unauthenticated by necessity (the UI
@@ -20,7 +21,7 @@
 #   - GET  /api/v1/tasks/<unknown-uuid> -> 404 "task not found" (the 404-vs-500
 #                                          distinction, commit fa0b3fd)
 #   - GET  /api/v1/deploy-lock          -> 200 (read-only, always registered)
-#   - POST /api/v1/deploy-lock          -> with Keycloak disabled the state-changing
+#   - POST /api/v1/deploy-lock          -> with OIDC disabled the state-changing
 #                                          handler is NOT registered, so the request
 #                                          falls through to the SPA static handler
 #                                          (200 HTML), not a 404. Asserted
@@ -65,10 +66,10 @@ if [[ "$CODE" != "200" ]]; then
   bad "config: code=${CODE}"
 elif ! jq -e '.oidc.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
   bad "config: oidc.enabled != false (lab runs without OIDC auth)"
-elif ! jq -e '.keycloak.enabled == false' <<<"$BODY" >/dev/null 2>&1; then
-  # The legacy keycloak mirror must keep matching the oidc block so pre-rename
-  # consumers still work; a divergence here is a backward-compat regression.
-  bad "config: legacy keycloak mirror missing or != oidc block"
+elif jq -e 'has("keycloak")' <<<"$BODY" >/dev/null 2>&1; then
+  # The legacy keycloak mirror was removed in 1.0.0; its return would re-expose a
+  # back-compat surface consumers must no longer be able to depend on.
+  bad "config: legacy keycloak mirror is back"
 elif grep -qF "$DEPLOY_TOKEN" <<<"$BODY"; then
   # A leaked secret here is the whole reason ServerConfig marks it json:"-".
   bad "config: deploy token leaked in /config response"
@@ -83,7 +84,7 @@ elif ! jq -e '.argo_cd_url != null' <<<"$BODY" >/dev/null 2>&1; then
   # The CLI client builds the app URL from this field; trimming must not take it.
   bad "config: argo_cd_url missing — the client needs it to build app URLs"
 else
-  ok "config: oidc disabled (+ legacy keycloak mirror), secrets and deployment detail withheld (${CODE})"
+  ok "config: oidc disabled (no legacy keycloak mirror), secrets and deployment detail withheld (${CODE})"
 fi
 
 echo "=== task-list filters ==="
@@ -115,7 +116,7 @@ if [[ "$CODE" == "200" ]] && jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
 else
   bad "GET deploy-lock: code=${CODE} body=${BODY} (want 200 false)"
 fi
-# Security property: with Keycloak disabled the state-changing POST/DELETE handlers
+# Security property: with OIDC disabled the state-changing POST/DELETE handlers
 # are NOT registered (router.go), so an unauthenticated caller cannot freeze
 # deploys. The unmatched route falls through to the SPA static handler (200 HTML),
 # NOT a 404 — so assert the guarantee behaviourally: after an unauthenticated POST
@@ -123,9 +124,9 @@ fi
 req POST "${AW_API}/deploy-lock"
 req GET "${AW_API}/deploy-lock"
 if jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
-  ok "POST deploy-lock did not set the lock (still unlocked without Keycloak)"
+  ok "POST deploy-lock did not set the lock (still unlocked without OIDC)"
 else
-  bad "POST deploy-lock set the lock without Keycloak (body=${BODY})"
+  bad "POST deploy-lock set the lock without OIDC (body=${BODY})"
 fi
 
 phase_end API-SURFACE

--- a/test/e2e/scripts/lockdown.sh
+++ b/test/e2e/scripts/lockdown.sh
@@ -21,7 +21,7 @@
 # happened un-observed, so that sub-check is skipped with a logged note rather
 # than flaking.
 #
-# A manual (Keycloak) lock/unlock is NOT a separate trigger: the API handlers do
+# A manual (OIDC-authenticated) lock/unlock is NOT a separate trigger: the API handlers do
 # not push, so it reaches clients through this same lockdown watcher and the same
 # one-poll-interval delay. state-postgres.sh asserts that path over the WS for a
 # lock written by another writer; TestDeployLockNotifiedOnlyByWatcher pins that the

--- a/test/e2e/scripts/read-auth.sh
+++ b/test/e2e/scripts/read-auth.sh
@@ -10,6 +10,7 @@
 #
 #   - no credential        -> 401 (answered before any provider call)
 #   - an OIDC token        -> 503 (the provider could not be consulted)
+#   - the removed alias    -> 401, never 503 (it reaches no strategy at all)
 #   - a deploy token / JWT -> 200 (validated locally)
 #
 # The last section also flips OIDC_REQUIRE_TASK_READ_AUTH, which closes the task
@@ -115,6 +116,16 @@ if [[ "$CODE" == "503" ]]; then
   ok "GET /tasks with an OIDC token -> 503 (provider unreachable)"
 else
   bad "GET /tasks with an OIDC token: code=${CODE} body=${BODY} (want 503)"
+fi
+
+# The Keycloak-Authorization alias was removed in 1.0.0. 401-not-503 is what proves it:
+# a 503 would mean the header still reaches the OIDC strategy, since only a strategy
+# consulting the unreachable provider can produce one.
+req GET "${AW_API}/tasks?from_timestamp=0" -H "Keycloak-Authorization: Bearer e2e-oidc-token"
+if [[ "$CODE" == "401" ]]; then
+  ok "GET /tasks with the removed Keycloak header -> 401 (reaches no strategy)"
+else
+  bad "GET /tasks with the removed Keycloak header: code=${CODE} body=${BODY} (want 401; 503 means the alias is still registered)"
 fi
 
 # Mixed outcomes across strategies: the provider-unavailable signal must win over the

--- a/web/src/auth/authFailure.ts
+++ b/web/src/auth/authFailure.ts
@@ -203,5 +203,5 @@ export const describeIncompleteConfig = (missing: readonly string[]): AuthFailur
   kind: 'config_incomplete',
   title: 'Argo Watcher is misconfigured for OIDC',
   detail: `OIDC is enabled but the server did not report: ${missing.join(', ')}.`,
-  hint: 'Set OIDC_ISSUER_URL and OIDC_CLIENT_ID on the Argo Watcher server (or the legacy KEYCLOAK_URL, KEYCLOAK_REALM and KEYCLOAK_CLIENT_ID).',
+  hint: 'Set OIDC_ISSUER_URL and OIDC_CLIENT_ID on the Argo Watcher server.',
 });


### PR DESCRIPTION
Closes #566.

Removes the three backward-compatibility surfaces left from when authentication was Keycloak-only: the `KEYCLOAK_*` environment aliases, the legacy `keycloak` key mirrored alongside `oidc` on `GET /api/v1/config`, and the `Keycloak-Authorization` header. `OIDC_*` and `Oidc-Authorization` are the only spellings left.

Leftover `KEYCLOAK_*` variables fail startup rather than being ignored, naming each one and its replacement. Ignoring them would be fail-open: a deployment carrying only `KEYCLOAK_ENABLED=true` boots with `OIDC.Enabled` false, which drops `requireAuthenticatedRead` and serves every read to anyone, with nothing in the log naming the cause.

The issue's open question about the `keycloak` mirror key resolves the other way round. `argo-watcher-mcp` does not consume it — its `client_test.go` lists `keycloak` among the keys that must *not* be forwarded — and the frontend never read it either.

Also fixes `OIDC_PRIVILEGED_GROUPS` not trimming its entries, since the deleted compat helper was the only code that ever did. Group names are matched exactly against the provider's claim, so a value written `"admins, operators"` silently denied every privileged action to the spaced entries. That bug predates this change for the `OIDC_*` spelling, so it ships as its own `Fixed` entry.