### PR TITLE
fix(server): refuse cross-origin requests in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The Swagger page's init script moved into a file of its own so that page needs no
   inline-script exemption either. A proxy that adds a policy of its own does not replace this
   one — the browser enforces both.
+- Cross-origin requests are refused again. `POST /api/v1/tasks` accepted them from any origin,
+  so a page on an unrelated site — opened by anyone whose browser can reach the instance, over a
+  VPN, an internal ingress or a `port-forward` — could start a real deployment with a `text/plain`
+  body. That is a CORS *simple* request: the browser sends it and the server acts on it before
+  deciding whether the calling script may read the reply, which the attacker never wanted. Neither
+  tightening `Access-Control-Allow-Origin` nor a reverse proxy addresses this, because the request
+  arrives through the ingress from a legitimate browser on an allowed network. Any request whose
+  `Origin` names a host other than the one it was sent to is now refused with `403` before it
+  reaches a handler. Nothing legitimate changes: the Web UI is served by the same binary on the
+  same origin, and the CLI client, the MCP server and `curl` send no `Origin` at all. There is no
+  new setting — `DEV_ENVIRONMENT=true` still admits the local frontend dev server, which the
+  contributing guide now spells out.
 
 ## [0.15.0] - 2026-08-11
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -45,7 +45,7 @@ go run ./cmd/mock
 Then the server, in-memory:
 
 ```bash
-LOG_LEVEL=debug ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
+LOG_LEVEL=debug DEV_ENVIRONMENT=true ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
   STATE_TYPE=in-memory go run ./cmd/argo-watcher
 ```
 
@@ -54,7 +54,7 @@ Or against Postgres:
 ```bash
 docker compose up -d postgres migrations
 
-LOG_LEVEL=debug ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
+LOG_LEVEL=debug DEV_ENVIRONMENT=true ARGO_URL=http://localhost:8081 ARGO_TOKEN=example \
   STATE_TYPE=postgres DB_HOST=localhost DB_PORT=5432 \
   DB_USER=watcher DB_PASSWORD=watcher DB_NAME=watcher \
   go run ./cmd/argo-watcher
@@ -67,6 +67,9 @@ cd web
 npm install
 npm run dev
 ```
+
+`DEV_ENVIRONMENT=true` above is what makes this work: the dev server is a different
+origin from the API, and the server allows no cross-origin request without it.
 
 ## Tasks
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -35,6 +35,12 @@ Two directives are filled in from the deployment. `connect-src` names `ws://` an
 
 A proxy that adds a `Content-Security-Policy` of its own does not replace this one. The browser enforces both, so anything either policy forbids is blocked.
 
+## Cross-origin requests
+
+A request whose `Origin` header names anything other than the host it was addressed to is refused with `403 Forbidden` before any handler runs. This is deliberately not left to CORS: a `text/plain` `POST /api/v1/tasks` is a CORS *simple* request, so the browser sends it and the deployment would already have started by the time the browser decided whether the calling script may read the response.
+
+Callers that are not browsers — the CLI client, argo-watcher-mcp, `curl` — send no `Origin` and are untouched by this. The Web UI is served by the same binary on the same origin, so it is untouched too. A browser application served from a different origin cannot use the API, and there is no allowlist to add it to: `DEV_ENVIRONMENT=true` admits the local frontend dev server and nothing else.
+
 ## Authentication
 
 A credential does two things: it authorizes the [GitOps updater](../guides/gitops-updater.md)'s write-back, and — when [OIDC](../guides/oidc.md) is enabled — it is what lets you read the API at all. Any one of:

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -240,11 +240,7 @@ func (env *Env) corsMiddleware() func(http.Handler) http.Handler {
 	handler := cors.New(options).Handler
 
 	allowed := make(map[string]bool, len(options.AllowedOrigins))
-	allowAny := false
 	for _, origin := range options.AllowedOrigins {
-		if origin == "*" {
-			allowAny = true
-		}
 		allowed[origin] = true
 	}
 
@@ -261,7 +257,7 @@ func (env *Env) corsMiddleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			if !allowAny && !allowed[origin] {
+			if !allowed[origin] {
 				slog.Debug("rejecting cross-origin request", "origin", origin, "url", r.URL.Path)
 				w.WriteHeader(http.StatusForbidden)
 				return
@@ -292,9 +288,9 @@ func isSameOrigin(origin, host string) bool {
 
 // corsOptions returns the CORS policy.
 //
-// Every entry in AllowedOrigins must stay an exact origin or "*": corsMiddleware
-// matches them literally, so a pattern would be annotated by the CORS library yet
-// refused by the gate in front of it.
+// Every entry in AllowedOrigins must stay an exact origin: corsMiddleware matches
+// them literally, so a pattern — `"*"` included — would be annotated by the CORS
+// library yet refused by the gate in front of it.
 func (env *Env) corsOptions() cors.Options {
 	options := cors.Options{
 		AllowedMethods:       []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -284,9 +284,10 @@ func (env *Env) corsMiddleware() func(http.Handler) http.Handler {
 }
 
 // isSameOrigin reports whether origin names the host the request was sent to, which
-// a browser may still label with an Origin header (the Fetch API does).
+// a browser may still label with an Origin header (the Fetch API does). Compared
+// case-insensitively, matching the WebSocket handshake's own check.
 func isSameOrigin(origin, host string) bool {
-	return origin == "http://"+host || origin == "https://"+host
+	return strings.EqualFold(origin, "http://"+host) || strings.EqualFold(origin, "https://"+host)
 }
 
 // corsOptions returns the CORS policy.
@@ -314,7 +315,12 @@ func (env *Env) corsOptions() cors.Options {
 		}
 		options.AllowCredentials = true
 	} else {
-		options.AllowedOrigins = []string{"*"}
+		// No origin is allowed outside dev: the Web UI is served by this same binary
+		// and so takes the same-origin branch, and non-browser callers send no Origin.
+		// rs/cors reads an empty AllowedOrigins as "allow every origin", so the func is
+		// what makes the library agree with the gate rather than depend on it.
+		options.AllowedOrigins = nil
+		options.AllowOriginFunc = func(string) bool { return false }
 	}
 
 	return options

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/cors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -2408,57 +2409,148 @@ func TestCORSPolicy(t *testing.T) {
 		assert.NotContains(t, strings.ToLower(w.Header().Get("Access-Control-Allow-Headers")), "keycloak-authorization")
 	})
 
-	t.Run("production preflight never pairs the wildcard with credentials", func(t *testing.T) {
-		// A browser rejects Access-Control-Allow-Origin: * alongside credentials.
+	t.Run("production refuses a deploy from another origin", func(t *testing.T) {
+		// A text/plain POST is a CORS simple request: the browser sends it and the
+		// deployment starts whether or not the attacker's script is ever allowed to
+		// read the response. This gate is the only thing that stops it.
 		router := newRouter(t, false)
 
-		w := do(router, http.MethodOptions, "/api/v1/tasks", map[string]string{
-			"Origin":                        "http://anywhere.test",
-			"Access-Control-Request-Method": http.MethodPost,
+		w := do(router, http.MethodPost, "/api/v1/tasks", map[string]string{
+			"Origin":       "http://evil.test",
+			"Content-Type": "text/plain",
 		})
 
-		assert.Equal(t, http.StatusNoContent, w.Code)
-		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
-		assert.Empty(t, w.Header().Get("Access-Control-Allow-Credentials"))
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 	})
 
-	t.Run("production accepts any origin", func(t *testing.T) {
+	t.Run("production refuses a read from another origin", func(t *testing.T) {
 		router := newRouter(t, false)
 
 		w := do(router, http.MethodGet, "/api/v1/config", map[string]string{"Origin": "http://anywhere.test"})
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 	})
 
-	t.Run("same-origin requests are served without CORS headers", func(t *testing.T) {
-		// Dev mode is where this matters: the server's own origin is not in the
-		// allowlist, so without the same-origin bypass the gate would 403 the Web UI.
-		for _, scheme := range []string{"http://", "https://"} {
-			t.Run(scheme, func(t *testing.T) {
-				router := newRouter(t, true)
+	t.Run("production refuses a preflight from another origin", func(t *testing.T) {
+		// A permissive preflight is why demanding application/json would not have
+		// helped: the browser would have been told the request was allowed.
+		router := newRouter(t, false)
+
+		w := do(router, http.MethodOptions, "/api/v1/tasks", map[string]string{
+			"Origin":                        "http://evil.test",
+			"Access-Control-Request-Method": http.MethodPost,
+		})
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("a caller that sends no Origin is untouched", func(t *testing.T) {
+		// The CLI client and argo-watcher-mcp are not browsers and send no Origin. The
+		// gate is a browser control, not authentication, so it must not reach them.
+		router := newRouter(t, false)
+
+		w := do(router, http.MethodGet, "/api/v1/config", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "state_type", "the handler must have run")
+
+		// The empty body is what addTask rejects, which is only reachable once the gate
+		// has let the request past.
+		w = do(router, http.MethodPost, "/api/v1/tasks", map[string]string{"Content-Type": "application/json"})
+		assert.Equal(t, http.StatusNotAcceptable, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid payload", "the handler must have run")
+	})
+
+	t.Run("production refuses a host that only extends the server's own", func(t *testing.T) {
+		// A substring or prefix comparison in isSameOrigin would admit these, and every
+		// other cross-origin subtest uses a host that shares nothing with the server's.
+		for _, pattern := range []string{"http://%s.evil.test", "http://evil-%s", "http://%s.", "http://x%s"} {
+			t.Run(pattern, func(t *testing.T) {
+				router := newRouter(t, false)
 
 				req := httptest.NewRequest(http.MethodGet, "/api/v1/config", http.NoBody)
-				req.Header.Set("Origin", scheme+req.Host)
+				req.Header.Set("Origin", fmt.Sprintf(pattern, req.Host))
 				w := httptest.NewRecorder()
 				router.ServeHTTP(w, req)
 
-				assert.Equal(t, http.StatusOK, w.Code)
-				assert.Contains(t, w.Body.String(), "state_type", "the handler must have run")
+				assert.Equal(t, http.StatusForbidden, w.Code)
 				assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 			})
 		}
 	})
 
+	t.Run("a host differing only in case is still same-origin", func(t *testing.T) {
+		// The WebSocket handshake compares the two case-insensitively, and a request
+		// that /ws accepts must not be refused on every other route.
+		router := newRouter(t, false)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/config", http.NoBody)
+		req.Header.Set("Origin", "http://"+strings.ToUpper(req.Host))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "state_type", "the handler must have run")
+	})
+
+	t.Run("the CORS library refuses a production origin on its own", func(t *testing.T) {
+		// The gate answers every cross-origin request before this handler is reached, so
+		// assert the policy directly: rs/cors reads an empty AllowedOrigins as "allow
+		// every origin", and a future path exemption must not turn that back on.
+		env, _ := readAuthEnv(t, false, nil)
+		env.config.DevEnvironment = false
+
+		handler := cors.New(env.corsOptions()).Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/config", http.NoBody)
+		req.Header.Set("Origin", "http://evil.test")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("same-origin requests are served without CORS headers", func(t *testing.T) {
+		// This branch is what keeps the Web UI working: the SPA is served by the same
+		// binary, so its requests carry the server's own origin, and neither mode
+		// carries that origin in its allowlist.
+		for _, dev := range []bool{true, false} {
+			for _, scheme := range []string{"http://", "https://"} {
+				t.Run(fmt.Sprintf("dev=%v %s", dev, scheme), func(t *testing.T) {
+					router := newRouter(t, dev)
+
+					req := httptest.NewRequest(http.MethodGet, "/api/v1/config", http.NoBody)
+					req.Header.Set("Origin", scheme+req.Host)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, req)
+
+					assert.Equal(t, http.StatusOK, w.Code)
+					assert.Contains(t, w.Body.String(), "state_type", "the handler must have run")
+					assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+				})
+			}
+		}
+	})
+
 	t.Run("the websocket handshake is never touched by CORS", func(t *testing.T) {
 		// The upgrade response goes to a hijacked connection, so a CORS header written
-		// here would be both useless and, before the migration, actively harmful.
-		router := newRouter(t, true)
+		// here would be both useless and, before the migration, actively harmful. The
+		// handshake runs its own origin check, and losing this exemption would refuse
+		// every browser socket in production.
+		for _, dev := range []bool{true, false} {
+			t.Run(fmt.Sprintf("dev=%v", dev), func(t *testing.T) {
+				router := newRouter(t, dev)
 
-		w := do(router, http.MethodGet, "/ws", map[string]string{"Origin": "http://evil.test"})
+				w := do(router, http.MethodGet, "/ws", map[string]string{"Origin": "http://evil.test"})
 
-		assert.Equal(t, http.StatusBadRequest, w.Code, "a non-upgrade /ws request is still answered, not refused")
-		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+				assert.Equal(t, http.StatusBadRequest, w.Code, "a non-upgrade /ws request is still answered, not refused")
+				assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+			})
+		}
 	})
 }
 

--- a/test/e2e/scripts/api-surface.sh
+++ b/test/e2e/scripts/api-surface.sh
@@ -24,6 +24,8 @@
 #   - POST /api/v1/tasks (>1 MiB)       -> 413; 51 images -> 406 (issue #562)
 #   - the four browser-facing security headers (issue #565) on the SPA document,
 #                                          an API payload and the swagger page
+#   - a cross-origin POST /tasks and GET   -> 403, while the server's own origin is
+#                                          served normally (issue #563)
 #   - POST /api/v1/deploy-lock          -> with OIDC disabled the state-changing
 #                                          handler is NOT registered, so the request
 #                                          falls through to the SPA static handler
@@ -216,4 +218,38 @@ for path in "/" "/api/v1/config" "/swagger/"; do
   done
 done
 
+echo "=== cross-origin gate ==="
+# The lab leaves DEV_ENVIRONMENT unset, which is the shape that matters: a
+# text/plain POST needs no preflight, so nothing but this gate stands between an
+# attacker's page and a real deployment (issue #563). A refused request creates
+# nothing, so the phase stays side-effect free.
+req POST "${AW_API}/tasks" -H 'Origin: http://evil.test' -H 'Content-Type: text/plain' \
+  -d "$(task_json cross-origin v0.1.0)"
+if [[ "$CODE" == "403" ]]; then
+  ok "cross-origin deploy -> 403"
+else
+  bad "cross-origin deploy: code=${CODE} body=${BODY} (want 403)"
+fi
+# The status alone is not the guarantee: the defect was that a deployment started.
+# `bindJSON` ignores the content type, so the payload above is perfectly valid and a
+# regression submits a real task for an application that does not exist.
+req GET "${AW_API}/tasks?from_timestamp=0&app=cross-origin"
+if jq -e '(.tasks // []) == []' <<<"$BODY" >/dev/null 2>&1; then
+  ok "the refused deploy created no task"
+else
+  bad "the refused cross-origin deploy created a task"
+fi
+req GET "${AW_API}/config" -H 'Origin: http://evil.test'
+if [[ "$CODE" == "403" ]]; then
+  ok "cross-origin read -> 403"
+else
+  bad "cross-origin read: code=${CODE} body=${BODY} (want 403)"
+fi
+# The Web UI's own requests carry this origin, so the gate must let them through.
+req GET "${AW_API}/config" -H "Origin: ${AW_URL}"
+if [[ "$CODE" == "200" ]]; then
+  ok "same-origin read -> 200"
+else
+  bad "same-origin read: code=${CODE} body=${BODY} (want 200)"
+fi
 phase_end API-SURFACE

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ npm install
 npm run dev        # http://localhost:5173, proxying /api and /ws to VITE_API_PROXY_TARGET
 ```
 
-The Go API must be running (`task bootstrap` from the repo root, or `go run ./cmd/argo-watcher`) unless you repoint the proxy.
+The Go API must be running (`task bootstrap` from the repo root, or `go run ./cmd/argo-watcher`) unless you repoint the proxy. Start it with `DEV_ENVIRONMENT=true`: the dev server is a different origin from the API, and the server allows no cross-origin request without it.
 
 | Command | Description |
 |---|---|
@@ -34,7 +34,7 @@ Everything runtime comes from the backend's `/api/v1/config` — issuer URL, cli
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_API_PROXY_TARGET` | `http://localhost:8080` | Dev-only proxy target for `/api` and `/ws` |
-| `VITE_API_BASE_URL` | `''` (same origin) | Prefix for every REST call — set it when serving the SPA from another origin |
+| `VITE_API_BASE_URL` | `''` (same origin) | Prefix for every REST call — of use only against a server that admits the calling origin, which outside `DEV_ENVIRONMENT=true` means the same origin |
 | `VITE_WS_BASE_URL` | `''` (from `window.location`) | WebSocket origin, when tunnelling through another host |
 
 ## Layout
@@ -81,7 +81,7 @@ The Keycloak client in `test/keycloak/argo-watcher-e2e-realm.json` has the autho
 
 ## Troubleshooting
 
-- **Dev server cannot reach the API** — check `VITE_API_PROXY_TARGET`, or set `VITE_API_BASE_URL` to call another origin directly.
+- **Dev server cannot reach the API** — check `VITE_API_PROXY_TARGET`. Pointing `VITE_API_BASE_URL` at another origin needs that server to admit this one, which only `DEV_ENVIRONMENT=true` does.
 - **Endless OIDC redirects** — the provider must list this app's origin (including any base path) as a valid redirect URI. If the loop only appears *after* a successful login, the callback query was stripped before `oidc-client-ts` read it; see the `bootstrapAuth()` note above.
 - **WebSocket errors** — confirm `/ws` is exposed and upgraded end to end; set `VITE_WS_BASE_URL` when a TLS terminator gets in the way.
 - **Timezones look wrong** — the preference lives under `argo-watcher:timezone` and is toggled from the user menu.


### PR DESCRIPTION
Closes #563.

The non-dev CORS policy allowed every origin, so the origin gate never fired and a `text/plain` `POST /api/v1/tasks` from an unrelated origin returned 202 and started a real deployment. Production now allows no origin at all: any request whose `Origin` names another host is refused with 403 before a handler runs.

`AllowOriginFunc` is set alongside `AllowedOrigins = nil` because rs/cors reads an empty `AllowedOrigins` as "allow every origin" — without it the library behind the gate stays permissive. `isSameOrigin` is now compared case-insensitively, matching the WebSocket handshake's own check.

No new configuration, and no client regresses: the Web UI is same-origin and non-browser callers send no `Origin`. The local frontend dev server is a different origin and needs `DEV_ENVIRONMENT=true`, which it already needed for the WebSocket; the contributing guide and `web/README.md` now say so.