### PR TITLE
feat(server): send security response headers on every route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,12 +254,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one click away: nothing stopped another site from framing the UI, and any script that
   reached the page would have run with that token. The policy is strict where the UI allows
   it — `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and
-  deliberately looser in six places the application cannot design away, each listed with its
+  deliberately looser in five places the application cannot design away, each listed with its
   reason in the API reference: inline styles, Google's font hosts, `https:` images, `https:`
-  API calls, and — for a silent token renewal with no refresh token to use — framing this
-  origin plus the provider's own login page. The Swagger page's init script moved into a file
-  of its own so that page needs no inline-script exemption either. A proxy that adds a policy
-  of its own does not replace this one — the browser enforces both.
+  API calls, and framing this origin, which a silent token renewal with no refresh token needs.
+  The Swagger page's init script moved into a file of its own so that page needs no
+  inline-script exemption either. A proxy that adds a policy of its own does not replace this
+  one — the browser enforces both.
 
 ## [0.15.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one inherited from `DEPLOYMENT_TIMEOUT` — is clamped to it. The server also sets read,
   write and idle timeouts, so a slow body or a slow reader can no longer hold a connection
   open indefinitely; established WebSocket connections are unaffected.
+- Every response now carries `Content-Security-Policy`, `X-Frame-Options`,
+  `X-Content-Type-Options` and `Referrer-Policy`. The server sent none of them, while the Web
+  UI holds an OIDC access token in JavaScript memory and puts the deploy lock and rollback
+  one click away: nothing stopped another site from framing the UI, and any script that
+  reached the page would have run with that token. The policy is strict where the UI allows
+  it — `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and
+  deliberately looser in five places the application cannot design away, each listed with its
+  reason in the API reference: inline styles, Google's font hosts, `https:` images, `https:`
+  API calls, and same-origin framing, which a silent token renewal without a refresh token
+  needs. The Swagger page's init script moved into a file of its own so that page needs no
+  inline-script exemption either. A proxy that adds a policy of its own does not replace this
+  one — the browser enforces both.
 
 ## [0.15.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,12 +254,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one click away: nothing stopped another site from framing the UI, and any script that
   reached the page would have run with that token. The policy is strict where the UI allows
   it — `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and
-  deliberately looser in five places the application cannot design away, each listed with its
+  deliberately looser in six places the application cannot design away, each listed with its
   reason in the API reference: inline styles, Google's font hosts, `https:` images, `https:`
-  API calls, and same-origin framing, which a silent token renewal without a refresh token
-  needs. The Swagger page's init script moved into a file of its own so that page needs no
-  inline-script exemption either. A proxy that adds a policy of its own does not replace this
-  one — the browser enforces both.
+  API calls, and — for a silent token renewal with no refresh token to use — framing this
+  origin plus the provider's own login page. The Swagger page's init script moved into a file
+  of its own so that page needs no inline-script exemption either. A proxy that adds a policy
+  of its own does not replace this one — the browser enforces both.
 
 ## [0.15.0] - 2026-08-11
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,6 +181,8 @@ tasks:
       - src/**/*.ts
       - src/**/*.tsx
       - vite.config.ts
+      # public/ is copied into dist verbatim, and the swagger page lives there.
+      - public/**
     # Without this, an unchanged src plus a deleted or partial dist/ is reported
     # up to date and the build is skipped — leaving the consumers of web/dist
     # (the images, the Playwright suite) pointed at nothing.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -205,6 +205,20 @@ curl -s $ARGO_WATCHER_URL/livez
 2. Confirm the TLS secret exists and matches the host.
 3. Confirm `STATIC_FILES_PATH` points at the built UI assets (`/app/static` in the published image). A server with no assets there answers `404` for every UI path while the API keeps working.
 
+## Web UI or Swagger page loads blank
+
+**Symptom:** the page returns `200` with an HTML body, but nothing renders. The API answers normally.
+
+**Likely cause:** a [Content-Security-Policy](../reference/api.md#security-headers) is blocking an asset. The server sends its own policy, and a proxy that adds a second one does not replace it — the browser enforces both, so a directive either policy omits blocks the load.
+
+**How to verify:** open the browser console. A blocked asset is reported as a policy violation naming the directive that refused it. Compare the header the browser received with the one the server sent:
+
+```bash
+curl -sI $ARGO_WATCHER_URL/ | grep -i content-security-policy
+```
+
+**Fix:** stop the proxy adding a policy of its own, or widen it to cover the same sources. Do not strip the server's policy at the proxy — it is the only one the published image guarantees.
+
 ## Web UI stops on "Sign-in failed"
 
 **Symptom:** with [OIDC](../guides/oidc.md) enabled, the loading screen shows a red error box under the logo and never reaches the task list. It does not return to the provider on its own.
@@ -234,6 +248,8 @@ curl -s $ARGO_WATCHER_URL/livez
 **Likely cause:** a proxy in front of the server strips the `Upgrade` and `Connection` headers, so the WebSocket handshake on `/ws` never happens and the server answers `400`.
 
 With [OIDC](../guides/oidc.md#the-websocket-handshake) enabled there is a second candidate: a proxy that forwards the upgrade but strips `Sec-WebSocket-Protocol` removes the credential the browser sends there, and the handshake is refused `401`.
+
+A third candidate is a proxy that rewrites `Host` to its upstream instead of preserving the client's: the [`Content-Security-Policy`](../reference/api.md#security-headers) then names the wrong `wss://` origin and the browser refuses the connection before it is made. The console reports it as a policy violation, and the server logs nothing at all.
 
 **How to verify:** with `LOG_LEVEL=debug`, look for `non-upgrade request to /ws` — it logs the `upgrade` and `connection` values that actually arrived. A `rejecting unauthenticated websocket` warning while REST reads work in the same browser points at a stripped subprotocol rather than a dead session.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -241,6 +241,14 @@ curl -sI $ARGO_WATCHER_URL/ | grep -i content-security-policy
 2. Correct whatever the error code points at: permitted scopes (`openid profile email`), exact redirect URI, web origin, group or user assignment. See [Redirect URI and web origin](../guides/oidc.md#redirect-uri-and-web-origin).
 3. Press **Try again**. Nothing is cached across the retry.
 
+## Signed-in users are sent back to the provider periodically
+
+**Symptom:** with [OIDC](../guides/oidc.md) enabled, a session that should renew itself quietly instead bounces through the provider's login page, and the browser console reports a `frame-src` policy violation.
+
+**Likely cause:** the renewal falls back to an iframe when the provider issues no refresh token, and that iframe navigates to the authorization endpoint. [`frame-src`](../reference/api.md#security-headers) allows the `OIDC_ISSUER_URL` origin only, so a provider that serves the endpoint from a different host — Amazon Cognito uses the managed-login domain — cannot renew this way.
+
+**Fix:** nothing to configure. Sign-in still works and the user keeps their session; only the silent part of the renewal is lost. Configure the provider to issue refresh tokens if the redirect is disruptive.
+
 ## Web UI does not update without a refresh
 
 **Symptom:** task status and deploy-lock changes appear only after a manual page reload.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -23,13 +23,14 @@ Every response, on every route, carries four browser-facing headers:
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` |
 
-The policy is strict where the Web UI allows it — `default-src 'self'`, `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and looser in five places that the application cannot design away:
+The policy is strict where the Web UI allows it — `default-src 'self'`, `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and looser in six places that the application cannot design away:
 
 - `style-src` allows `'unsafe-inline'`. The UI's styling engine and the Swagger page both inject stylesheets and style attributes, and a nonce cannot cover the attributes. It also allows `https://fonts.googleapis.com`, the stylesheet the UI loads its font from.
 - `font-src` allows `https://fonts.gstatic.com`, the host that stylesheet serves the font files from.
 - `img-src` allows any `https:` origin. An avatar comes from the OIDC `picture` claim or from Gravatar, so its host is not known in advance.
 - `connect-src` allows any `https:` origin. A provider may serve its token and userinfo endpoints from hosts other than its issuer, and a policy that breaks sign-in is the worse trade.
 - `frame-ancestors` is `'self'` rather than `'none'`, matching `X-Frame-Options: SAMEORIGIN`. A silent token renewal with no refresh token loads this application in an iframe of its own origin.
+- `frame-src` allows any `https:` origin. That renewal iframe first navigates to the authorization endpoint the provider advertises in its discovery document, which need not be on the issuer's host (Amazon Cognito serves it from the managed-login domain).
 
 Two directives are filled in from the deployment: `connect-src` names `ws://` and `wss://` on the host the request was addressed to, because `'self'` does not resolve to a WebSocket scheme in every browser, and both `connect-src` and `frame-src` name the origin of `OIDC_ISSUER_URL` — an issuer on plain `http` matches nothing else in the policy.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,6 +12,29 @@ The server exposes a REST API on its own port (default `8080`), with every endpo
 - Authentication failures return `401 Unauthorized`, and `503 Service Unavailable` when the credential could not be checked because the OIDC provider was unreachable.
 - Server-side problems return `500 Internal Server Error`.
 
+## Security headers
+
+Every response, on every route, carries four browser-facing headers:
+
+| Header | Value |
+|---|---|
+| `Content-Security-Policy` | see below |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `SAMEORIGIN` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+
+The policy is strict where the Web UI allows it — `default-src 'self'`, `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and looser in five places that the application cannot design away:
+
+- `style-src` allows `'unsafe-inline'`. The UI's styling engine and the Swagger page both inject stylesheets and style attributes, and a nonce cannot cover the attributes. It also allows `https://fonts.googleapis.com`, the stylesheet the UI loads its font from.
+- `font-src` allows `https://fonts.gstatic.com`, the host that stylesheet serves the font files from.
+- `img-src` allows any `https:` origin. An avatar comes from the OIDC `picture` claim or from Gravatar, so its host is not known in advance.
+- `connect-src` allows any `https:` origin. A provider may serve its token and userinfo endpoints from hosts other than its issuer, and a policy that breaks sign-in is the worse trade.
+- `frame-ancestors` is `'self'` rather than `'none'`, matching `X-Frame-Options: SAMEORIGIN`. A silent token renewal with no refresh token loads this application in an iframe of its own origin.
+
+Two directives are filled in from the deployment: `connect-src` names `ws://` and `wss://` on the host the request was addressed to, because `'self'` does not resolve to a WebSocket scheme in every browser, and both `connect-src` and `frame-src` name the origin of `OIDC_ISSUER_URL` — an issuer on plain `http` matches nothing else in the policy.
+
+A proxy that adds a `Content-Security-Policy` of its own does not replace this one. The browser enforces both, so anything either policy forbids is blocked.
+
 ## Authentication
 
 A credential does two things: it authorizes the [GitOps updater](../guides/gitops-updater.md)'s write-back, and — when [OIDC](../guides/oidc.md) is enabled — it is what lets you read the API at all. Any one of:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -23,16 +23,15 @@ Every response, on every route, carries four browser-facing headers:
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` |
 
-The policy is strict where the Web UI allows it — `default-src 'self'`, `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and looser in six places that the application cannot design away:
+The policy is strict where the Web UI allows it — `default-src 'self'`, `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — and looser in five places that the application cannot design away:
 
 - `style-src` allows `'unsafe-inline'`. The UI's styling engine and the Swagger page both inject stylesheets and style attributes, and a nonce cannot cover the attributes. It also allows `https://fonts.googleapis.com`, the stylesheet the UI loads its font from.
 - `font-src` allows `https://fonts.gstatic.com`, the host that stylesheet serves the font files from.
 - `img-src` allows any `https:` origin. An avatar comes from the OIDC `picture` claim or from Gravatar, so its host is not known in advance.
 - `connect-src` allows any `https:` origin. A provider may serve its token and userinfo endpoints from hosts other than its issuer, and a policy that breaks sign-in is the worse trade.
 - `frame-ancestors` is `'self'` rather than `'none'`, matching `X-Frame-Options: SAMEORIGIN`. A silent token renewal with no refresh token loads this application in an iframe of its own origin.
-- `frame-src` allows any `https:` origin. That renewal iframe first navigates to the authorization endpoint the provider advertises in its discovery document, which need not be on the issuer's host (Amazon Cognito serves it from the managed-login domain).
 
-Two directives are filled in from the deployment: `connect-src` names `ws://` and `wss://` on the host the request was addressed to, because `'self'` does not resolve to a WebSocket scheme in every browser, and both `connect-src` and `frame-src` name the origin of `OIDC_ISSUER_URL` — an issuer on plain `http` matches nothing else in the policy.
+Two directives are filled in from the deployment. `connect-src` names `ws://` and `wss://` on the host the request was addressed to, because `'self'` does not resolve to a WebSocket scheme in every browser. Both `connect-src` and `frame-src` name the origin of `OIDC_ISSUER_URL`, which an issuer on plain `http` depends on — nothing else in the policy matches it. `frame-src` names that origin and nothing more, so a provider serving its authorization endpoint from another host (Amazon Cognito uses the managed-login domain) cannot renew a session silently; the renewal becomes an ordinary interactive sign-in.
 
 A proxy that adds a `Content-Security-Policy` of its own does not replace this one. The browser enforces both, so anything either policy forbids is blocked.
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -28,6 +28,7 @@ func (env *Env) CreateRouter() *chi.Mux {
 
 	router := chi.NewRouter()
 	router.Use(middleware.Recoverer)
+	router.Use(env.securityHeaders())
 	router.Use(env.corsMiddleware())
 
 	// The upgrade response is written straight to the connection the handler

--- a/internal/server/security_headers.go
+++ b/internal/server/security_headers.go
@@ -44,7 +44,10 @@ func (env *Env) securityHeaders() func(http.Handler) http.Handler {
 	// An issuer on plain http matches neither 'self' nor https:, and the browser
 	// fetches discovery, the token exchange and userinfo from it.
 	head := cspHead + issuer
-	tail := "; frame-src 'self'" + issuer + cspTail
+	// frame-src takes any https origin because the silent-renewal iframe navigates to
+	// the DISCOVERED authorization endpoint, which a provider may host off the issuer
+	// origin (Amazon Cognito serves it from the managed-login domain).
+	tail := "; frame-src 'self' https:" + issuer + cspTail
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/security_headers.go
+++ b/internal/server/security_headers.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/shini4i/argo-watcher/internal/config"
+)
+
+// cspHead is the invariant part of the Content-Security-Policy, ending on
+// connect-src so a request's own websocket sources can be appended. Directives
+// looser than 'self' are commented where they are set.
+const cspHead = "default-src 'self'; " +
+	"script-src 'self'; " +
+	// emotion (MUI) and swagger-ui inject stylesheets and style attributes, and a
+	// nonce cannot cover the attributes. Google Fonts is loaded by web/index.html.
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+	"font-src 'self' https://fonts.gstatic.com; " +
+	// An avatar comes from the OIDC `picture` claim or Gravatar, so its host is not
+	// known here; swagger-ui's stylesheet embeds data: images.
+	"img-src 'self' data: https:; " +
+	// A provider may serve its token and userinfo endpoints from hosts other than
+	// its issuer (Google does), and a policy that breaks sign-in is the worse trade.
+	// securityHeaders appends the issuer origin and the websocket sources.
+	"connect-src 'self' https:"
+
+// cspTail closes the policy. frame-ancestors is 'self' rather than 'none' because a
+// silent renewal without a refresh token falls back to an iframe of this
+// application's own origin (oidc-client-ts signinSilent).
+const cspTail = "; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
+
+// securityHeaders returns middleware that sets the browser-facing response headers
+// on every route. It sets them before delegating, so a response written further down
+// the chain — the CORS gate's 403, the panic recoverer's 500 — carries them too.
+func (env *Env) securityHeaders() func(http.Handler) http.Handler {
+	// Only the websocket sources depend on the request; the issuer is fixed for the
+	// process lifetime.
+	issuer := ""
+	if origin := issuerOrigin(env.config.OIDC); origin != "" {
+		issuer = " " + origin
+	}
+	// An issuer on plain http matches neither 'self' nor https:, and the browser
+	// fetches discovery, the token exchange and userinfo from it.
+	head := cspHead + issuer
+	tail := "; frame-src 'self'" + issuer + cspTail
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := w.Header()
+			header.Set("Content-Security-Policy", head+webSocketSources(r.Host)+tail)
+			header.Set("X-Content-Type-Options", "nosniff")
+			header.Set("X-Frame-Options", "SAMEORIGIN")
+			header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// webSocketSources returns the connect-src entries for the /ws handshake against
+// host, or an empty string when host cannot be spelled in a policy. They are named
+// explicitly because connect-src 'self' does not resolve to a websocket scheme in
+// every browser (w3c/webappsec-csp#7).
+func webSocketSources(host string) string {
+	if !isPolicySafeHost(host) {
+		slog.Debug("omitting websocket sources from the content security policy", "host", host)
+		return ""
+	}
+
+	return " ws://" + host + " wss://" + host
+}
+
+// issuerOrigin returns the scheme and host of the configured OIDC issuer, which a
+// silent renewal iframe navigates to. It is empty when OIDC is off or the issuer is
+// not a usable absolute URL.
+func issuerOrigin(oidc config.OIDCConfig) string {
+	if !oidc.Enabled {
+		return ""
+	}
+
+	issuer, err := url.Parse(strings.TrimSpace(oidc.IssuerURL))
+	if err != nil || (issuer.Scheme != "http" && issuer.Scheme != "https") || !isPolicySafeHost(issuer.Host) {
+		slog.Warn("OIDC issuer is not a usable origin; leaving it out of the content security policy",
+			"issuer_url", oidc.IssuerURL)
+		return ""
+	}
+
+	return issuer.Scheme + "://" + issuer.Host
+}
+
+// isPolicySafeHost reports whether host is a non-empty host[:port] built only from
+// characters that carry no meaning in a policy. Both callers need it: net/http
+// accepts ";" and "'" in a Host header and url.Parse accepts them in an issuer, so
+// an unvalidated host could append directives to the policy this server serves.
+func isPolicySafeHost(host string) bool {
+	if host == "" {
+		return false
+	}
+
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '.', c == '-', c == ':', c == '[', c == ']':
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/server/security_headers.go
+++ b/internal/server/security_headers.go
@@ -44,10 +44,11 @@ func (env *Env) securityHeaders() func(http.Handler) http.Handler {
 	// An issuer on plain http matches neither 'self' nor https:, and the browser
 	// fetches discovery, the token exchange and userinfo from it.
 	head := cspHead + issuer
-	// frame-src takes any https origin because the silent-renewal iframe navigates to
-	// the DISCOVERED authorization endpoint, which a provider may host off the issuer
-	// origin (Amazon Cognito serves it from the managed-login domain).
-	tail := "; frame-src 'self' https:" + issuer + cspTail
+	// The issuer origin is all frame-src gets: a provider that serves the authorization
+	// endpoint off it (Amazon Cognito uses the managed-login domain) loses the silent
+	// renewal iframe and falls back to an interactive sign-in, which is a smaller price
+	// than allowing this page to frame any origin.
+	tail := "; frame-src 'self'" + issuer + cspTail
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/security_headers_test.go
+++ b/internal/server/security_headers_test.go
@@ -147,7 +147,7 @@ func TestContentSecurityPolicyDirectives(t *testing.T) {
 		// 'self' rather than 'none': a silent token renewal without a refresh token
 		// frames this application's own origin.
 		"frame-ancestors": "'self'",
-		"frame-src":       "'self'",
+		"frame-src":       "'self' https:",
 		// emotion (MUI) and swagger-ui both inject stylesheets and style attributes,
 		// and the Web UI loads its font from Google Fonts.
 		"style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com",
@@ -211,31 +211,32 @@ func TestContentSecurityPolicyFrameSrc(t *testing.T) {
 		{
 			name:  "without OIDC only this origin may be framed",
 			oidc:  config.OIDCConfig{},
-			frame: "'self'",
+			frame: "'self' https:",
 		},
 		{
 			// A deployment that turned OIDC off without clearing the issuer must not
 			// widen the policy to a third-party origin with authentication disabled.
 			name:  "an issuer left behind with OIDC off is ignored",
 			oidc:  config.OIDCConfig{IssuerURL: "https://sso.example.com/realms/watcher"},
-			frame: "'self'",
+			frame: "'self' https:",
 		},
 		{
 			// A silent renewal without a refresh token navigates an iframe to the
-			// provider's authorization endpoint, which lives on the issuer origin.
+			// provider's DISCOVERED authorization endpoint, which https: already covers;
+			// naming the issuer is what carries a non-https one (see the http case above).
 			name:  "with OIDC the issuer origin is allowed",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: " https://sso.example.com/realms/watcher "},
-			frame: "'self' https://sso.example.com",
+			frame: "'self' https: https://sso.example.com",
 		},
 		{
 			name:  "an unusable issuer is left out",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "not a url"},
-			frame: "'self'",
+			frame: "'self' https:",
 		},
 		{
 			name:  "an issuer host that cannot be spelled in a policy is left out",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "https://sso.example.com;script-src 'unsafe-inline'"},
-			frame: "'self'",
+			frame: "'self' https:",
 		},
 	}
 
@@ -253,7 +254,7 @@ func TestContentSecurityPolicyFrameSrc(t *testing.T) {
 			assert.Equal(t, "'self'", directives["script-src"])
 			// The issuer feeds connect-src too, so frame-src alone would not prove a
 			// rejected issuer stayed out of the policy.
-			if tt.frame == "'self'" {
+			if tt.frame == "'self' https:" {
 				assert.NotContains(t, policy, "sso.example.com")
 			}
 		})

--- a/internal/server/security_headers_test.go
+++ b/internal/server/security_headers_test.go
@@ -1,0 +1,273 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
+)
+
+// newHeaderRouter builds a router over a static directory holding an index.html and
+// a swagger page, so the SPA fallback and the swagger route both answer 200.
+func newHeaderRouter(t *testing.T, cfg config.ServerConfig) *chi.Mux {
+	t.Helper()
+
+	staticPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staticPath, "index.html"), []byte("<html></html>"), 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(staticPath, "swagger"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(staticPath, "swagger", "index.html"), []byte("<html></html>"), 0o600))
+
+	cfg.StaticFilePath = staticPath
+	env := &Env{config: &cfg}
+
+	var err error
+	env.lockdown, err = NewLockdown("", lock.NewInMemoryDeployLockStore())
+	require.NoError(t, err)
+
+	return env.CreateRouter()
+}
+
+// cspDirectives parses a policy into directive name -> source list.
+func cspDirectives(t *testing.T, policy string) map[string]string {
+	t.Helper()
+	require.NotEmpty(t, policy, "no Content-Security-Policy header")
+
+	directives := map[string]string{}
+	for _, directive := range strings.Split(policy, ";") {
+		name, sources, _ := strings.Cut(strings.TrimSpace(directive), " ")
+		if name != "" {
+			directives[name] = strings.TrimSpace(sources)
+		}
+	}
+	return directives
+}
+
+// assertSecurityHeaders asserts the three single-purpose headers and that a policy
+// was set at all. Its content is pinned by TestContentSecurityPolicyDirectives.
+func assertSecurityHeaders(t *testing.T, header http.Header) {
+	t.Helper()
+	assert.NotEmpty(t, header.Get("Content-Security-Policy"))
+	assert.Equal(t, "nosniff", header.Get("X-Content-Type-Options"))
+	// SAMEORIGIN, not DENY: a silent token renewal with no refresh token falls back
+	// to an iframe of this application's own origin.
+	assert.Equal(t, "SAMEORIGIN", header.Get("X-Frame-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", header.Get("Referrer-Policy"))
+}
+
+func TestSecurityHeadersOnEveryRoute(t *testing.T) {
+	router := newHeaderRouter(t, config.ServerConfig{})
+
+	// One request per kind of response the server produces: a probe, an API payload,
+	// the metrics endpoint, a served file, the SPA fallback, the swagger page, and
+	// the websocket route — the one route the CORS gate deliberately exempts.
+	routes := map[string]int{
+		"/livez":                 http.StatusOK,
+		"/api/v1/config":         http.StatusOK,
+		"/metrics":               http.StatusOK,
+		"/index.html":            http.StatusOK,
+		"/deep/link/into/the/ui": http.StatusOK,
+		"/swagger/":              http.StatusOK,
+		"/ws":                    http.StatusBadRequest,
+	}
+
+	for path, status := range routes {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, status, w.Code)
+			assertSecurityHeaders(t, w.Header())
+		})
+	}
+}
+
+func TestSecurityHeadersOnPanic(t *testing.T) {
+	// The middleware sets the headers before delegating, which is what carries them
+	// onto a response it never sees written.
+	env := &Env{config: &config.ServerConfig{}}
+
+	router := chi.NewRouter()
+	router.Use(middleware.Recoverer)
+	router.Use(env.securityHeaders())
+	router.Get("/boom", func(http.ResponseWriter, *http.Request) { panic("boom") })
+
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assertSecurityHeaders(t, w.Header())
+}
+
+func TestSecurityHeadersOnRefusedRequest(t *testing.T) {
+	// The origin allowlist is only non-empty in a dev environment; production allows
+	// any origin, so nothing to refuse there.
+	router := newHeaderRouter(t, config.ServerConfig{DevEnvironment: true})
+
+	// The CORS gate answers before any handler; a response it writes itself must still
+	// carry the headers.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assertSecurityHeaders(t, w.Header())
+}
+
+func TestContentSecurityPolicyDirectives(t *testing.T) {
+	router := newHeaderRouter(t, config.ServerConfig{})
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	req.Host = "watcher.example.com:8080"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	directives := cspDirectives(t, w.Header().Get("Content-Security-Policy"))
+
+	// Asserted whole, not by substring: for a security policy the source list IS the
+	// contract, and a widened one must fail here.
+	assert.Equal(t, map[string]string{
+		"default-src": "'self'",
+		"script-src":  "'self'",
+		"object-src":  "'none'",
+		"base-uri":    "'self'",
+		"form-action": "'self'",
+		// 'self' rather than 'none': a silent token renewal without a refresh token
+		// frames this application's own origin.
+		"frame-ancestors": "'self'",
+		"frame-src":       "'self'",
+		// emotion (MUI) and swagger-ui both inject stylesheets and style attributes,
+		// and the Web UI loads its font from Google Fonts.
+		"style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com",
+		"font-src":  "'self' https://fonts.gstatic.com",
+		// Avatars come from the OIDC `picture` claim or Gravatar, and swagger-ui's
+		// stylesheet embeds data: images.
+		"img-src": "'self' data: https:",
+		// A provider may serve its token and userinfo endpoints off other hosts. The
+		// handshake host is named explicitly because 'self' does not resolve to a
+		// websocket scheme in every browser.
+		"connect-src": "'self' https: ws://watcher.example.com:8080 wss://watcher.example.com:8080",
+	}, directives)
+
+	assert.NotContains(t, w.Header().Get("Content-Security-Policy"), "unsafe-eval")
+}
+
+func TestContentSecurityPolicyRejectsHostileHost(t *testing.T) {
+	router := newHeaderRouter(t, config.ServerConfig{})
+
+	// Go accepts ";" and "'" in a Host header, so an unvalidated host would let a
+	// request append its own directives to the policy it is served.
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	req.Host = "evil.example.com;script-src 'unsafe-inline'"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	policy := w.Header().Get("Content-Security-Policy")
+	directives := cspDirectives(t, policy)
+
+	assert.Equal(t, "'self'", directives["script-src"])
+	assert.NotContains(t, policy, "evil.example.com")
+	// The websocket sources are dropped rather than guessed.
+	assert.NotContains(t, directives["connect-src"], "ws://")
+}
+
+func TestContentSecurityPolicyAllowsTheIssuer(t *testing.T) {
+	// An issuer on plain http matches neither 'self' nor https:, and the browser
+	// fetches discovery, the token exchange and userinfo from it. The lab's Keycloak
+	// (web/e2e) is exactly that shape.
+	router := newHeaderRouter(t, config.ServerConfig{
+		OIDC: config.OIDCConfig{Enabled: true, IssuerURL: "http://localhost:8090/realms/argo-watcher-e2e"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	directives := cspDirectives(t, w.Header().Get("Content-Security-Policy"))
+	assert.Contains(t, directives["connect-src"], "http://localhost:8090")
+	assert.Contains(t, directives["frame-src"], "http://localhost:8090")
+	// The path is not part of an origin.
+	assert.NotContains(t, w.Header().Get("Content-Security-Policy"), "realms")
+}
+
+func TestContentSecurityPolicyFrameSrc(t *testing.T) {
+	tests := []struct {
+		name  string
+		oidc  config.OIDCConfig
+		frame string
+	}{
+		{
+			name:  "without OIDC only this origin may be framed",
+			oidc:  config.OIDCConfig{},
+			frame: "'self'",
+		},
+		{
+			// A deployment that turned OIDC off without clearing the issuer must not
+			// widen the policy to a third-party origin with authentication disabled.
+			name:  "an issuer left behind with OIDC off is ignored",
+			oidc:  config.OIDCConfig{IssuerURL: "https://sso.example.com/realms/watcher"},
+			frame: "'self'",
+		},
+		{
+			// A silent renewal without a refresh token navigates an iframe to the
+			// provider's authorization endpoint, which lives on the issuer origin.
+			name:  "with OIDC the issuer origin is allowed",
+			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: " https://sso.example.com/realms/watcher "},
+			frame: "'self' https://sso.example.com",
+		},
+		{
+			name:  "an unusable issuer is left out",
+			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "not a url"},
+			frame: "'self'",
+		},
+		{
+			name:  "an issuer host that cannot be spelled in a policy is left out",
+			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "https://sso.example.com;script-src 'unsafe-inline'"},
+			frame: "'self'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := newHeaderRouter(t, config.ServerConfig{OIDC: tt.oidc})
+
+			req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			policy := w.Header().Get("Content-Security-Policy")
+			directives := cspDirectives(t, policy)
+			assert.Equal(t, tt.frame, directives["frame-src"])
+			assert.Equal(t, "'self'", directives["script-src"])
+			// The issuer feeds connect-src too, so frame-src alone would not prove a
+			// rejected issuer stayed out of the policy.
+			if tt.frame == "'self'" {
+				assert.NotContains(t, policy, "sso.example.com")
+			}
+		})
+	}
+}
+
+func TestIsPolicySafeHost(t *testing.T) {
+	// The sole barrier between an attacker-controlled Host header and the policy this
+	// server serves, so its accepted set is pinned rather than described.
+	for _, host := range []string{"host", "host.example.com:8080", "[::1]:8080", "127.0.0.1:30080"} {
+		assert.True(t, isPolicySafeHost(host), host)
+	}
+
+	for _, host := range []string{"", "a;b", "a'b", "a b", "a,b", "a/b", "a\"b", "a*b", "host\n"} {
+		assert.False(t, isPolicySafeHost(host), host)
+	}
+}

--- a/internal/server/security_headers_test.go
+++ b/internal/server/security_headers_test.go
@@ -147,7 +147,7 @@ func TestContentSecurityPolicyDirectives(t *testing.T) {
 		// 'self' rather than 'none': a silent token renewal without a refresh token
 		// frames this application's own origin.
 		"frame-ancestors": "'self'",
-		"frame-src":       "'self' https:",
+		"frame-src":       "'self'",
 		// emotion (MUI) and swagger-ui both inject stylesheets and style attributes,
 		// and the Web UI loads its font from Google Fonts.
 		"style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com",
@@ -211,32 +211,32 @@ func TestContentSecurityPolicyFrameSrc(t *testing.T) {
 		{
 			name:  "without OIDC only this origin may be framed",
 			oidc:  config.OIDCConfig{},
-			frame: "'self' https:",
+			frame: "'self'",
 		},
 		{
 			// A deployment that turned OIDC off without clearing the issuer must not
 			// widen the policy to a third-party origin with authentication disabled.
 			name:  "an issuer left behind with OIDC off is ignored",
 			oidc:  config.OIDCConfig{IssuerURL: "https://sso.example.com/realms/watcher"},
-			frame: "'self' https:",
+			frame: "'self'",
 		},
 		{
 			// A silent renewal without a refresh token navigates an iframe to the
-			// provider's DISCOVERED authorization endpoint, which https: already covers;
-			// naming the issuer is what carries a non-https one (see the http case above).
+			// provider's authorization endpoint. Only the issuer origin is allowed, so a
+			// provider that serves it elsewhere renews interactively instead.
 			name:  "with OIDC the issuer origin is allowed",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: " https://sso.example.com/realms/watcher "},
-			frame: "'self' https: https://sso.example.com",
+			frame: "'self' https://sso.example.com",
 		},
 		{
 			name:  "an unusable issuer is left out",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "not a url"},
-			frame: "'self' https:",
+			frame: "'self'",
 		},
 		{
 			name:  "an issuer host that cannot be spelled in a policy is left out",
 			oidc:  config.OIDCConfig{Enabled: true, IssuerURL: "https://sso.example.com;script-src 'unsafe-inline'"},
-			frame: "'self' https:",
+			frame: "'self'",
 		},
 	}
 
@@ -254,7 +254,7 @@ func TestContentSecurityPolicyFrameSrc(t *testing.T) {
 			assert.Equal(t, "'self'", directives["script-src"])
 			// The issuer feeds connect-src too, so frame-src alone would not prove a
 			// rejected issuer stayed out of the policy.
-			if tt.frame == "'self' https:" {
+			if tt.frame == "'self'" {
 				assert.NotContains(t, policy, "sso.example.com")
 			}
 		})

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -22,6 +22,8 @@
 #                                          distinction, commit fa0b3fd)
 #   - GET  /api/v1/deploy-lock          -> 200 (read-only, always registered)
 #   - POST /api/v1/tasks (>1 MiB)       -> 413; 51 images -> 406 (issue #562)
+#   - the four browser-facing security headers (issue #565) on the SPA document,
+#                                          an API payload and the swagger page
 #   - POST /api/v1/deploy-lock          -> with OIDC disabled the state-changing
 #                                          handler is NOT registered, so the request
 #                                          falls through to the SPA static handler
@@ -156,5 +158,59 @@ if jq -e '. == false' <<<"$BODY" >/dev/null 2>&1; then
 else
   bad "POST deploy-lock set the lock without OIDC (body=${BODY})"
 fi
+
+echo "=== security response headers ==="
+# The Web UI keeps an OIDC access token in JavaScript memory and puts the deploy
+# lock and rollback one click away, so the four browser-facing headers must reach
+# every route — the SPA document included (issue #565).
+aw_host="${AW_URL#*://}"
+# Reads from the $headers the loop below refreshes per path. An absent header is
+# empty, not an error: under `set -e` a failing grep would abort the phase instead
+# of letting the assertion report it.
+header_value() { grep -i "^$1:" <<<"$headers" | cut -d' ' -f2- || true; }
+
+for path in "/" "/api/v1/config" "/swagger/"; do
+  out=$(curl -s -m "${REQ_TIMEOUT:-10}" -o /dev/null -D - -w $'\n%{http_code}' "${AW_URL}${path}" | tr -d '\r')
+  code="${out##*$'\n'}"
+  headers="${out%$'\n'*}"
+
+  # The headers are set before the handler runs, so they are present on a failed
+  # response too — without this the block would report OK for a broken route.
+  if [[ "$code" != 2* && "$code" != 3* ]]; then
+    bad "${path}: HTTP ${code}"
+    continue
+  fi
+
+  csp=$(header_value content-security-policy)
+  if [[ -z "$csp" ]]; then
+    bad "${path}: no Content-Security-Policy"
+  elif [[ "$csp" != *"frame-ancestors 'self'"* || "$csp" != *"object-src 'none'"* ]]; then
+    # The anti-clickjacking and anti-plugin half of the policy.
+    bad "${path}: unexpected framing policy: ${csp}"
+  elif [[ "$csp" != *"default-src 'self'"* || "$csp" != *"script-src 'self';"* ]]; then
+    # A bare "script-src 'self';" is the assertion: an appended 'unsafe-inline' or
+    # a nonce-less relaxation would break the match.
+    bad "${path}: unexpected script policy: ${csp}"
+  elif [[ "$csp" == *"unsafe-eval"* ]]; then
+    bad "${path}: policy allows unsafe-eval: ${csp}"
+  elif [[ "$csp" != *"ws://${aw_host}"* ]]; then
+    # connect-src 'self' does not resolve to a websocket scheme in every browser,
+    # so the /ws host is named explicitly.
+    bad "${path}: policy omits ws://${aw_host}: ${csp}"
+  else
+    ok "${path}: Content-Security-Policy"
+  fi
+
+  for pair in "x-content-type-options=nosniff" \
+    "x-frame-options=SAMEORIGIN" \
+    "referrer-policy=strict-origin-when-cross-origin"; do
+    got=$(header_value "${pair%%=*}")
+    if [[ "$got" == "${pair#*=}" ]]; then
+      ok "${path}: ${pair%%=*}: ${got}"
+    else
+      bad "${path}: ${pair%%=*}=${got:-<absent>} (want ${pair#*=})"
+    fi
+  done
+done
 
 phase_end API-SURFACE

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -167,7 +167,10 @@ aw_host="${AW_URL#*://}"
 # Reads from the $headers the loop below refreshes per path. An absent header is
 # empty, not an error: under `set -e` a failing grep would abort the phase instead
 # of letting the assertion report it.
-header_value() { grep -i "^$1:" <<<"$headers" | cut -d' ' -f2- || true; }
+header_value() {
+  local name="$1"
+  grep -i "^${name}:" <<<"$headers" | cut -d' ' -f2- || true
+}
 
 for path in "/" "/api/v1/config" "/swagger/"; do
   out=$(curl -s -m "${REQ_TIMEOUT:-10}" -o /dev/null -D - -w $'\n%{http_code}' "${AW_URL}${path}" | tr -d '\r')

--- a/web/public/swagger/index.html
+++ b/web/public/swagger/index.html
@@ -9,17 +9,6 @@
     <div id="swagger-ui"></div>
     <script src="swagger-ui-bundle.js"></script>
     <script src="swagger-ui-standalone-preset.js"></script>
-    <script>
-        window.onload = function () {
-            SwaggerUIBundle({
-                url: "swagger.json",
-                dom_id: "#swagger-ui",
-                presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
-                layout: "StandaloneLayout",
-                validatorUrl: null,
-                defaultModelsExpandDepth: -1,
-            });
-        };
-    </script>
+    <script src="swagger-init.js"></script>
 </body>
 </html>

--- a/web/public/swagger/swagger-init.js
+++ b/web/public/swagger/swagger-init.js
@@ -1,0 +1,11 @@
+// Loaded as a file rather than inlined so the page needs no script-src 'unsafe-inline'.
+window.onload = function () {
+    SwaggerUIBundle({
+        url: "swagger.json",
+        dom_id: "#swagger-ui",
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        layout: "StandaloneLayout",
+        validatorUrl: null,
+        defaultModelsExpandDepth: -1,
+    });
+};


### PR DESCRIPTION
Closes #565.

`connect-src` and `img-src` deliberately allow any `https:` origin: a provider may serve its token and userinfo endpoints off hosts other than its issuer (Google does), and an avatar comes from the OIDC `picture` claim or Gravatar. `frame-ancestors` is `'self'`, not `'none'` — a silent token renewal without a refresh token frames this application's own origin. The issuer origin is added to `connect-src` as well as `frame-src`, since an issuer on plain `http` matches nothing else in the policy.

The Swagger page's init script moved into a file so `script-src 'self'` needs no exemption, which makes `web/public` a build input for `build-ui`. No new environment variables and no escape hatch for the policy.