### PR TITLE
chore(security): scan bundled JavaScript with retire.js

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -129,7 +129,7 @@ The lab is not part of the standard PR checks because it is expensive. Maintaine
 
 ## What CI Checks
 
-These must be green before a merge: backend tests, frontend tests, integration tests, the Keycloak auth end-to-end job, the Go scanners (gosec and govulncheck), Trivy, TruffleHog, CodeQL, and SonarCloud.
+These must be green before a merge: backend tests, frontend tests, integration tests, the Keycloak auth end-to-end job, the Go scanners (gosec and govulncheck), Trivy, retire.js, TruffleHog, CodeQL, and SonarCloud.
 
 The nuclei DAST scan runs weekly on `main` rather than per pull request, so it does not gate your PR.
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install web dependencies
         working-directory: web
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Scan for vulnerable JavaScript libraries
         # trivy and npm audit read package-lock.json, so they see only declared

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,6 +96,34 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: '1'
 
+  retirejs:
+    name: retire.js (bundled JavaScript libraries)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Scan for vulnerable JavaScript libraries
+        # trivy and npm audit read package-lock.json, so they see only declared
+        # dependencies. retire.js fingerprints versions in the JavaScript itself,
+        # which is the only way to catch a library a prebuilt bundle vendors in
+        # without declaring it — swagger-ui-dist inlines DOMPurify exactly so.
+        working-directory: web
+        run: npm run scan:js
+
   trufflehog:
     name: TruffleHog (secret scan)
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,6 +116,20 @@ jobs:
         working-directory: web
         run: npm ci --ignore-scripts
 
+      - name: Assert the scanner still detects a vulnerable library
+        # A scanner whose fingerprints stopped matching reports exactly like a clean
+        # tree, so prove it fails on a known-bad version before the run below is
+        # trusted. Same reasoning as the fuzz-seed assertion in dast.yml.
+        working-directory: web
+        run: |
+          canary=$(mktemp -d)
+          printf 'DOMPurify.version="3.4.11";\n' > "$canary/canary.js"
+          if npx retire --path "$canary" --severity low >/dev/null 2>&1; then
+            echo "::error::retire.js did not flag a known-vulnerable library; the gate is not working"
+            exit 1
+          fi
+          echo "retire.js flagged the canary; fingerprints are live"
+
       - name: Scan for vulnerable JavaScript libraries
         # trivy and npm audit read package-lock.json, so they see only declared
         # dependencies. retire.js fingerprints versions in the JavaScript itself,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,6 +144,19 @@ tasks:
       - npm run test
       - echo "===> Done"
 
+  scan-web:
+    desc: Scan the web workspace's JavaScript for known-vulnerable libraries (retire.js)
+    deps: [install-web-dependencies]
+    dir: web
+    cmds:
+      # Fingerprints library versions inside JavaScript file contents, so it sees
+      # dependencies a bundle vendors in without declaring them — which npm audit
+      # and trivy, both of which read package-lock.json, cannot. Needs network:
+      # retire.js fetches its advisory repository (cached under /tmp).
+      - echo "===> Scanning web JavaScript for vulnerable libraries"
+      - npm run scan:js
+      - echo "===> Done"
+
   test-web-e2e:
     desc: Run the Playwright browser suite (requires docker; brings up keycloak). Must not be run concurrently with test-integration.
     deps: [install-web-dependencies, build-ui]

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -10,7 +10,7 @@ Setting up a local environment. What a change must satisfy before it can be merg
 - **[Task](https://taskfile.dev/)** — every automation lives in `Taskfile.yml`
 - **[pre-commit](https://pre-commit.com/)** — `pre-commit install`
 
-`nix develop` provides all of the above plus the scanners CI runs (`trufflehog`, `gosec`, `govulncheck`, `trivy`, `zizmor`). Without Nix, install `trufflehog` yourself — one pre-commit hook is a secret scan and fails without it.
+`nix develop` provides all of the above plus the scanners CI runs (`trufflehog`, `gosec`, `govulncheck`, `trivy`, `zizmor`). Without Nix, install `trufflehog` yourself — one pre-commit hook is a secret scan and fails without it. The frontend scanner, retire.js, is a `web/` dev dependency rather than a Nix package, so `task scan-web` provides it via `npm ci`.
 
 Then install the Go tooling (`swag`, `mockgen`, `migrate`):
 
@@ -85,6 +85,7 @@ origin from the API, and the server allows no cross-origin request without it.
 | `task test-web` | Frontend unit tests (Vitest) |
 | `task test-web-e2e` | Playwright browser suite against the built UI (Docker) |
 | `task lint-web` | Lint the frontend (oxlint) |
+| `task scan-web` | Scan the frontend's JavaScript for known-vulnerable libraries (retire.js) |
 | `task bootstrap` / `task teardown` | Bring the Compose stack up / down |
 
 `task --list` shows the rest, including the kind-cluster helpers.

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,9 @@
           (bats.withLibraries (p: [ p.bats-support p.bats-assert ]))
         ];
 
-        # Security scanners, mirroring the CI security workflow so they can be
-        # run locally. gosec is already part of goToolchain. nuclei is
-        # intentionally absent — DAST runs only in CI against a live server.
+        # Security scanners from the CI security workflow, minus gosec (in
+        # goToolchain), nuclei (CI-only DAST) and retire.js (absent from nixpkgs,
+        # so pinned as a web/ dev dependency and run by `task scan-web`).
         securityTools = with pkgs; [
           govulncheck
           trivy

--- a/web/README.md
+++ b/web/README.md
@@ -26,6 +26,7 @@ The Go API must be running (`task bootstrap` from the repo root, or `go run ./cm
 | `npm run test:e2e` | Playwright — expects `dist/` built and Keycloak up; `task test-web-e2e` does both |
 | `npm run test:e2e:install` | Install the Chromium build Playwright drives |
 | `npm run typecheck:e2e` | Type-check the node-side project (`playwright.config.ts`, `vite.config.ts`, `e2e/`). Playwright does not type-check specs, so this is its own CI gate; `src/` is not covered. |
+| `npm run scan:js` | retire.js scan for known-vulnerable JavaScript libraries, including ones a bundled dependency vendors in without declaring (`swagger-ui-dist` inlines DOMPurify this way). `task scan-web` runs the same check. Needs network for the advisory repository. |
 
 ## Configuration
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,7 +32,8 @@
         "jsdom": "^29.1.1",
         "oxlint": "^1.73.0",
         "postcss": "^8.5.23",
-        "swagger-ui-dist": "^5.32.8",
+        "retire": "^5.7.0",
+        "swagger-ui-dist": "^5.32.14",
         "typescript": "^7.0.2",
         "vite": "^8.1.4",
         "vite-plugin-static-copy": "^4.1.1",
@@ -1680,6 +1681,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2298,6 +2306,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2370,6 +2398,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
@@ -2388,6 +2429,16 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astronomical": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/astronomical/-/astronomical-3.2.0.tgz",
+      "integrity": "sha512-nRKPza8f1nYpAyymI5edTgWwo4+BRgeqFtyVrKgN0tBwi9eIlVL4UpSyAOYhUSoSTln7IEHtShGSYUPgnHzveg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "meriyah": "^7.1.0"
+      }
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -2420,6 +2471,16 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -2558,6 +2619,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -2634,6 +2705,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2724,6 +2805,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/dequal": {
@@ -2864,6 +2960,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2872,6 +3025,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -3009,6 +3172,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -3115,6 +3293,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3148,6 +3354,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-arrayish": {
@@ -3718,6 +3934,16 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/meriyah": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-7.3.2.tgz",
+      "integrity": "sha512-uFPXbsoxaEd7PafMz3K/n/Z3kXz7iZBJtYU0VQB/kcV7i33+JghLTKweabLir480FUsyLz6gUIj4LW7kCQ35TA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3735,9 +3961,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3751,6 +3977,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-polyglot": {
@@ -3896,6 +4132,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/parent-module": {
@@ -4097,6 +4367,43 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -4455,6 +4762,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/retire": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/retire/-/retire-5.7.0.tgz",
+      "integrity": "sha512-v5u3d2+D9SNi8iwXqRI3SHc8N0ei/SE1Yv0uuemYLCvhRk5q4vihhT4KcI95wPuQj8zZLqjUwQ02xKHWMVbIhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "astronomical": "^3.2.0",
+        "commander": "^10.0.1",
+        "proxy-agent": "^6.4.0",
+        "walkdir": "0.4.1",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "retire": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -4550,6 +4878,47 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -4647,9 +5016,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.8",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
-      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
+      "version": "5.32.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.14.tgz",
+      "integrity": "sha512-nOA2pSQhcmODMUQZpJHYKNuwniDUqcOWGNaSCOoZv12FdOSJ9JxV95HtyRGNMqEBj6h6lCNTy20TgZDYTSuUIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5028,6 +5397,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -5105,6 +5484,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install --with-deps chromium",
-    "typecheck:e2e": "tsc -p tsconfig.node.json --noEmit"
+    "typecheck:e2e": "tsc -p tsconfig.node.json --noEmit",
+    "scan:js": "retire --path . --ext js,mjs --severity low --ignore dist,coverage,playwright-report,test-results"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -40,7 +41,8 @@
     "jsdom": "^29.1.1",
     "oxlint": "^1.73.0",
     "postcss": "^8.5.23",
-    "swagger-ui-dist": "^5.32.8",
+    "retire": "^5.7.0",
+    "swagger-ui-dist": "^5.32.14",
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
     "vite-plugin-static-copy": "^4.1.1",


### PR DESCRIPTION
Adds retire.js as a CI gate over the web workspace, and bumps `swagger-ui-dist` to 5.32.14 so the DOMPurify copy inlined in `swagger-ui-bundle.js` moves from 3.4.11 to 3.4.13.

The bundle inlines DOMPurify instead of depending on it, so trivy, `npm audit` and the `overrides.dompurify` pin all reported clean — each of them reads `package-lock.json`. retire.js fingerprints versions in the JavaScript itself, which is what catches that.

The gate scans `.js` and `.mjs` and ignores build output (`dist`, `coverage`, `playwright-report`, `test-results`); `dist` is derived from the inputs it does scan.

`nanoid` moves to 3.3.18 in the lockfile, within the range postcss already declares.