### PR TITLE
fix(auth): bind OIDC and JWT credentials to this application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same origin, and the CLI client, the MCP server and `curl` send no `Origin` at all. There is no
   new setting — `DEV_ENVIRONMENT=true` still admits the local frontend dev server, which the
   contributing guide now spells out.
+- An OIDC access token must now have been issued to Argo Watcher's own client. Validation was
+  "the provider's userinfo endpoint returned 200", which one realm serving a whole organisation
+  answers for every client it hosts — so a token another application obtained from the same
+  provider authenticated here. Each accepted token is now also checked against
+  `OIDC_CLIENT_ID`, which was already mandatory: it passes when `azp`, `client_id`, `cid` or
+  `appid` names that client id — providers disagree on which claim carries it — or when `aud`
+  contains it, and is refused with `401` otherwise. Nothing to configure,
+  and browser sessions are unaffected — the Web UI signs in with that very client id. A token
+  that names no client at all, including an opaque one that is not a JWT, is still accepted:
+  binding it would need introspection, which a public client cannot perform. That case logs a
+  warning the first time it is seen.
+- Client JWTs can now be bound to this deployment with the new `JWT_ISSUER` and `JWT_AUDIENCE`
+  settings. The JWT strategy checked the signature and that `exp` was present, so where one
+  `JWT_SECRET` is reused across a CI estate, that other system's tokens were valid deploy
+  credentials here. Both settings are unset by default and unchecked while unset, so an
+  existing fleet keeps working untouched. Once set they are strict — a token that omits the
+  claim is rejected, not passed — so update every pipeline to mint the claim before
+  configuring the variable, or tokens already in flight are refused.
+- The deploy token is compared in constant time. The previous comparison returned as soon as
+  two bytes differed, so how long a rejection took leaked how much of the token was right.
+  Remote exploitation was impractical through network jitter; the comparison is now immune to
+  it regardless.
 
 ## [0.15.0] - 2026-08-11
 

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -128,9 +128,23 @@ openssl rand -base64 32
 | `exp` | Yes | **Required.** A token without it is rejected. |
 | `iat` | Yes | A future `iat` is rejected. `date +%s` gives you the current value. |
 | `nbf` | Yes | Optional; enforced by the JWT library. |
+| `iss` | Only if `JWT_ISSUER` is set | Must equal it exactly. |
+| `aud` | Only if `JWT_AUDIENCE` is set | A list matches when it contains the configured value. |
 | `sub` | No | Informational — service or team name. |
 | `cluster` | No | Informational. |
 | `allowed_apps` | No | **Not enforced yet.** Per-application restriction is planned; today any valid token authorizes any application. |
+
+### Binding a token to this server
+
+`JWT_SECRET` alone says nothing about *who* minted a token. Where the same secret is reused across a CI estate, another system's tokens are valid deploy credentials here. Set `JWT_ISSUER`, `JWT_AUDIENCE`, or both on the server to require that a token names this deployment.
+
+Both are unchecked while unset, so an existing fleet is unaffected. Once set they are strict — a token that omits the claim is rejected, not passed — which fixes the rollout order:
+
+1. Update every pipeline to mint tokens carrying the claim.
+2. Wait until no token minted without it is still in use (they last until their `exp`).
+3. Set the variable on the server.
+
+Doing it the other way round rejects every token in flight at once.
 
 ### Minting a token
 
@@ -141,6 +155,8 @@ jwt encode \
   --secret="YOUR_JWT_SECRET" \
   '{"sub":"argo-watcher-client","cluster":"prod","allowed_apps":["app1"],"iat":1773352800,"exp":1804888800}'
 ```
+
+Add `"iss"` and `"aud"` to the payload when the server is configured to require them.
 
 ## Pipeline configuration
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -8,9 +8,10 @@ With OIDC disabled (the default) nothing is protected: there is no backend to va
 
 1. The browser is redirected to the provider before the Web UI loads any data (Authorization Code + PKCE, a top-level redirect — not a hidden iframe).
 2. The backend validates the token by calling the provider's **userinfo** endpoint, which it discovers from `<issuer>/.well-known/openid-configuration`. Discovery happens lazily on the first validation, so a provider that is briefly down at boot does not stop Argo Watcher from starting.
-3. Reads the Web UI performs require a credential — being signed in is enough, no group needed.
-4. Users in a **privileged group** additionally get the **Rollback to this version** button on a task, and control of the [deployment lock](deployment-lock.md).
-5. Signed-in users get an account card in the side panel (opened from the logo) showing their avatar, name and email, with **Log out** in its menu.
+3. An accepted token that names a client other than `OIDC_CLIENT_ID` is refused — see [Audience binding](#audience-binding).
+4. Reads the Web UI performs require a credential — being signed in is enough, no group needed.
+5. Users in a **privileged group** additionally get the **Rollback to this version** button on a task, and control of the [deployment lock](deployment-lock.md).
+6. Signed-in users get an account card in the side panel (opened from the logo) showing their avatar, name and email, with **Log out** in its menu.
 
 The browser performs discovery and the code exchange itself, so the issuer must be reachable **from the browser as well as from the server**. When a sign-in cannot complete, the Web UI stops on its loading screen and names the reason instead of bouncing back to the provider — see [Web UI stops on "Sign-in failed"](../operations/troubleshooting.md#web-ui-stops-on-sign-in-failed).
 
@@ -59,6 +60,29 @@ Every authorization decision means asking the provider's userinfo endpoint about
 The interval is the upper bound on how stale a **read** authorization can be, and each decision is additionally capped by the token's own expiry, so it never outlives the credential. `0` validates every request.
 
 Privileged actions are exempt and always re-verify against the provider, so removing a user from `OIDC_PRIVILEGED_GROUPS` takes effect immediately. Clicking a lock toggle is rare enough that the extra round trip costs nothing.
+
+## Audience binding
+
+One realm commonly serves an entire organisation, so "the provider accepted this token" does not mean the token was issued to Argo Watcher. Every accepted token is therefore also checked against `OIDC_CLIENT_ID`. A token minted for another client of the same issuer is refused with 401.
+
+Providers disagree on which claim names the client, so all of them are read. The token passes when **any** of `azp`, `client_id`, `cid` or `appid` is `OIDC_CLIENT_ID`, or when `aud` contains it:
+
+| Claim | Who uses it |
+|---|---|
+| `azp` | Keycloak, Auth0, Entra ID (v2.0 tokens) |
+| `client_id` | required of a JWT access token by [RFC 9068](https://www.rfc-editor.org/rfc/rfc9068#section-2.2) |
+| `cid` | Okta |
+| `appid` | Entra ID (v1.0 tokens) |
+| `aud` | providers that audience a token to the client rather than to a resource server |
+
+Nothing to configure — `OIDC_CLIENT_ID` is already required — and the Web UI is unaffected, since it signs in with that very client id. What it stops is a caller presenting a token some other application obtained from your provider.
+
+Two cases pass unbound, and log a warning the first time one is seen:
+
+- The access token is **opaque** rather than a JWT (Okta, for instance, can issue either). Binding it would need token introspection, which a public client cannot perform.
+- The token names no client in any of those claims and carries no `aud` either.
+
+A provider that names its client in some other claim *and* audiences the token to a resource server would be refused on every sign-in, with `token was not issued to <client id>`. None of the providers above behaves that way; please open an issue if yours does.
 
 ## Provider setup
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -93,6 +93,7 @@ The server warning and the counter are what identify the credential as the cause
 
 - The pipeline sets neither `ARGO_WATCHER_DEPLOY_TOKEN` nor `BEARER_TOKEN`.
 - The value does not match the server's `ARGO_WATCHER_DEPLOY_TOKEN` or `JWT_SECRET`.
+- The server sets `JWT_ISSUER` or `JWT_AUDIENCE` and the token carries no such claim, or a different value. Both are strict once set — see [Binding a token to this server](../guides/gitops-updater.md#binding-a-token-to-this-server).
 - **Something redirects the client to a different host**, and a credential does not survive that hop. The two behave differently:
     - `Authorization` (`BEARER_TOKEN`) is stripped by Go's HTTP client on every client version, but only when the *hostname* changes. A port-only change (`host:8080` → `host:9090`) keeps it, and so does a move to a subdomain (`example.com` → `sub.example.com`). A sibling host does not: `watcher.example.com` → `watcher.int.example.com` drops it.
     - `ARGO_WATCHER_DEPLOY_TOKEN` is a custom header, which Go always forwards, so from v0.15.0 the client deletes it itself on any change of host **or** port. Earlier clients forwarded it, so this can appear on a client upgrade with nothing else changing.

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -40,6 +40,8 @@ The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you 
 |---|---|---|---|
 | `ARGO_WATCHER_DEPLOY_TOKEN` | Shared token clients present to authorize a write-back | | No |
 | `JWT_SECRET` | HMAC secret for validating client JWTs | | No |
+| `JWT_ISSUER` | `iss` a client JWT must carry; unset leaves it unchecked | | No |
+| `JWT_AUDIENCE` | `aud` a client JWT must carry; unset leaves it unchecked | | No |
 | `OIDC_ENABLED` | Enable OIDC authentication | `false` | No |
 | `OIDC_ISSUER_URL` | Provider issuer URL, used for discovery | | When OIDC is on |
 | `OIDC_CLIENT_ID` | Client id registered with the provider | | When OIDC is on |
@@ -47,6 +49,8 @@ The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you 
 | `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
 | `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}` too | `false` | No |
 | `OIDC_GRAVATAR_FALLBACK` | Let the account card fall back to Gravatar when the provider sends no `picture` claim | `false` | No |
+
+`JWT_ISSUER` and `JWT_AUDIENCE` are enforced strictly once set: a token that omits the claim is rejected, so every pipeline must mint it *before* the variable is configured — see [JWT configuration](../guides/gitops-updater.md#jwt-configuration).
 
 Enabling OIDC also makes the Web UI's read endpoints require a credential — see [Protected endpoints](../guides/oidc.md#protected-endpoints). The `KEYCLOAK_*` variables were removed in 1.0.0 and now fail startup ([migration table](../guides/oidc.md#migrating-from-keycloak_)).
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/shini4i/argo-watcher/internal/config"
 )
 
@@ -212,10 +214,26 @@ func NewDeployTokenAuthService(token string) *DeployTokenAuthService {
 	}
 }
 
-// NewJWTAuthService initializes a JWT authentication service.
-func NewJWTAuthService(secret string) *JWTAuthService {
+// NewJWTAuthService initializes a JWT authentication service. An empty issuer or
+// audience leaves that claim unchecked, so a fleet minting tokens without it keeps
+// working; a configured value is enforced strictly — a token missing the claim is
+// rejected, not accepted. Roll the claim out to every pipeline before configuring it.
+func NewJWTAuthService(secret, issuer, audience string) *JWTAuthService {
+	// exp is required and a future iat rejected whatever the configuration: both were
+	// enforced before the claim binding existed.
+	options := []jwt.ParserOption{jwt.WithExpirationRequired(), jwt.WithIssuedAt()}
+
+	if issuer != "" {
+		options = append(options, jwt.WithIssuer(issuer))
+	}
+
+	if audience != "" {
+		options = append(options, jwt.WithAudience(audience))
+	}
+
 	return &JWTAuthService{
 		secretKey: []byte(secret),
+		options:   options,
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -67,7 +67,7 @@ func TestNewOIDCAuthService(t *testing.T) {
 
 func TestNewJWTAuthService(t *testing.T) {
 	secret := "testSecret"
-	jwtAuthService := NewJWTAuthService(secret)
+	jwtAuthService := NewJWTAuthService(secret, "", "")
 	assert.Equal(t, jwtAuthService.secretKey, []byte(secret))
 }
 
@@ -223,7 +223,7 @@ func TestAuthenticatorAuthenticateRequest(t *testing.T) {
 		// Oidc-Authorization; with JWT_SECRET set the former is parsed as an HMAC
 		// JWT and fails. One working credential must still authenticate.
 		authenticator := NewAuthenticator(map[string]AuthStrategy{
-			"Authorization":      NewJWTAuthService("secret"),
+			"Authorization":      NewJWTAuthService("secret", "", ""),
 			"Oidc-Authorization": splitStrategy{authenticated: true},
 		})
 		request := newRequest(t, "Authorization", "Bearer not-an-hmac-jwt")
@@ -243,7 +243,7 @@ func TestAuthenticatorAuthenticateRequest(t *testing.T) {
 		// coin-flipping precedence — and a 401 here signs the user out of a session
 		// that may be entirely valid.
 		authenticator := NewAuthenticator(map[string]AuthStrategy{
-			"Authorization":      NewJWTAuthService("secret"),
+			"Authorization":      NewJWTAuthService("secret", "", ""),
 			"Oidc-Authorization": unavailableStrategy{},
 		})
 
@@ -260,7 +260,7 @@ func TestAuthenticatorAuthenticateRequest(t *testing.T) {
 
 	t.Run("reports a rejection when every credential was actually evaluated", func(t *testing.T) {
 		authenticator := NewAuthenticator(map[string]AuthStrategy{
-			"Authorization":      NewJWTAuthService("secret"),
+			"Authorization":      NewJWTAuthService("secret", "", ""),
 			"Oidc-Authorization": splitStrategy{authenticated: false},
 		})
 		request := newRequest(t, "Authorization", "Bearer not-an-hmac-jwt")
@@ -535,7 +535,7 @@ func TestAuthenticatorValidateJWTWithAndWithoutBearerPrefix(t *testing.T) {
 	for name, headerValue := range cases {
 		t.Run(name, func(t *testing.T) {
 			authenticator := NewAuthenticator(map[string]AuthStrategy{
-				"Authorization": NewJWTAuthService(secret),
+				"Authorization": NewJWTAuthService(secret, "", ""),
 			})
 
 			request, reqErr := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)

--- a/internal/auth/deployToken.go
+++ b/internal/auth/deployToken.go
@@ -1,6 +1,9 @@
 package auth
 
-import "fmt"
+import (
+	"crypto/subtle"
+	"fmt"
+)
 
 // DeployTokenAuthService validates deploy tokens.
 type DeployTokenAuthService struct {
@@ -10,8 +13,11 @@ type DeployTokenAuthService struct {
 // Validate checks the provided token against the stored deploy token. The
 // authenticator only invokes it with a non-empty token, so the failure mode is
 // always "wrong value", never "missing" — the error wording reflects that.
+//
+// The comparison is constant-time so the rejection tells an attacker nothing about
+// how much of the token they guessed right.
 func (s *DeployTokenAuthService) Validate(token string) (bool, error) {
-	if s.token != token {
+	if subtle.ConstantTimeCompare([]byte(s.token), []byte(token)) != 1 {
 		return false, fmt.Errorf("deploy token is invalid")
 	}
 	return true, nil

--- a/internal/auth/deployToken_test.go
+++ b/internal/auth/deployToken_test.go
@@ -15,6 +15,17 @@ func TestValidateDeployToken(t *testing.T) {
 		assert.True(t, isValid)
 	})
 
+	t.Run("wrong token of the same length", func(t *testing.T) {
+		// The only input that exercises the comparison itself: a length mismatch is
+		// refused before a single byte is compared.
+		service := NewDeployTokenAuthService("valid_token")
+		isValid, err := service.Validate("valid_tokeX")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid")
+		assert.False(t, isValid)
+	})
+
 	t.Run("invalid token", func(t *testing.T) {
 		service := NewDeployTokenAuthService("valid_token")
 		_, err := service.Validate("invalid_token")

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -3,14 +3,15 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// JWTAuthService manages JSON Web Token authentication.
+// JWTAuthService validates the HMAC-signed tokens a CI pipeline presents. Beyond the
+// signature it enforces the claim policy assembled in NewJWTAuthService.
 type JWTAuthService struct {
 	secretKey []byte
+	options   []jwt.ParserOption
 }
 
 // Validate verifies a JSON Web Token, checking signature and claims.
@@ -24,7 +25,7 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return j.secretKey, nil
-	})
+	}, j.options...)
 
 	if err != nil {
 		return false, err
@@ -32,21 +33,6 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 
 	if !token.Valid {
 		return false, errors.New("invalid token")
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return false, errors.New("invalid claims type")
-	}
-
-	if _, exists := claims["exp"]; !exists {
-		return false, errors.New("missing exp claim")
-	}
-
-	if iatVal, ok := claims["iat"].(float64); ok {
-		if time.Now().Unix() < int64(iatVal) {
-			return false, errors.New("token used before issued")
-		}
 	}
 
 	return true, nil

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJWTAuthService(t *testing.T) {
 	secretKey := "test_secret_key"
-	service := &JWTAuthService{secretKey: []byte(secretKey)}
+	service := NewJWTAuthService(secretKey, "", "")
 
 	t.Run("valid JWT", func(t *testing.T) {
 		claims := jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}
@@ -49,7 +50,7 @@ func TestJWTAuthService(t *testing.T) {
 
 		isValid, err := service.Validate(tokenStr)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "missing exp claim")
+		assert.Contains(t, err.Error(), "exp claim is required")
 		assert.False(t, isValid)
 	})
 
@@ -112,6 +113,89 @@ func TestJWTAuthService(t *testing.T) {
 		isValid, err := service.Validate(tokenStr)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "token is not valid yet")
+		assert.False(t, isValid)
+	})
+}
+
+// TestJWTAuthService_ClaimBinding covers the optional iss/aud binding. The checks are
+// strict once configured: a token missing the claim is rejected, so an operator must
+// roll the new claims out to every pipeline before setting the variables.
+func TestJWTAuthService_ClaimBinding(t *testing.T) {
+	secretKey := "test_secret_key"
+
+	sign := func(t *testing.T, claims jwt.MapClaims) string {
+		t.Helper()
+		claims["exp"] = float64(time.Now().Add(time.Hour).Unix())
+		tokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secretKey))
+		require.NoError(t, err)
+		return tokenStr
+	}
+
+	t.Run("unconfigured service ignores iss and aud", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "", "")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{"iss": "https://gitlab.com", "aud": "someone-else"}))
+
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+	})
+
+	t.Run("issuer must match when configured", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "https://ci.example.com", "")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{"iss": "https://ci.example.com"}))
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+
+		isValid, err = service.Validate(sign(t, jwt.MapClaims{"iss": "https://gitlab.com"}))
+		assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
+		assert.False(t, isValid)
+	})
+
+	t.Run("a token without iss is rejected once an issuer is configured", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "https://ci.example.com", "")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{}))
+
+		assert.ErrorIs(t, err, jwt.ErrTokenRequiredClaimMissing)
+		assert.False(t, isValid)
+	})
+
+	t.Run("audience must match when configured", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "", "argo-watcher")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{"aud": "argo-watcher"}))
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+
+		// A list carrying the expected value among others is a match.
+		isValid, err = service.Validate(sign(t, jwt.MapClaims{"aud": []string{"other", "argo-watcher"}}))
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+
+		isValid, err = service.Validate(sign(t, jwt.MapClaims{"aud": "other-system"}))
+		assert.ErrorIs(t, err, jwt.ErrTokenInvalidAudience)
+		assert.False(t, isValid)
+	})
+
+	t.Run("a token without aud is rejected once an audience is configured", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "", "argo-watcher")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{}))
+
+		assert.ErrorIs(t, err, jwt.ErrTokenRequiredClaimMissing)
+		assert.False(t, isValid)
+	})
+
+	t.Run("both claims are enforced together", func(t *testing.T) {
+		service := NewJWTAuthService(secretKey, "https://ci.example.com", "argo-watcher")
+
+		isValid, err := service.Validate(sign(t, jwt.MapClaims{"iss": "https://ci.example.com", "aud": "argo-watcher"}))
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+
+		isValid, err = service.Validate(sign(t, jwt.MapClaims{"iss": "https://ci.example.com"}))
+		assert.Error(t, err)
 		assert.False(t, isValid)
 	})
 }

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // userInfoResponse holds the subset of OIDC userinfo claims argo-watcher needs.
@@ -46,6 +48,7 @@ type OIDCAuthService struct {
 	PrivilegedGroups []string
 	client           *http.Client
 	cache            *validationCache
+	warnUnbound      sync.Once
 
 	mu          sync.Mutex
 	userinfoURL string
@@ -276,7 +279,72 @@ func (o *OIDCAuthService) fetchUserInfo(token string) (*userInfoResponse, error)
 		return nil, ErrProviderUnavailable
 	}
 
+	if err := o.verifyAudience(token); err != nil {
+		return nil, err
+	}
+
 	return &info, nil
+}
+
+// verifyAudience rejects a token the issuer minted for another of its clients. Reading
+// the claims unverified is sound only here: the provider has just accepted this exact
+// string. A token saying nothing about who it is for is accepted, since binding it
+// would need introspection that a public client cannot perform.
+func (o *OIDCAuthService) verifyAudience(token string) error {
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, &claims); err != nil {
+		o.warnUnboundToken("the access token is not a JWT")
+		return nil
+	}
+
+	namesAny, namesUs := clientName(claims, o.ClientId)
+	audience, err := claims.GetAudience()
+	if err != nil {
+		audience = nil
+	}
+
+	if namesUs || slices.Contains(audience, o.ClientId) {
+		return nil
+	}
+
+	// Nothing in the token says who it is for.
+	if !namesAny && len(audience) == 0 {
+		o.warnUnboundToken("the access token names no client and carries no aud claim")
+		return nil
+	}
+
+	return fmt.Errorf("token was not issued to %s", o.ClientId)
+}
+
+// clientClaims are the claims a provider uses to name the client a token was issued
+// to: azp (Keycloak, Auth0, Entra v2.0), client_id (required of a JWT access token by
+// RFC 9068), cid (Okta) and appid (Entra v1.0). aud is judged separately — RFC 9068
+// gives it to the resource server, while other providers put the client id there.
+var clientClaims = []string{"azp", "client_id", "cid", "appid"}
+
+// clientName reports whether the token names a client at all, and whether any of the
+// claims that do names clientID.
+func clientName(claims jwt.MapClaims, clientID string) (namesAny, namesUs bool) {
+	for _, claim := range clientClaims {
+		value, ok := claims[claim].(string)
+		if !ok || value == "" {
+			continue
+		}
+		namesAny = true
+		if value == clientID {
+			namesUs = true
+		}
+	}
+
+	return namesAny, namesUs
+}
+
+// warnUnboundToken reports once that tokens cannot be bound to this application, so an
+// operator sees the gap without a log line per request.
+func (o *OIDCAuthService) warnUnboundToken(reason string) {
+	o.warnUnbound.Do(func() {
+		slog.Warn("oidc: accepting tokens without checking they were issued to this application", "reason", reason, "client_id", o.ClientId)
+	})
 }
 
 // allowedToRollback checks if the user is a member of any of the privileged groups.

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,14 +1,18 @@
 package auth
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -541,4 +545,185 @@ func TestValidateUserinfoURL(t *testing.T) {
 	assert.Error(t, validateUserinfoURL("ftp://example.com/userinfo"))
 	assert.Error(t, validateUserinfoURL("https:///userinfo"))
 	assert.NoError(t, validateUserinfoURL("https://example.com/userinfo"))
+}
+
+// signedToken mints a JWT whose signature this package never verifies: the binding
+// check reads the claims of a token the provider has already vouched for.
+func signedToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("irrelevant"))
+	require.NoError(t, err)
+	return tokenStr
+}
+
+// TestOIDCAuthService_TokenBinding covers the audience binding: a token the provider
+// accepts must also have been issued to this application, so one realm shared by the
+// whole organisation cannot authenticate its every client here.
+func TestOIDCAuthService_TokenBinding(t *testing.T) {
+	newService := func(t *testing.T, server *httptest.Server) *OIDCAuthService {
+		t.Helper()
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "argo-watcher", []string{"group1"}, 0))
+		service.client = server.Client()
+		return service
+	}
+
+	accepted := []struct {
+		name   string
+		claims jwt.MapClaims
+	}{
+		{"azp names this client", jwt.MapClaims{"azp": "argo-watcher", "aud": []string{"account"}}},
+		{"aud is this client", jwt.MapClaims{"aud": "argo-watcher"}},
+		{"aud lists this client", jwt.MapClaims{"aud": []string{"other", "argo-watcher"}}},
+		{"token carries neither claim", jwt.MapClaims{"sub": "user"}},
+		{"aud is malformed and no client is named", jwt.MapClaims{"aud": 42}},
+		// An array holding a non-string is unreadable as a whole, so the client id
+		// beside it does not count as a match — the token names nobody.
+		{"aud array is unreadable and no client is named", jwt.MapClaims{"aud": []any{"argo-watcher", 42}}},
+		// RFC 9068 gives aud to the resource server and names the client in client_id;
+		// Okta spells that claim cid. Neither emits azp, so both would 401 wholesale
+		// if only azp and aud were read.
+		{"client_id names this client (RFC 9068)", jwt.MapClaims{"client_id": "argo-watcher", "aud": []string{"https://api.example.com"}}},
+		{"cid names this client (Okta)", jwt.MapClaims{"cid": "argo-watcher", "aud": []string{"https://api.example.com"}}},
+		{"appid names this client (Entra v1.0)", jwt.MapClaims{"appid": "argo-watcher", "aud": "https://graph.microsoft.com"}},
+		// Issued by another client but deliberately audienced to this one, as an
+		// audience mapper or a token exchange produces.
+		{"azp names another client but aud names this one", jwt.MapClaims{"azp": "other-app", "aud": []string{"argo-watcher"}}},
+	}
+
+	for _, tc := range accepted {
+		t.Run("accepts a token whose "+tc.name, func(t *testing.T) {
+			server := newOIDCTestServer(t, http.StatusOK, `{"groups": ["group1"]}`, nil, false)
+			defer server.Close()
+
+			ok, err := newService(t, server).Validate(signedToken(t, tc.claims))
+
+			assert.NoError(t, err)
+			assert.True(t, ok)
+		})
+	}
+
+	t.Run("accepts an opaque token the provider vouches for", func(t *testing.T) {
+		// Binding an opaque token would need introspection, which a public client
+		// cannot perform; the provider's judgement stays the only gate.
+		server := newOIDCTestServer(t, http.StatusOK, `{"groups": ["group1"]}`, nil, false)
+		defer server.Close()
+
+		ok, err := newService(t, server).Validate("not-a-jwt")
+
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	rejected := []struct {
+		name   string
+		claims jwt.MapClaims
+	}{
+		{"azp names another client", jwt.MapClaims{"azp": "other-app", "aud": []string{"account"}}},
+		{"aud names another client", jwt.MapClaims{"aud": "other-app"}},
+		{"aud lists only other clients", jwt.MapClaims{"aud": []string{"other-app", "account"}}},
+		{"client_id names another client", jwt.MapClaims{"client_id": "other-app", "aud": []string{"https://api.example.com"}}},
+		{"cid names another client", jwt.MapClaims{"cid": "other-app", "aud": []string{"https://api.example.com"}}},
+		{"appid names another client", jwt.MapClaims{"appid": "other-app", "aud": "https://graph.microsoft.com"}},
+		// An unreadable aud must not rescue a token another client owns.
+		{"azp names another client and aud is malformed", jwt.MapClaims{"azp": "other-app", "aud": 42}},
+		{"azp names another client and the aud array is unreadable", jwt.MapClaims{"azp": "other-app", "aud": []any{"argo-watcher", 42}}},
+	}
+
+	for _, tc := range rejected {
+		t.Run("rejects a token whose "+tc.name, func(t *testing.T) {
+			server := newOIDCTestServer(t, http.StatusOK, `{"groups": ["group1"]}`, nil, false)
+			defer server.Close()
+			service := newService(t, server)
+			token := signedToken(t, tc.claims)
+
+			ok, err := service.Validate(token)
+			require.Error(t, err)
+			assert.False(t, ok)
+			assert.Contains(t, err.Error(), "not issued to")
+			// A foreign token is the client's problem (401), not the provider's (503).
+			assert.NotErrorIs(t, err, ErrProviderUnavailable)
+
+			// The read path must reject it too, not only the privileged one.
+			assert.Error(t, service.Authenticate(token))
+		})
+	}
+}
+
+// TestOIDCAuthService_TokenBindingCache exercises the binding on the path a real
+// deployment takes, where OIDC_TOKEN_VALIDATION_INTERVAL is non-zero: a rejection is
+// cached, must survive reuse without another provider call, and must not poison a
+// token that is properly bound.
+func TestOIDCAuthService_TokenBindingCache(t *testing.T) {
+	server, hits := newCountingOIDCServer(t, `["group1"]`)
+	service := &OIDCAuthService{}
+	require.NoError(t, service.Init(server.URL, "argo-watcher", []string{"group1"}, time.Minute))
+	service.client = server.Client()
+
+	foreign := signedToken(t, jwt.MapClaims{"azp": "other-app", "aud": []string{"account"}})
+
+	ok, err := service.Validate(foreign)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "not issued to")
+	after := atomic.LoadInt32(hits)
+
+	ok, err = service.Validate(foreign)
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, after, atomic.LoadInt32(hits), "a cached rejection must not re-ask the provider")
+
+	ok, err = service.Validate(signedToken(t, jwt.MapClaims{"azp": "argo-watcher"}))
+	assert.NoError(t, err)
+	assert.True(t, ok, "the cached rejection is keyed per token and must not deny a bound one")
+}
+
+// TestOIDCAuthService_UnboundTokenWarning pins the one operator-visible signal that
+// tokens are not being bound: it names the reason and is logged once, not per request.
+func TestOIDCAuthService_UnboundTokenWarning(t *testing.T) {
+	newService := func(t *testing.T, server *httptest.Server) *OIDCAuthService {
+		t.Helper()
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "argo-watcher", []string{"group1"}, 0))
+		service.client = server.Client()
+		return service
+	}
+
+	captureWarnings := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		logs := &bytes.Buffer{}
+		previous := slog.Default()
+		t.Cleanup(func() { slog.SetDefault(previous) })
+		slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		return logs
+	}
+
+	t.Run("an opaque token warns once, however many requests arrive", func(t *testing.T) {
+		server := newOIDCTestServer(t, http.StatusOK, `{"groups": ["group1"]}`, nil, false)
+		defer server.Close()
+		service := newService(t, server)
+		logs := captureWarnings(t)
+
+		for range 3 {
+			ok, err := service.Validate("not-a-jwt")
+			require.NoError(t, err)
+			require.True(t, ok)
+		}
+
+		assert.Equal(t, 1, strings.Count(logs.String(), "accepting tokens without checking"))
+		assert.Contains(t, logs.String(), "the access token is not a JWT")
+	})
+
+	t.Run("a JWT naming nobody warns with its own reason", func(t *testing.T) {
+		server := newOIDCTestServer(t, http.StatusOK, `{"groups": ["group1"]}`, nil, false)
+		defer server.Close()
+		service := newService(t, server)
+		logs := captureWarnings(t)
+
+		ok, err := service.Validate(signedToken(t, jwt.MapClaims{"sub": "user"}))
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		assert.Contains(t, logs.String(), "names no client and carries no aud claim")
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,8 @@ type ServerConfig struct {
 	Port               string           `env:"PORT" envDefault:"8080" json:"-"`
 	DeployToken        string           `env:"ARGO_WATCHER_DEPLOY_TOKEN" json:"-"`
 	JWTSecret          string           `env:"JWT_SECRET" json:"-"`
+	JWTIssuer          string           `env:"JWT_ISSUER" json:"-"`
+	JWTAudience        string           `env:"JWT_AUDIENCE" json:"-"`
 	Db                 DatabaseConfig   `json:"-"`
 	OIDC               OIDCConfig       `json:"oidc,omitempty"`
 	LockdownSchedule   string           `env:"LOCKDOWN_SCHEDULE" json:"lockdown_schedule,omitempty"`
@@ -203,10 +205,15 @@ func NewServerConfig() (*ServerConfig, error) {
 	config.ArgoToken = strings.TrimSpace(config.ArgoToken)
 	config.DeployToken = strings.TrimSpace(config.DeployToken)
 	config.JWTSecret = strings.TrimSpace(config.JWTSecret)
+	config.JWTIssuer = strings.TrimSpace(config.JWTIssuer)
+	config.JWTAudience = strings.TrimSpace(config.JWTAudience)
 	config.Mattermost.Token = strings.TrimSpace(config.Mattermost.Token)
 	// Group membership is matched exactly against the provider's claim, so a spaced
-	// list entry would silently deny every privileged action to that group.
+	// list entry would silently deny every privileged action to that group. The client
+	// id is matched the same way, against the claim naming the token's client.
 	config.OIDC.PrivilegedGroups = trimEntries(config.OIDC.PrivilegedGroups)
+	config.OIDC.IssuerURL = strings.TrimSpace(config.OIDC.IssuerURL)
+	config.OIDC.ClientId = strings.TrimSpace(config.OIDC.ClientId)
 
 	if err := rejectRemovedKeycloakVars(); err != nil {
 		return nil, err
@@ -214,6 +221,12 @@ func NewServerConfig() (*ServerConfig, error) {
 
 	if err := validateServerConfig(&config); err != nil {
 		return nil, err
+	}
+
+	// Without a secret no JWT strategy is registered, so the claim bindings guard
+	// nothing. Inert rather than contradictory, hence a warning.
+	if config.JWTSecret == "" && (config.JWTIssuer != "" || config.JWTAudience != "") {
+		slog.Warn("JWT_ISSUER and JWT_AUDIENCE have no effect without JWT_SECRET; JWT authentication is disabled.")
 	}
 
 	// Retention prunes rows from the tasks table, which the in-memory state does

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/url"
 	"strings"
 	"testing"
@@ -41,6 +43,8 @@ func TestNewServerConfig(t *testing.T) {
 		t.Setenv("ARGO_TOKEN", "  secret-token\n")
 		t.Setenv("ARGO_WATCHER_DEPLOY_TOKEN", "  deploy-token\n")
 		t.Setenv("JWT_SECRET", "  jwt-secret\n")
+		t.Setenv("JWT_ISSUER", "  https://ci.example.com\n")
+		t.Setenv("JWT_AUDIENCE", "  argo-watcher\n")
 		t.Setenv("STATE_TYPE", "postgres")
 
 		cfg, err := NewServerConfig()
@@ -49,6 +53,70 @@ func TestNewServerConfig(t *testing.T) {
 		assert.Equal(t, "secret-token", cfg.ArgoToken)
 		assert.Equal(t, "deploy-token", cfg.DeployToken)
 		assert.Equal(t, "jwt-secret", cfg.JWTSecret)
+		assert.Equal(t, "https://ci.example.com", cfg.JWTIssuer)
+		assert.Equal(t, "argo-watcher", cfg.JWTAudience)
+	})
+
+	t.Run("OIDC issuer and client id are trimmed", func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+		t.Setenv("OIDC_ENABLED", "true")
+		t.Setenv("OIDC_ISSUER_URL", "  https://idp.example.com/realms/x\n")
+		t.Setenv("OIDC_CLIENT_ID", "  argo-watcher\n")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com/realms/x", cfg.OIDC.IssuerURL)
+		// Matched against the claim naming the token's client, so a stray newline
+		// would refuse every token the provider issued for this very client.
+		assert.Equal(t, "argo-watcher", cfg.OIDC.ClientId)
+	})
+
+	t.Run("a claim binding without JWT_SECRET warns that it is inert", func(t *testing.T) {
+		// Without a secret no JWT strategy is registered, so the binding guards
+		// nothing — the warning is the only sign the setting does not apply.
+		for _, binding := range []string{"JWT_ISSUER", "JWT_AUDIENCE"} {
+			t.Run(binding, func(t *testing.T) {
+				t.Setenv("ARGO_URL", "https://example.com")
+				t.Setenv("ARGO_TOKEN", "secret-token")
+				t.Setenv("STATE_TYPE", "postgres")
+				t.Setenv(binding, "value")
+				logs := captureWarnings(t)
+
+				_, err := NewServerConfig()
+
+				assert.NoError(t, err)
+				assert.Contains(t, logs.String(), "no effect without JWT_SECRET")
+			})
+		}
+	})
+
+	t.Run("a claim binding with JWT_SECRET does not warn", func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+		t.Setenv("JWT_SECRET", "jwt-secret")
+		t.Setenv("JWT_ISSUER", "https://ci.example.com")
+		logs := captureWarnings(t)
+
+		_, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.NotContains(t, logs.String(), "no effect without JWT_SECRET")
+	})
+
+	t.Run("JWT claim bindings are unset by default", func(t *testing.T) {
+		t.Setenv("ARGO_URL", "https://example.com")
+		t.Setenv("ARGO_TOKEN", "secret-token")
+		t.Setenv("STATE_TYPE", "postgres")
+
+		cfg, err := NewServerConfig()
+
+		assert.NoError(t, err)
+		assert.Empty(t, cfg.JWTIssuer)
+		assert.Empty(t, cfg.JWTAudience)
 	})
 }
 
@@ -739,4 +807,15 @@ func TestNewServerConfig_ArgoUrlKeepsSubPath(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "/argocd/", cfg.ArgoUrl.Path)
+}
+
+// captureWarnings redirects the default logger into a buffer for the duration of a
+// test, so an assertion can observe a warning NewServerConfig only logs.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	logs := &bytes.Buffer{}
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	return logs
 }

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -214,7 +214,7 @@ func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prome
 	}
 
 	if env.config.JWTSecret != "" {
-		env.strategies["Authorization"] = auth.NewJWTAuthService(env.config.JWTSecret)
+		env.strategies["Authorization"] = auth.NewJWTAuthService(env.config.JWTSecret, env.config.JWTIssuer, env.config.JWTAudience)
 	}
 
 	env.authenticator = auth.NewAuthenticator(env.strategies)

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,6 +31,9 @@ const (
 	keycloakBaseURL  = "http://localhost:8090"
 	keycloakRealm    = "argo-watcher-e2e"
 	keycloakClientID = "argo-watcher"
+	// A second client of the same realm, standing in for any other application an
+	// organisation registers there.
+	foreignClientID = "other-app"
 )
 
 // waitForKeycloak polls the realm's OIDC discovery document until Keycloak has
@@ -56,10 +60,17 @@ func waitForKeycloak(t *testing.T) {
 // grant (password) flow against the test realm's public client.
 func keycloakToken(t *testing.T, username, password string) string {
 	t.Helper()
+	return keycloakTokenForClient(t, keycloakClientID, username, password)
+}
+
+// keycloakTokenForClient obtains an access token minted for a named client of the
+// realm, so a test can present one issued to something other than argo-watcher.
+func keycloakTokenForClient(t *testing.T, clientID, username, password string) string {
+	t.Helper()
 	tokenURL := keycloakBaseURL + "/realms/" + keycloakRealm + "/protocol/openid-connect/token"
 	form := url.Values{
 		"grant_type": {"password"},
-		"client_id":  {keycloakClientID},
+		"client_id":  {clientID},
 		"username":   {username},
 		"password":   {password},
 		// Keycloak 26's userinfo endpoint rejects tokens without the openid
@@ -240,6 +251,66 @@ func TestKeycloakReadAuthn(t *testing.T) {
 	t.Run("no token is rejected", func(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, callProtectedRead(t, srv, ""))
 	})
+}
+
+// TestKeycloakForeignClientToken proves the audience binding against a real provider:
+// a token the same realm minted for another of its clients is valid at userinfo, and
+// must still be refused here. It also pins the claim the check relies on — Keycloak
+// names the client in azp, and leaves the client id out of aud entirely.
+func TestKeycloakForeignClientToken(t *testing.T) {
+	waitForKeycloak(t)
+	env := newKeycloakEnv(t)
+	readSrv := protectedReadServer(t, env)
+	lockSrv := deployLockServer(t, env)
+
+	foreign := keycloakTokenForClient(t, foreignClientID, "priv-user", "priv-pass")
+	own := keycloakToken(t, "priv-user", "priv-pass")
+
+	// Without this the test could pass for the wrong reason: were the foreign token
+	// invalid at the provider, userinfo would produce the same 401s the binding must.
+	requireUserinfoAccepts(t, foreign)
+
+	assert.Equal(t, foreignClientID, tokenClaims(t, foreign)["azp"])
+	assert.Equal(t, keycloakClientID, tokenClaims(t, own)["azp"])
+	assert.NotContains(t, tokenClaims(t, own)["aud"], keycloakClientID)
+
+	t.Run("a foreign token may not read", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, callProtectedRead(t, readSrv, foreign))
+	})
+
+	t.Run("a foreign token may not take the deploy lock", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, callDeployLock(t, lockSrv, http.MethodPost, foreign))
+	})
+
+	t.Run("the same user's own token still works", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, callProtectedRead(t, readSrv, own))
+		assert.Equal(t, http.StatusOK, callDeployLock(t, lockSrv, http.MethodPost, own))
+		assert.Equal(t, http.StatusOK, callDeployLock(t, lockSrv, http.MethodDelete, own))
+	})
+}
+
+// requireUserinfoAccepts asserts Keycloak itself accepts the token, establishing the
+// premise the binding assertions rest on.
+func requireUserinfoAccepts(t *testing.T, token string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, keycloakBaseURL+"/realms/"+keycloakRealm+"/protocol/openid-connect/userinfo", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "keycloak must accept the foreign token, or the 401s below prove nothing")
+}
+
+// tokenClaims decodes an access token's payload without verifying it, so a test can
+// assert what the provider actually put in it.
+func tokenClaims(t *testing.T, token string) jwt.MapClaims {
+	t.Helper()
+	claims := jwt.MapClaims{}
+	_, _, err := jwt.NewParser().ParseUnverified(token, &claims)
+	require.NoError(t, err)
+	return claims
 }
 
 // TestKeycloakWebSocketHandshake proves the browser's transport against a real

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -256,7 +256,7 @@ func TestKeycloakReadAuthn(t *testing.T) {
 // TestKeycloakForeignClientToken proves the audience binding against a real provider:
 // a token the same realm minted for another of its clients is valid at userinfo, and
 // must still be refused here. It also pins the claim the check relies on — Keycloak
-// names the client in azp, and leaves the client id out of aud entirely.
+// names the client in azp and keeps the client id out of aud.
 func TestKeycloakForeignClientToken(t *testing.T) {
 	waitForKeycloak(t)
 	env := newKeycloakEnv(t)
@@ -272,7 +272,12 @@ func TestKeycloakForeignClientToken(t *testing.T) {
 
 	assert.Equal(t, foreignClientID, tokenClaims(t, foreign)["azp"])
 	assert.Equal(t, keycloakClientID, tokenClaims(t, own)["azp"])
-	assert.NotContains(t, tokenClaims(t, own)["aud"], keycloakClientID)
+
+	// Read through GetAudience: an absent aud is an untyped nil in the map, which
+	// NotContains cannot measure.
+	ownAudience, err := tokenClaims(t, own).GetAudience()
+	require.NoError(t, err)
+	assert.NotContains(t, ownAudience, keycloakClientID, "keycloak names the client in azp, so aud alone would refuse this token")
 
 	t.Run("a foreign token may not read", func(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, callProtectedRead(t, readSrv, foreign))

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -222,7 +222,7 @@ func TestReadAuthProtectedEndpoints(t *testing.T) {
 		// here would sign users out of valid sessions on roughly half of requests.
 		env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
 			oidcHeader:      oidcLikeStrategy{unavailable: true},
-			"Authorization": auth.NewJWTAuthService("secret"),
+			"Authorization": auth.NewJWTAuthService("secret", "", ""),
 		})
 		router := env.CreateRouter()
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/rs/cors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -268,6 +269,16 @@ func TestWebSocketConnectionsConcurrentAccess(t *testing.T) {
 	connectionsMutex.Unlock()
 }
 
+// signJWT mints an HS256 token valid for an hour, so a claim assertion is never
+// decided by expiry.
+func signJWT(t *testing.T, secret string, claims jwt.MapClaims) string {
+	t.Helper()
+	claims["exp"] = float64(time.Now().Add(time.Hour).Unix())
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+	require.NoError(t, err)
+	return signed
+}
+
 func TestNewEnv(t *testing.T) {
 	serverConfig := &config.ServerConfig{
 		Host:        "localhost",
@@ -278,7 +289,9 @@ func TestNewEnv(t *testing.T) {
 			IssuerURL: "http://localhost:8080/realms/test",
 			ClientId:  "test",
 		},
-		JWTSecret: "jwtSecret",
+		JWTSecret:   "jwtSecret",
+		JWTIssuer:   "https://ci.example.com",
+		JWTAudience: "argo-watcher",
 	}
 
 	argo := &argocd.Argo{}
@@ -293,16 +306,47 @@ func TestNewEnv(t *testing.T) {
 	assert.Equal(t, env.metrics, metrics)
 	assert.Equal(t, env.updater, updater)
 
-	expectedOIDC, oidcErr := auth.NewOIDCAuthService(serverConfig)
-	assert.NoError(t, oidcErr)
+	// The strategies are compared by type and behaviour: the JWT one holds parser
+	// options, and two function values are never equal.
+	require.Len(t, env.strategies, 3)
+	require.IsType(t, &auth.DeployTokenAuthService{}, env.strategies["ARGO_WATCHER_DEPLOY_TOKEN"])
+	require.IsType(t, &auth.JWTAuthService{}, env.strategies["Authorization"])
+	require.IsType(t, &auth.OIDCAuthService{}, env.strategies[oidcHeader])
 
-	expectedStrategies := map[string]auth.AuthStrategy{
-		"ARGO_WATCHER_DEPLOY_TOKEN": auth.NewDeployTokenAuthService(serverConfig.DeployToken),
-		"Authorization":             auth.NewJWTAuthService(serverConfig.JWTSecret),
-		oidcHeader:                  expectedOIDC,
-	}
+	accepted, err := env.strategies["ARGO_WATCHER_DEPLOY_TOKEN"].Validate(serverConfig.DeployToken)
+	assert.NoError(t, err)
+	assert.True(t, accepted)
 
-	assert.Equal(t, expectedStrategies, env.strategies)
+	oidcService := env.strategies[oidcHeader].(*auth.OIDCAuthService)
+	assert.Equal(t, serverConfig.OIDC.IssuerURL, oidcService.IssuerURL)
+	assert.Equal(t, serverConfig.OIDC.ClientId, oidcService.ClientId)
+
+	// The JWT claim binding lives in unexported parser options, so only a token can
+	// show whether NewEnv passed the configured issuer and audience through.
+	jwtStrategy := env.strategies["Authorization"]
+	accepted, err = jwtStrategy.Validate(signJWT(t, serverConfig.JWTSecret, jwt.MapClaims{
+		"iss": serverConfig.JWTIssuer,
+		"aud": serverConfig.JWTAudience,
+	}))
+	assert.NoError(t, err)
+	assert.True(t, accepted)
+
+	accepted, err = jwtStrategy.Validate(signJWT(t, serverConfig.JWTSecret, jwt.MapClaims{
+		"iss": "https://elsewhere.example.com",
+		"aud": serverConfig.JWTAudience,
+	}))
+	assert.Error(t, err)
+	assert.False(t, accepted)
+
+	// Each half is pinned on its own: a token wrong in only one claim proves that
+	// claim's option reached the strategy.
+	accepted, err = jwtStrategy.Validate(signJWT(t, serverConfig.JWTSecret, jwt.MapClaims{
+		"iss": serverConfig.JWTIssuer,
+		"aud": "someone-else",
+	}))
+	assert.Error(t, err)
+	assert.False(t, accepted)
+
 	assert.NotNil(t, env.authenticator)
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -62,7 +62,7 @@ task api-surface          # assert the read-only HTTP surface (version/config/ta
 task read-auth            # assert OIDC read protection: 401 without a credential, 503 when the provider is unreachable, exemptions still open
 task smoke                # one authenticated deploy through the full write-back loop, via the real client binary
 task client-knobs         # assert client env knobs: TASK_REFRESH override deploys, DEBUG cURL log redacts the token
-task jwt-auth             # assert the JWT (BEARER_TOKEN) auth path drives an authenticated write-back to deployed
+task jwt-auth             # assert the JWT (BEARER_TOKEN) auth path drives an authenticated write-back, and that JWT_ISSUER/JWT_AUDIENCE bind the token
 task fire-and-forget      # assert fire-and-forget mode: a managed CronJob app's write-back reaches deployed without the image rolling out
 task commit-format        # assert COMMIT_MESSAGE_FORMAT renders into the git write-back commit message
 task multi-image          # assert a multi-image deploy bumps and writes back both images in one commit
@@ -132,8 +132,8 @@ again instead of re-establishing a forward.
 | `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: the `/livez` + `/readyz` probes, version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when OIDC auth is off |
 | `scripts/read-auth.sh` | assert OIDC read protection: toggles `OIDC_ENABLED` on the release with the issuer pointed at a closed port and reverts, asserting 401 without a credential, 503 (never 401) when the provider cannot be consulted — including with a rejected JWT alongside, 15× because strategy order is randomized — 200 for a deploy token / JWT, the `/tasks/:id`, `/config`, `/livez`, `/readyz`, `/metrics` and `POST /tasks` exemptions, and the `unauthenticated_reads` counter semantics. Also asserts the /ws handshake: 401 with no credential, accepted with a deploy token, and 503 for a subprotocol-borne token whose provider is unreachable. Needs no identity provider; group-based authorization is covered by the Keycloak integration suite instead |
 | `scripts/client-knobs.sh` | assert client env knobs via the real client: `TASK_REFRESH=false` still deploys, `DEBUG=true` cURL log redacts the deploy token |
-| `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed |
-| `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency) |
+| `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed. Then sets `JWT_ISSUER` + `JWT_AUDIENCE` on the release and reverts, asserting a claimless token turns 401, a matching one 202, one from another issuer 401, and that unsetting them restores the claimless token |
+| `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency). `JWT_ISS` / `JWT_AUD` add those claims |
 | `scripts/fire-and-forget.sh` | assert `argo-watcher/fire-and-forget` on a managed CronJob app: the write-back updates the CronJob's image and the deploy reports "deployed" even though the image never rolls out (no pod until the schedule fires) |
 | `fixtures/fire-and-forget-app.yaml` + `fixtures/fire-and-forget-chart/` | dedicated `ffapp` Argo Application (managed) and its CronJob chart (image tag a write-back target, effectively-never schedule), outside the app1..N soak range |
 | `scripts/commit-format.sh` | assert `COMMIT_MESSAGE_FORMAT` renders into the real write-back commit message (reads the commit back from the gitops repo) |

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -81,7 +81,7 @@ phase() {
   phase client-knobs.sh
 }
 
-@test "jwt-auth: the BEARER_TOKEN path drives an authenticated write-back" {
+@test "jwt-auth: the BEARER_TOKEN path drives a write-back, and iss/aud bind it" {
   phase jwt-auth.sh
 }
 

--- a/test/e2e/scripts/jwt-auth.sh
+++ b/test/e2e/scripts/jwt-auth.sh
@@ -1,29 +1,34 @@
 #!/usr/bin/env bash
-# Prove the JWT (BEARER_TOKEN) auth path end to end, distinct from the deploy-token
-# path every other phase uses. argo-watcher runs with JWT_SECRET set, which
-# registers the HMAC JWT strategy on the Authorization header. We mint a token with
-# that same secret and deploy through the real client using BEARER_TOKEN and NO
-# deploy token.
-#
-# The assertion is a real tag transition, not just "deployed": we deploy a tag
-# DIFFERENT from the app's current one, so reaching "deployed" (client exit 0)
-# requires the git write-back to have pushed the new tag — which only happens when
-# the task is Validated, i.e. when the JWT was accepted. A rejected JWT leaves the
-# task unvalidated, no write-back, and the client times out non-zero.
-#
-# Usage: jwt-auth.sh [app]
+# Prove the JWT (BEARER_TOKEN) auth path, the one every other phase does not use: a
+# token minted with the lab's JWT_SECRET deploys through the real client with no
+# deploy token, then the optional iss/aud binding is set on the live release for this
+# phase's duration and reverted. Usage: jwt-auth.sh [app]
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lib.sh
 . "${here}/lib.sh"
 
+: "${AW_CHART_REPO:?AW_CHART_REPO is required}" "${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+VALUES="${E2E_DIR}/values/argo-watcher.yaml"
+
 APP="${1:-app2}"
 # MUST match JWT_SECRET in values/argo-watcher.yaml.
 JWT_SECRET="${JWT_SECRET:-e2e-jwt-secret}"
+ISSUER="https://ci.e2e.invalid"
+AUDIENCE="argo-watcher-e2e"
 
 bin_dir="$(mktemp -d)"
-trap 'rm -rf "$bin_dir"' EXIT
+
+revert() {
+  echo "reverting JWT_ISSUER / JWT_AUDIENCE"
+  helm_apply_aw || true
+  wait_service || true
+  rm -rf "$bin_dir"
+  return
+}
+trap revert EXIT
+
 build_client "$bin_dir" || die "client build failed"
 
 require_app_synced "$APP"
@@ -32,19 +37,71 @@ require_app_synced "$APP"
 # write-back regardless of what earlier phases left the app on.
 TAG="$(other_tag "$APP")"
 
-# Mint a short-lived HS256 JWT signed with JWT_SECRET via the in-repo Go minter
-# (signs with the same library the server validates with; no openssl dependency).
-jwt="$(cd "$E2E_ROOT" && JWT_SECRET="$JWT_SECRET" go run ./test/e2e/tools/mintjwt)"
+# Minted by the in-repo Go tool, which signs with the very library the server
+# validates with (no openssl dependency).
+mint() { (cd "$E2E_ROOT" && env JWT_SECRET="$JWT_SECRET" "$@" go run ./test/e2e/tools/mintjwt); }
+plain_jwt="$(mint)"
+bound_jwt="$(mint JWT_ISS="$ISSUER" JWT_AUD="$AUDIENCE")"
 
 wait_service || die "argo-watcher never answered on ${AW_URL}"
 
+# --- 1. A claimless token authenticates while nothing is configured -----------
 echo "deploying ${APP} -> ${IMAGE}:${TAG} via BEARER_TOKEN (JWT), no deploy token"
 
-# BEARER_TOKEN only, ARGO_WATCHER_DEPLOY_TOKEN unset: the deploy is authenticated
-# solely by the JWT, so a successful write-back proves the JWT strategy validated it.
-if run_client "$APP" "$TAG" BEARER_TOKEN="$jwt"; then
-  echo "JWT-AUTH: PASS (JWT-authenticated write-back reached 'deployed' on ${TAG})"
-  exit 0
+# BEARER_TOKEN only, no deploy token: reaching "deployed" on a tag the app is not on
+# takes a write-back, which only a Validated task gets — so the JWT was accepted. A
+# rejected one leaves the task unvalidated and the client times out non-zero.
+if run_client "$APP" "$TAG" BEARER_TOKEN="$plain_jwt"; then
+  ok "JWT-authenticated write-back reached 'deployed' on ${TAG}"
+else
+  bad "client exited non-zero — JWT likely rejected, so no write-back happened"
 fi
-echo "JWT-AUTH: FAIL (client exited non-zero — JWT likely rejected, so no write-back happened)"
-exit 1
+
+# --- 2. Configure the claim binding -------------------------------------------
+idx=$(extra_envs_index "$VALUES")
+helm_apply_aw --set-string "extraEnvs[${idx}].name=JWT_ISSUER" \
+              --set-string "extraEnvs[${idx}].value=${ISSUER}" \
+              --set-string "extraEnvs[$((idx + 1))].name=JWT_AUDIENCE" \
+              --set-string "extraEnvs[$((idx + 1))].value=${AUDIENCE}"
+wait_service || die "argo-watcher never came back after setting the claim binding"
+
+# The same token section 1 deployed with. Strict means strict: a missing claim is a
+# rejection, which is why the rollout order is mint-first, configure-second.
+# Every POST below reuses TAG, which section 1 already rolled out, so an accepted task
+# finishes on its first poll and no watch is left running across the helm upgrades.
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${plain_jwt}"
+if [[ "$CODE" == "401" ]]; then
+  ok "a token without iss/aud -> 401 once the binding is configured"
+else
+  bad "token without iss/aud: code=${CODE} body=${BODY} (want 401)"
+fi
+
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${bound_jwt}"
+if [[ "$CODE" == "202" ]]; then
+  ok "a token carrying the configured iss/aud is accepted"
+else
+  bad "token with iss/aud: code=${CODE} body=${BODY} (want 202)"
+fi
+
+# The point of the setting: one HMAC secret shared across a CI estate no longer
+# authorizes another system's tokens here.
+foreign_jwt="$(mint JWT_ISS="https://elsewhere.invalid" JWT_AUD="$AUDIENCE")"
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${foreign_jwt}"
+if [[ "$CODE" == "401" ]]; then
+  ok "a token from another issuer -> 401"
+else
+  bad "token from another issuer: code=${CODE} body=${BODY} (want 401)"
+fi
+
+# --- 3. Revert and prove the binding is the only thing that changed -----------
+revert
+trap - EXIT
+
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${plain_jwt}"
+if [[ "$CODE" == "202" ]]; then
+  ok "the claimless token is accepted again once the binding is unset"
+else
+  bad "after revert, token without iss/aud: code=${CODE} body=${BODY} (want 202)"
+fi
+
+phase_end JWT-AUTH

--- a/test/e2e/tools/mintjwt/main.go
+++ b/test/e2e/tools/mintjwt/main.go
@@ -5,6 +5,8 @@
 // library the server validates with (golang-jwt/jwt/v5), so the token is
 // guaranteed compatible. The token carries the iat and exp claims the server
 // requires and is valid for one hour — long enough for a single deploy phase.
+// JWT_ISS and JWT_AUD add the iss and aud claims a server configured with
+// JWT_ISSUER / JWT_AUDIENCE requires.
 package main
 
 import (
@@ -23,10 +25,21 @@ func main() {
 	}
 
 	now := time.Now()
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+	claims := jwt.MapClaims{
 		"iat": now.Unix(),
 		"exp": now.Add(time.Hour).Unix(),
-	})
+	}
+
+	// Set only when asked for, so the same tool mints both the claimless token an
+	// unconfigured server accepts and the bound one JWT_ISSUER/JWT_AUDIENCE demand.
+	if issuer := os.Getenv("JWT_ISS"); issuer != "" {
+		claims["iss"] = issuer
+	}
+	if audience := os.Getenv("JWT_AUD"); audience != "" {
+		claims["aud"] = audience
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	signed, err := token.SignedString([]byte(secret))
 	if err != nil {

--- a/test/keycloak/argo-watcher-e2e-realm.json
+++ b/test/keycloak/argo-watcher-e2e-realm.json
@@ -34,6 +34,16 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "other-app",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [ "http://localhost:8102/" ],
+      "webOrigins": [ "http://localhost:8102" ]
     }
   ],
   "users": [


### PR DESCRIPTION
Closes #564.

An OIDC token the provider accepts must now also have been issued to this application, client JWTs can be pinned with the new `JWT_ISSUER` / `JWT_AUDIENCE`, and the deploy token is compared in constant time.

The JWT claims are unchecked while unset and strict once set, so every pipeline must mint the claim before the variable is configured.