### PR TITLE
ci: gate the Go tree with golangci-lint, document the network boundary

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,9 @@ on:
       - 'go.sum'
       - 'web/**'
       - '.golangci.yml'
+      # Every job here runs `task install-deps`, `task mocks`, `task ci-migrate`
+      # or `task test`, so a Taskfile-only change can break this workflow.
+      - 'Taskfile.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -17,6 +20,9 @@ on:
       - 'go.sum'
       - 'web/**'
       - '.golangci.yml'
+      # Every job here runs `task install-deps`, `task mocks`, `task ci-migrate`
+      # or `task test`, so a Taskfile-only change can break this workflow.
+      - 'Taskfile.yml'
 
 jobs:
   lint:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,14 +5,57 @@ on:
       - main
     paths:
       - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
       - 'web/**'
+      - '.golangci.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
       - 'web/**'
+      - '.golangci.yml'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # An exact version skips the unauthenticated go-task tags API
+          # lookup, which shares the runner IP 60 req/h anonymous quota.
+          version: 3.53.1
+
+      - name: Install environment dependencies
+        run: task install-deps
+
+      - name: Generate mocks
+        # golangci-lint type-checks _test.go files, which import the gitignored
+        # internal/mocks package; it must exist before the linters run.
+        run: task mocks
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          # Matches the version the flake's nixpkgs pin gives the dev shell, so
+          # `task lint-go` and this job report the same findings.
+          version: v2.13.1
+
   # gosec and govulncheck moved to the dedicated security.yml workflow.
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+
+run:
+  # The full package graph including _test.go files; the 1m default is tight
+  # for a cold CI cache.
+  timeout: 5m
+  # The integration-tagged suites run in CI, so they are linted too. No file
+  # carries a negated constraint, so this only adds packages.
+  build-tags:
+    - integration
+
+linters:
+  exclusions:
+    warn-unused: true
+    rules:
+      # The client prints these errors verbatim for a human reading a CI log
+      # (handleDeploymentError does log.Println(err)), so they are sentences
+      # rather than the lowercase fragments ST1005 expects.
+      - path: internal/client/client\.go
+        linters:
+          - staticcheck
+        text: "^ST1005:"
+
+issues:
+  # The defaults cap a report at 50 issues per linter and 3 per identical
+  # message, which lets a gate pass while hiding findings. Report every one.
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the provider serves no `picture` claim. It is opt-in because it sends a hash of the
   signed-in user's email address to gravatar.com — hashed, but a hash of a known address
   is trivially reversible. An address with no Gravatar still falls back to the initial.
+- A new **Network Exposure** page in the documentation states the boundary the server
+  assumes: what answers without a credential — including the task history, the whole
+  configuration and every application name on `/metrics` — what enabling OIDC does and
+  does not close, and what an operator is expected to put in front. Following the
+  installation guide's `ingress` block publishes an unauthenticated deploy trigger, and
+  nothing said so; that block now carries the warning and the link.
 
 ### Changed
 
@@ -219,6 +225,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   up on a rollout that is still being watched: with Postgres it skips tasks under a live
   lease, and with the in-memory backend a task is stale only once its own rollout window
   plus an hour has passed, rather than an hour flat.
+- The GitOps updater guide no longer says `ARGO_WATCHER_DEPLOY_TOKEN` is planned for
+  deprecation in 1.0.0. It is not going anywhere, and nothing outside that sentence ever
+  backed the promise — unlike `KEYCLOAK_*` and `GIT_TIMEOUT`, both of which logged a real
+  deprecation warning. Keep using the token if a JWT does not suit your pipeline.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clear. Such a deployment now fails immediately naming both endpoints, rather than being
   retried as a network blip. Only stepping down from TLS is refused: a client pointed at an
   `http://` URL keeps working, and so does any redirect that stays on `https`.
-- Bumped the Go toolchain to `1.26.6`, resolving six standard library vulnerabilities
+- Bumped the Go toolchain to `1.26.7`, resolving six standard library vulnerabilities
   reachable from this code base in `go1.26.5`: `GO-2026-6218` (`net/url`), `GO-2026-6090`
   (`crypto/tls`), `GO-2026-6089` and `GO-2026-5026` (`net/http`), `GO-2026-6088`
   (`encoding/xml`) and `GO-2026-5972` (`encoding/asn1`). The `go` directive stays at

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,15 @@ tasks:
     generates:
       - ../../web/public/swagger/swagger.json
 
+  lint-go:
+    desc: Lint the Go tree with golangci-lint
+    deps: [mocks]
+    cmds:
+      - echo "===> Linting Go code"
+      # Config, including the timeout, lives in .golangci.yml so this and the CI
+      # job run the same checks.
+      - golangci-lint run ./...
+
   test:
     desc: Run tests
     deps: [mocks, docs]

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -74,7 +74,7 @@ func mockReturnAppStatus(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		// Reproduces the message Argo CD returns, which the updater matches on. The
 		// name is echoed into a text/plain body served only by this local test double.
-		fmt.Fprintf(w, "applications.argoproj.io \"%s\" not found", app) // #nosec G705 -- not HTML, and this server never runs outside a dev or e2e host
+		_, _ = fmt.Fprintf(w, "applications.argoproj.io \"%s\" not found", app) // #nosec G705 -- not HTML, and this server never runs outside a dev or e2e host
 		return
 	}
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -8,7 +8,7 @@ Already on Argo CD Image Updater? See [Migrating from Argo CD Image Updater](#mi
 
 A working [installation](install.md), plus:
 
-1. **A credential the client can present.** Either a **JWT** (recommended, see [JWT configuration](#jwt-configuration)) stored under the `JWT_SECRET` key of the Argo Watcher secret, or an arbitrary string under `ARGO_WATCHER_DEPLOY_TOKEN` — the deploy token is planned for deprecation in v1.0.0. Without a valid credential the write-back is skipped, and the deployment fails blaming the image instead ([why](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped)).
+1. **A credential the client can present.** Either a **JWT** (recommended, see [JWT configuration](#jwt-configuration)) stored under the `JWT_SECRET` key of the Argo Watcher secret, or an arbitrary string under `ARGO_WATCHER_DEPLOY_TOKEN`. Without a valid credential the write-back is skipped, and the deployment fails blaming the image instead ([why](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped)).
 2. **An SSH key with write access** to the GitOps repository, stored in a Kubernetes secret (the chart reads the `sshPrivateKey` key by default).
 3. **Chart values pointing at that key:**
 
@@ -150,7 +150,7 @@ Pass the credential to the client:
 # JWT (recommended). The raw token, with no "Bearer " prefix, so CI can mask it.
 export BEARER_TOKEN="your_jwt_token"
 
-# Or the deploy token (planned for deprecation)
+# Or the deploy token
 export ARGO_WATCHER_DEPLOY_TOKEN=your_deploy_token
 ```
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -71,6 +71,9 @@ ingress:
 
 The chart maps its own values onto the server's environment variables and exposes `extraEnvs` for anything it does not cover. Every variable is listed in [Server Environment Variables](../reference/server-env.md); OIDC has [its own values block](oidc.md#helm-chart-values).
 
+!!! warning "That ingress publishes an unauthenticated API"
+    Argo Watcher ships with no authentication. Reachable at that host, anyone can submit a deployment task, read every application name in the history, and scrape `/metrics`. Read [Network Exposure](../operations/network-exposure.md) before exposing it beyond the cluster.
+
 !!! note
     The chart sets `livenessProbe` to `/livez` and `readinessProbe` to `/readyz`, which is the correct pairing — see [Health and probe endpoints](../reference/api.md#health-and-probe-endpoints) before overriding either.
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -5,4 +5,5 @@ Maintain and troubleshoot Argo Watcher in production.
 - **[Observability](observability.md)** — Prometheus metrics, suggested alerts, and an example Grafana dashboard.
 - **[Database](database.md)** — Schema, migrations, backups, sizing, and retention.
 - **[High Availability](high-availability.md)** — Running multiple replicas: what is shared, how a deployment is handed over when a replica stops, and the known limits.
+- **[Network Exposure](network-exposure.md)** — What is reachable without a credential, what OIDC closes, and what to put in front of it.
 - **[Troubleshooting](troubleshooting.md)** — Symptom-driven runbook for common issues.

--- a/docs/operations/network-exposure.md
+++ b/docs/operations/network-exposure.md
@@ -1,0 +1,58 @@
+# Network Exposure
+
+Argo Watcher ships with no authentication. A default install serves the Web UI, the full deployment history and an open deployment endpoint to anyone who can reach its port, so where you put it matters as much as how you configure it.
+
+Decide the network boundary before you follow the `ingress` block in the [installation guide](../guides/install.md#install-the-server) — TLS there protects the traffic, not the API.
+
+## What is open without a credential
+
+With `OIDC_ENABLED` unset — the default — every endpoint below answers any caller that can reach the port.
+
+| Endpoint | What a caller gets |
+|---|---|
+| `POST /api/v1/tasks` | Accepts a deployment (see below) |
+| `GET /api/v1/tasks` | The whole history: application, author, project, images and tags |
+| `GET /api/v1/tasks/{id}` | The same fields for one task |
+| `GET /api/v1/config` | Every non-secret server setting: `argo_cd_url` and its alias, `registry_proxy_url` — both of which usually name an internal host — the OIDC issuer, client id and `privileged_groups`, the lockdown schedule, the state backend type, and the timeouts. Tokens, secrets and the database DSN are excluded |
+| `GET /api/v1/reachability`, `GET /api/v1/version`, `GET /api/v1/deploy-lock` | Argo CD and database reachability, the build version, the lock state |
+| `/ws` | The deploy-lock and reachability transitions, as they happen |
+| `/metrics` | Every application name Argo Watcher has seen, with deployment counts, outcomes and durations |
+| `/livez`, `/readyz` | Up/down only |
+| `/`, `/swagger` | The Web UI and the API specification |
+
+### What an anonymous submission can do
+
+`POST /api/v1/tasks` takes an [optional credential](../reference/api.md#submitting-a-task), so a request without one is still accepted. It does **not** deploy anything: the git write-back is skipped, and the task cannot supersede an in-flight deployment that did present a credential. What it does do, for up to its `timeout`:
+
+- Polls Argo CD against the server's own `ARGO_TOKEN`, once per interval — asking it to reconcile first, unless `ARGO_REFRESH_APP` is off.
+- Fires the start and result [notifications](../guides/notifications.md) to your webhook or Mattermost channel.
+- Adds a permanent row to the deployment history, whatever application name it claimed.
+
+It cannot mint a metric series, though: no per-application metric is labelled until Argo CD confirms the application exists, so an invented name lands on the labelless `accepted_deployments` and `unconfirmed_deployment_failures` counters instead ([why](observability.md)).
+
+A caller *with* a valid credential deploys for real — the write-back commits the tag it was given, unvalidated against any registry.
+
+The payload is [bounded](../reference/api.md#submitting-a-task) so one request cannot ask for unbounded work, and the [cross-origin gate](../reference/api.md#cross-origin-requests) stops a page on an unrelated site from submitting through a visitor's browser. Neither is a substitute for a credential: `curl` sends no `Origin`.
+
+## What enabling OIDC closes
+
+[OIDC](../guides/oidc.md) closes the reads only the Web UI consumes — `GET /api/v1/tasks`, `/version`, `/reachability`, `GET /api/v1/deploy-lock` and `/ws` — and makes the deploy-lock writes available to `OIDC_PRIVILEGED_GROUPS` alone. [Protected endpoints](../guides/oidc.md#protected-endpoints) is the full table.
+
+Four things stay open by design, and OIDC does not change any of them:
+
+- **`POST /api/v1/tasks`.** The credential remains optional, because a pipeline that commits image tags elsewhere is a supported setup. Enabling OIDC does not close the submission endpoint.
+- **`GET /api/v1/config`.** The Web UI reads the issuer and client id from it before it can hold a token.
+- **`GET /api/v1/tasks/{id}`.** Open until you also set [`OIDC_REQUIRE_TASK_READ_AUTH=true`](../guides/oidc.md#closing-the-task-lookup), which every pipeline must be ready for.
+- **`/metrics`, `/livez`, `/readyz`.** Prometheus and the kubelet cannot perform an OIDC flow.
+
+## What to put in front
+
+Argo Watcher expects something else to decide who reaches it. In rough order of what most installs need:
+
+- **Keep it off the public internet unless you need it there.** Cluster-internal access, a VPN, or an identity-aware proxy in front of the ingress all remove the whole table above from public reach. This is the only control that covers `POST /api/v1/tasks`.
+- **Enable [OIDC](../guides/oidc.md)** whenever the Web UI has more than one user, then set `OIDC_REQUIRE_TASK_READ_AUTH=true` once every pipeline sends a credential. The [`unauthenticated_reads`](observability.md#tracking-the-read-auth-migration) metric tells you when that is true.
+- **Restrict `/metrics` at the ingress** to your Prometheus. Application names are usually the most sensitive thing a default install publishes, and nothing in Argo Watcher gates that route.
+- **Terminate TLS.** The deploy token and CI JWT travel in a header on every submission and every status poll. The client refuses a redirect that steps down from `https` to `http`, but it cannot rescue a plain-`http` endpoint you pointed it at.
+
+!!! warning "A published instance with no proxy in front is a deploy trigger anyone can pull"
+    Anyone who can reach the ingress can submit tasks, read every application name you deploy, and — with a leaked deploy token or CI JWT — commit an arbitrary image tag to your GitOps repository. Neither the payload caps nor the cross-origin gate authenticates anybody.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,7 +53,7 @@ A credential does two things: it authorizes the [GitOps updater](../guides/gitop
 
 ### Reads
 
-With OIDC **disabled** — the default — every endpoint is readable without a credential.
+With OIDC **disabled** — the default — every endpoint is readable without a credential. [Network Exposure](../operations/network-exposure.md) lists what that means in practice, and what to put in front of the instance.
 
 With OIDC **enabled**, the endpoints the Web UI consumes require one, group membership is not needed, and two stay open on purpose: `GET /api/v1/tasks/{id}` (guarded by the unguessable task id, and closable with `OIDC_REQUIRE_TASK_READ_AUTH`) and `GET /api/v1/config`, which the Web UI reads before it can hold a token. [Protected endpoints](../guides/oidc.md#protected-endpoints) has the full table.
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786247143,
-        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
           gopls
           gotools
           gosec
+          golangci-lint
           mockgen
           go-swag
           toxiproxy

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/shini4i/argo-watcher
 
 go 1.26.5
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -175,7 +175,7 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 		return nil, errors.New(models.StatusArgoCDUnavailableMessage)
 	}
 
-	if task.Images == nil || len(task.Images) == 0 {
+	if len(task.Images) == 0 {
 		return nil, fmt.Errorf("trying to create task without images")
 	}
 

--- a/internal/argocd/git_writeback_test.go
+++ b/internal/argocd/git_writeback_test.go
@@ -271,7 +271,7 @@ func TestUpdateGitImageTag(t *testing.T) {
 	t.Run("Returns error when NewGitRepo fails (no SSH_KEY_PATH)", func(t *testing.T) {
 		t.Setenv("SSH_KEY_PATH", "")
 		// caarlos0/env treats empty-string the same as unset for required fields.
-		os.Unsetenv("SSH_KEY_PATH")
+		_ = os.Unsetenv("SSH_KEY_PATH")
 
 		err := UpdateGitImageTag(
 			context.Background(),

--- a/internal/argocd/integration_helpers_test.go
+++ b/internal/argocd/integration_helpers_test.go
@@ -133,7 +133,7 @@ func giteaAPIPost(t *testing.T, user, pass, path string, body map[string]any) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	require.Less(t, resp.StatusCode, 300, "gitea %s returned %d", path, resp.StatusCode)
 }
 

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -31,7 +31,7 @@ func newOIDCTestServer(t *testing.T, userinfoStatus int, userinfoBody string, di
 			return
 		}
 		rw.WriteHeader(http.StatusOK)
-		_, err := rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		_, err := fmt.Fprintf(rw, `{"userinfo_endpoint": %q}`, server.URL+"/userinfo")
 		if err != nil {
 			t.Error(err)
 		}
@@ -224,14 +224,14 @@ func newCountingOIDCServer(t *testing.T, groups string) (*httptest.Server, *int3
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
-		_, err := rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+		_, err := fmt.Fprintf(rw, `{"userinfo_endpoint": %q}`, server.URL+"/userinfo")
 		if err != nil {
 			t.Error(err)
 		}
 	})
 	mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&hits, 1)
-		_, err := rw.Write([]byte(fmt.Sprintf(`{"preferred_username": "someone", "groups": %s}`, groups)))
+		_, err := fmt.Fprintf(rw, `{"preferred_username": "someone", "groups": %s}`, groups)
 		if err != nil {
 			t.Error(err)
 		}
@@ -381,7 +381,7 @@ func TestOIDCAuthService_ValidationCaching(t *testing.T) {
 		var server *httptest.Server
 		mux := http.NewServeMux()
 		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
-			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+			_, _ = fmt.Fprintf(rw, `{"userinfo_endpoint": %q}`, server.URL+"/userinfo")
 		})
 		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
 			if atomic.AddInt32(&hits, 1) == 1 {
@@ -414,7 +414,7 @@ func TestOIDCAuthService_ValidationCaching(t *testing.T) {
 		var server *httptest.Server
 		mux := http.NewServeMux()
 		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
-			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+			_, _ = fmt.Fprintf(rw, `{"userinfo_endpoint": %q}`, server.URL+"/userinfo")
 		})
 		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
 			atomic.AddInt32(&hits, 1)
@@ -490,7 +490,7 @@ func TestOIDCAuthService_ValidationCaching(t *testing.T) {
 		var server *httptest.Server
 		mux := http.NewServeMux()
 		mux.HandleFunc("/.well-known/openid-configuration", func(rw http.ResponseWriter, _ *http.Request) {
-			_, _ = rw.Write([]byte(fmt.Sprintf(`{"userinfo_endpoint": %q}`, server.URL+"/userinfo")))
+			_, _ = fmt.Fprintf(rw, `{"userinfo_endpoint": %q}`, server.URL+"/userinfo")
 		})
 		mux.HandleFunc("/userinfo", func(rw http.ResponseWriter, _ *http.Request) {
 			if atomic.AddInt32(&hits, 1) == 1 {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -804,7 +804,7 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WebSocket connection failed: %v", err)
 	}
-	defer conn.Close(websocket.StatusNormalClosure, "test complete")
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test complete") }()
 
 	t.Log("WebSocket connection established successfully")
 
@@ -900,7 +900,7 @@ func TestDeployLockNotifiedOnlyByWatcher(t *testing.T) {
 			conn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http")+"/ws",
 				&websocket.DialOptions{HTTPHeader: http.Header{oidcHeader: []string{"Bearer token"}}})
 			require.NoError(t, err)
-			defer conn.Close(websocket.StatusNormalClosure, "test complete")
+			defer func() { _ = conn.Close(websocket.StatusNormalClosure, "test complete") }()
 
 			// Run the watcher far faster than production so the test does not wait 5s.
 			stop := make(chan struct{})
@@ -1024,14 +1024,14 @@ func TestSafeFileSystem(t *testing.T) {
 		f, err := fs.Open("/file.txt")
 		require.NoError(t, err)
 		require.NotNil(t, f)
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	})
 
 	t.Run("nested valid path opens file", func(t *testing.T) {
 		f, err := fs.Open("/subdir/nested.txt")
 		require.NoError(t, err)
 		require.NotNil(t, f)
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	})
 
 	t.Run("path traversal attack returns error", func(t *testing.T) {
@@ -1053,14 +1053,14 @@ func TestSafeFileSystem(t *testing.T) {
 		f, err := fs.Open("/./subdir/../file.txt")
 		require.NoError(t, err)
 		require.NotNil(t, f)
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	})
 
 	t.Run("open root directory", func(t *testing.T) {
 		f, err := fs.Open("/")
 		require.NoError(t, err)
 		require.NotNil(t, f)
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		stat, err := f.Stat()
 		require.NoError(t, err)
 		assert.True(t, stat.IsDir())

--- a/internal/server/staticfs.go
+++ b/internal/server/staticfs.go
@@ -87,7 +87,7 @@ func tryServeStaticFile(w http.ResponseWriter, r *http.Request, fs safeFileSyste
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // #nosec G104 - read-only handle, close error is not actionable
 
 	stat, err := f.Stat()
 	if err != nil || stat.IsDir() {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Observability: 'operations/observability.md'
     - Database: 'operations/database.md'
     - High Availability: 'operations/high-availability.md'
+    - Network Exposure: 'operations/network-exposure.md'
     - Troubleshooting: 'operations/troubleshooting.md'
   - Contributing:
     - Overview: 'contributing/index.md'

--- a/test/e2e/load/main.go
+++ b/test/e2e/load/main.go
@@ -193,7 +193,7 @@ func deployAndWait(ctx context.Context, client *http.Client, cfg config, app, ta
 	}
 	var created models.TaskStatus
 	_ = json.NewDecoder(resp.Body).Decode(&created)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if created.Id == "" {
 		return "no-id"
 	}
@@ -217,7 +217,7 @@ func getStatus(ctx context.Context, client *http.Client, baseURL, id string) str
 	if err != nil {
 		return ""
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var ts models.TaskStatus
 	if err := json.NewDecoder(resp.Body).Decode(&ts); err != nil {
 		return ""
@@ -239,6 +239,6 @@ func runWSClient(ctx context.Context, wsURL string) {
 				break
 			}
 		}
-		conn.Close(websocket.StatusNormalClosure, "")
+		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}
 }

--- a/test/e2e/tools/wsprobe/main.go
+++ b/test/e2e/tools/wsprobe/main.go
@@ -115,7 +115,7 @@ func main() {
 			// DURATION elapsed with the connection still healthy: not a close.
 			if ctx.Err() != nil {
 				fmt.Println("DEADLINE")
-				conn.Close(websocket.StatusNormalClosure, "")
+				_ = conn.Close(websocket.StatusNormalClosure, "")
 				return
 			}
 			// The server closed the connection: surface the close code + reason


### PR DESCRIPTION
Closes #560, closes #568.

Adds a golangci-lint gate to CI and the dev shell, and documents the network boundary the server assumes.

The lint config disables the report caps on purpose. The defaults stop at 50 issues per linter and 3 per identical message, which hid 8 of the 25 findings on this tree — including a production errcheck in `staticfs.go` that #560 never listed. `build-tags` carries `integration` for the same reason: CI runs those suites, so they are linted too.

Two things #560 did not ask for. nixpkgs moves to 2026-08-22 so the dev shell and the CI job run the same golangci-lint, and the Go toolchain goes to 1.26.7 — nixpkgs still ships 1.26.5, whose six stdlib vulnerabilities the `toolchain` directive is what avoids, so that line has to stay.

#568's third bullet was already satisfied: the caps, the cross-origin change and the `KEYCLOAK_*` removal were each documented by their own bundle, and `argo_cd_url` has no prose to update — the `/config` payload shape only ever lived in the generated OpenAPI spec.