### PR TITLE
fix(server)!: serve argo_cd_url as a URL string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anything alerting on failures should add `unconfirmed_deployment_failures` to keep seeing
   the failures that never reached Argo CD. `unauthenticated_reads` is unchanged and still
   uses `app="unknown"` for a read that did not resolve to a task.
+- **Breaking:** `GET /api/v1/config` serves `argo_cd_url` as a URL string —
+  `"https://argo-cd.example.com"` — instead of the eleven fields of a Go `url.URL` object.
+  Anything reading that field must now take the string as it is rather than rebuilding it
+  from `Scheme`, `Host` and `Path`; `argo_cd_url_alias` was already a plain string and is
+  unchanged. The Web UI and the CLI client ship updated in lockstep, so a matched pair
+  needs nothing. Basic-auth userinfo in `ARGO_URL` is stripped from the field, which the
+  object form dropped implicitly — this endpoint takes no credential. Mixing versions
+  costs only the Argo CD link the CLI prints for an already-failed deployment: an old
+  client cannot decode a new server's field, and prints a decode error in its place.
+- Authentication and cross-origin rejection logs name the request path in their `url`
+  field, where they used to render a Go `url.URL` as an object of eleven mostly-empty
+  fields. The query string is no longer part of that field.
 
 ### Removed
 
@@ -166,6 +178,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Argo CD link the client prints for a failed deployment keeps a sub-path in
+  `ARGO_URL`. With `ARGO_URL=https://platform.example.com/argocd` it pointed at
+  `https://platform.example.com/applications/<app>`, dropping the `/argocd` prefix and
+  landing nowhere; the Web UI always kept it. A trailing slash on `ARGO_URL_ALIAS` no
+  longer doubles either.
 - `OIDC_PRIVILEGED_GROUPS` now tolerates spaces around its entries. A value written
   `"admins, operators"` kept the leading space on every entry after the first, and group
   names are matched exactly against the provider's claim, so those groups silently got no

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,6 +41,14 @@ tasks:
     cmds:
       - echo "===> Generating swagger spec"
       - swag init --parseDependency --parseInternal --dir ./,../../internal/server --outputTypes json -o ../../web/public/swagger
+      # argo_cd_url is documented as a string only because of the swaggertype tag on
+      # ServerConfig; without it swag emits the fields of a url.URL and the published
+      # spec silently contradicts what the endpoint serves.
+      - |
+        if ! grep -A1 '"argo_cd_url":' ../../web/public/swagger/swagger.json | grep -q '"type": "string"'; then
+          echo "===> ERROR: argo_cd_url is not documented as a string (check the swaggertype tag)"
+          exit 1
+        fi
     sources:
       - main.go
       - ../../internal/server/router.go

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -46,7 +46,7 @@ func NewArgoApi() *ArgoApi {
 
 func (api *ArgoApi) Init(serverConfig *config.ServerConfig) error {
 	slog.Debug("Initializing argo-watcher client...")
-	api.baseUrl = serverConfig.ArgoUrl
+	api.baseUrl = serverConfig.ArgoUrl.URL
 
 	jar, err := api.cookieJarFn(nil)
 	if err != nil {

--- a/internal/argocd/argo_api_test.go
+++ b/internal/argocd/argo_api_test.go
@@ -61,7 +61,7 @@ func TestArgoApiInit(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.ServerConfig{
-		ArgoUrl:        *argoURL,
+		ArgoUrl:        config.URL{URL: *argoURL},
 		ArgoToken:      "super-secret",
 		ArgoApiTimeout: 42,
 		SkipTlsVerify:  true,
@@ -72,7 +72,7 @@ func TestArgoApiInit(t *testing.T) {
 	api := NewArgoApi()
 	require.NoError(t, api.Init(cfg))
 
-	assert.Equal(t, cfg.ArgoUrl, api.baseUrl)
+	assert.Equal(t, cfg.ArgoUrl.URL, api.baseUrl)
 	require.NotNil(t, api.client)
 	assert.Equal(t, time.Duration(cfg.ArgoApiTimeout)*time.Second, api.client.Timeout)
 	require.NotNil(t, api.client.Jar)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -377,10 +377,10 @@ func TestGetWatcherConfig(t *testing.T) {
 		assert.Equal(t, req.URL.String(), "/api/v1/config")
 
 		configResponse := struct {
-			ArgoCDURL      url.URL `json:"argo_cd_url"`
-			ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
+			ArgoCDURL      string `json:"argo_cd_url"`
+			ArgoCDURLAlias string `json:"argo_cd_url_alias"`
 		}{
-			ArgoCDURL:      url.URL{Scheme: "http", Host: "localhost:8080"},
+			ArgoCDURL:      "http://localhost:8080",
 			ArgoCDURLAlias: "https://argo-cd.example.com",
 		}
 
@@ -403,7 +403,7 @@ func TestGetWatcherConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedUrl, _ := url.Parse("http://localhost:8080")
-	assert.Equal(t, expectedUrl, &serverConfig.ArgoUrl)
+	assert.Equal(t, *expectedUrl, serverConfig.ArgoUrl.URL)
 	assert.Equal(t, "https://argo-cd.example.com", serverConfig.ArgoUrlAlias)
 }
 

--- a/internal/client/utility.go
+++ b/internal/client/utility.go
@@ -163,16 +163,20 @@ func printClientConfiguration(watcher *Watcher, task models.Task) {
 	}
 }
 
+// generateAppUrl builds the ArgoCD UI link for the task's application from the
+// server's config, preferring ARGO_URL_ALIAS when the server publishes one.
+// It fails when that config cannot be fetched.
 func generateAppUrl(watcher *Watcher, task models.Task) (string, error) {
 	cfg, err := watcher.getWatcherConfig()
 	if err != nil {
 		return "", err
 	}
 
-	if cfg.ArgoUrlAlias != "" {
-		return fmt.Sprintf("%s/applications/%s", cfg.ArgoUrlAlias, task.App), nil
+	base := cfg.ArgoUrlAlias
+	if base == "" {
+		base = cfg.ArgoUrl.String()
 	}
-	return fmt.Sprintf("%s://%s/applications/%s", cfg.ArgoUrl.Scheme, cfg.ArgoUrl.Host, task.App), nil
+	return fmt.Sprintf("%s/applications/%s", strings.TrimSuffix(base, "/"), task.App), nil
 }
 
 // setupWatcher takes application configuration and initializes a new Watcher instance

--- a/internal/client/utility.go
+++ b/internal/client/utility.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -165,7 +166,7 @@ func printClientConfiguration(watcher *Watcher, task models.Task) {
 
 // generateAppUrl builds the ArgoCD UI link for the task's application from the
 // server's config, preferring ARGO_URL_ALIAS when the server publishes one.
-// It fails when that config cannot be fetched.
+// It fails when that config cannot be fetched or carries an unparsable URL.
 func generateAppUrl(watcher *Watcher, task models.Task) (string, error) {
 	cfg, err := watcher.getWatcherConfig()
 	if err != nil {
@@ -176,7 +177,9 @@ func generateAppUrl(watcher *Watcher, task models.Task) (string, error) {
 	if base == "" {
 		base = cfg.ArgoUrl.String()
 	}
-	return fmt.Sprintf("%s/applications/%s", strings.TrimSuffix(base, "/"), task.App), nil
+	// JoinPath puts the route in the path, where a query or fragment on the base
+	// would otherwise swallow it, and folds a trailing slash on the way.
+	return url.JoinPath(base, "applications", task.App)
 }
 
 // setupWatcher takes application configuration and initializes a new Watcher instance

--- a/internal/client/utility_test.go
+++ b/internal/client/utility_test.go
@@ -563,6 +563,34 @@ func TestGenerateAppUrl(t *testing.T) {
 		assert.Equal(t, "https://platform.example.com/argocd/applications/test-app", appUrl)
 	})
 
+	// The application route belongs in the path. Appending it as text put it inside
+	// the query value instead, and a fragment swallowed it the same way.
+	t.Run("SuccessScenarioUrlWithQueryAndFragment", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, req.URL.String(), "/api/v1/config")
+
+			configResponse := struct {
+				ArgoCDURL string `json:"argo_cd_url"`
+			}{
+				ArgoCDURL: "https://platform.example.com/argocd?view=tree#overview",
+			}
+
+			jsonData, _ := json.Marshal(configResponse)
+			_, err := rw.Write(jsonData)
+			if err != nil {
+				t.Error(err)
+			}
+		}))
+		defer server.Close()
+
+		watcher := NewWatcher(server.URL, false, 30*time.Second)
+
+		appUrl, err := generateAppUrl(watcher, models.Task{App: "test-app"})
+
+		assert.Nil(t, err)
+		assert.Equal(t, "https://platform.example.com/argocd/applications/test-app?view=tree#overview", appUrl)
+	})
+
 	t.Run("ErrorScenario", func(t *testing.T) {
 		// Create a new Watcher instance with an invalid URL. A dial failure is
 		// transient, so use the zero-backoff test watcher to skip retry sleeps.

--- a/internal/client/utility_test.go
+++ b/internal/client/utility_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -443,10 +442,10 @@ func TestGenerateAppUrl(t *testing.T) {
 			assert.Equal(t, req.URL.String(), "/api/v1/config")
 
 			configResponse := struct {
-				ArgoCDURL      url.URL `json:"argo_cd_url"`
-				ArgoCDURLAlias string  `json:"argo_cd_url_alias"`
+				ArgoCDURL      string `json:"argo_cd_url"`
+				ArgoCDURLAlias string `json:"argo_cd_url_alias"`
 			}{
-				ArgoCDURL:      url.URL{Scheme: "http", Host: "localhost:8080"},
+				ArgoCDURL:      "http://localhost:8080",
 				ArgoCDURLAlias: "https://argo-cd.example.com",
 			}
 
@@ -478,9 +477,9 @@ func TestGenerateAppUrl(t *testing.T) {
 			assert.Equal(t, req.URL.String(), "/api/v1/config")
 
 			configResponse := struct {
-				ArgoCDURL url.URL `json:"argo_cd_url"`
+				ArgoCDURL string `json:"argo_cd_url"`
 			}{
-				ArgoCDURL: url.URL{Scheme: "http", Host: "localhost:8080"},
+				ArgoCDURL: "http://localhost:8080",
 			}
 
 			jsonData, _ := json.Marshal(configResponse)
@@ -504,6 +503,64 @@ func TestGenerateAppUrl(t *testing.T) {
 		expectedOutput := "http://localhost:8080/applications/test-app"
 
 		assert.Equal(t, expectedOutput, appUrl)
+	})
+
+	// The alias wins over argo_cd_url, and a trailing slash on it must not produce
+	// a doubled one in the link.
+	t.Run("SuccessScenarioAliasWithTrailingSlash", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, req.URL.String(), "/api/v1/config")
+
+			configResponse := struct {
+				ArgoCDURL      string `json:"argo_cd_url"`
+				ArgoCDURLAlias string `json:"argo_cd_url_alias"`
+			}{
+				ArgoCDURL:      "http://argo-cd.internal:8080",
+				ArgoCDURLAlias: "https://argo-cd.example.com/",
+			}
+
+			jsonData, _ := json.Marshal(configResponse)
+			_, err := rw.Write(jsonData)
+			if err != nil {
+				t.Error(err)
+			}
+		}))
+		defer server.Close()
+
+		watcher := NewWatcher(server.URL, false, 30*time.Second)
+
+		appUrl, err := generateAppUrl(watcher, models.Task{App: "test-app"})
+
+		assert.Nil(t, err)
+		assert.Equal(t, "https://argo-cd.example.com/applications/test-app", appUrl)
+	})
+
+	// An ArgoCD published under a sub-path is reachable only with that path kept,
+	// and the Web UI has always kept it.
+	t.Run("SuccessScenarioUrlWithPath", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, req.URL.String(), "/api/v1/config")
+
+			configResponse := struct {
+				ArgoCDURL string `json:"argo_cd_url"`
+			}{
+				ArgoCDURL: "https://platform.example.com/argocd/",
+			}
+
+			jsonData, _ := json.Marshal(configResponse)
+			_, err := rw.Write(jsonData)
+			if err != nil {
+				t.Error(err)
+			}
+		}))
+		defer server.Close()
+
+		watcher := NewWatcher(server.URL, false, 30*time.Second)
+
+		appUrl, err := generateAppUrl(watcher, models.Task{App: "test-app"})
+
+		assert.Nil(t, err)
+		assert.Equal(t, "https://platform.example.com/argocd/applications/test-app", appUrl)
 	})
 
 	t.Run("ErrorScenario", func(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,34 @@ import (
 // sweep instead, once an hour, without naming the setting at fault.
 const maxTaskRetentionDays = 36500
 
+// URL is a url.URL that crosses every boundary as a URL string: the JSON of
+// GET /api/v1/config and the structured logs, which would otherwise carry the
+// eleven exported fields of a url.URL for every consumer to reassemble. It parses
+// from a string too, so both env parsing and JSON decoding accept the same form.
+type URL struct {
+	url.URL
+}
+
+// MarshalText renders the URL as a string, minus any userinfo. encoding/json uses
+// it, so the value serialises as "https://argo-cd.example.com" rather than as an
+// object. Userinfo is dropped because GET /api/v1/config is unauthenticated and
+// url.URL.String() renders basic-auth credentials, password included.
+func (u URL) MarshalText() ([]byte, error) {
+	u.User = nil
+	return []byte(u.String()), nil
+}
+
+// UnmarshalText parses a URL string, rejecting one url.Parse cannot read. It backs
+// both env parsing and JSON decoding of the config payload.
+func (u *URL) UnmarshalText(text []byte) error {
+	parsed, err := url.Parse(string(text))
+	if err != nil {
+		return err
+	}
+	u.URL = *parsed
+	return nil
+}
+
 // OIDCConfig holds the settings for the generic OIDC authentication provider.
 // IssuerURL is the provider's issuer (e.g. "https://kc/realms/foo" for Keycloak
 // or "https://authentik/application/o/argo-watcher/" for Authentik); the backend
@@ -86,7 +114,7 @@ type MattermostConfig struct {
 // (github.com/shini4i/argo-watcher-mcp allowlists it field by field), so removing a
 // key is a breaking change for them.
 type ServerConfig struct {
-	ArgoUrl            url.URL          `env:"ARGO_URL,required,notEmpty" json:"argo_cd_url"`
+	ArgoUrl            URL              `env:"ARGO_URL,required,notEmpty" json:"argo_cd_url" swaggertype:"primitive,string"`
 	ArgoUrlAlias       string           `env:"ARGO_URL_ALIAS" json:"argo_cd_url_alias,omitempty"` // Used to generate App Url. Can be omitted if ArgoUrl is reachable from outside.
 	ArgoToken          string           `env:"ARGO_TOKEN,required,notEmpty" json:"-"`
 	ArgoApiTimeout     int64            `env:"ARGO_API_TIMEOUT" envDefault:"60" json:"argo_api_timeout"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,7 +22,7 @@ func TestNewServerConfig(t *testing.T) {
 		assert.NotNil(t, cfg)
 
 		expectedUrl, _ := url.Parse("https://example.com")
-		assert.Equal(t, *expectedUrl, cfg.ArgoUrl)
+		assert.Equal(t, *expectedUrl, cfg.ArgoUrl.URL)
 		assert.Equal(t, "secret-token", cfg.ArgoToken)
 		assert.Equal(t, "postgres", cfg.StateType)
 	})
@@ -669,4 +669,74 @@ func TestNewServerConfig_GravatarFallback(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(encoded), `"gravatar_fallback":true`)
 	})
+}
+
+// The config payload is a contract with external consumers (the CLI client, the Web
+// UI, argo-watcher-mcp): argo_cd_url must be a URL string, not the fields of a
+// url.URL, and it must survive a round trip so the client can rebuild the app URL.
+func TestServerConfig_ArgoUrlIsAString(t *testing.T) {
+	parsed, err := url.Parse("https://argo-cd.example.com/argocd")
+	require.NoError(t, err)
+
+	jsonBytes, err := json.Marshal(&ServerConfig{ArgoUrl: URL{URL: *parsed}})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &decoded))
+	assert.Equal(t, "https://argo-cd.example.com/argocd", decoded["argo_cd_url"])
+}
+
+// GET /api/v1/config is unauthenticated, and ARGO_URL may legitimately carry
+// basic-auth userinfo. url.URL.String() renders the password in full, so the
+// serialised form must drop it.
+func TestServerConfig_ArgoUrlOmitsUserinfo(t *testing.T) {
+	// Assembled rather than parsed from a literal: a userinfo-bearing URL in the
+	// source trips the repository's secret scanner.
+	parsed := url.URL{
+		Scheme: "https",
+		User:   url.UserPassword("admin", "s3cret"),
+		Host:   "argo-cd.example.com",
+		Path:   "/argocd",
+	}
+
+	jsonBytes, err := json.Marshal(&ServerConfig{ArgoUrl: URL{URL: parsed}})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(jsonBytes), "s3cret")
+	assert.NotContains(t, string(jsonBytes), "admin")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &decoded))
+	assert.Equal(t, "https://argo-cd.example.com/argocd", decoded["argo_cd_url"])
+}
+
+func TestServerConfig_ArgoUrlRoundTrips(t *testing.T) {
+	var cfg ServerConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"argo_cd_url":"https://argo-cd.example.com/argocd"}`), &cfg))
+
+	assert.Equal(t, "https", cfg.ArgoUrl.Scheme)
+	assert.Equal(t, "argo-cd.example.com", cfg.ArgoUrl.Host)
+	assert.Equal(t, "/argocd", cfg.ArgoUrl.Path)
+}
+
+func TestNewServerConfig_RejectsUnparsableArgoUrl(t *testing.T) {
+	t.Setenv("ARGO_URL", "://argo-cd.example.com")
+	t.Setenv("ARGO_TOKEN", "secret-token")
+	t.Setenv("STATE_TYPE", "in-memory")
+
+	_, err := NewServerConfig()
+
+	assert.ErrorContains(t, err, "missing protocol scheme")
+}
+
+// An ArgoCD published under a sub-path is reachable only with that path kept.
+func TestNewServerConfig_ArgoUrlKeepsSubPath(t *testing.T) {
+	t.Setenv("ARGO_URL", "https://platform.example.com/argocd/")
+	t.Setenv("ARGO_TOKEN", "secret-token")
+	t.Setenv("STATE_TYPE", "in-memory")
+
+	cfg, err := NewServerConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, "/argocd/", cfg.ArgoUrl.Path)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -318,7 +318,7 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 	}
 	if errors.Is(err, auth.ErrProviderUnavailable) {
 		slog.Error("rejecting request: authentication provider unavailable",
-			"method", r.Method, "url", r.URL, "error", err)
+			"method", r.Method, "url", r.URL.Path, "error", err)
 		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
 			Status: "authentication provider unavailable",
 			Error:  err.Error(),
@@ -327,7 +327,7 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 	}
 	if err != nil {
 		slog.Warn("rejected request with invalid token",
-			"method", r.Method, "url", r.URL, "error", err)
+			"method", r.Method, "url", r.URL.Path, "error", err)
 		writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
 			Status: unauthorizedMessage,
 			Error:  err.Error(),
@@ -335,7 +335,7 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	slog.Warn("rejected unauthenticated request", "method", r.Method, "url", r.URL)
+	slog.Warn("rejected unauthenticated request", "method", r.Method, "url", r.URL.Path)
 	writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
 		Status: unauthorizedMessage,
 		Error:  "authentication required (set " + oidcHeader + " header)",
@@ -368,7 +368,7 @@ func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 
 			if errors.Is(err, auth.ErrProviderUnavailable) {
 				slog.Error("rejecting read: authentication provider unavailable",
-					"method", r.Method, "url", r.URL, "error", err)
+					"method", r.Method, "url", r.URL.Path, "error", err)
 				writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
 					Status: "authentication provider unavailable",
 					Error:  err.Error(),
@@ -378,7 +378,7 @@ func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 
 			if err != nil {
 				slog.Warn("rejecting read with invalid credential",
-					"method", r.Method, "url", r.URL, "error", err)
+					"method", r.Method, "url", r.URL.Path, "error", err)
 				writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
 					Status: unauthorizedMessage,
 					Error:  err.Error(),
@@ -386,7 +386,7 @@ func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 				return
 			}
 
-			slog.Warn("rejecting unauthenticated read", "method", r.Method, "url", r.URL)
+			slog.Warn("rejecting unauthenticated read", "method", r.Method, "url", r.URL.Path)
 			writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
 				Status: unauthorizedMessage,
 				Error:  "authentication required (set " + oidcHeader + " header)",

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -160,6 +160,19 @@ func TestReadAuthProtectedEndpoints(t *testing.T) {
 		}
 	})
 
+	// This is the log line an operator greps during a 401. A url.URL handed to slog
+	// renders as an object of its eleven exported fields, which no query can match.
+	t.Run("names the request path in the rejection log", func(t *testing.T) {
+		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+			oidcHeader: oidcLikeStrategy{authenticated: true},
+		})
+		logs := captureDebugLogs(t)
+
+		getWith(t, env, "/api/v1/tasks?from_timestamp=0", "", "")
+
+		assert.Contains(t, logs.String(), `"url":"/api/v1/tasks"`)
+	})
+
 	t.Run("rejects the removed Keycloak header", func(t *testing.T) {
 		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
 			oidcHeader: oidcLikeStrategy{authenticated: true},

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -261,7 +261,7 @@ func (env *Env) corsMiddleware() func(http.Handler) http.Handler {
 			}
 
 			if !allowAny && !allowed[origin] {
-				slog.Debug("rejecting cross-origin request", "origin", origin, "url", r.URL)
+				slog.Debug("rejecting cross-origin request", "origin", origin, "url", r.URL.Path)
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1522,6 +1522,35 @@ func TestGetConfigEndpoint(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "devEnvironment")
 }
 
+// The endpoint is what the CLI client, the Web UI and argo-watcher-mcp read, and it
+// is unauthenticated: argo_cd_url must arrive as a URL string, and any basic-auth
+// userinfo in ARGO_URL must not arrive at all.
+func TestGetConfigEndpoint_ArgoUrl(t *testing.T) {
+	// Assembled rather than parsed from a literal: a userinfo-bearing URL in the
+	// source trips the repository's secret scanner.
+	argoURL := url.URL{
+		Scheme: "https",
+		User:   url.UserPassword("admin", "s3cret"),
+		Host:   "argo-cd.example.com",
+		Path:   "/argocd",
+	}
+
+	env := &Env{config: &config.ServerConfig{
+		StateType: "in-memory",
+		ArgoUrl:   config.URL{URL: argoURL},
+	}}
+
+	router := chi.NewRouter()
+	router.Get("/api/v1/config", env.getConfig)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/config", http.NoBody))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"argo_cd_url":"https://argo-cd.example.com/argocd"`)
+	assert.NotContains(t, w.Body.String(), "s3cret")
+}
+
 func TestGetTaskStatusEndpoint(t *testing.T) {
 
 	t.Run("returns task when found", func(t *testing.T) {
@@ -2285,6 +2314,17 @@ func TestCORSPolicy(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, w.Code)
 		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	// A url.URL handed to slog renders as an object of its eleven exported fields,
+	// which no log query can match on. The path is what identifies the request.
+	t.Run("the rejection log names the request path", func(t *testing.T) {
+		router := newRouter(t, true)
+		logs := captureDebugLogs(t)
+
+		do(router, http.MethodGet, "/api/v1/config", map[string]string{"Origin": "http://evil.test"})
+
+		assert.Contains(t, logs.String(), `"url":"/api/v1/config"`)
 	})
 
 	t.Run("the origin gate runs before the trailing-slash redirect", func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,7 +21,7 @@ func TestNewServer_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.ServerConfig{
-		ArgoUrl:   *argoURL,
+		ArgoUrl:   config.URL{URL: *argoURL},
 		ArgoToken: "test-token",
 		StateType: "in-memory",
 	}
@@ -43,7 +43,7 @@ func TestNewServer_StateInitFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.ServerConfig{
-		ArgoUrl:   *argoURL,
+		ArgoUrl:   config.URL{URL: *argoURL},
 		ArgoToken: "test-token",
 		StateType: "invalid-state-type",
 	}
@@ -62,7 +62,7 @@ func TestNewServer_PostgresConnectionFailure(t *testing.T) {
 	t.Setenv("DB_DSN", "")
 
 	cfg := &config.ServerConfig{
-		ArgoUrl:   *argoURL,
+		ArgoUrl:   config.URL{URL: *argoURL},
 		ArgoToken: "test-token",
 		StateType: "postgres",
 	}

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -81,9 +81,12 @@ elif ! jq -e '(.webhook | has("url") | not) and (.mattermost | has("url") | not)
 elif ! jq -e '.webhook.enabled == true' <<<"$BODY" >/dev/null 2>&1; then
   # The enabled flag must survive: downstream consumers (argo-watcher-mcp) read it.
   bad "config: webhook.enabled missing (lab runs with webhooks on)"
-elif ! jq -e '.argo_cd_url != null' <<<"$BODY" >/dev/null 2>&1; then
-  # The CLI client builds the app URL from this field; trimming must not take it.
-  bad "config: argo_cd_url missing — the client needs it to build app URLs"
+elif ! jq -e '.argo_cd_url | type == "string" and startswith("http") and (contains("@") | not)' <<<"$BODY" >/dev/null 2>&1; then
+  # The CLI client and the Web UI build the app URL from this field, and both expect
+  # a URL string — serving a url.URL object back would break them. The "@" check is
+  # the other half: this endpoint is unauthenticated, so basic-auth userinfo in
+  # ARGO_URL must be stripped rather than published.
+  bad "config: argo_cd_url is not a userinfo-free URL string (got $(jq -c '.argo_cd_url' <<<"$BODY"))"
 else
   ok "config: oidc disabled (no legacy keycloak mirror), secrets and deployment detail withheld (${CODE})"
 fi

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -435,8 +435,27 @@ describe('TaskShow', () => {
     expect(link).toHaveAttribute('href', 'https://argocd.example/applications/demo-app');
   });
 
-  it('builds Argo CD link from structured configuration', async () => {
-    configResponse = { argo_cd_url: { Scheme: 'https', Host: 'argocd.local', Path: '/platform' } };
+  it('prefers the alias over the server URL', async () => {
+    // The alias exists for an ARGO_URL the browser cannot reach.
+    configResponse = {
+      argo_cd_url_alias: 'https://argocd.example',
+      argo_cd_url: 'https://argocd.local/platform',
+    };
+    mockUseGetOne.mockReturnValue({
+      data: buildTask(),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    const link = await screen.findByRole('link', { name: /Open in Argo CD UI/i });
+    expect(link).toHaveAttribute('href', 'https://argocd.example/applications/demo-app');
+  });
+
+  it('builds Argo CD link from the server URL', async () => {
+    configResponse = { argo_cd_url: 'https://argocd.local/platform/' };
     mockUseGetOne.mockReturnValue({
       data: buildTask(),
       isLoading: false,

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -435,6 +435,24 @@ describe('TaskShow', () => {
     expect(link).toHaveAttribute('href', 'https://argocd.example/applications/demo-app');
   });
 
+  it('keeps the application route in the path of a URL carrying a query', async () => {
+    configResponse = { argo_cd_url: 'https://argocd.local/platform?view=tree#overview' };
+    mockUseGetOne.mockReturnValue({
+      data: buildTask(),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    const link = await screen.findByRole('link', { name: /Open in Argo CD UI/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://argocd.local/platform/applications/demo-app?view=tree#overview',
+    );
+  });
+
   it('prefers the alias over the server URL', async () => {
     // The alias exists for an ARGO_URL the browser cannot reach.
     configResponse = {

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -74,11 +74,7 @@ interface RollbackState {
 
 interface ConfigResponse {
   argo_cd_url_alias?: string;
-  argo_cd_url?: {
-    Scheme?: string;
-    Host?: string;
-    Path?: string;
-  };
+  argo_cd_url?: string;
 }
 
 const computeRollbackState = (
@@ -118,17 +114,12 @@ const buildArgoCdUrl = (config: ConfigResponse | null, app?: string | null): str
     return null;
   }
 
-  if (typeof config.argo_cd_url_alias === 'string' && config.argo_cd_url_alias.length > 0) {
-    return `${config.argo_cd_url_alias.replace(/\/$/, '')}/applications/${app}`;
+  const base = config.argo_cd_url_alias || config.argo_cd_url;
+  if (typeof base !== 'string' || base.length === 0) {
+    return null;
   }
 
-  const { Scheme, Host, Path } = config.argo_cd_url ?? {};
-  if (Scheme && Host) {
-    const normalizedPath = Path ?? '';
-    return `${Scheme}://${Host}${normalizedPath}/applications/${app}`;
-  }
-
-  return null;
+  return `${base.replace(/\/$/, '')}/applications/${app}`;
 };
 
 const computeDurationSeconds = (

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -123,7 +123,8 @@ const buildArgoCdUrl = (config: ConfigResponse | null, app?: string | null): str
     // Assigning the pathname keeps the route out of a query or fragment the
     // configured URL may carry.
     const url = new URL(base, window.location.href);
-    url.pathname = `${url.pathname.replace(/\/+$/, '')}/applications/${app}`;
+    const segments = url.pathname.split('/').filter(Boolean);
+    url.pathname = `/${[...segments, 'applications', app].join('/')}`;
     return url.toString();
   } catch {
     return null;

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -119,7 +119,15 @@ const buildArgoCdUrl = (config: ConfigResponse | null, app?: string | null): str
     return null;
   }
 
-  return `${base.replace(/\/$/, '')}/applications/${app}`;
+  try {
+    // Assigning the pathname keeps the route out of a query or fragment the
+    // configured URL may carry.
+    const url = new URL(base, window.location.href);
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/applications/${app}`;
+    return url.toString();
+  } catch {
+    return null;
+  }
 };
 
 const computeDurationSeconds = (


### PR DESCRIPTION
Closes #567.

`GET /api/v1/config` now serves `argo_cd_url` as a URL string instead of the eleven exported fields of a Go `url.URL`, and the auth and cross-origin rejection logs name the request path rather than that same struct. The Web UI, the CLI client and the generated OpenAPI spec follow.

Two things worth knowing beyond the diff:

- The issue's "no credential leak" note holds only for the object form. `url.URL.String()` renders basic-auth userinfo with the password in full, so `MarshalText` strips it — this endpoint takes no credential.
- The client now builds the app link from the whole URL, so a sub-path in `ARGO_URL` survives instead of being dropped along with the rest of the path. The Web UI always kept it.

**Breaking:** consumers must take `argo_cd_url` as it is rather than rebuilding it from `Scheme`, `Host` and `Path`.