### PR TITLE
feat(auth): add revocable per-application deploy tokens

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -119,7 +119,8 @@ jobs:
 
       # task test runs the whole tree without -race; run the server package under
       # the race detector so goroutine/shutdown races (e.g. the WebSocket hijack
-      # path) fail CI instead of staying hidden. These tests are untagged and
+      # path) fail CI instead of staying hidden. internal/apptoken is included for
+      # its contended-revocation tests. These tests are untagged and
       # self-contained, so no integration services are required.
       - name: Race-detect the server package
         env:
@@ -131,7 +132,7 @@ jobs:
           STATE_TYPE: in-memory
           ARGO_URL: http://localhost:8081
           POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
-        run: go test -race -count=1 -timeout=5m ./internal/server/...
+        run: go test -race -count=1 -timeout=5m ./internal/server/... ./internal/apptoken/...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Application deploy tokens: opaque, revocable credentials scoped to the applications
+  they may deploy, issued and revoked from **Workspace Controls → Deploy Tokens** by a
+  member of `OIDC_PRIVILEGED_GROUPS`. A token covers either a list of applications or,
+  with the wildcard, every application present and future — the revocable, attributable
+  equivalent of the shared `ARGO_WATCHER_DEPLOY_TOKEN`. Each token may carry an expiry
+  and a description, and revoking one takes effect on its next use rather than after a
+  cache interval.
+
+  A token travels in `BEARER_TOKEN` like a JWT; the server tells the two apart by the
+  `awt_` prefix every token carries, so nothing else in a pipeline changes. Only the
+  SHA-256 of a token is stored, so it is displayed exactly once, in the dialog that
+  creates it, and a lost token has to be revoked and replaced.
+
+  The feature requires `OIDC_ENABLED=true` and `STATE_TYPE=postgres`: issuing and
+  revoking need a privileged session, and a token has to outlive the process holding it
+  and be honoured by every replica. There is no in-memory equivalent, and no new
+  environment variable. Where either prerequisite is missing a presented token is
+  rejected `401` naming the setting at fault, rather than being ignored — so a pipeline
+  holding one is told why instead of watching its write-back get skipped. A new database
+  migration adds the `app_tokens` table.
+
+### Changed
+
+- The `allowed_apps` JWT claim is now enforced, closing a gap the documentation has
+  described as planned. A token carrying the claim may only deploy the applications it
+  names; **a token omitting it still authorizes every application**, so a fleet that
+  never set the claim is unaffected. Worth knowing before upgrading: a pipeline that set
+  `allowed_apps` while it was documented as unenforced, and relies on that token
+  deploying something the claim does not list, will now be rejected `401`. The claim
+  remains a self-restriction rather than a boundary — it is written by whoever holds
+  `JWT_SECRET` — so an application deploy token is the stronger option where the scope
+  must not be self-asserted.
+
+- `POST /api/v1/tasks` now answers `503` instead of `401` when a credential could not be
+  judged at all, such as an unreachable OIDC provider or state backend. A blip no longer
+  tells a pipeline its credential is bad, and the client can retry.
+
 ## [1.0.0] - 2026-08-23
 
 ### Added

--- a/db/migrations/000009_app_tokens.down.sql
+++ b/db/migrations/000009_app_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS app_tokens;

--- a/db/migrations/000009_app_tokens.up.sql
+++ b/db/migrations/000009_app_tokens.up.sql
@@ -1,0 +1,42 @@
+-- Application deploy tokens: opaque credentials, each authorizing a git
+-- write-back for a named set of applications, issued and revoked through the API.
+--
+-- Only the SHA-256 of a token is stored, so a database dump does not hand out
+-- working credentials. The token is 256 bits of CSPRNG output, which is why a
+-- plain digest is enough and a password KDF would only add cost per request.
+CREATE TABLE IF NOT EXISTS app_tokens
+(
+    id           UUID PRIMARY KEY      DEFAULT gen_random_uuid(),
+    token_hash   BYTEA        NOT NULL UNIQUE,
+    -- The applications this token covers, or an empty array when all_apps is set.
+    -- JSONB rather than TEXT[] to match how the tasks table already stores lists;
+    -- nothing queries inside it, because scope matching happens in Go once the
+    -- row has been found by its hash.
+    apps         JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    -- A wildcard covering every application, present and future. It is a column
+    -- of its own rather than a sentinel entry in apps, so granting the whole
+    -- estate can never be the accidental result of building that list wrongly.
+    all_apps     BOOLEAN      NOT NULL DEFAULT false,
+    -- The token's last few characters, so the UI can name a token whose secret it
+    -- can never show again.
+    hint         VARCHAR(8)   NOT NULL,
+    description  VARCHAR(255) NOT NULL DEFAULT '',
+    created_by   VARCHAR(255) NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- NULL means the token never expires.
+    expires_at   TIMESTAMPTZ,
+    -- NULL while the token is live. A revoked token keeps its row, so who issued
+    -- it and when it was withdrawn stay on record.
+    revoked_at   TIMESTAMPTZ,
+    -- Recorded only when the token authorizes a deployment, never on a read, so a
+    -- status endpoint polled for the length of every rollout is not turned into a
+    -- stream of writes. It is the signal for pruning tokens nothing uses.
+    last_used_at TIMESTAMPTZ,
+    -- jsonb_typeof is checked first so the constraint fails rather than evaluating to
+    -- NULL (which a CHECK passes) if a writer ever stores JSON null instead of [].
+    CONSTRAINT app_tokens_scope_exclusive CHECK (
+        jsonb_typeof(apps) = 'array'
+            AND ((all_apps AND jsonb_array_length(apps) = 0)
+                OR (NOT all_apps AND jsonb_array_length(apps) > 0))
+        )
+);

--- a/docs/guides/gitops-updater.md
+++ b/docs/guides/gitops-updater.md
@@ -8,7 +8,7 @@ Already on Argo CD Image Updater? See [Migrating from Argo CD Image Updater](#mi
 
 A working [installation](install.md), plus:
 
-1. **A credential the client can present.** Either a **JWT** (recommended, see [JWT configuration](#jwt-configuration)) stored under the `JWT_SECRET` key of the Argo Watcher secret, or an arbitrary string under `ARGO_WATCHER_DEPLOY_TOKEN`. Without a valid credential the write-back is skipped, and the deployment fails blaming the image instead ([why](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped)).
+1. **A credential the client can present.** An **application deploy token** (recommended, see [Application deploy tokens](#application-deploy-tokens)), a **JWT** (see [JWT configuration](#jwt-configuration)) stored under the `JWT_SECRET` key of the Argo Watcher secret, or an arbitrary string under `ARGO_WATCHER_DEPLOY_TOKEN`. Without a valid credential the write-back is skipped, and the deployment fails blaming the image instead ([why](../operations/troubleshooting.md#image-tag-is-never-committed-write-back-skipped)).
 2. **An SSH key with write access** to the GitOps repository, stored in a Kubernetes secret (the chart reads the `sshPrivateKey` key by default).
 3. **Chart values pointing at that key:**
 
@@ -96,6 +96,56 @@ extraEnvs:
 
 The available fields are the same ones the [notification templates](notifications.md#template-variables) use.
 
+## Application deploy tokens
+
+An application deploy token is an opaque credential scoped to the applications it may deploy, issued and revoked from the Web UI. It is the recommended credential: unlike the shared deploy token it can be withdrawn individually, and unlike a JWT its scope is decided by the server rather than asserted by whoever mints it.
+
+### Requirements
+
+| Requirement | Why |
+|---|---|
+| `OIDC_ENABLED=true` | Issuing and revoking a token needs a privileged session, and honouring tokens an operator cannot enumerate or withdraw is the wrong default. Turning OIDC off stops the tokens working. |
+| `STATE_TYPE=postgres` | A token outlives the process holding it and must be honoured by every replica. There is no in-memory equivalent. |
+| Membership of `OIDC_PRIVILEGED_GROUPS` | Issuing, listing and revoking all require it. The list names who holds a credential for which applications, so reading it is as restricted as writing it. |
+
+Where either of the first two is missing, a presented token is rejected `401` naming the setting at fault, rather than being ignored — a pipeline holding one is told why instead of watching its write-back get skipped.
+
+### Issuing one
+
+Open **Workspace Controls → Deploy Tokens → Manage**, then **Issue token**. A token is scoped to either:
+
+- **a list of applications** — the usual choice, one token per pipeline; or
+- **all applications** — the wildcard, covering every application present and future. This is the revocable, attributable equivalent of `ARGO_WATCHER_DEPLOY_TOKEN`.
+
+An optional expiry and a description round it out. The description is what the list shows, so name the pipeline that holds the token.
+
+!!! warning
+    The token is displayed **once**, in the dialog that creates it. Only its SHA-256 is stored, so a lost token cannot be recovered — revoke it and issue a new one.
+
+### Using one
+
+The token rides the same variable as a JWT, so nothing else in a pipeline changes:
+
+```bash
+export BEARER_TOKEN="awt_..."
+```
+
+The server routes on the `awt_` prefix every token carries, and hands anything else to the JWT parser. `Authorization` is deliberately the header it travels in: Go's HTTP client strips that header when a redirect crosses to another host, which it does not do for a custom one.
+
+### Revoking one
+
+**Revoke** in the same table. It takes effect on the token's next use — there is no cache to wait out. The row stays, so the record of who issued the token and when it was withdrawn survives.
+
+### Choosing between the three credentials
+
+| | Application deploy token | JWT | Shared deploy token |
+|---|---|---|---|
+| Scope | set by the server at issue time | asserted by the minter via `allowed_apps` | every application |
+| Revocable individually | yes, immediately | no, not before `exp` | no |
+| Attributed to an issuer | yes | no | no |
+| Needs OIDC + Postgres | yes | no | no |
+| Survives a leak of the signing secret | n/a — there is none | no, rotate `JWT_SECRET` | no, rotate the token |
+
 ## JWT configuration
 
 JWT is the recommended credential: unlike the shared deploy token, each pipeline can hold its own, with an expiry.
@@ -132,7 +182,13 @@ openssl rand -base64 32
 | `aud` | Only if `JWT_AUDIENCE` is set | A list matches when it contains the configured value. |
 | `sub` | No | Informational — service or team name. |
 | `cluster` | No | Informational. |
-| `allowed_apps` | No | **Not enforced yet.** Per-application restriction is planned; today any valid token authorizes any application. |
+| `allowed_apps` | When present | A list of application names the token may deploy. **A token omitting the claim still authorizes every application**, so an existing fleet is unaffected; one that carries it is confined to what it names. See the caveat below. |
+
+
+!!! warning "`allowed_apps` is a self-restriction, not a boundary"
+    The claim is written by whoever mints the token, so anyone holding `JWT_SECRET` can name any application. It limits the blast radius of a **minted token** leaking out of one pipeline; it is no defence against the secret itself leaking, for which only rotation helps. Where you need a scope the holder cannot assert, use an [application deploy token](#application-deploy-tokens) — its scope is a server-side column.
+
+    Setting the claim on a token that previously relied on it being ignored will now confine that token. Check your pipelines before rolling it out.
 
 ### Binding a token to this server
 
@@ -163,8 +219,9 @@ Add `"iss"` and `"aud"` to the payload when the server is configured to require 
 Pass the credential to the client:
 
 ```bash
-# JWT (recommended). The raw token, with no "Bearer " prefix, so CI can mask it.
-export BEARER_TOKEN="your_jwt_token"
+# An application deploy token (recommended) or a JWT. The raw token, with no
+# "Bearer " prefix, so CI can mask it.
+export BEARER_TOKEN="awt_your_application_deploy_token"
 
 # Or the deploy token
 export ARGO_WATCHER_DEPLOY_TOKEN=your_deploy_token

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -122,13 +122,14 @@ Enabling OIDC closes the endpoints only the Web UI consumes, so no pipeline is a
 | `GET /api/v1/reachability` | Credential required |
 | `GET /api/v1/deploy-lock` | Credential required |
 | `POST`/`DELETE /api/v1/deploy-lock` | Credential required **and** privileged group |
+| `/api/v1/app-tokens`, `/api/v1/app-tokens/{id}` | Credential required **and** privileged group; registered only with `STATE_TYPE=postgres` |
 | `/ws` | Credential required — as a subprotocol from a browser ([why](#the-websocket-handshake)) |
 | `POST /api/v1/tasks` | Unchanged — optional credential, which governs the git write-back |
 | `GET /api/v1/tasks/{id}` | **Open** unless `OIDC_REQUIRE_TASK_READ_AUTH=true` ([below](#closing-the-task-lookup)) |
 | `GET /api/v1/config` | **Open** — the Web UI reads the issuer and client id from it before it can hold a token |
 | `/livez`, `/readyz`, `/metrics` | **Open** — probes and Prometheus cannot perform an OIDC flow |
 
-Any configured credential is accepted on a read: an OIDC session, the `ARGO_WATCHER_DEPLOY_TOKEN`, or a [JWT](gitops-updater.md#jwt-configuration). Read access is deliberately **not** limited to `OIDC_PRIVILEGED_GROUPS` — that gate covers the deploy lock only.
+Any configured credential is accepted on a read: an OIDC session, the `ARGO_WATCHER_DEPLOY_TOKEN`, a [JWT](gitops-updater.md#jwt-configuration), or an [application deploy token](gitops-updater.md#application-deploy-tokens) of any scope. Read access is deliberately **not** limited to `OIDC_PRIVILEGED_GROUPS` — that gate covers the deploy lock and the token endpoints.
 
 !!! warning "`GET /api/v1/tasks/{id}` is open by default"
     The client polls this endpoint for the whole length of every deployment, so requiring a credential rejects any client too old to send one. The task id is a random v4 UUID handed only to the submitter, and the enumerable `GET /api/v1/tasks` list is protected — but anyone holding a task id (from a CI log or a webhook payload) can read that task's app, author, project, images and status. The `unauthenticated_reads` metric counts such reads; see [Tracking the read-auth migration](../operations/observability.md#tracking-the-read-auth-migration).

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -93,6 +93,9 @@ The server warning and the counter are what identify the credential as the cause
 
 - The pipeline sets neither `ARGO_WATCHER_DEPLOY_TOKEN` nor `BEARER_TOKEN`.
 - The value does not match the server's `ARGO_WATCHER_DEPLOY_TOKEN` or `JWT_SECRET`.
+- The credential is scoped to other applications. An [application deploy token](../guides/gitops-updater.md#application-deploy-tokens), and a JWT carrying `allowed_apps`, is rejected `401` for an application it does not name — so this shows up as a failed submission, not a skipped write-back.
+- The application deploy token was revoked or has expired. Both are reported `401` naming which.
+- Application deploy tokens are not available on this server: they need `OIDC_ENABLED=true` and `STATE_TYPE=postgres`, and a token presented without both is rejected `401` naming the missing setting.
 - The server sets `JWT_ISSUER` or `JWT_AUDIENCE` and the token carries no such claim, or a different value. Both are strict once set — see [Binding a token to this server](../guides/gitops-updater.md#binding-a-token-to-this-server).
 - **Something redirects the client to a different host**, and a credential does not survive that hop. The two behave differently:
     - `Authorization` (`BEARER_TOKEN`) is stripped by Go's HTTP client on every client version, but only when the *hostname* changes. A port-only change (`host:8080` → `host:9090`) keeps it, and so does a move to a subdomain (`example.com` → `sub.example.com`). A sibling host does not: `watcher.example.com` → `watcher.int.example.com` drops it.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -47,9 +47,12 @@ A credential does two things: it authorizes the [GitOps updater](../guides/gitop
 
 | Credential | How to send it |
 |---|---|
+| Application deploy token | `Authorization: <token>` (raw; `Bearer <token>` also accepted) |
 | Deploy token | `ARGO_WATCHER_DEPLOY_TOKEN: <token>` |
 | JWT | `Authorization: <token>` (raw; `Bearer <token>` also accepted) |
 | OIDC session | `Oidc-Authorization: <access token>` |
+
+An application deploy token and a JWT share the `Authorization` header. The server tells them apart by the `awt_` prefix an application deploy token always carries, so a client needs no configuration to send either.
 
 ### Reads
 
@@ -64,6 +67,7 @@ With OIDC **enabled**, the endpoints the Web UI consumes require one, group memb
 - **With a valid credential** the task is authorized: the git write-back runs, and the task can supersede an in-flight deployment of the same images.
 - **Without one** the task is still accepted (`202`) and monitored normally — the expected setup when image tags are committed elsewhere (Argo CD Image Updater, your pipeline). The write-back is skipped, and it cannot cancel a deployment that did present a credential.
 - **With an invalid or expired one** the request is rejected `401`.
+- **With a credential scoped to other applications** the request is rejected `401`. An application deploy token, and a JWT carrying `allowed_apps`, authorize only the applications they name.
 
 Because the endpoint is open, its payload is bounded: at most 50 images per task, no name longer than 255 characters, and a `timeout` above 86400 seconds is clamped to it. That cap is what limits how long one request keeps the watcher polling Argo CD — a task still being monitored is not given up on by the staleness sweep.
 
@@ -74,6 +78,14 @@ An unauthorized task on an application that relies on the built-in updater fails
 `POST` and `DELETE /api/v1/deploy-lock` are **registered only when OIDC is enabled**, and require a session in one of the `OIDC_PRIVILEGED_GROUPS`. With OIDC disabled they are not routes at all: the request falls through to the Web UI's catch-all and answers `200 OK` with an HTML body. Check the `Content-Type`, not the status code, to tell "not exposed" from a successful call.
 
 `GET /api/v1/deploy-lock` needs no privileged group, but with OIDC enabled it needs a credential like every other read.
+
+### Managing application deploy tokens
+
+`GET`, `POST /api/v1/app-tokens` and `DELETE /api/v1/app-tokens/{id}` are **registered only when OIDC is enabled and `STATE_TYPE=postgres`**, and each requires a session in one of the `OIDC_PRIVILEGED_GROUPS` — listing tokens included, since the list names who holds a credential for which applications. As with the deploy lock, an unregistered route falls through to the Web UI's catch-all: check the `Content-Type`.
+
+`POST` takes a scope of either `apps` (a list of application names) or `all_apps: true` (a wildcard), never both, plus an optional `description` and `expires_in_days`. It answers `201` with the token's `secret` — the only time that value exists anywhere. `406` means the scope or the payload was refused.
+
+`DELETE` revokes a token, effective on its next use. The row is kept, so who issued it and when it was withdrawn stay on record.
 
 ## Health and probe endpoints
 

--- a/docs/reference/client-env.md
+++ b/docs/reference/client-env.md
@@ -17,7 +17,7 @@ The client is a small CLI shipped as [`ghcr.io/shini4i/argo-watcher-client`](htt
 
 | Variable | Description | Default |
 |---|---|---|
-| `BEARER_TOKEN` | JWT authorizing the deployment. Takes precedence over `ARGO_WATCHER_DEPLOY_TOKEN`. | |
+| `BEARER_TOKEN` | An application deploy token or a JWT authorizing the deployment. Takes precedence over `ARGO_WATCHER_DEPLOY_TOKEN`. | |
 | `ARGO_WATCHER_DEPLOY_TOKEN` | Shared deploy token, the alternative to a JWT | |
 | `TIMEOUT` | Per-request HTTP timeout | `60s` |
 | `RETRY_INTERVAL` | Wait between status polls | `15s` |

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -45,10 +45,12 @@ The chart mounts its persistent volume at `REPO_CACHE_PATH`; change one and you 
 | `OIDC_ENABLED` | Enable OIDC authentication | `false` | No |
 | `OIDC_ISSUER_URL` | Provider issuer URL, used for discovery | | When OIDC is on |
 | `OIDC_CLIENT_ID` | Client id registered with the provider | | When OIDC is on |
-| `OIDC_PRIVILEGED_GROUPS` | Groups allowed to roll back a task and manage the deploy lock | | No |
+| `OIDC_PRIVILEGED_GROUPS` | Groups allowed to roll back a task, manage the deploy lock, and issue or revoke application deploy tokens | | No |
 | `OIDC_TOKEN_VALIDATION_INTERVAL` | How long (ms) a provider decision may be reused | `300000` | No |
 | `OIDC_REQUIRE_TASK_READ_AUTH` | Require a credential on `GET /api/v1/tasks/{id}` too | `false` | No |
 | `OIDC_GRAVATAR_FALLBACK` | Let the account card fall back to Gravatar when the provider sends no `picture` claim | `false` | No |
+
+[Application deploy tokens](../guides/gitops-updater.md#application-deploy-tokens) have no variable of their own: they are enabled by `OIDC_ENABLED=true` together with `STATE_TYPE=postgres`, and refused by name when either is missing.
 
 `JWT_ISSUER` and `JWT_AUDIENCE` are enforced strictly once set: a token that omits the claim is rejected, so every pipeline must mint it *before* the variable is configured — see [JWT configuration](../guides/gitops-updater.md#jwt-configuration).
 

--- a/internal/apptoken/postgres.go
+++ b/internal/apptoken/postgres.go
@@ -11,6 +11,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// whereID is the predicate every by-id statement in this store shares.
+const whereID = "id = ?"
+
 // tokenRow is the app_tokens table. It stays unexported: the scope is two columns
 // on the wire and one Scope everywhere else, and nothing outside this file should
 // have to know which.
@@ -134,7 +137,7 @@ func (s *PostgresStore) List() ([]Token, error) {
 // no-op from an unknown id needs the follow-up existence check.
 func (s *PostgresStore) Revoke(id uuid.UUID) error {
 	result := s.db.Model(&tokenRow{}).
-		Where("id = ?", id).
+		Where(whereID, id).
 		Where("revoked_at IS NULL").
 		Update("revoked_at", time.Now())
 
@@ -146,7 +149,7 @@ func (s *PostgresStore) Revoke(id uuid.UUID) error {
 	}
 
 	var count int64
-	if err := s.db.Model(&tokenRow{}).Where("id = ?", id).Count(&count).Error; err != nil {
+	if err := s.db.Model(&tokenRow{}).Where(whereID, id).Count(&count).Error; err != nil {
 		return fmt.Errorf("failed to confirm the application deploy token exists: %w", err)
 	}
 	if count == 0 {
@@ -159,7 +162,7 @@ func (s *PostgresStore) Revoke(id uuid.UUID) error {
 // MarkUsed records that the token authorized a deployment. A failure here must not
 // fail the deployment, so callers log it and carry on; it is bookkeeping.
 func (s *PostgresStore) MarkUsed(id uuid.UUID) error {
-	if err := s.db.Model(&tokenRow{}).Where("id = ?", id).Update("last_used_at", time.Now()).Error; err != nil {
+	if err := s.db.Model(&tokenRow{}).Where(whereID, id).Update("last_used_at", time.Now()).Error; err != nil {
 		return fmt.Errorf("failed to record use of the application deploy token: %w", err)
 	}
 

--- a/internal/apptoken/postgres.go
+++ b/internal/apptoken/postgres.go
@@ -1,0 +1,172 @@
+package apptoken
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// tokenRow is the app_tokens table. It stays unexported: the scope is two columns
+// on the wire and one Scope everywhere else, and nothing outside this file should
+// have to know which.
+type tokenRow struct {
+	Id          uuid.UUID                   `gorm:"column:id;type:uuid;not null;default:gen_random_uuid();"`
+	TokenHash   []byte                      `gorm:"column:token_hash;not null;uniqueIndex;"`
+	Apps        datatypes.JSONSlice[string] `gorm:"column:apps;type:jsonb;not null;"`
+	AllApps     bool                        `gorm:"column:all_apps;not null;default:false;"`
+	Hint        string                      `gorm:"column:hint;not null;"`
+	Description string                      `gorm:"column:description;not null;default:'';"`
+	CreatedBy   string                      `gorm:"column:created_by;not null;"`
+	CreatedAt   time.Time                   `gorm:"column:created_at;autoCreateTime;not null;"`
+	ExpiresAt   sql.NullTime                `gorm:"column:expires_at;"`
+	RevokedAt   sql.NullTime                `gorm:"column:revoked_at;"`
+	LastUsedAt  sql.NullTime                `gorm:"column:last_used_at;"`
+}
+
+func (tokenRow) TableName() string {
+	return "app_tokens"
+}
+
+// toToken maps the row onto the metadata callers work with.
+func (row *tokenRow) toToken() Token {
+	return Token{
+		Id:          row.Id,
+		Scope:       Scope{Apps: row.Apps, AllApps: row.AllApps},
+		Hint:        row.Hint,
+		Description: row.Description,
+		CreatedBy:   row.CreatedBy,
+		CreatedAt:   row.CreatedAt,
+		ExpiresAt:   row.ExpiresAt.Time,
+		RevokedAt:   row.RevokedAt.Time,
+		LastUsedAt:  row.LastUsedAt.Time,
+	}
+}
+
+// PostgresStore persists application deploy tokens in Postgres, so a token issued
+// through one replica is honored by all of them and revoking it takes effect
+// everywhere on the next request.
+type PostgresStore struct {
+	db *gorm.DB
+}
+
+// NewPostgresStore creates a Store backed by the given database handle.
+func NewPostgresStore(db *gorm.DB) Store {
+	return &PostgresStore{db: db}
+}
+
+// Issue mints a token and stores everything about it except the secret.
+func (s *PostgresStore) Issue(scope Scope, description, createdBy string, expiresAt time.Time) (*IssuedToken, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
+	credential, err := NewCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	// A nil slice would marshal to JSON null rather than an empty array, and the
+	// scope CHECK evaluates to NULL against that instead of failing.
+	apps := scope.Apps
+	if apps == nil {
+		apps = []string{}
+	}
+
+	row := tokenRow{
+		TokenHash:   credential.Hash,
+		Apps:        datatypes.NewJSONSlice(apps),
+		AllApps:     scope.AllApps,
+		Hint:        credential.Hint,
+		Description: description,
+		CreatedBy:   createdBy,
+		ExpiresAt:   nullTime(expiresAt),
+	}
+
+	if err := s.db.Create(&row).Error; err != nil {
+		return nil, fmt.Errorf("failed to store the application deploy token: %w", err)
+	}
+
+	return &IssuedToken{Token: row.toToken(), Secret: credential.Secret}, nil
+}
+
+// Lookup finds a token by the digest of the presented secret, one indexed read.
+// No constant-time comparison is needed: there is no stored secret to compare
+// against, only a digest a caller cannot reach without already holding 256 bits
+// of the right value.
+func (s *PostgresStore) Lookup(secret string) (*Token, error) {
+	var row tokenRow
+
+	err := s.db.Where("token_hash = ?", Hash(secret)).Take(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up the application deploy token: %w", err)
+	}
+
+	token := row.toToken()
+	return &token, nil
+}
+
+// List returns every token, newest first.
+func (s *PostgresStore) List() ([]Token, error) {
+	var rows []tokenRow
+
+	if err := s.db.Order("created_at DESC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to list application deploy tokens: %w", err)
+	}
+
+	tokens := make([]Token, 0, len(rows))
+	for index := range rows {
+		tokens = append(tokens, rows[index].toToken())
+	}
+
+	return tokens, nil
+}
+
+// Revoke withdraws a token. The revoked_at guard makes a second revocation a
+// no-op rather than rewriting when the first one happened, and distinguishing that
+// no-op from an unknown id needs the follow-up existence check.
+func (s *PostgresStore) Revoke(id uuid.UUID) error {
+	result := s.db.Model(&tokenRow{}).
+		Where("id = ?", id).
+		Where("revoked_at IS NULL").
+		Update("revoked_at", time.Now())
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to revoke the application deploy token: %w", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		return nil
+	}
+
+	var count int64
+	if err := s.db.Model(&tokenRow{}).Where("id = ?", id).Count(&count).Error; err != nil {
+		return fmt.Errorf("failed to confirm the application deploy token exists: %w", err)
+	}
+	if count == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// MarkUsed records that the token authorized a deployment. A failure here must not
+// fail the deployment, so callers log it and carry on; it is bookkeeping.
+func (s *PostgresStore) MarkUsed(id uuid.UUID) error {
+	if err := s.db.Model(&tokenRow{}).Where("id = ?", id).Update("last_used_at", time.Now()).Error; err != nil {
+		return fmt.Errorf("failed to record use of the application deploy token: %w", err)
+	}
+
+	return nil
+}
+
+// nullTime renders a zero time as SQL NULL, which is how "no expiry" is stored.
+func nullTime(value time.Time) sql.NullTime {
+	return sql.NullTime{Time: value, Valid: !value.IsZero()}
+}

--- a/internal/apptoken/postgres_test.go
+++ b/internal/apptoken/postgres_test.go
@@ -1,0 +1,349 @@
+package apptoken
+
+import (
+	"encoding/hex"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newTestStore connects to the migrated test database, skipped unless
+// POSTGRES_DSN is set (migrations applied by task ci-migrate). Each test starts
+// and ends with an empty table, so a run leaves no working credential behind.
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode.")
+	}
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("POSTGRES_DSN environment variable not set. Skipping integration test.")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	truncate := func() { require.NoError(t, db.Exec("DELETE FROM app_tokens").Error) }
+	truncate()
+	t.Cleanup(truncate)
+
+	return db
+}
+
+func newTestStore(t *testing.T) Store {
+	t.Helper()
+	return NewPostgresStore(newTestDB(t))
+}
+
+func TestPostgresStoreIssueAndLookup(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{Apps: []string{"app1", "app2"}}, "ci pipeline", "alice", time.Time{})
+	require.NoError(t, err)
+
+	assert.True(t, HasPrefix(issued.Secret))
+	assert.Equal(t, issued.Secret[len(issued.Secret)-hintLength:], issued.Hint)
+	assert.Equal(t, "alice", issued.CreatedBy)
+	assert.Equal(t, "ci pipeline", issued.Description)
+	assert.Equal(t, []string{"app1", "app2"}, issued.Scope.Apps)
+	assert.False(t, issued.Scope.AllApps)
+	assert.NotEqual(t, uuid.Nil, issued.Id)
+	assert.False(t, issued.CreatedAt.IsZero())
+	assert.True(t, issued.ExpiresAt.IsZero(), "no expiry was requested")
+
+	found, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+
+	assert.Equal(t, issued.Id, found.Id)
+	assert.Equal(t, []string{"app1", "app2"}, found.Scope.Apps)
+	assert.True(t, found.Usable(time.Now()))
+	assert.True(t, found.Scope.Allows("app1"))
+	assert.False(t, found.Scope.Allows("app3"))
+}
+
+func TestPostgresStoreIssueWildcard(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{AllApps: true}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	found, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+
+	assert.True(t, found.Scope.AllApps)
+	assert.Empty(t, found.Scope.Apps)
+	assert.True(t, found.Scope.Allows("any-application-at-all"))
+}
+
+func TestPostgresStoreIssueRejectsAnUnstorableScope(t *testing.T) {
+	store := newTestStore(t)
+
+	_, err := store.Issue(Scope{}, "", "alice", time.Time{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one application or to all of them")
+}
+
+func TestPostgresStoreIssuePersistsAnExpiry(t *testing.T) {
+	store := newTestStore(t)
+	expiry := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+
+	issued, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", expiry)
+	require.NoError(t, err)
+
+	found, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+
+	assert.WithinDuration(t, expiry, found.ExpiresAt, time.Second)
+	assert.True(t, found.Usable(time.Now()))
+	assert.False(t, found.Usable(expiry.Add(time.Second)))
+}
+
+func TestPostgresStoreLookupUnknownSecret(t *testing.T) {
+	store := newTestStore(t)
+
+	_, err := store.Lookup("awt_thisWasNeverIssued")
+
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestPostgresStoreLookupReturnsARevokedToken(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+	require.NoError(t, store.Revoke(issued.Id))
+
+	// A revoked token is still found, so the holder can be told it was withdrawn
+	// rather than that it never existed.
+	found, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+
+	assert.False(t, found.RevokedAt.IsZero())
+	assert.False(t, found.Usable(time.Now()))
+}
+
+func TestPostgresStoreRevoke(t *testing.T) {
+	store := newTestStore(t)
+
+	t.Run("reports an unknown id", func(t *testing.T) {
+		require.ErrorIs(t, store.Revoke(uuid.New()), ErrNotFound)
+	})
+
+	t.Run("revoking twice keeps the first revocation time", func(t *testing.T) {
+		issued, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+		require.NoError(t, err)
+
+		require.NoError(t, store.Revoke(issued.Id))
+		first, err := store.Lookup(issued.Secret)
+		require.NoError(t, err)
+
+		require.NoError(t, store.Revoke(issued.Id))
+		second, err := store.Lookup(issued.Secret)
+		require.NoError(t, err)
+
+		assert.Equal(t, first.RevokedAt, second.RevokedAt)
+	})
+}
+
+func TestPostgresStoreList(t *testing.T) {
+	store := newTestStore(t)
+
+	older, err := store.Issue(Scope{Apps: []string{"app1"}}, "older", "alice", time.Time{})
+	require.NoError(t, err)
+	newer, err := store.Issue(Scope{AllApps: true}, "newer", "bob", time.Time{})
+	require.NoError(t, err)
+	require.NoError(t, store.Revoke(older.Id))
+
+	tokens, err := store.List()
+	require.NoError(t, err)
+
+	require.Len(t, tokens, 2)
+	assert.Equal(t, newer.Id, tokens[0].Id, "the newest token comes first")
+	assert.Equal(t, older.Id, tokens[1].Id)
+	assert.False(t, tokens[1].RevokedAt.IsZero(), "a revoked token stays on the list")
+
+	// The store cannot return a secret -- Token has no such field -- so assert the
+	// contract Hint does have. The secret-leak guard lives at the API boundary.
+	for index, token := range tokens {
+		assert.Len(t, token.Hint, hintLength, "row %d", index)
+	}
+	assert.Equal(t, newer.Hint, tokens[0].Hint)
+	assert.Equal(t, older.Hint, tokens[1].Hint)
+}
+
+func TestPostgresStoreMarkUsed(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+	require.True(t, issued.LastUsedAt.IsZero())
+
+	require.NoError(t, store.MarkUsed(issued.Id))
+
+	found, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+	assert.False(t, found.LastUsedAt.IsZero())
+}
+
+func TestPostgresStoreIssueProducesDistinctTokens(t *testing.T) {
+	store := newTestStore(t)
+
+	first, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+	second, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first.Secret, second.Secret)
+	assert.NotEqual(t, first.Id, second.Id)
+
+	found, err := store.Lookup(first.Secret)
+	require.NoError(t, err)
+	assert.Equal(t, first.Id, found.Id)
+}
+
+func TestAppTokensScopeConstraint(t *testing.T) {
+	db := newTestDB(t)
+
+	// The hash travels as hex because gorm expands a []byte argument into a list of
+	// values, which makes the statement itself malformed.
+	insert := func(label, apps string, allApps bool) error {
+		return db.Exec(`
+			INSERT INTO app_tokens (token_hash, apps, all_apps, hint, created_by)
+			VALUES (decode(?, 'hex'), CAST(? AS jsonb), ?, 'aaaa', 'test')`,
+			hex.EncodeToString(Hash(label)), apps, allApps).Error
+	}
+
+	t.Run("accepts a wildcard with an empty array", func(t *testing.T) {
+		require.NoError(t, insert("wildcard", `[]`, true))
+	})
+
+	t.Run("accepts a list without the wildcard", func(t *testing.T) {
+		require.NoError(t, insert("scoped", `["app1"]`, false))
+	})
+
+	rejected := []struct {
+		name    string
+		apps    string
+		allApps bool
+	}{
+		{name: "a wildcard that also lists applications", apps: `["app1"]`, allApps: true},
+		{name: "neither a wildcard nor a list", apps: `[]`, allApps: false},
+		// JSON null would make jsonb_array_length return SQL NULL, and a CHECK
+		// evaluating to NULL passes — jsonb_typeof is what closes that hole.
+		{name: "JSON null instead of an array", apps: `null`, allApps: true},
+		{name: "an object instead of an array", apps: `{"app":"app1"}`, allApps: true},
+	}
+
+	for _, test := range rejected {
+		t.Run("refuses "+test.name, func(t *testing.T) {
+			err := insert(test.name, test.apps, test.allApps)
+
+			// Naming the constraint keeps a malformed statement from passing as a
+			// refusal, which is what hid a broken cast in this test once already.
+			require.ErrorContains(t, err, "app_tokens_scope_exclusive")
+		})
+	}
+}
+
+// TestAppTokensHashIsUnique pins the UNIQUE index on token_hash, which is what makes
+// Lookup's single indexed Take() deterministic: a duplicate row would leave which
+// token a secret resolves to up to the planner.
+func TestAppTokensHashIsUnique(t *testing.T) {
+	db := newTestDB(t)
+
+	insert := func() error {
+		return db.Exec(`
+			INSERT INTO app_tokens (token_hash, apps, all_apps, hint, created_by)
+			VALUES (decode(?, 'hex'), CAST('["app1"]' AS jsonb), false, 'aaaa', 'test')`,
+			hex.EncodeToString(Hash("awt_collision"))).Error
+	}
+
+	require.NoError(t, insert())
+
+	// Naming the index keeps a malformed statement from passing as a refusal.
+	require.ErrorContains(t, insert(), "app_tokens_token_hash_key")
+}
+
+// TestPostgresStoreRevokeIsSafeUnderContention pins Revoke's non-atomic
+// UPDATE-then-existence-check. Two operators reacting to the same leaked credential
+// must both be told it worked, and the first revocation time must stand.
+func TestPostgresStoreRevokeIsSafeUnderContention(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	const racers = 8
+	errs := make([]error, racers)
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for i := range racers {
+		go func(index int) {
+			defer wg.Done()
+			errs[index] = store.Revoke(issued.Id)
+		}(i)
+	}
+	wg.Wait()
+
+	for index, err := range errs {
+		// The loser of the race must not be told the token does not exist.
+		assert.NoError(t, err, "racer %d", index)
+	}
+
+	revoked, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+	require.False(t, revoked.RevokedAt.IsZero())
+	assert.False(t, revoked.Usable(time.Now()))
+
+	// A later revocation is a no-op that keeps the original instant.
+	require.NoError(t, store.Revoke(issued.Id))
+	again, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+	assert.Equal(t, revoked.RevokedAt, again.RevokedAt)
+}
+
+// TestPostgresStoreConcurrentRevokeAndUse covers the pair that genuinely races in
+// production: a revocation landing while the token is authorizing a deployment.
+func TestPostgresStoreConcurrentRevokeAndUse(t *testing.T) {
+	store := newTestStore(t)
+
+	issued, err := store.Issue(Scope{AllApps: true}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var revokeErr, markErr error
+	wg.Add(2)
+	go func() { defer wg.Done(); revokeErr = store.Revoke(issued.Id) }()
+	go func() { defer wg.Done(); markErr = store.MarkUsed(issued.Id) }()
+	wg.Wait()
+
+	assert.NoError(t, revokeErr)
+	assert.NoError(t, markErr)
+
+	stored, err := store.Lookup(issued.Secret)
+	require.NoError(t, err)
+	assert.False(t, stored.RevokedAt.IsZero(), "revocation must survive a concurrent use")
+	assert.False(t, stored.Usable(time.Now()))
+}
+
+// TestPostgresStoreMarkUsedOnAnUnknownId pins the documented contract: bookkeeping
+// for a row that is gone is not an error, because a failure here must never fail a
+// deployment.
+func TestPostgresStoreMarkUsedOnAnUnknownId(t *testing.T) {
+	store := newTestStore(t)
+
+	assert.NoError(t, store.MarkUsed(uuid.New()))
+}

--- a/internal/apptoken/store.go
+++ b/internal/apptoken/store.go
@@ -1,0 +1,45 @@
+package apptoken
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IssuedToken is the result of minting a token: the stored metadata, plus the
+// Secret, which exists in clear only here and in the response built from it.
+type IssuedToken struct {
+	Token
+	Secret string
+}
+
+// Store persists application deploy tokens. There is deliberately no in-memory
+// implementation: a token outlives the process holding it, so an in-memory store
+// would revoke every token on restart and never agree between replicas. The
+// feature is therefore available only with STATE_TYPE=postgres.
+type Store interface {
+	// Issue mints a token for the given scope. The scope is validated and
+	// normalized first, so a caller cannot store one that matches nothing. A zero
+	// expiresAt means the token never expires.
+	Issue(scope Scope, description, createdBy string, expiresAt time.Time) (*IssuedToken, error)
+
+	// Lookup finds the token a secret belongs to, returning ErrNotFound when none
+	// does. It returns revoked and expired tokens too, so the caller can tell an
+	// operator that their token was withdrawn rather than that it never existed;
+	// callers must gate on Token.Usable before granting anything.
+	Lookup(secret string) (*Token, error)
+
+	// List returns every token, newest first, including revoked ones — the record
+	// of what was withdrawn is part of what the list is for.
+	List() ([]Token, error)
+
+	// Revoke withdraws a token, keeping its row. Revoking an already-revoked token
+	// succeeds without moving the original revocation time. It reports ErrNotFound
+	// when no token has that id.
+	Revoke(id uuid.UUID) error
+
+	// MarkUsed records that the token authorized a deployment just now. An id that no
+	// longer exists is not an error: this is bookkeeping, and it must never be able to
+	// fail a deployment.
+	MarkUsed(id uuid.UUID) error
+}

--- a/internal/apptoken/token.go
+++ b/internal/apptoken/token.go
@@ -1,0 +1,197 @@
+// Package apptoken issues and validates application deploy tokens: opaque,
+// revocable credentials authorizing a git write-back for a named set of
+// applications. A token carries no claims — scope, expiry and revocation live in
+// the row keyed by its hash, so revoking one takes effect on the next request.
+package apptoken
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Prefix marks a string as an application deploy token. It is what lets a single
+// Authorization header carry either credential: the server routes on this prefix
+// and hands anything else to the JWT parser. It is also the pattern a secret
+// scanner registers, so a token pasted into a repository can be detected.
+const Prefix = "awt_"
+
+// secretBytes is the entropy behind a token. 256 bits leaves nothing to
+// brute-force, which is why the stored hash is a plain SHA-256 rather than a
+// password KDF: there is no low-entropy secret for a KDF to protect.
+const secretBytes = 32
+
+// hintLength is how many trailing characters of a token are stored in clear, so
+// the UI can identify a token it can never show again.
+const hintLength = 4
+
+// MaxApps caps an explicit application list. A token meant for more applications
+// than this is really an all-apps token, and saying so is more honest than a list
+// nobody reads. It mirrors models.MaxTaskImages in intent: a sanity bound on a
+// field that is read back on every request.
+const MaxApps = 200
+
+// MaxAppNameLength bounds a single entry of the application list. It matches
+// models.MaxTaskFieldLength, since the entries are compared against a task's
+// application name.
+const MaxAppNameLength = 255
+
+// ErrNotFound reports that no token matches the presented secret. Callers must
+// treat it as a rejection, never as a backend failure.
+var ErrNotFound = errors.New("application deploy token not found")
+
+// Scope names the applications a token authorizes. AllApps and a non-empty Apps
+// are mutually exclusive — the database rejects the combination — because a token
+// that is both bounded and unbounded has no meaning.
+type Scope struct {
+	// Apps is the explicit list of application names, empty when AllApps is set.
+	Apps []string
+	// AllApps authorizes every application. It is a distinct field rather than a
+	// wildcard entry in Apps so that granting the whole estate cannot be the
+	// accidental result of building the list wrongly.
+	AllApps bool
+}
+
+// Allows reports whether the scope covers the named application. Comparison is
+// exact: application names are Kubernetes object names, which are already
+// lowercase, so case folding would only widen the scope beyond what was granted.
+func (s Scope) Allows(app string) bool {
+	if s.AllApps {
+		return true
+	}
+
+	return slices.Contains(s.Apps, app)
+}
+
+// String renders the scope for logs and error messages.
+func (s Scope) String() string {
+	if s.AllApps {
+		return "all applications"
+	}
+
+	return strings.Join(s.Apps, ", ")
+}
+
+// Validate normalizes the scope and reports why it cannot be stored. It trims and
+// deduplicates the application list, so the same scope always round-trips to the
+// same row and Allows cannot be defeated by stray whitespace.
+func (s *Scope) Validate() error {
+	if s.AllApps {
+		if len(s.Apps) > 0 {
+			return errors.New("a token scoped to all applications must not also list applications")
+		}
+		s.Apps = nil
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(s.Apps))
+	normalized := make([]string, 0, len(s.Apps))
+
+	for _, app := range s.Apps {
+		app = strings.TrimSpace(app)
+		if app == "" {
+			return errors.New("an application name must not be empty")
+		}
+		if len(app) > MaxAppNameLength {
+			return fmt.Errorf("an application name must be at most %d characters", MaxAppNameLength)
+		}
+		if _, duplicate := seen[app]; duplicate {
+			continue
+		}
+		seen[app] = struct{}{}
+		normalized = append(normalized, app)
+	}
+
+	if len(normalized) == 0 {
+		return errors.New("a token must be scoped either to at least one application or to all of them")
+	}
+	if len(normalized) > MaxApps {
+		return fmt.Errorf("a token must not list more than %d applications; scope it to all applications instead", MaxApps)
+	}
+
+	s.Apps = normalized
+	return nil
+}
+
+// Token is a stored token's metadata. The secret itself is never part of it: it
+// exists in clear exactly once, in the response to the request that created it.
+type Token struct {
+	Id          uuid.UUID
+	Scope       Scope
+	Hint        string
+	Description string
+	CreatedBy   string
+	CreatedAt   time.Time
+	// ExpiresAt is zero when the token never expires.
+	ExpiresAt time.Time
+	// RevokedAt is zero while the token is live. A revoked token keeps its row so
+	// the audit trail of who issued it, and when it was withdrawn, survives.
+	RevokedAt time.Time
+	// LastUsedAt is zero until the token authorizes a deployment. It is recorded
+	// only on that path, not on reads, so a polled status endpoint does not turn
+	// every request into a write.
+	LastUsedAt time.Time
+}
+
+// Usable reports whether the token may still authorize anything at the given
+// instant. now is a parameter so the caller decides the clock, which keeps the
+// expiry boundary testable.
+func (t *Token) Usable(now time.Time) bool {
+	if t == nil {
+		return false
+	}
+	if !t.RevokedAt.IsZero() {
+		return false
+	}
+
+	return t.ExpiresAt.IsZero() || now.Before(t.ExpiresAt)
+}
+
+// Credential is a freshly minted token: the Secret to hand to the operator once,
+// and the values stored in its place.
+type Credential struct {
+	// Secret is the only copy of the token. Nothing persists it.
+	Secret string
+	// Hash is the SHA-256 of Secret, the value the token is looked up by.
+	Hash []byte
+	// Hint is the last few characters of Secret, shown by the UI to identify a
+	// token whose secret is gone.
+	Hint string
+}
+
+// NewCredential mints a token from the system CSPRNG.
+func NewCredential() (Credential, error) {
+	buf := make([]byte, secretBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return Credential{}, fmt.Errorf("failed to generate an application deploy token: %w", err)
+	}
+
+	secret := Prefix + base64.RawURLEncoding.EncodeToString(buf)
+
+	return Credential{
+		Secret: secret,
+		Hash:   Hash(secret),
+		Hint:   secret[len(secret)-hintLength:],
+	}, nil
+}
+
+// HasPrefix reports whether the string is shaped like an application deploy
+// token. It is the routing test, not a validity check: a prefixed string still
+// has to match a live row.
+func HasPrefix(token string) bool {
+	return strings.HasPrefix(token, Prefix)
+}
+
+// Hash derives the value a token is stored and looked up by. A plain SHA-256 is
+// the right primitive here — see secretBytes.
+func Hash(token string) []byte {
+	sum := sha256.Sum256([]byte(token))
+	return sum[:]
+}

--- a/internal/apptoken/token_test.go
+++ b/internal/apptoken/token_test.go
@@ -176,3 +176,11 @@ func TestHashIsStable(t *testing.T) {
 	assert.NotEqual(t, Hash("awt_example"), Hash("awt_examplf"))
 	assert.Len(t, Hash("awt_example"), 32)
 }
+
+func TestScopeString(t *testing.T) {
+	// This text reaches the operator in the rejection an out-of-scope token gets.
+	assert.Equal(t, "all applications", Scope{AllApps: true}.String())
+	assert.Equal(t, "app1, app2", Scope{Apps: []string{"app1", "app2"}}.String())
+	assert.Equal(t, "app1", Scope{Apps: []string{"app1"}}.String())
+	assert.Empty(t, Scope{}.String())
+}

--- a/internal/apptoken/token_test.go
+++ b/internal/apptoken/token_test.go
@@ -1,0 +1,178 @@
+package apptoken
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeAllows(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope Scope
+		app   string
+		want  bool
+	}{
+		{name: "wildcard covers any application", scope: Scope{AllApps: true}, app: "anything", want: true},
+		{name: "wildcard covers an empty application name", scope: Scope{AllApps: true}, app: "", want: true},
+		{name: "listed application is covered", scope: Scope{Apps: []string{"app1", "app2"}}, app: "app2", want: true},
+		{name: "unlisted application is not covered", scope: Scope{Apps: []string{"app1"}}, app: "app2", want: false},
+		{name: "empty scope covers nothing", scope: Scope{}, app: "app1", want: false},
+		{name: "comparison is case sensitive", scope: Scope{Apps: []string{"app1"}}, app: "App1", want: false},
+		{name: "a wildcard entry is not a wildcard", scope: Scope{Apps: []string{"*"}}, app: "app1", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.scope.Allows(test.app))
+		})
+	}
+}
+
+func TestScopeValidate(t *testing.T) {
+	t.Run("normalizes an explicit list", func(t *testing.T) {
+		scope := Scope{Apps: []string{" app1 ", "app2", "app1"}}
+
+		require.NoError(t, scope.Validate())
+		assert.Equal(t, []string{"app1", "app2"}, scope.Apps)
+	})
+
+	t.Run("clears the list of a wildcard token", func(t *testing.T) {
+		scope := Scope{AllApps: true}
+
+		require.NoError(t, scope.Validate())
+		assert.Nil(t, scope.Apps)
+	})
+
+	t.Run("accepts the maximum list length", func(t *testing.T) {
+		scope := Scope{Apps: distinctApps(MaxApps)}
+
+		require.NoError(t, scope.Validate())
+		assert.Len(t, scope.Apps, MaxApps)
+	})
+
+	tests := []struct {
+		name  string
+		scope Scope
+		error string
+	}{
+		{
+			name:  "rejects a wildcard that also lists applications",
+			scope: Scope{AllApps: true, Apps: []string{"app1"}},
+			error: "must not also list applications",
+		},
+		{
+			name:  "rejects an empty scope",
+			scope: Scope{},
+			error: "at least one application or to all of them",
+		},
+		{
+			name:  "rejects a scope that is only whitespace",
+			scope: Scope{Apps: []string{"   "}},
+			error: "must not be empty",
+		},
+		{
+			name:  "rejects an oversized application name",
+			scope: Scope{Apps: []string{strings.Repeat("a", MaxAppNameLength+1)}},
+			error: "at most 255 characters",
+		},
+		{
+			name:  "rejects a list longer than the cap",
+			scope: Scope{Apps: distinctApps(MaxApps + 1)},
+			error: "not list more than 200 applications",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.scope.Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.error)
+		})
+	}
+}
+
+// distinctApps builds count distinct application names, so a test of the list cap
+// exercises unique entries rather than reaching it with duplicates that
+// normalization would have collapsed first.
+func distinctApps(count int) []string {
+	apps := make([]string, count)
+	for i := range apps {
+		apps[i] = fmt.Sprintf("app-%d", i)
+	}
+	return apps
+}
+
+func TestTokenUsable(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		token *Token
+		want  bool
+	}{
+		{name: "a nil token is unusable", token: nil, want: false},
+		{name: "a live token without an expiry is usable", token: &Token{}, want: true},
+		{name: "a token expiring later is usable", token: &Token{ExpiresAt: now.Add(time.Minute)}, want: true},
+		{name: "a token expiring now is not usable", token: &Token{ExpiresAt: now}, want: false},
+		{name: "an expired token is not usable", token: &Token{ExpiresAt: now.Add(-time.Second)}, want: false},
+		{name: "a revoked token is not usable", token: &Token{RevokedAt: now.Add(-time.Hour)}, want: false},
+		{
+			name:  "revocation outranks an expiry in the future",
+			token: &Token{ExpiresAt: now.Add(time.Hour), RevokedAt: now.Add(-time.Hour)},
+			want:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.token.Usable(now))
+		})
+	}
+}
+
+func TestNewCredential(t *testing.T) {
+	credential, err := NewCredential()
+	require.NoError(t, err)
+
+	assert.True(t, HasPrefix(credential.Secret), "the secret must carry the routing prefix")
+	assert.Len(t, credential.Secret, len(Prefix)+43, "32 random bytes render as 43 base64url characters")
+	assert.Equal(t, Hash(credential.Secret), credential.Hash)
+	assert.Equal(t, credential.Secret[len(credential.Secret)-hintLength:], credential.Hint)
+	assert.NotContains(t, credential.Secret, "=", "the secret must be URL safe and unpadded")
+
+	other, err := NewCredential()
+	require.NoError(t, err)
+	assert.NotEqual(t, credential.Secret, other.Secret)
+}
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{token: "awt_abc", want: true},
+		{token: Prefix, want: true},
+		{token: "", want: false},
+		{token: "eyJhbGciOiJIUzI1NiJ9.e30.sig", want: false},
+		{token: "AWT_abc", want: false},
+		{token: " awt_abc", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.token, func(t *testing.T) {
+			assert.Equal(t, test.want, HasPrefix(test.token))
+		})
+	}
+}
+
+func TestHashIsStable(t *testing.T) {
+	assert.Equal(t, Hash("awt_example"), Hash("awt_example"))
+	assert.NotEqual(t, Hash("awt_example"), Hash("awt_examplf"))
+	assert.Len(t, Hash("awt_example"), 32)
+}

--- a/internal/auth/appToken.go
+++ b/internal/auth/appToken.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/shini4i/argo-watcher/internal/apptoken"
+)
+
+// AppTokenAuthService validates application deploy tokens against the store that
+// issued them. It alone answers a question about a *named application*: the scope
+// is set server-side at issue time and the holder cannot assert anything about it,
+// so the unscoped Validate refuses rather than treating the token as global.
+type AppTokenAuthService struct {
+	store apptoken.Store
+}
+
+// NewAppTokenAuthService initializes an application deploy token strategy over the
+// given store.
+func NewAppTokenAuthService(store apptoken.Store) *AppTokenAuthService {
+	return &AppTokenAuthService{store: store}
+}
+
+// Validate refuses: an application deploy token authorizes named applications, and
+// there is nothing here to weigh its scope against. Privileged endpoints are
+// restricted to the OIDC strategy anyway, so this path only guards against a
+// future caller reaching for the wrong method.
+func (s *AppTokenAuthService) Validate(_ string) (bool, error) {
+	return false, errors.New("an application deploy token cannot authorize a request with no application context")
+}
+
+// Authenticate reports whether the token identifies a live credential, without
+// asking which applications it covers, because a read names no application to judge
+// a scope against. Note this grants the whole task list, not only the token's own
+// applications — the same breadth a CI JWT already has.
+func (s *AppTokenAuthService) Authenticate(token string) error {
+	_, err := s.resolve(token)
+	return err
+}
+
+// ValidateForApp reports whether the token authorizes a deployment of the named
+// application, recording the use when it does.
+func (s *AppTokenAuthService) ValidateForApp(token, app string) (bool, error) {
+	if app == "" {
+		return false, errors.New("the request names no application, so an application deploy token cannot authorize it")
+	}
+
+	stored, err := s.resolve(token)
+	if err != nil {
+		return false, err
+	}
+
+	if !stored.Scope.Allows(app) {
+		return false, fmt.Errorf("this application deploy token does not authorize application %s (its scope is: %s)", app, stored.Scope)
+	}
+
+	// Bookkeeping for finding tokens nothing uses. It must never fail a deployment,
+	// so a write failure is logged and the authorization stands.
+	if err := s.store.MarkUsed(stored.Id); err != nil {
+		slog.Warn("failed to record use of an application deploy token", "token_id", stored.Id, "error", err)
+	}
+
+	return true, nil
+}
+
+// resolve finds the token behind a secret and confirms it may still be used. A
+// store failure becomes ErrProviderUnavailable rather than a rejection, so a
+// database blip answers 503 instead of telling a pipeline its credential is bad.
+// Revocation and expiry are reported apart: the holder can act on the difference.
+func (s *AppTokenAuthService) resolve(token string) (*apptoken.Token, error) {
+	stored, err := s.store.Lookup(token)
+	if errors.Is(err, apptoken.ErrNotFound) {
+		return nil, errors.New("the presented credential is not a known application deploy token")
+	}
+	if err != nil {
+		slog.Error("app token: store lookup failed", "error", err)
+		return nil, ErrProviderUnavailable
+	}
+
+	if !stored.RevokedAt.IsZero() {
+		return nil, errors.New("this application deploy token has been revoked")
+	}
+	if !stored.Usable(time.Now()) {
+		return nil, errors.New("this application deploy token has expired")
+	}
+
+	return stored, nil
+}
+
+// disabledAppTokens rejects application deploy tokens with the configuration they
+// need. Without it the token would be an unreadable header: the task would be
+// accepted as uncredentialed, and only the skipped write-back would hint at why
+// the rollout then failed.
+type disabledAppTokens struct{}
+
+// DisabledAppTokenStrategy returns the stand-in used while application deploy
+// tokens are unavailable.
+func DisabledAppTokenStrategy() AuthStrategy {
+	return disabledAppTokens{}
+}
+
+func (disabledAppTokens) Validate(_ string) (bool, error) {
+	return false, errors.New("application deploy tokens require OIDC_ENABLED and STATE_TYPE=postgres")
+}
+
+func (d disabledAppTokens) Authenticate(token string) error {
+	_, err := d.Validate(token)
+	return err
+}
+
+func (d disabledAppTokens) ValidateForApp(token, _ string) (bool, error) {
+	return d.Validate(token)
+}
+
+// PrefixRouter puts two credential types on one header. Application deploy tokens
+// and CI JWTs both arrive in Authorization, and the strategy map is keyed by
+// header, so it cannot hold one entry for each. This routes on the token's shape:
+// apptoken.Prefix goes to the prefixed strategy, anything else to the fallback.
+type PrefixRouter struct {
+	prefixed AuthStrategy
+	fallback AuthStrategy
+}
+
+// NewPrefixRouter builds a router over the two strategies. A nil fallback means
+// nothing evaluates a non-prefixed token, which is reported as ErrNoCredential —
+// the header is then ignored, exactly as it was before any strategy read it.
+func NewPrefixRouter(prefixed, fallback AuthStrategy) *PrefixRouter {
+	return &PrefixRouter{prefixed: prefixed, fallback: fallback}
+}
+
+// strategyFor picks the strategy a token's shape names.
+func (r *PrefixRouter) strategyFor(token string) AuthStrategy {
+	if apptoken.HasPrefix(token) {
+		return r.prefixed
+	}
+
+	return r.fallback
+}
+
+// Handles reports whether any strategy would evaluate a token of this shape, which
+// a bare header-presence check cannot tell apart from a header nobody reads.
+func (r *PrefixRouter) Handles(token string) bool {
+	return r.strategyFor(token) != nil
+}
+
+func (r *PrefixRouter) Validate(token string) (bool, error) {
+	strategy := r.strategyFor(token)
+	if strategy == nil {
+		return false, ErrNoCredential
+	}
+
+	return strategy.Validate(token)
+}
+
+func (r *PrefixRouter) Authenticate(token string) error {
+	strategy := r.strategyFor(token)
+	if strategy == nil {
+		return ErrNoCredential
+	}
+
+	if _, err := authenticate(strategy, token); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *PrefixRouter) ValidateForApp(token, app string) (bool, error) {
+	strategy := r.strategyFor(token)
+	if strategy == nil {
+		return false, ErrNoCredential
+	}
+
+	return validateForApp(strategy, token, app)
+}
+
+var (
+	_ AuthStrategy = (*AppTokenAuthService)(nil)
+	_ AuthStrategy = (*PrefixRouter)(nil)
+	_ AuthStrategy = disabledAppTokens{}
+)

--- a/internal/auth/appToken_test.go
+++ b/internal/auth/appToken_test.go
@@ -337,3 +337,76 @@ func TestNoCredentialIsNotARejection(t *testing.T) {
 	assert.False(t, valid)
 	assert.NoError(t, err)
 }
+
+// TestDisabledAppTokenStrategyRefusesEveryQuestion covers the stand-in used while
+// the feature is off, including the read path: a pipeline polling a task status with
+// a prefixed token must be told why rather than being treated as uncredentialed.
+func TestDisabledAppTokenStrategyRefusesEveryQuestion(t *testing.T) {
+	strategy := DisabledAppTokenStrategy()
+
+	t.Run("Validate", func(t *testing.T) {
+		valid, err := strategy.Validate("awt_someIssuedToken")
+
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OIDC_ENABLED")
+	})
+
+	t.Run("ValidateForApp", func(t *testing.T) {
+		scoped, ok := strategy.(interface {
+			ValidateForApp(token, app string) (bool, error)
+		})
+		require.True(t, ok)
+
+		valid, err := scoped.ValidateForApp("awt_someIssuedToken", "app1")
+
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "STATE_TYPE=postgres")
+	})
+
+	t.Run("Authenticate", func(t *testing.T) {
+		authenticator, ok := strategy.(interface{ Authenticate(token string) error })
+		require.True(t, ok)
+
+		err := authenticator.Authenticate("awt_someIssuedToken")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OIDC_ENABLED")
+	})
+
+	t.Run("a read through the authenticator is refused, not ignored", func(t *testing.T) {
+		router := NewPrefixRouter(strategy, nil)
+		authenticator := NewAuthenticator(map[string]AuthStrategy{"Authorization": router})
+
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+		request.Header.Set("Authorization", "Bearer awt_someIssuedToken")
+
+		valid, err := authenticator.AuthenticateRequest(request)
+
+		assert.False(t, valid)
+		require.Error(t, err, "an unevaluable feature must not read as no credential")
+	})
+}
+
+// TestPrefixRouterHandles pins the predicate hasCredential relies on to tell a
+// credential apart from a header nothing reads.
+func TestPrefixRouterHandles(t *testing.T) {
+	store := newStubStore()
+	appTokens := NewAppTokenAuthService(store)
+
+	t.Run("with a fallback everything is handled", func(t *testing.T) {
+		router := NewPrefixRouter(appTokens, NewJWTAuthService("secret", "", ""))
+
+		assert.True(t, router.Handles("awt_prefixed"))
+		assert.True(t, router.Handles("eyJhbGciOiJIUzI1NiJ9.e30.sig"))
+	})
+
+	t.Run("without a fallback only prefixed tokens are handled", func(t *testing.T) {
+		router := NewPrefixRouter(appTokens, nil)
+
+		assert.True(t, router.Handles("awt_prefixed"))
+		assert.False(t, router.Handles("eyJhbGciOiJIUzI1NiJ9.e30.sig"),
+			"nothing evaluates this, so it is not a credential")
+	})
+}

--- a/internal/auth/appToken_test.go
+++ b/internal/auth/appToken_test.go
@@ -1,0 +1,339 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/apptoken"
+)
+
+// stubStore is an in-process Store standing in for Postgres. The production code
+// has no in-memory implementation on purpose (see apptoken.Store), so the double
+// lives here, where losing it on restart is the point.
+type stubStore struct {
+	tokens    map[string]*apptoken.Token
+	lookupErr error
+	usedIds   []uuid.UUID
+	usedErr   error
+}
+
+func newStubStore() *stubStore {
+	return &stubStore{tokens: map[string]*apptoken.Token{}}
+}
+
+func (s *stubStore) add(secret string, token apptoken.Token) string {
+	if token.Id == uuid.Nil {
+		token.Id = uuid.New()
+	}
+	s.tokens[secret] = &token
+	return secret
+}
+
+func (s *stubStore) Issue(apptoken.Scope, string, string, time.Time) (*apptoken.IssuedToken, error) {
+	return nil, errors.New("not used in these tests")
+}
+
+func (s *stubStore) Lookup(secret string) (*apptoken.Token, error) {
+	if s.lookupErr != nil {
+		return nil, s.lookupErr
+	}
+	token, ok := s.tokens[secret]
+	if !ok {
+		return nil, apptoken.ErrNotFound
+	}
+	return token, nil
+}
+
+func (s *stubStore) List() ([]apptoken.Token, error) { return nil, nil }
+
+func (s *stubStore) Revoke(uuid.UUID) error { return nil }
+
+func (s *stubStore) MarkUsed(id uuid.UUID) error {
+	s.usedIds = append(s.usedIds, id)
+	return s.usedErr
+}
+
+func TestAppTokenValidateForApp(t *testing.T) {
+	t.Run("accepts a token scoped to the application", func(t *testing.T) {
+		store := newStubStore()
+		secret := store.add("awt_scoped", apptoken.Token{Scope: apptoken.Scope{Apps: []string{"app1", "app2"}}})
+		service := NewAppTokenAuthService(store)
+
+		valid, err := service.ValidateForApp(secret, "app2")
+
+		require.NoError(t, err)
+		assert.True(t, valid)
+	})
+
+	t.Run("accepts a wildcard token for any application", func(t *testing.T) {
+		store := newStubStore()
+		secret := store.add("awt_wildcard", apptoken.Token{Scope: apptoken.Scope{AllApps: true}})
+		service := NewAppTokenAuthService(store)
+
+		valid, err := service.ValidateForApp(secret, "some-app-issued-after-the-token")
+
+		require.NoError(t, err)
+		assert.True(t, valid)
+	})
+
+	t.Run("records that the token authorized a deployment", func(t *testing.T) {
+		store := newStubStore()
+		secret := store.add("awt_used", apptoken.Token{Scope: apptoken.Scope{AllApps: true}})
+		service := NewAppTokenAuthService(store)
+
+		_, err := service.ValidateForApp(secret, "app1")
+		require.NoError(t, err)
+
+		require.Len(t, store.usedIds, 1)
+		assert.Equal(t, store.tokens[secret].Id, store.usedIds[0])
+	})
+
+	t.Run("authorizes even when recording the use fails", func(t *testing.T) {
+		store := newStubStore()
+		store.usedErr = errors.New("write failed")
+		secret := store.add("awt_bookkeeping", apptoken.Token{Scope: apptoken.Scope{AllApps: true}})
+		service := NewAppTokenAuthService(store)
+
+		valid, err := service.ValidateForApp(secret, "app1")
+
+		require.NoError(t, err, "bookkeeping must never fail a deployment")
+		assert.True(t, valid)
+	})
+
+	tests := []struct {
+		name    string
+		secret  string
+		token   *apptoken.Token
+		app     string
+		message string
+	}{
+		{
+			name:    "rejects an application outside the scope",
+			secret:  "awt_narrow",
+			token:   &apptoken.Token{Scope: apptoken.Scope{Apps: []string{"app1"}}},
+			app:     "app2",
+			message: "not authorize application app2",
+		},
+		{
+			name:    "rejects an unknown token",
+			secret:  "awt_unknown",
+			app:     "app1",
+			message: "not a known application deploy token",
+		},
+		{
+			name:    "rejects a revoked token",
+			secret:  "awt_revoked",
+			token:   &apptoken.Token{Scope: apptoken.Scope{AllApps: true}, RevokedAt: time.Now().Add(-time.Hour)},
+			app:     "app1",
+			message: "has been revoked",
+		},
+		{
+			name:    "rejects an expired token",
+			secret:  "awt_expired",
+			token:   &apptoken.Token{Scope: apptoken.Scope{AllApps: true}, ExpiresAt: time.Now().Add(-time.Minute)},
+			app:     "app1",
+			message: "has expired",
+		},
+		{
+			name:    "rejects a request with no application",
+			secret:  "awt_noapp",
+			token:   &apptoken.Token{Scope: apptoken.Scope{AllApps: true}},
+			app:     "",
+			message: "names no application",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newStubStore()
+			if test.token != nil {
+				store.add(test.secret, *test.token)
+			}
+			service := NewAppTokenAuthService(store)
+
+			valid, err := service.ValidateForApp(test.secret, test.app)
+
+			assert.False(t, valid)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.message)
+			assert.Empty(t, store.usedIds, "a rejected token must not be recorded as used")
+		})
+	}
+}
+
+func TestAppTokenStoreFailureIsNotARejection(t *testing.T) {
+	store := newStubStore()
+	store.lookupErr = errors.New("connection refused")
+	service := NewAppTokenAuthService(store)
+
+	t.Run("ValidateForApp", func(t *testing.T) {
+		valid, err := service.ValidateForApp("awt_anything", "app1")
+
+		assert.False(t, valid)
+		// A database that cannot be consulted must map to 503, not 401: a blip must
+		// not tell a pipeline its credential is bad.
+		require.ErrorIs(t, err, ErrProviderUnavailable)
+	})
+
+	t.Run("Authenticate", func(t *testing.T) {
+		require.ErrorIs(t, service.Authenticate("awt_anything"), ErrProviderUnavailable)
+	})
+}
+
+func TestAppTokenValidateRefusesWithoutAnApplication(t *testing.T) {
+	store := newStubStore()
+	secret := store.add("awt_wildcard", apptoken.Token{Scope: apptoken.Scope{AllApps: true}})
+	service := NewAppTokenAuthService(store)
+
+	// Plain Validate has no application to weigh the scope against. It must refuse
+	// even a wildcard token, so a call site that forgets ValidateForApp fails closed
+	// instead of treating an app token as a global credential.
+	valid, err := service.Validate(secret)
+
+	assert.False(t, valid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no application context")
+}
+
+func TestAppTokenAuthenticate(t *testing.T) {
+	store := newStubStore()
+	live := store.add("awt_live", apptoken.Token{Scope: apptoken.Scope{Apps: []string{"app1"}}})
+	revoked := store.add("awt_revoked", apptoken.Token{Scope: apptoken.Scope{AllApps: true}, RevokedAt: time.Now()})
+	service := NewAppTokenAuthService(store)
+
+	// Reads need no application context, so a live token of any scope grants them.
+	require.NoError(t, service.Authenticate(live))
+	assert.Empty(t, store.usedIds, "a read must not count as a deployment")
+
+	require.Error(t, service.Authenticate(revoked))
+	require.Error(t, service.Authenticate("awt_unknown"))
+}
+
+func TestPrefixRouter(t *testing.T) {
+	store := newStubStore()
+	secret := store.add("awt_scoped", apptoken.Token{Scope: apptoken.Scope{Apps: []string{"app1"}}})
+	jwtService := NewJWTAuthService("secret", "", "")
+	router := NewPrefixRouter(NewAppTokenAuthService(store), jwtService)
+
+	t.Run("routes a prefixed token to the app token strategy", func(t *testing.T) {
+		valid, err := router.ValidateForApp(secret, "app1")
+
+		require.NoError(t, err)
+		assert.True(t, valid)
+	})
+
+	t.Run("routes anything else to the fallback", func(t *testing.T) {
+		valid, err := router.ValidateForApp("not-a-jwt-either", "app1")
+
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "application deploy token")
+	})
+
+	t.Run("forwards the unscoped question too", func(t *testing.T) {
+		valid, err := router.Validate(secret)
+
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no application context")
+	})
+
+	t.Run("forwards authentication", func(t *testing.T) {
+		require.NoError(t, router.Authenticate(secret))
+	})
+
+	t.Run("reports no credential when the fallback is absent", func(t *testing.T) {
+		bare := NewPrefixRouter(NewAppTokenAuthService(store), nil)
+
+		valid, err := bare.Validate("eyJhbGciOiJIUzI1NiJ9.e30.sig")
+
+		assert.False(t, valid)
+		require.ErrorIs(t, err, ErrNoCredential)
+	})
+}
+
+func TestDisabledAppTokenStrategy(t *testing.T) {
+	jwtService := NewJWTAuthService("secret", "", "")
+	router := NewPrefixRouter(DisabledAppTokenStrategy(), jwtService)
+
+	valid, err := router.ValidateForApp("awt_whatever", "app1")
+
+	assert.False(t, valid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OIDC_ENABLED")
+	assert.Contains(t, err.Error(), "STATE_TYPE=postgres")
+}
+
+func TestAppTokenStrategyIsRecognisedByTheAuthenticator(t *testing.T) {
+	store := newStubStore()
+	secret := store.add("awt_scoped", apptoken.Token{Scope: apptoken.Scope{Apps: []string{"app1"}}})
+	authenticator := NewAuthenticator(map[string]AuthStrategy{
+		"Authorization": NewPrefixRouter(NewAppTokenAuthService(store), NewJWTAuthService("secret", "", "")),
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", nil)
+	request.Header.Set("Authorization", "Bearer "+secret)
+
+	valid, err := authenticator.ValidateForApp(request, "app1")
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	valid, err = authenticator.ValidateForApp(request, "app2")
+	assert.False(t, valid)
+	require.Error(t, err)
+}
+
+func TestAuthenticatorValidateForAppFallsBackForUnscopedStrategies(t *testing.T) {
+	authenticator := NewAuthenticator(map[string]AuthStrategy{
+		"ARGO_WATCHER_DEPLOY_TOKEN": NewDeployTokenAuthService("shared-secret"),
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", nil)
+	request.Header.Set("ARGO_WATCHER_DEPLOY_TOKEN", "shared-secret")
+
+	// The shared deploy token has no application scope, so it answers the unscoped
+	// question and keeps authorizing every application exactly as before.
+	valid, err := authenticator.ValidateForApp(request, "any-app")
+
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	// The fallback must still be the strategy's own answer, not a blanket grant.
+	request.Header.Set("ARGO_WATCHER_DEPLOY_TOKEN", "wrong-secret")
+
+	valid, err = authenticator.ValidateForApp(request, "any-app")
+
+	assert.False(t, valid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deploy token is invalid")
+}
+
+func TestNoCredentialIsNotARejection(t *testing.T) {
+	store := newStubStore()
+	// No JWT secret is configured, so nothing evaluates a non-prefixed token on
+	// Authorization. Such a header must stay ignored rather than becoming a 401:
+	// a client setting Authorization for an unrelated proxy kept working before
+	// application deploy tokens existed, and must keep working now.
+	authenticator := NewAuthenticator(map[string]AuthStrategy{
+		"Authorization": NewPrefixRouter(NewAppTokenAuthService(store), nil),
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", nil)
+	request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.e30.sig")
+
+	valid, err := authenticator.ValidateForApp(request, "app1")
+
+	assert.False(t, valid)
+	assert.NoError(t, err, "an unevaluated header is 'no credential', not a rejection")
+
+	valid, err = authenticator.AuthenticateRequest(request)
+	assert.False(t, valid)
+	assert.NoError(t, err)
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,6 +17,12 @@ type AuthStrategy interface {
 	Validate(token string) (bool, error)
 }
 
+// ErrNoCredential reports that no configured strategy evaluates a token of the
+// presented shape, so the request carries nothing to judge. walk skips it instead
+// of recording a rejection, which keeps a header no strategy reads behaving as it
+// always has: ignored, not refused.
+var ErrNoCredential = errors.New("no configured strategy handles this credential")
+
 // Authenticator coordinates multiple AuthStrategy implementations against an HTTP request.
 type Authenticator struct {
 	strategies map[string]AuthStrategy
@@ -37,9 +43,9 @@ func NewAuthenticator(strategies map[string]AuthStrategy) *Authenticator {
 	}
 }
 
-// parseAuthToken extracts and normalizes a token from the given request header.
+// ParseAuthToken extracts and normalizes a token from the given request header.
 // It strips the "Bearer " prefix if present and returns an empty string for missing or empty tokens.
-func parseAuthToken(request *http.Request, header string) string {
+func ParseAuthToken(request *http.Request, header string) string {
 	token := request.Header.Get(header)
 	if token == "" {
 		return ""
@@ -76,6 +82,16 @@ func (a *Authenticator) Validate(request *http.Request) (bool, error) {
 // credential sent" from "credential rejected".
 func (a *Authenticator) AuthenticateRequest(request *http.Request) (bool, error) {
 	return a.walk(request, authenticate)
+}
+
+// ValidateForApp reports whether the request carries a credential authorizing a
+// deployment of the named application, with the same three return states as
+// Validate. Only application deploy tokens and JWTs carrying allowed_apps narrow
+// their answer by application; every other credential authorizes every one.
+func (a *Authenticator) ValidateForApp(request *http.Request, app string) (bool, error) {
+	return a.walk(request, func(strategy AuthStrategy, token string) (bool, error) {
+		return validateForApp(strategy, token, app)
+	})
 }
 
 // AuthenticateToken authenticates a bare token against the strategy registered under
@@ -117,6 +133,20 @@ func authenticate(strategy AuthStrategy, token string) (bool, error) {
 	return true, nil
 }
 
+// validateForApp asks a strategy the application-scoped question. One whose tokens
+// are confined to named applications exposes ValidateForApp; one whose tokens
+// authorize the whole estate does not, and answers the unscoped question instead.
+func validateForApp(strategy AuthStrategy, token, app string) (bool, error) {
+	scoped, ok := strategy.(interface {
+		ValidateForApp(token, app string) (bool, error)
+	})
+	if !ok {
+		return strategy.Validate(token)
+	}
+
+	return scoped.ValidateForApp(token, app)
+}
+
 // walk applies check to every strategy whose header carries a token, returning on
 // the first acceptance. When no strategy accepts, it returns a nil error if no
 // strategy was invoked at all — the "authentication not provided" state described
@@ -135,7 +165,7 @@ func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, str
 	var rejectedErr, unavailableErr error
 
 	for header, strategy := range a.strategies {
-		token := parseAuthToken(request, header)
+		token := ParseAuthToken(request, header)
 		if token == "" {
 			continue
 		}
@@ -143,6 +173,9 @@ func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, str
 		valid, err := check(strategy, token)
 		if valid {
 			return true, nil
+		}
+		if errors.Is(err, ErrNoCredential) {
+			continue
 		}
 		if errors.Is(err, ErrProviderUnavailable) {
 			unavailableErr = err
@@ -160,6 +193,34 @@ func (a *Authenticator) walk(request *http.Request, check func(AuthStrategy, str
 	return false, rejectedErr
 }
 
+// IdentifyRequest names the user behind the credential in the given header, for
+// attributing a privileged action. It returns an empty name when no strategy is
+// registered there, the strategy cannot name a user, or no token was sent.
+func (a *Authenticator) IdentifyRequest(request *http.Request, header string) (string, error) {
+	if a == nil || request == nil {
+		return "", nil
+	}
+
+	strategy, ok := a.strategies[header]
+	if !ok {
+		return "", nil
+	}
+
+	identifier, ok := strategy.(interface {
+		Identify(token string) (string, error)
+	})
+	if !ok {
+		return "", nil
+	}
+
+	token := ParseAuthToken(request, header)
+	if token == "" {
+		return "", nil
+	}
+
+	return identifier.Identify(token)
+}
+
 // ValidateStrategy restricts validation to the strategy registered under allowedHeader.
 func (a *Authenticator) ValidateStrategy(request *http.Request, allowedHeader string) (bool, error) {
 	if a == nil || request == nil {
@@ -171,7 +232,7 @@ func (a *Authenticator) ValidateStrategy(request *http.Request, allowedHeader st
 		return false, nil
 	}
 
-	token := parseAuthToken(request, allowedHeader)
+	token := ParseAuthToken(request, allowedHeader)
 	if token == "" {
 		return false, nil
 	}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -3,9 +3,16 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/golang-jwt/jwt/v5"
 )
+
+// allowedAppsClaim optionally confines a token to a set of applications. It is a
+// self-restriction, not an authorization decision: anyone holding JWT_SECRET can
+// name any application, so it limits the blast radius of a leaked *minted token*
+// only. A token omitting the claim keeps authorizing every application.
+const allowedAppsClaim = "allowed_apps"
 
 // JWTAuthService validates the HMAC-signed tokens a CI pipeline presents. Beyond the
 // signature it enforces the claim policy assembled in NewJWTAuthService.
@@ -14,10 +21,45 @@ type JWTAuthService struct {
 	options   []jwt.ParserOption
 }
 
-// Validate verifies a JSON Web Token, checking signature and claims.
+// Validate verifies a JSON Web Token, checking signature and claims. It says
+// nothing about which applications the token covers — see ValidateForApp.
 func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
+	if _, err := j.parse(tokenStr); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ValidateForApp verifies the token and additionally honors allowedAppsClaim,
+// confining the token to the applications it names.
+func (j *JWTAuthService) ValidateForApp(tokenStr, app string) (bool, error) {
+	token, err := j.parse(tokenStr)
+	if err != nil {
+		return false, err
+	}
+
+	allowed, present, err := allowedApps(token)
+	if err != nil {
+		return false, err
+	}
+
+	if !present {
+		return true, nil
+	}
+
+	if !slices.Contains(allowed, app) {
+		return false, fmt.Errorf("this token's %s claim does not cover application %s", allowedAppsClaim, app)
+	}
+
+	return true, nil
+}
+
+// parse verifies the token's signature and claim policy, returning it for callers
+// that need to read further claims.
+func (j *JWTAuthService) parse(tokenStr string) (*jwt.Token, error) {
 	if tokenStr == "" {
-		return false, fmt.Errorf("empty token")
+		return nil, fmt.Errorf("empty token")
 	}
 
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
@@ -28,12 +70,43 @@ func (j *JWTAuthService) Validate(tokenStr string) (bool, error) {
 	}, j.options...)
 
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	if !token.Valid {
-		return false, errors.New("invalid token")
+		return nil, errors.New("invalid token")
 	}
 
-	return true, nil
+	return token, nil
+}
+
+// allowedApps reads allowedAppsClaim, reporting whether the token carries it at
+// all. A claim present but malformed is reported rather than ignored: treating it
+// as absent would widen the token to the whole estate.
+func allowedApps(token *jwt.Token) (apps []string, present bool, err error) {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, false, nil
+	}
+
+	raw, present := claims[allowedAppsClaim]
+	if !present {
+		return nil, false, nil
+	}
+
+	entries, ok := raw.([]any)
+	if !ok {
+		return nil, true, fmt.Errorf("the %s claim must be an array of application names", allowedAppsClaim)
+	}
+
+	apps = make([]string, 0, len(entries))
+	for _, entry := range entries {
+		app, ok := entry.(string)
+		if !ok {
+			return nil, true, fmt.Errorf("the %s claim must contain only application names", allowedAppsClaim)
+		}
+		apps = append(apps, app)
+	}
+
+	return apps, true, nil
 }

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -199,3 +199,96 @@ func TestJWTAuthService_ClaimBinding(t *testing.T) {
 		assert.False(t, isValid)
 	})
 }
+
+func TestJWTAuthServiceValidateForApp(t *testing.T) {
+	const secretKey = "test_secret_key"
+	service := NewJWTAuthService(secretKey, "", "")
+
+	mint := func(t *testing.T, claims jwt.MapClaims) string {
+		t.Helper()
+		claims["exp"] = float64(time.Now().Add(time.Hour).Unix())
+		tokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secretKey))
+		require.NoError(t, err)
+		return tokenStr
+	}
+
+	t.Run("a token without the claim authorizes every application", func(t *testing.T) {
+		tokenStr := mint(t, jwt.MapClaims{"sub": "ci"})
+
+		isValid, err := service.ValidateForApp(tokenStr, "any-app")
+
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+	})
+
+	t.Run("a token is confined to the applications it names", func(t *testing.T) {
+		tokenStr := mint(t, jwt.MapClaims{"allowed_apps": []string{"app1", "app2"}})
+
+		isValid, err := service.ValidateForApp(tokenStr, "app2")
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+
+		isValid, err = service.ValidateForApp(tokenStr, "app3")
+		assert.False(t, isValid)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not cover application app3")
+	})
+
+	t.Run("an empty claim authorizes nothing", func(t *testing.T) {
+		tokenStr := mint(t, jwt.MapClaims{"allowed_apps": []string{}})
+
+		isValid, err := service.ValidateForApp(tokenStr, "app1")
+
+		assert.False(t, isValid)
+		require.Error(t, err)
+	})
+
+	t.Run("the unscoped Validate ignores the claim", func(t *testing.T) {
+		tokenStr := mint(t, jwt.MapClaims{"allowed_apps": []string{"app1"}})
+
+		// Endpoints with no application to check against — the deploy lock, a read —
+		// keep judging the token on its signature and claim policy alone.
+		isValid, err := service.Validate(tokenStr)
+
+		assert.NoError(t, err)
+		assert.True(t, isValid)
+	})
+
+	t.Run("a malformed claim is a rejection, not an absent claim", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			claim any
+		}{
+			{name: "a bare string", claim: "app1"},
+			{name: "a list of numbers", claim: []int{1, 2}},
+			{name: "an object", claim: map[string]string{"app": "app1"}},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				tokenStr := mint(t, jwt.MapClaims{"allowed_apps": test.claim})
+
+				isValid, err := service.ValidateForApp(tokenStr, "app1")
+
+				assert.False(t, isValid, "treating it as absent would widen the token to the whole estate")
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "allowed_apps")
+			})
+		}
+	})
+
+	t.Run("an invalid signature is rejected before the claim is read", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"exp":          float64(time.Now().Add(time.Hour).Unix()),
+			"allowed_apps": []string{"app1"},
+		}
+		tokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("wrong_secret"))
+		require.NoError(t, err)
+
+		isValid, err := service.ValidateForApp(tokenStr, "app1")
+
+		assert.False(t, isValid)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "allowed_apps")
+	})
+}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -187,6 +187,19 @@ func (o *OIDCAuthService) Authenticate(token string) error {
 	return err
 }
 
+// Identify returns the username the provider associates with the token, so an
+// action can be attributed to the operator who took it. It answers from the
+// validation cache, which a preceding Validate has just populated, so attributing
+// a privileged action costs no extra userinfo round trip.
+func (o *OIDCAuthService) Identify(token string) (string, error) {
+	info, err := o.resolveIdentity(token, true)
+	if err != nil {
+		return "", err
+	}
+
+	return info.Username, nil
+}
+
 // Validate implements AuthStrategy for privileged operations: it calls the OIDC
 // provider's userinfo endpoint with the bearer token and treats HTTP 200 as proof
 // the token is valid, effectively delegating validation to the provider. The user

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -727,3 +727,101 @@ func TestOIDCAuthService_UnboundTokenWarning(t *testing.T) {
 		assert.Contains(t, logs.String(), "names no client and carries no aud claim")
 	})
 }
+
+// TestOIDCAuthService_Identify covers the sole source of the created_by attribution
+// stored on every issued application deploy token.
+func TestOIDCAuthService_Identify(t *testing.T) {
+	t.Run("returns the username the provider reports", func(t *testing.T) {
+		server, _ := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		username, err := service.Identify("token")
+
+		require.NoError(t, err)
+		assert.Equal(t, "someone", username)
+	})
+
+	t.Run("answers a privileged action from the cache Validate just filled", func(t *testing.T) {
+		// Identify passes allowCached=true precisely so attributing an action costs no
+		// extra round trip. Flipping that adds one userinfo call per issue and revoke.
+		server, hits := newCountingOIDCServer(t, `["privileged"]`)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, time.Minute))
+		service.client = server.Client()
+
+		valid, err := service.Validate("token")
+		require.NoError(t, err)
+		require.True(t, valid)
+		before := atomic.LoadInt32(hits)
+
+		_, err = service.Identify("token")
+		require.NoError(t, err)
+
+		assert.Equal(t, before, atomic.LoadInt32(hits), "the cached identity must be reused")
+	})
+
+	t.Run("reports a rejected token without naming a user", func(t *testing.T) {
+		server := newOIDCTestServer(t, http.StatusUnauthorized, "", nil, false)
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init(server.URL, "test", []string{"privileged"}, 0))
+		service.client = server.Client()
+
+		username, err := service.Identify("token")
+
+		require.Error(t, err)
+		assert.Empty(t, username)
+	})
+
+	t.Run("surfaces an unreachable provider as such", func(t *testing.T) {
+		service := &OIDCAuthService{}
+		require.NoError(t, service.Init("http://127.0.0.1:1", "test", nil, 0))
+
+		username, err := service.Identify("token")
+
+		require.ErrorIs(t, err, ErrProviderUnavailable)
+		assert.Empty(t, username)
+	})
+}
+
+// TestAuthenticatorIdentifyRequest covers the branch that keeps attribution from
+// panicking when nothing can name a user.
+func TestAuthenticatorIdentifyRequest(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/app-tokens", nil)
+	request.Header.Set("Oidc-Authorization", "Bearer token")
+
+	t.Run("no strategy registered under the header", func(t *testing.T) {
+		authenticator := NewAuthenticator(map[string]AuthStrategy{})
+
+		username, err := authenticator.IdentifyRequest(request, "Oidc-Authorization")
+
+		assert.NoError(t, err)
+		assert.Empty(t, username)
+	})
+
+	t.Run("a strategy that cannot name a user", func(t *testing.T) {
+		// The deploy token has no identity behind it, so the caller falls back to
+		// recording the action against an unnamed operator rather than failing it.
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Oidc-Authorization": NewDeployTokenAuthService("shared"),
+		})
+
+		username, err := authenticator.IdentifyRequest(request, "Oidc-Authorization")
+
+		assert.NoError(t, err)
+		assert.Empty(t, username)
+	})
+
+	t.Run("no token sent", func(t *testing.T) {
+		bare := httptest.NewRequest(http.MethodPost, "/api/v1/app-tokens", nil)
+		authenticator := NewAuthenticator(map[string]AuthStrategy{
+			"Oidc-Authorization": &OIDCAuthService{},
+		})
+
+		username, err := authenticator.IdentifyRequest(bare, "Oidc-Authorization")
+
+		assert.NoError(t, err)
+		assert.Empty(t, username)
+	})
+}

--- a/internal/models/app_token.go
+++ b/internal/models/app_token.go
@@ -1,0 +1,38 @@
+package models
+
+// AppTokenRequest is the body of POST /api/v1/app-tokens. Apps and AllApps are
+// mutually exclusive; the server rejects a request setting both.
+type AppTokenRequest struct {
+	// Apps names the applications the token may deploy.
+	Apps []string `json:"apps,omitempty" binding:"max=200,dive,max=255"`
+	// AllApps is the wildcard: every application, present and future.
+	AllApps bool `json:"all_apps,omitempty"`
+	// Description is free text identifying the holder, e.g. the pipeline name.
+	Description string `json:"description,omitempty" binding:"max=255"`
+	// ExpiresInDays bounds the token's life; zero means it never expires. The cap of
+	// ten years rejects a mistyped value, and lives in the tag because a struct tag
+	// cannot reference a constant.
+	ExpiresInDays int `json:"expires_in_days,omitempty" binding:"min=0,max=3650"`
+}
+
+// AppTokenResponse describes an issued token. Secret is populated only in the
+// response to the request that created it, which is the one time the token is
+// ever shown; every other response carries Hint instead.
+type AppTokenResponse struct {
+	Id          string   `json:"id"`
+	Apps        []string `json:"apps,omitempty"`
+	AllApps     bool     `json:"all_apps"`
+	Hint        string   `json:"hint"`
+	Description string   `json:"description,omitempty"`
+	CreatedBy   string   `json:"created_by"`
+	// Timestamps are Unix milliseconds, matching how a task reports its own.
+	CreatedAt  int64  `json:"created_at"`
+	ExpiresAt  int64  `json:"expires_at,omitempty"`
+	RevokedAt  int64  `json:"revoked_at,omitempty"`
+	LastUsedAt int64  `json:"last_used_at,omitempty"`
+	Secret     string `json:"secret,omitempty"`
+}
+
+// UnknownUser attributes an action whose operator could not be named, so the
+// audit trail records that it happened rather than dropping the row.
+const UnknownUser = "unknown"

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/shini4i/argo-watcher/internal/apptoken"
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
@@ -24,6 +25,9 @@ type Env struct {
 	lockdown      *Lockdown
 	strategies    map[string]auth.AuthStrategy
 	authenticator *auth.Authenticator
+	// appTokens is nil unless application deploy tokens are available, which is
+	// what the issue and revoke endpoints are registered on.
+	appTokens apptoken.Store
 	// shutdownCh is closed to signal graceful shutdown to all WebSocket goroutines.
 	shutdownCh chan struct{}
 	// draining is set once graceful shutdown begins, so the readiness probe can
@@ -184,8 +188,10 @@ func (env *Env) Shutdown(ctx context.Context) {
 }
 
 // NewEnv wires up an Env from the server config: lockdown schedules backed by the
-// given deploy lock store, and the enabled auth strategies.
-func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater, deployLockStore lock.DeployLockStore) (*Env, error) {
+// given deploy lock store, and the enabled auth strategies. appTokenStore is nil
+// when application deploy tokens are unavailable, which the caller decides from
+// the state backend; they additionally require OIDC.
+func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prometheus.Metrics, updater *argocd.ArgoStatusUpdater, deployLockStore lock.DeployLockStore, appTokenStore apptoken.Store) (*Env, error) {
 	var env *Env
 	var err error
 
@@ -213,11 +219,37 @@ func NewEnv(serverConfig *config.ServerConfig, argo *argocd.Argo, metrics *prome
 		env.strategies[oidcHeader] = oidcService
 	}
 
+	// Application deploy tokens and CI JWTs share the Authorization header, so one
+	// router owns it and dispatches on the token's own shape.
+	var jwtStrategy auth.AuthStrategy
 	if env.config.JWTSecret != "" {
-		env.strategies["Authorization"] = auth.NewJWTAuthService(env.config.JWTSecret, env.config.JWTIssuer, env.config.JWTAudience)
+		jwtStrategy = auth.NewJWTAuthService(env.config.JWTSecret, env.config.JWTIssuer, env.config.JWTAudience)
 	}
+
+	// A non-nil store is what CreateRouter registers the token endpoints on, so the
+	// assignment stays here rather than inside the resolver.
+	appTokenStrategy, appTokens := env.resolveAppTokens(appTokenStore)
+	env.appTokens = appTokens
+	env.strategies["Authorization"] = auth.NewPrefixRouter(appTokenStrategy, jwtStrategy)
 
 	env.authenticator = auth.NewAuthenticator(env.strategies)
 
 	return env, nil
+}
+
+// resolveAppTokens returns the strategy for application deploy tokens and the store
+// to serve them from, which is nil unless both preconditions hold. When either is
+// missing the tokens are refused by name rather than ignored, so a pipeline holding
+// one is told why instead of having its write-back silently skipped.
+func (env *Env) resolveAppTokens(store apptoken.Store) (auth.AuthStrategy, apptoken.Store) {
+	switch {
+	case store == nil:
+		slog.Warn("Application deploy tokens are unavailable: they require STATE_TYPE=postgres.")
+	case !env.config.OIDC.Enabled:
+		slog.Warn("Application deploy tokens are unavailable: they require OIDC_ENABLED, the only way to issue and revoke them.")
+	default:
+		return auth.NewAppTokenAuthService(store), store
+	}
+
+	return auth.DisabledAppTokenStrategy(), nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -75,6 +75,7 @@ func (env *Env) getVersion(w http.ResponseWriter, _ *http.Request) {
 // @Failure 401 {object} models.TaskStatus
 // @Failure 406 {object} models.TaskStatus
 // @Failure 413 {object} models.TaskStatus "the request body is larger than the server accepts"
+// @Failure 503 {object} models.TaskStatus "the credential could not be checked; retry"
 // @Router /api/v1/tasks [post]
 func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 	var task models.Task
@@ -99,7 +100,20 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenValid, err := env.validateToken(r, "")
+	// Scoped to the requested application: an application deploy token, and a JWT
+	// carrying allowed_apps, authorize only the applications they name.
+	tokenValid, err := env.authenticator.ValidateForApp(r, task.App)
+	if errors.Is(err, auth.ErrProviderUnavailable) {
+		// The credential could not be judged at all. Accepting the task as
+		// uncredentialed would skip the write-back and fail the rollout blaming the
+		// image, so refuse and let the client retry.
+		slog.Error("rejecting task: authentication provider unavailable", "app", task.App, "error", err)
+		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
+			Status: "authentication provider unavailable",
+			Error:  err.Error(),
+		})
+		return
+	}
 	if err != nil {
 		// A non-nil error means the strategy was invoked and rejected the
 		// token: a client mistake, not a server failure. Return 401 with
@@ -427,13 +441,22 @@ func (env *Env) countUnauthenticatedRead() func(http.Handler) http.Handler {
 	}
 }
 
-// hasCredential reports whether the request carries a non-empty value in any header a
-// configured auth strategy reads, saying nothing about whether it is valid.
+// hasCredential reports whether the request carries a value some configured strategy
+// would actually evaluate, saying nothing about whether it is valid. Presence alone
+// would count a header nobody reads, letting unauthenticated_reads fall to zero while
+// the callers that closing the endpoint would break are still polling.
 func (env *Env) hasCredential(request *http.Request) bool {
-	for header := range env.strategies {
-		if request.Header.Get(header) != "" {
-			return true
+	for header, strategy := range env.strategies {
+		token := auth.ParseAuthToken(request, header)
+		if token == "" {
+			continue
 		}
+
+		if handler, ok := strategy.(interface{ Handles(token string) bool }); ok && !handler.Handles(token) {
+			continue
+		}
+
+		return true
 	}
 
 	return false

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -35,6 +35,12 @@ const maxRequestBodyBytes = 1 << 20
 
 const (
 	unauthorizedMessage = "You are not authorized to perform this action"
+	// providerUnavailableMessage is the 503 status for a credential that could not be
+	// judged at all, as distinct from one that was rejected.
+	providerUnavailableMessage = "authentication provider unavailable"
+	// internalErrorMessage is the client-facing text for a failure whose real cause
+	// stays in the server log.
+	internalErrorMessage = "internal server error"
 	// oidcHeader carries the OIDC bearer token for privileged
 	// (deploy-lock/rollback) requests.
 	oidcHeader = "Oidc-Authorization"
@@ -109,7 +115,7 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 		// image, so refuse and let the client retry.
 		slog.Error("rejecting task: authentication provider unavailable", "app", task.App, "error", err)
 		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-			Status: "authentication provider unavailable",
+			Status: providerUnavailableMessage,
 			Error:  err.Error(),
 		})
 		return
@@ -241,7 +247,7 @@ func (env *Env) getTaskStatus(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to retrieve task", "id", id, "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Id:    id,
-			Error: "internal server error",
+			Error: internalErrorMessage,
 		})
 	} else {
 		setTaskApp(r, task.MetricApp())
@@ -334,7 +340,7 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 		slog.Error("rejecting request: authentication provider unavailable",
 			"method", r.Method, "url", r.URL.Path, "error", err)
 		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-			Status: "authentication provider unavailable",
+			Status: providerUnavailableMessage,
 			Error:  err.Error(),
 		})
 		return false
@@ -384,7 +390,7 @@ func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 				slog.Error("rejecting read: authentication provider unavailable",
 					"method", r.Method, "url", r.URL.Path, "error", err)
 				writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-					Status: "authentication provider unavailable",
+					Status: providerUnavailableMessage,
 					Error:  err.Error(),
 				})
 				return

--- a/internal/server/handlers_app_tokens.go
+++ b/internal/server/handlers_app_tokens.go
@@ -35,7 +35,7 @@ func (env *Env) listAppTokens(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to list application deploy tokens", "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Status: "failed to list application deploy tokens",
-			Error:  "internal server error",
+			Error:  internalErrorMessage,
 		})
 		return
 	}
@@ -95,7 +95,7 @@ func (env *Env) issueAppToken(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to issue an application deploy token", "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Status: "failed to issue an application deploy token",
-			Error:  "internal server error",
+			Error:  internalErrorMessage,
 		})
 		return
 	}
@@ -146,7 +146,7 @@ func (env *Env) revokeAppToken(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to revoke an application deploy token", "token_id", id, "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Status: "failed to revoke the application deploy token",
-			Error:  "internal server error",
+			Error:  internalErrorMessage,
 		})
 		return
 	}

--- a/internal/server/handlers_app_tokens.go
+++ b/internal/server/handlers_app_tokens.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/shini4i/argo-watcher/internal/apptoken"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// appTokensEndpoint is the collection of application deploy tokens.
+const appTokensEndpoint = "/app-tokens" // #nosec G101 - a route path, not a credential
+
+// listAppTokens godoc
+// @Summary List application deploy tokens
+// @Description List every issued token, revoked ones included. Requires membership of OIDC_PRIVILEGED_GROUPS. Never returns a token's secret.
+// @Tags frontend
+// @Produce json
+// @Success 200 {array} models.AppTokenResponse
+// @Failure 401 {object} models.TaskStatus
+// @Failure 503 {object} models.TaskStatus
+// @Router /api/v1/app-tokens [get]
+func (env *Env) listAppTokens(w http.ResponseWriter, r *http.Request) {
+	if !env.requireOIDCAuth(w, r) {
+		return
+	}
+
+	tokens, err := env.appTokens.List()
+	if err != nil {
+		slog.Error("failed to list application deploy tokens", "error", err)
+		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
+			Status: "failed to list application deploy tokens",
+			Error:  "internal server error",
+		})
+		return
+	}
+
+	payload := make([]models.AppTokenResponse, 0, len(tokens))
+	for index := range tokens {
+		payload = append(payload, appTokenPayload(&tokens[index], ""))
+	}
+
+	writeJSON(w, http.StatusOK, payload)
+}
+
+// issueAppToken godoc
+// @Summary Issue an application deploy token
+// @Description Mint a token for a set of applications, or for all of them. Requires membership of OIDC_PRIVILEGED_GROUPS. The secret is returned once and never again.
+// @Tags frontend
+// @Accept json
+// @Produce json
+// @Param request body models.AppTokenRequest true "Token scope"
+// @Success 201 {object} models.AppTokenResponse
+// @Failure 406 {object} models.TaskStatus "the scope or the payload was refused"
+// @Failure 401 {object} models.TaskStatus
+// @Failure 503 {object} models.TaskStatus
+// @Router /api/v1/app-tokens [post]
+func (env *Env) issueAppToken(w http.ResponseWriter, r *http.Request) {
+	if !env.requireOIDCAuth(w, r) {
+		return
+	}
+
+	var request models.AppTokenRequest
+	if err := bindJSON(r, &request); err != nil {
+		slog.Warn("failed to parse an application deploy token request", "error", err)
+		writeJSON(w, payloadRejectionStatus(err), models.TaskStatus{
+			Status: "invalid payload",
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	scope := apptoken.Scope{Apps: request.Apps, AllApps: request.AllApps}
+	if err := scope.Validate(); err != nil {
+		// The same code the rest of the API answers for a body it will not accept.
+		writeJSON(w, http.StatusNotAcceptable, models.TaskStatus{
+			Status: "invalid scope",
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	var expiresAt time.Time
+	if request.ExpiresInDays > 0 {
+		expiresAt = time.Now().AddDate(0, 0, request.ExpiresInDays)
+	}
+
+	issued, err := env.appTokens.Issue(scope, request.Description, env.requestUsername(r), expiresAt)
+	if err != nil {
+		slog.Error("failed to issue an application deploy token", "error", err)
+		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
+			Status: "failed to issue an application deploy token",
+			Error:  "internal server error",
+		})
+		return
+	}
+
+	slog.Info("issued an application deploy token",
+		"token_id", issued.Id, "scope", scope.String(), "created_by", issued.CreatedBy)
+
+	// This is the only response that ever carries the secret.
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusCreated, appTokenPayload(&issued.Token, issued.Secret))
+}
+
+// revokeAppToken godoc
+// @Summary Revoke an application deploy token
+// @Description Withdraw a token, effective on its next use. Requires membership of OIDC_PRIVILEGED_GROUPS.
+// @Tags frontend
+// @Produce json
+// @Param id path string true "Token id"
+// @Success 200 {string} string
+// @Failure 400 {object} models.TaskStatus
+// @Failure 401 {object} models.TaskStatus
+// @Failure 404 {object} models.TaskStatus
+// @Failure 503 {object} models.TaskStatus
+// @Router /api/v1/app-tokens/{id} [delete]
+func (env *Env) revokeAppToken(w http.ResponseWriter, r *http.Request) {
+	if !env.requireOIDCAuth(w, r) {
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, models.TaskStatus{
+			Status: "invalid token id",
+			Error:  "the token id must be a UUID",
+		})
+		return
+	}
+
+	err = env.appTokens.Revoke(id)
+	if errors.Is(err, apptoken.ErrNotFound) {
+		writeJSON(w, http.StatusNotFound, models.TaskStatus{
+			Status: "not found",
+			Error:  "no such application deploy token",
+		})
+		return
+	}
+	if err != nil {
+		slog.Error("failed to revoke an application deploy token", "token_id", id, "error", err)
+		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
+			Status: "failed to revoke the application deploy token",
+			Error:  "internal server error",
+		})
+		return
+	}
+
+	slog.Info("revoked an application deploy token", "token_id", id, "revoked_by", env.requestUsername(r))
+
+	writeJSON(w, http.StatusOK, "application deploy token revoked")
+}
+
+// requestUsername resolves who is making a privileged request, for attribution.
+// It is best-effort: the request is already authorized by the time it is called,
+// so an operator the provider will not name must not fail the action.
+func (env *Env) requestUsername(r *http.Request) string {
+	username, err := env.authenticator.IdentifyRequest(r, oidcHeader)
+	if err != nil || username == "" {
+		slog.Debug("could not attribute a privileged action to a user", "error", err)
+		return models.UnknownUser
+	}
+
+	return username
+}
+
+// appTokenPayload renders a token for the API. secret is empty everywhere except
+// the response to the request that created the token.
+func appTokenPayload(token *apptoken.Token, secret string) models.AppTokenResponse {
+	return models.AppTokenResponse{
+		Id:          token.Id.String(),
+		Apps:        token.Scope.Apps,
+		AllApps:     token.Scope.AllApps,
+		Hint:        token.Hint,
+		Description: token.Description,
+		CreatedBy:   token.CreatedBy,
+		CreatedAt:   unixMillis(token.CreatedAt),
+		ExpiresAt:   unixMillis(token.ExpiresAt),
+		RevokedAt:   unixMillis(token.RevokedAt),
+		LastUsedAt:  unixMillis(token.LastUsedAt),
+		Secret:      secret,
+	}
+}
+
+// unixMillis renders a timestamp for the API, mapping the zero time to 0 so an
+// absent expiry or revocation is omitted from the JSON rather than sent as a date
+// in year one.
+func unixMillis(value time.Time) int64 {
+	if value.IsZero() {
+		return 0
+	}
+
+	return value.UnixMilli()
+}

--- a/internal/server/handlers_app_tokens_test.go
+++ b/internal/server/handlers_app_tokens_test.go
@@ -1,0 +1,513 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/apptoken"
+	"github.com/shini4i/argo-watcher/internal/argocd"
+	"github.com/shini4i/argo-watcher/internal/auth"
+	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// fakeTokenStore is an in-process apptoken.Store for the handler tests. The
+// production code ships no in-memory implementation on purpose, so the double
+// lives here where losing it on restart does not matter.
+type fakeTokenStore struct {
+	tokens   []apptoken.Token
+	used     []uuid.UUID
+	secrets  map[string]uuid.UUID
+	issueErr error
+	listErr  error
+}
+
+func newFakeTokenStore() *fakeTokenStore {
+	return &fakeTokenStore{secrets: map[string]uuid.UUID{}}
+}
+
+func (s *fakeTokenStore) Issue(scope apptoken.Scope, description, createdBy string, expiresAt time.Time) (*apptoken.IssuedToken, error) {
+	if s.issueErr != nil {
+		return nil, s.issueErr
+	}
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
+	credential, err := apptoken.NewCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	token := apptoken.Token{
+		Id:          uuid.New(),
+		Scope:       scope,
+		Hint:        credential.Hint,
+		Description: description,
+		CreatedBy:   createdBy,
+		CreatedAt:   time.Now(),
+		ExpiresAt:   expiresAt,
+	}
+	s.tokens = append(s.tokens, token)
+	s.secrets[credential.Secret] = token.Id
+
+	return &apptoken.IssuedToken{Token: token, Secret: credential.Secret}, nil
+}
+
+func (s *fakeTokenStore) Lookup(secret string) (*apptoken.Token, error) {
+	id, ok := s.secrets[secret]
+	if !ok {
+		return nil, apptoken.ErrNotFound
+	}
+	for index := range s.tokens {
+		if s.tokens[index].Id == id {
+			return &s.tokens[index], nil
+		}
+	}
+	return nil, apptoken.ErrNotFound
+}
+
+func (s *fakeTokenStore) List() ([]apptoken.Token, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.tokens, nil
+}
+
+func (s *fakeTokenStore) Revoke(id uuid.UUID) error {
+	for index := range s.tokens {
+		if s.tokens[index].Id == id {
+			if s.tokens[index].RevokedAt.IsZero() {
+				s.tokens[index].RevokedAt = time.Now()
+			}
+			return nil
+		}
+	}
+	return apptoken.ErrNotFound
+}
+
+func (s *fakeTokenStore) MarkUsed(id uuid.UUID) error {
+	s.used = append(s.used, id)
+	return nil
+}
+
+// namedOIDCStrategy is oidcLikeStrategy that can also name its user, which is how
+// an issued token gets attributed to the operator who created it.
+type namedOIDCStrategy struct {
+	oidcLikeStrategy
+	username string
+}
+
+func (s namedOIDCStrategy) Identify(string) (string, error) {
+	return s.username, nil
+}
+
+// appTokenEnv builds a routed Env whose app token endpoints are registered, with
+// the OIDC strategy standing in for the provider.
+func appTokenEnv(t *testing.T, strategy auth.AuthStrategy, store apptoken.Store) *Env {
+	t.Helper()
+
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{oidcHeader: strategy})
+	env.appTokens = store
+
+	return env
+}
+
+// callAppTokens issues a request to the token endpoints carrying an OIDC session.
+func callAppTokens(t *testing.T, env *Env, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var reader io.Reader = http.NoBody
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, "/api/v1"+path, reader)
+	require.NoError(t, err)
+	req.Header.Set(oidcHeader, "Bearer oidc-token")
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	env.CreateRouter().ServeHTTP(recorder, req)
+
+	return recorder
+}
+
+func privilegedStrategy(username string) auth.AuthStrategy {
+	return namedOIDCStrategy{
+		oidcLikeStrategy: oidcLikeStrategy{authenticated: true, privileged: true},
+		username:         username,
+	}
+}
+
+func TestIssueAppToken(t *testing.T) {
+	t.Run("issues a scoped token and shows the secret once", func(t *testing.T) {
+		store := newFakeTokenStore()
+		env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+		recorder := callAppTokens(t, env, http.MethodPost, appTokensEndpoint,
+			`{"apps":["app1","app2"],"description":"ci pipeline"}`)
+
+		require.Equal(t, http.StatusCreated, recorder.Code, recorder.Body.String())
+
+		var issued models.AppTokenResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &issued))
+
+		assert.True(t, apptoken.HasPrefix(issued.Secret), "the secret is returned to the operator once")
+		assert.Equal(t, []string{"app1", "app2"}, issued.Apps)
+		assert.False(t, issued.AllApps)
+		assert.Equal(t, "alice", issued.CreatedBy, "the token is attributed to its issuer")
+		assert.Equal(t, "ci pipeline", issued.Description)
+		assert.NotEmpty(t, issued.Hint)
+		assert.Zero(t, issued.ExpiresAt)
+
+		// Without this a proxy or browser cache could replay the one copy of a secret
+		// that can never be shown again.
+		assert.Equal(t, "no-store", recorder.Header().Get("Cache-Control"))
+
+		// The list is the only other view of the token, and it must never carry it.
+		listed := callAppTokens(t, env, http.MethodGet, appTokensEndpoint, "")
+		require.Equal(t, http.StatusOK, listed.Code)
+		assert.NotContains(t, listed.Body.String(), issued.Secret)
+		assert.NotContains(t, listed.Body.String(), `"secret"`)
+	})
+
+	t.Run("issues a wildcard token", func(t *testing.T) {
+		store := newFakeTokenStore()
+		env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+		recorder := callAppTokens(t, env, http.MethodPost, appTokensEndpoint, `{"all_apps":true}`)
+
+		require.Equal(t, http.StatusCreated, recorder.Code, recorder.Body.String())
+
+		var issued models.AppTokenResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &issued))
+		assert.True(t, issued.AllApps)
+		assert.Empty(t, issued.Apps)
+	})
+
+	t.Run("records the requested expiry", func(t *testing.T) {
+		store := newFakeTokenStore()
+		env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+		recorder := callAppTokens(t, env, http.MethodPost, appTokensEndpoint,
+			`{"apps":["app1"],"expires_in_days":30}`)
+
+		require.Equal(t, http.StatusCreated, recorder.Code, recorder.Body.String())
+
+		var issued models.AppTokenResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &issued))
+		assert.InDelta(t, time.Now().AddDate(0, 0, 30).UnixMilli(), issued.ExpiresAt, float64(time.Minute.Milliseconds()))
+	})
+
+	rejected := []struct {
+		name string
+		body string
+	}{
+		{name: "an empty scope", body: `{}`},
+		{name: "a wildcard that also lists applications", body: `{"all_apps":true,"apps":["app1"]}`},
+		{name: "a blank application name", body: `{"apps":["  "]}`},
+		{name: "an expiry beyond the cap", body: `{"apps":["app1"],"expires_in_days":4000}`},
+		{name: "a negative expiry", body: `{"apps":["app1"],"expires_in_days":-1}`},
+		{name: "a malformed body", body: `{"apps":`},
+		{name: "an over-long description", body: `{"apps":["app1"],"description":"` + strings.Repeat("d", 256) + `"}`},
+		{name: "more applications than the cap", body: `{"apps":` + jsonAppList(201) + `}`},
+	}
+
+	for _, test := range rejected {
+		t.Run("rejects "+test.name, func(t *testing.T) {
+			store := newFakeTokenStore()
+			env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+			recorder := callAppTokens(t, env, http.MethodPost, appTokensEndpoint, test.body)
+
+			assert.Equal(t, http.StatusNotAcceptable, recorder.Code, recorder.Body.String())
+			assert.Empty(t, store.tokens, "a rejected request must not mint a token")
+		})
+	}
+}
+
+func TestAppTokenEndpointsRequirePrivilege(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy auth.AuthStrategy
+		status   int
+	}{
+		{
+			name:     "an authenticated but unprivileged user",
+			strategy: oidcLikeStrategy{authenticated: true},
+			status:   http.StatusUnauthorized,
+		},
+		{
+			name:     "an unauthenticated request",
+			strategy: oidcLikeStrategy{},
+			status:   http.StatusUnauthorized,
+		},
+		{
+			name:     "a provider that cannot be consulted",
+			strategy: oidcLikeStrategy{unavailable: true},
+			status:   http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newFakeTokenStore()
+			env := appTokenEnv(t, test.strategy, store)
+
+			issue := callAppTokens(t, env, http.MethodPost, appTokensEndpoint, `{"all_apps":true}`)
+			assert.Equal(t, test.status, issue.Code)
+			assert.Empty(t, store.tokens, "an unauthorized request must not mint a token")
+
+			list := callAppTokens(t, env, http.MethodGet, appTokensEndpoint, "")
+			assert.Equal(t, test.status, list.Code, "the list names who holds which credential")
+
+			revoke := callAppTokens(t, env, http.MethodDelete, appTokensEndpoint+"/"+uuid.NewString(), "")
+			assert.Equal(t, test.status, revoke.Code)
+		})
+	}
+}
+
+func TestRevokeAppToken(t *testing.T) {
+	store := newFakeTokenStore()
+	env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+	issued, err := store.Issue(apptoken.Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	t.Run("revokes a token", func(t *testing.T) {
+		recorder := callAppTokens(t, env, http.MethodDelete, appTokensEndpoint+"/"+issued.Id.String(), "")
+
+		require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+		stored, err := store.Lookup(issued.Secret)
+		require.NoError(t, err)
+		assert.False(t, stored.Usable(time.Now()), "a revoked token must stop authorizing")
+	})
+
+	t.Run("reports an unknown token", func(t *testing.T) {
+		recorder := callAppTokens(t, env, http.MethodDelete, appTokensEndpoint+"/"+uuid.NewString(), "")
+
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+
+	t.Run("rejects an id that is not a UUID", func(t *testing.T) {
+		recorder := callAppTokens(t, env, http.MethodDelete, appTokensEndpoint+"/not-a-uuid", "")
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+}
+
+func TestAppTokenEndpointsUnregisteredWithoutAStore(t *testing.T) {
+	// Without a Postgres store the feature is off, and its endpoints must not exist
+	// rather than answering 500 from a nil store.
+	env := appTokenEnv(t, privilegedStrategy("alice"), nil)
+	env.appTokens = nil
+
+	for _, call := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, appTokensEndpoint},
+		{http.MethodPost, appTokensEndpoint},
+		{http.MethodDelete, appTokensEndpoint + "/" + uuid.NewString()},
+	} {
+		t.Run(call.method, func(t *testing.T) {
+			recorder := callAppTokens(t, env, call.method, call.path, `{"all_apps":true}`)
+
+			// The one discriminator that holds in both places: an unregistered route is
+			// answered by the Web UI fallback, never by a handler. Here that is 404
+			// text/plain because the static path is an empty temp dir; with a real bundle
+			// it is 200 HTML. Either way it must not be the API, so a route that became
+			// reachable (401/200/201 JSON) fails this.
+			assert.NotContains(t, recorder.Header().Get("Content-Type"), "application/json",
+				"the request must not have reached a handler")
+			assert.Equal(t, http.StatusNotFound, recorder.Code)
+		})
+	}
+}
+
+func TestListAppTokensSurfacesAStoreFailure(t *testing.T) {
+	store := newFakeTokenStore()
+	store.listErr = errors.New("connection refused")
+	env := appTokenEnv(t, privilegedStrategy("alice"), store)
+
+	recorder := callAppTokens(t, env, http.MethodGet, appTokensEndpoint, "")
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotContains(t, recorder.Body.String(), "connection refused", "the internal reason stays in the log")
+}
+
+func TestAppTokenAttributionFallsBackToUnknown(t *testing.T) {
+	store := newFakeTokenStore()
+	// A provider that authorizes but names nobody: the action is still recorded.
+	env := appTokenEnv(t, oidcLikeStrategy{authenticated: true, privileged: true}, store)
+
+	recorder := callAppTokens(t, env, http.MethodPost, appTokensEndpoint, `{"apps":["app1"]}`)
+
+	require.Equal(t, http.StatusCreated, recorder.Code, recorder.Body.String())
+
+	var issued models.AppTokenResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &issued))
+	assert.Equal(t, models.UnknownUser, issued.CreatedBy)
+}
+
+func TestAppTokenScopesTaskSubmission(t *testing.T) {
+	store := newFakeTokenStore()
+	scoped, err := store.Issue(apptoken.Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{
+		oidcHeader:      privilegedStrategy("alice"),
+		"Authorization": auth.NewPrefixRouter(auth.NewAppTokenAuthService(store), nil),
+	})
+	env.appTokens = store
+	router := env.CreateRouter()
+
+	submit := func(t *testing.T, app string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := fmt.Sprintf(`{"app":%q,"author":"ci","project":"demo","images":[{"image":"nginx","tag":"1.0"}]}`, app)
+		req, err := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+scoped.Secret)
+		req.Header.Set("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	// The task submission endpoint takes an optional credential, so a token outside
+	// its scope is a rejection rather than a silently unvalidated task: accepting it
+	// would skip the write-back and fail the rollout blaming the image.
+	assert.Equal(t, http.StatusUnauthorized, submit(t, "app2").Code)
+}
+
+// TestAppTokenAuthorizesAnInScopeSubmission is the feature's central assertion: an
+// in-scope token produces an accepted, *validated* task, which is what
+// git_updater.go gates the write-back on. Without it, reverting addTask to the
+// unscoped validateToken leaves the whole suite green — every app-token deployment
+// would 401 and only the negative case would still pass.
+func TestAppTokenAuthorizesAnInScopeSubmission(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope apptoken.Scope
+		app   string
+	}{
+		{name: "a token scoped to the application", scope: apptoken.Scope{Apps: []string{"app1"}}, app: "app1"},
+		{name: "a wildcard token on an unrelated application", scope: apptoken.Scope{AllApps: true}, app: "some-other-app"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newFakeTokenStore()
+			issued, err := store.Issue(test.scope, "", "alice", time.Time{})
+			require.NoError(t, err)
+
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewMockTaskRepository(ctrl)
+			repo.EXPECT().Check().Return(true).AnyTimes()
+			repo.EXPECT().CancelInProgressTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(int64(0), nil).AnyTimes()
+			// AddTask consults the history for rollback detection before inserting.
+			repo.EXPECT().GetTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]models.Task{}, int64(0)).AnyTimes()
+
+			// Capture the task, then fail the insert: the success path would spawn the
+			// real rollout goroutine. Validated is already decided by this point.
+			var stored models.Task
+			repo.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+				stored = task
+				return nil, errors.New("stop before the rollout goroutine")
+			})
+
+			lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
+			require.NoError(t, err)
+			argo := &argocd.Argo{}
+			argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+			strategies := map[string]auth.AuthStrategy{
+				"Authorization": auth.NewPrefixRouter(auth.NewAppTokenAuthService(store), nil),
+			}
+			env := &Env{
+				lockdown:      lockdown,
+				strategies:    strategies,
+				authenticator: auth.NewAuthenticator(strategies),
+				argo:          argo,
+				config:        &config.ServerConfig{DeploymentTimeout: 900},
+			}
+
+			router := chi.NewRouter()
+			router.Post("/api/v1/tasks", env.addTask)
+
+			body := fmt.Sprintf(
+				`{"app":%q,"author":"ci","project":"demo","images":[{"image":"nginx","tag":"1.0"}]}`, test.app)
+			req, err := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+issued.Secret)
+			req.Header.Set("Content-Type", "application/json")
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			assert.True(t, stored.Validated, "an in-scope token must authorize the git write-back")
+			assert.Equal(t, test.app, stored.App)
+			assert.Equal(t, []uuid.UUID{issued.Id}, store.used, "an authorized deployment is recorded as a use")
+		})
+	}
+}
+
+// TestAppTokenDoesNotRecordAnUnauthorizedUse pairs with the above: the out-of-scope
+// rejection must not look like a use of the token.
+func TestAppTokenDoesNotRecordAnUnauthorizedUse(t *testing.T) {
+	store := newFakeTokenStore()
+	issued, err := store.Issue(apptoken.Scope{Apps: []string{"app1"}}, "", "alice", time.Time{})
+	require.NoError(t, err)
+
+	strategies := map[string]auth.AuthStrategy{
+		"Authorization": auth.NewPrefixRouter(auth.NewAppTokenAuthService(store), nil),
+	}
+	valid, err := auth.NewAuthenticator(strategies).ValidateForApp(
+		requestWithToken(t, issued.Secret), "app2")
+
+	assert.False(t, valid)
+	require.Error(t, err)
+	assert.Empty(t, store.used)
+}
+
+func requestWithToken(t *testing.T, secret string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/tasks", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+secret)
+	return req
+}
+
+// jsonAppList renders count distinct application names as a JSON array, for testing
+// the list-length cap against unique entries rather than duplicates.
+func jsonAppList(count int) string {
+	apps := make([]string, count)
+	for i := range apps {
+		apps[i] = fmt.Sprintf("app-%d", i)
+	}
+	encoded, err := json.Marshal(apps)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}

--- a/internal/server/handlers_lock.go
+++ b/internal/server/handlers_lock.go
@@ -30,7 +30,7 @@ func (env *Env) SetDeployLock(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to set deploy lock", "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Status: "failed to set deploy lock",
-			Error:  "internal server error",
+			Error:  internalErrorMessage,
 		})
 		return
 	}
@@ -57,7 +57,7 @@ func (env *Env) ReleaseDeployLock(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to release deploy lock", "error", err)
 		writeJSON(w, http.StatusInternalServerError, models.TaskStatus{
 			Status: "failed to release deploy lock",
-			Error:  "internal server error",
+			Error:  internalErrorMessage,
 		})
 		return
 	}

--- a/internal/server/read_auth_test.go
+++ b/internal/server/read_auth_test.go
@@ -512,3 +512,37 @@ func TestReadAuthTaskLookupEnforced(t *testing.T) {
 		assert.Zero(t, unauthenticatedReads(metrics, routePath, models.UnknownApp))
 	})
 }
+
+// TestUnauthenticatedReadCountsAnUnevaluatedHeader pins the counter against the
+// Authorization header now being registered unconditionally. A value nothing
+// evaluates is a genuinely uncredentialed read: counting it as credentialed would
+// let the number fall to zero while un-migrated callers are still polling, and that
+// number reaching zero is what licenses closing the endpoint.
+func TestUnauthenticatedReadCountsAnUnevaluatedHeader(t *testing.T) {
+	// The metric label, which dashboards select on.
+	const routePath = "/api/v1/tasks/:id"
+	const unknownTask = "/api/v1/tasks/00000000-0000-0000-0000-000000000000"
+
+	// No JWT secret, so the router's fallback is nil and nothing reads a
+	// non-prefixed Authorization value.
+	strategies := map[string]auth.AuthStrategy{
+		oidcHeader:      oidcLikeStrategy{authenticated: true},
+		"Authorization": auth.NewPrefixRouter(auth.DisabledAppTokenStrategy(), nil),
+	}
+
+	t.Run("counts a bearer token no strategy evaluates", func(t *testing.T) {
+		env, metrics := readAuthEnv(t, true, strategies)
+
+		getWith(t, env, unknownTask, "Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.e30.sig")
+
+		assert.Equal(t, float64(1), unauthenticatedReads(metrics, routePath, models.UnknownApp))
+	})
+
+	t.Run("does not count a token the router does evaluate", func(t *testing.T) {
+		env, metrics := readAuthEnv(t, true, strategies)
+
+		getWith(t, env, unknownTask, "Authorization", "Bearer awt_someIssuedToken")
+
+		assert.Zero(t, unauthenticatedReads(metrics, routePath, models.UnknownApp))
+	})
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -102,6 +102,16 @@ func (env *Env) CreateRouter() *chi.Mux {
 		if env.config.OIDC.Enabled {
 			r.Post(deployLockEndpoint, env.SetDeployLock)
 			r.Delete(deployLockEndpoint, env.ReleaseDeployLock)
+
+			// Registered only where the tokens can actually live (see
+			// Env.appTokenStrategy). Every one enforces privileged membership itself,
+			// so listing tokens is as restricted as issuing them: the list names who
+			// holds a credential for which applications.
+			if env.appTokens != nil {
+				r.Get(appTokensEndpoint, env.listAppTokens)
+				r.Post(appTokensEndpoint, env.issueAppToken)
+				r.Delete(appTokensEndpoint+"/{id}", env.revokeAppToken)
+			}
 		}
 	})
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/shini4i/argo-watcher/internal/apptoken"
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
@@ -298,7 +299,7 @@ func TestNewEnv(t *testing.T) {
 	metrics := &prometheus.Metrics{}
 	updater := &argocd.ArgoStatusUpdater{}
 
-	env, err := NewEnv(serverConfig, argo, metrics, updater, lock.NewInMemoryDeployLockStore())
+	env, err := NewEnv(serverConfig, argo, metrics, updater, lock.NewInMemoryDeployLockStore(), nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, env.config, serverConfig)
@@ -310,10 +311,19 @@ func TestNewEnv(t *testing.T) {
 	// options, and two function values are never equal.
 	require.Len(t, env.strategies, 3)
 	require.IsType(t, &auth.DeployTokenAuthService{}, env.strategies["ARGO_WATCHER_DEPLOY_TOKEN"])
-	require.IsType(t, &auth.JWTAuthService{}, env.strategies["Authorization"])
+	// Authorization carries either a CI JWT or an application deploy token, so a
+	// router owns it and dispatches on the token's shape.
+	require.IsType(t, &auth.PrefixRouter{}, env.strategies["Authorization"])
 	require.IsType(t, &auth.OIDCAuthService{}, env.strategies[oidcHeader])
 
-	accepted, err := env.strategies["ARGO_WATCHER_DEPLOY_TOKEN"].Validate(serverConfig.DeployToken)
+	// No store was passed, so the feature is off and its endpoints stay unregistered.
+	assert.Nil(t, env.appTokens)
+	accepted, err := env.strategies["Authorization"].Validate("awt_someIssuedToken")
+	assert.False(t, accepted)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STATE_TYPE=postgres")
+
+	accepted, err = env.strategies["ARGO_WATCHER_DEPLOY_TOKEN"].Validate(serverConfig.DeployToken)
 	assert.NoError(t, err)
 	assert.True(t, accepted)
 
@@ -361,7 +371,7 @@ func TestNewEnvInvalidOIDCURL(t *testing.T) {
 		},
 	}
 
-	env, err := NewEnv(serverConfig, &argocd.Argo{}, &prometheus.Metrics{}, &argocd.ArgoStatusUpdater{}, lock.NewInMemoryDeployLockStore())
+	env, err := NewEnv(serverConfig, &argocd.Argo{}, &prometheus.Metrics{}, &argocd.ArgoStatusUpdater{}, lock.NewInMemoryDeployLockStore(), nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to initialize OIDC auth")
@@ -2667,4 +2677,67 @@ func TestAddTaskResolvesTheDeploymentWindow(t *testing.T) {
 			assert.Equal(t, tt.want, stored.Timeout)
 		})
 	}
+}
+
+// TestNewEnvAppTokenGate covers both arms of the two-part enablement rule. Without
+// the OIDC arm, deleting its case leaves the suite green while making tokens usable
+// with OIDC off — at which point no /app-tokens route is registered, so rows keep
+// authorizing write-backs with no way left to list or revoke them.
+func TestNewEnvAppTokenGate(t *testing.T) {
+	baseConfig := func(oidcEnabled bool) *config.ServerConfig {
+		return &config.ServerConfig{
+			Host: "localhost",
+			Port: "8080",
+			OIDC: config.OIDCConfig{
+				Enabled:   oidcEnabled,
+				IssuerURL: "http://localhost:8080/realms/test",
+				ClientId:  "test",
+			},
+			StaticFilePath: t.TempDir(),
+		}
+	}
+
+	newEnvWithStore := func(t *testing.T, oidcEnabled bool) (*Env, apptoken.Store) {
+		t.Helper()
+		store := newFakeTokenStore()
+		env, err := NewEnv(baseConfig(oidcEnabled), &argocd.Argo{}, &prometheus.Metrics{},
+			&argocd.ArgoStatusUpdater{}, lock.NewInMemoryDeployLockStore(), store)
+		require.NoError(t, err)
+		return env, store
+	}
+
+	t.Run("a store without OIDC leaves the feature off", func(t *testing.T) {
+		env, _ := newEnvWithStore(t, false)
+
+		assert.Nil(t, env.appTokens, "no store means no endpoints get registered")
+
+		valid, err := env.strategies["Authorization"].Validate("awt_someIssuedToken")
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OIDC_ENABLED",
+			"a token must be refused by name, so a pipeline is told why")
+	})
+
+	t.Run("a store with OIDC enables the feature and its endpoints", func(t *testing.T) {
+		env, store := newEnvWithStore(t, true)
+
+		require.NotNil(t, env.appTokens)
+		assert.Same(t, store, env.appTokens, "the endpoints must serve the store that was passed in")
+
+		// The strategy now evaluates prefixed tokens instead of refusing them.
+		valid, err := env.strategies["Authorization"].Validate("awt_someIssuedToken")
+		assert.False(t, valid)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "OIDC_ENABLED")
+
+		// And the routes exist: an unregistered path answers the SPA fallback in HTML.
+		req, err := http.NewRequest(http.MethodGet, "/api/v1/app-tokens", http.NoBody)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		env.CreateRouter().ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusUnauthorized, recorder.Code,
+			"the route exists and enforces privilege rather than falling through to the UI")
+		assert.Contains(t, recorder.Header().Get("Content-Type"), "application/json")
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/shini4i/argo-watcher/internal/apptoken"
 	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/config"
 	"github.com/shini4i/argo-watcher/internal/lock"
@@ -78,6 +79,9 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 	// correct for a single replica only.
 	var locker lock.Locker
 	var deployLockStore lock.DeployLockStore
+	// Nil unless the state is Postgres, which turns application deploy tokens off:
+	// they must survive a restart and be visible to every replica.
+	var appTokenStore apptoken.Store
 	if serverConfig.StateType == "postgres" {
 		pgState, ok := s.(*state.PostgresState)
 		if !ok {
@@ -89,6 +93,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		}
 		locker = lock.NewPostgresLocker(db)
 		deployLockStore = lock.NewPostgresDeployLockStore(db)
+		appTokenStore = apptoken.NewPostgresStore(db)
 		slog.Info("Using Postgres advisory locks for distributed locking and a shared deploy lock.")
 	} else {
 		locker = lock.NewInMemoryLocker()
@@ -121,7 +126,7 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 		return nil, fmt.Errorf("failed to initialize the argo updater: %w", err)
 	}
 
-	env, err := NewEnv(serverConfig, argo, metrics, statusUpdater, deployLockStore)
+	env, err := NewEnv(serverConfig, argo, metrics, statusUpdater, deployLockStore, appTokenStore)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -60,7 +60,7 @@ func (env *Env) authorizeWebSocket(w http.ResponseWriter, r *http.Request) bool 
 	if errors.Is(err, auth.ErrProviderUnavailable) {
 		slog.Error("rejecting websocket: authentication provider unavailable", "error", err)
 		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-			Status: "authentication provider unavailable",
+			Status: providerUnavailableMessage,
 			Error:  err.Error(),
 		})
 		return false

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -113,7 +113,7 @@ describe('App', () => {
     expect(resourceCalls[0].name).toBe('tasks');
     expect(resourceCalls[0].list).toBe(RecentTasksListStub);
 
-    expect(routeCalls.map(props => props.path)).toEqual(['/history', '/task/:id']);
+    expect(routeCalls.map(props => props.path)).toEqual(['/history', '/task/:id', '/app-tokens']);
 
     const historyRoute = routeCalls.find(props => props.path === '/history');
     expect((historyRoute?.element as ReactElement)?.type).toBe(HistoryTasksListStub);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { RecentTasksList } from './features/tasks/RecentTasksList';
 import { HistoryTasksList } from './features/tasks/HistoryTasksList';
 import { AppNotification } from './layout/components/AppNotification';
 import { TaskShow } from './features/tasks/show/TaskShow';
+import { AppTokensPage } from './features/appTokens/AppTokensPage';
 import { useThemeMode } from './theme';
 
 /**
@@ -32,6 +33,7 @@ export const App = () => {
       <CustomRoutes>
         <Route path="/history" element={<HistoryTasksList />} />
         <Route path="/task/:id" element={<TaskShow />} />
+        <Route path="/app-tokens" element={<AppTokensPage />} />
       </CustomRoutes>
     </Admin>
   );

--- a/web/src/features/appTokens/AppTokensPage.test.tsx
+++ b/web/src/features/appTokens/AppTokensPage.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppTokensPage } from './AppTokensPage';
+import type { AppToken } from './appTokensService';
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+const notifyMock = vi.fn();
+const availableMock = vi.fn();
+const permissionsMock = vi.fn();
+const listMock = vi.fn();
+const issueMock = vi.fn();
+const revokeMock = vi.fn();
+
+vi.mock('./appTokensService', async () => {
+  const actual = await vi.importActual<typeof import('./appTokensService')>('./appTokensService');
+  return {
+    ...actual,
+    listAppTokens: () => listMock(),
+    issueAppToken: (request: unknown) => issueMock(request),
+    revokeAppToken: (id: string) => revokeMock(id),
+  };
+});
+
+vi.mock('../../shared/hooks/useAppTokensAvailable', () => ({
+  useAppTokensAvailable: () => availableMock(),
+}));
+
+vi.mock('react-admin', async () => {
+  const actual = await vi.importActual<typeof import('react-admin')>('react-admin');
+  return {
+    ...actual,
+    usePermissions: () => permissionsMock(),
+    useNotify: () => notifyMock,
+  };
+});
+
+const token = (overrides: Partial<AppToken> = {}): AppToken => ({
+  id: 'a1',
+  all_apps: false,
+  apps: ['app1'],
+  hint: '3f9a',
+  description: 'ci pipeline',
+  created_by: 'alice',
+  created_at: 1_700_000_000_000,
+  ...overrides,
+});
+
+const privileged = () => ({ permissions: { groups: ['admins'], privilegedGroups: ['admins'] } });
+
+describe('AppTokensPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    availableMock.mockReturnValue(true);
+    permissionsMock.mockReturnValue(privileged());
+    listMock.mockResolvedValue([]);
+  });
+
+  describe('access', () => {
+    it.each([
+      ['an unprivileged user', true, { permissions: { groups: ['devs'], privilegedGroups: ['admins'] } }],
+      ['a server without the feature', false, privileged()],
+      ['an unresolved availability', null, privileged()],
+    ])('refuses %s', async (_name, oidc, permissions) => {
+      availableMock.mockReturnValue(oidc);
+      permissionsMock.mockReturnValue(permissions);
+
+      render(<AppTokensPage />);
+
+      expect(
+        await screen.findByText(/require authentication, the Postgres state backend, and privileged/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Issue token' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('lists the issued tokens without ever showing a secret', async () => {
+    listMock.mockResolvedValue([
+      token(),
+      token({ id: 'a2', all_apps: true, apps: [], hint: 'bb01', description: '' }),
+      token({ id: 'a3', hint: 'cc02', revoked_at: 1_700_000_100_000 }),
+    ]);
+
+    render(<AppTokensPage />);
+
+    expect(await screen.findByText('awt_…3f9a')).toBeInTheDocument();
+    expect(screen.getByText('All applications')).toBeInTheDocument();
+    expect(screen.getAllByText('app1')).toHaveLength(2);
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+    expect(screen.getAllByText('Active')).toHaveLength(2);
+
+    // A revoked token cannot be revoked again, so it carries no action.
+    expect(screen.getAllByRole('button', { name: 'Revoke' })).toHaveLength(2);
+  });
+
+  it('says so when nothing has been issued', async () => {
+    render(<AppTokensPage />);
+
+    expect(await screen.findByText(/No deploy tokens have been issued/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a failure to load', async () => {
+    listMock.mockRejectedValue(new Error('unauthorized'));
+
+    render(<AppTokensPage />);
+
+    expect(await screen.findByText('unauthorized')).toBeInTheDocument();
+  });
+
+  it('shows a freshly issued secret once, then forgets it', async () => {
+    const user = userEvent.setup();
+    issueMock.mockResolvedValue(token({ secret: 'awt_brandNewSecret' }));
+
+    render(<AppTokensPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Issue token' }));
+    await user.type(screen.getByLabelText(/^Applications/), 'app1');
+    await user.click(screen.getByRole('button', { name: 'Issue' }));
+
+    const secretField = await screen.findByLabelText('Deploy token secret');
+    expect(secretField).toHaveValue('awt_brandNewSecret');
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apps: ['app1'] }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Deploy token secret')).not.toBeInTheDocument();
+    });
+  });
+
+  it('revokes a token and reloads the list', async () => {
+    const user = userEvent.setup();
+    listMock.mockResolvedValue([token()]);
+    revokeMock.mockResolvedValue(undefined);
+
+    render(<AppTokensPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => {
+      expect(revokeMock).toHaveBeenCalledWith('a1');
+    });
+    // Two loads: the initial one and the reload after the mutation, so the table
+    // shows what the server holds rather than an optimistic guess.
+    expect(listMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a failed revocation without dropping the row', async () => {
+    const user = userEvent.setup();
+    listMock.mockResolvedValue([token()]);
+    revokeMock.mockRejectedValue(new Error('token is gone'));
+
+    render(<AppTokensPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => {
+      expect(notifyMock).toHaveBeenCalledWith('token is gone', { type: 'error' });
+    });
+    expect(screen.getByText('awt_…3f9a')).toBeInTheDocument();
+  });
+});

--- a/web/src/features/appTokens/AppTokensPage.tsx
+++ b/web/src/features/appTokens/AppTokensPage.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useNotify, usePermissions } from 'react-admin';
+import { formatDateTime, hasPrivilegedAccess } from '../../shared/utils';
+import { useAppTokensAvailable } from '../../shared/hooks/useAppTokensAvailable';
+import { type AppToken, describeScope, isTokenActive } from './appTokensService';
+import { useAppTokens } from './useAppTokens';
+import { IssueTokenDialog } from './IssueTokenDialog';
+import { SecretRevealDialog } from './SecretRevealDialog';
+
+/** Renders a timestamp, or an em dash where the server sent none. */
+const timestamp = (value?: number): string => (value ? formatDateTime(value) : '—');
+
+const StatusChip = ({ token }: { token: AppToken }) => {
+  if (token.revoked_at) {
+    return <Chip label="Revoked" size="small" color="error" variant="outlined" />;
+  }
+  if (!isTokenActive(token)) {
+    return <Chip label="Expired" size="small" color="warning" variant="outlined" />;
+  }
+  return <Chip label="Active" size="small" color="success" variant="outlined" />;
+};
+
+/**
+ * Management page for application deploy tokens. Reachable only with privileged
+ * access: the list names who holds a credential for which applications, so it is
+ * as restricted as issuing one.
+ */
+export const AppTokensPage = () => {
+  const notify = useNotify();
+  const available = useAppTokensAvailable();
+  const { permissions } = usePermissions();
+  const { tokens, loading, error, issue, revoke } = useAppTokens();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  const groups: readonly string[] = (permissions as { groups?: string[] })?.groups ?? [];
+  const privilegedGroups: readonly string[] =
+    (permissions as { privilegedGroups?: string[] })?.privilegedGroups ?? [];
+  const privileged = hasPrivilegedAccess(groups, privilegedGroups);
+
+  const handleIssue = useCallback(
+    async (request: Parameters<typeof issue>[0]) => {
+      const created = await issue(request);
+      setSecret(created.secret ?? null);
+      notify('Deploy token issued.', { type: 'info' });
+    },
+    [issue, notify],
+  );
+
+  const handleRevoke = useCallback(
+    async (token: AppToken) => {
+      setRevoking(token.id);
+      try {
+        await revoke(token.id);
+        notify('Deploy token revoked.', { type: 'info' });
+      } catch (err) {
+        notify(err instanceof Error ? err.message : 'Failed to revoke the token.', { type: 'error' });
+      } finally {
+        setRevoking(null);
+      }
+    },
+    [notify, revoke],
+  );
+
+  // Default-deny while the config is still loading (available === null): the
+  // endpoints do not exist without OIDC and Postgres, so there is nothing to manage.
+  if (available !== true || !privileged) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="info">
+          Deploy tokens require authentication, the Postgres state backend, and privileged
+          access.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Stack direction="row" alignItems="center" sx={{ mb: 2, width: '100%' }}>
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          <Typography variant="h6">Deploy tokens</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Credentials a pipeline presents to authorize a git write-back.
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          size="small"
+          onClick={() => setDialogOpen(true)}
+          sx={{ ml: 'auto', flexShrink: 0 }}
+        >
+          Issue token
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading && tokens.length === 0 ? (
+        <Stack alignItems="center" sx={{ py: 4 }}>
+          <CircularProgress size={28} />
+        </Stack>
+      ) : (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small" aria-label="Deploy tokens">
+            <TableHead>
+              <TableRow>
+                <TableCell>Token</TableCell>
+                <TableCell>Scope</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell>Issued by</TableCell>
+                <TableCell>Created</TableCell>
+                <TableCell>Expires</TableCell>
+                <TableCell>Last used</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {tokens.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={9}>
+                    <Typography variant="body2" color="text.secondary">
+                      No deploy tokens have been issued.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                tokens.map(token => (
+                  <TableRow key={token.id} hover>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                        awt_…{token.hint}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{describeScope(token)}</TableCell>
+                    <TableCell>{token.description || '—'}</TableCell>
+                    <TableCell>{token.created_by}</TableCell>
+                    <TableCell>{timestamp(token.created_at)}</TableCell>
+                    <TableCell>{token.expires_at ? timestamp(token.expires_at) : 'Never'}</TableCell>
+                    <TableCell>{timestamp(token.last_used_at)}</TableCell>
+                    <TableCell>
+                      <StatusChip token={token} />
+                    </TableCell>
+                    <TableCell align="right">
+                      {token.revoked_at ? null : (
+                        <Button
+                          size="small"
+                          color="error"
+                          disabled={revoking === token.id}
+                          onClick={() => void handleRevoke(token)}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <IssueTokenDialog open={dialogOpen} onClose={() => setDialogOpen(false)} onIssue={handleIssue} />
+      <SecretRevealDialog secret={secret} onClose={() => setSecret(null)} />
+    </Box>
+  );
+};

--- a/web/src/features/appTokens/IssueTokenDialog.test.tsx
+++ b/web/src/features/appTokens/IssueTokenDialog.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueTokenDialog, parseApps } from './IssueTokenDialog';
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+describe('parseApps', () => {
+  it.each([
+    ['app1', ['app1']],
+    ['app1\napp2', ['app1', 'app2']],
+    ['app1, app2', ['app1', 'app2']],
+    ['  app1  \n\n  app2 ', ['app1', 'app2']],
+    ['', []],
+    ['   \n  ', []],
+  ])('parses %j', (input, expected) => {
+    expect(parseApps(input)).toEqual(expected);
+  });
+});
+
+describe('IssueTokenDialog', () => {
+  const onIssue = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    onIssue.mockResolvedValue(undefined);
+  });
+
+  const renderDialog = () =>
+    render(<IssueTokenDialog open onClose={onClose} onIssue={onIssue} />);
+
+  it('refuses to submit an empty scope', async () => {
+    renderDialog();
+
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeDisabled();
+  });
+
+  it('submits an explicit application list', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/^Applications/), 'app1, app2');
+    await user.type(screen.getByLabelText(/^Description/), 'ci pipeline');
+    await user.click(screen.getByRole('button', { name: 'Issue' }));
+
+    await waitFor(() => {
+      expect(onIssue).toHaveBeenCalledWith({
+        apps: ['app1', 'app2'],
+        all_apps: undefined,
+        description: 'ci pipeline',
+        expires_in_days: undefined,
+      });
+    });
+  });
+
+  it('sends the wildcard instead of a list', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    // A stale list must not travel with the wildcard: the server rejects a request
+    // that sets both.
+    await user.type(screen.getByLabelText(/^Applications/), 'app1');
+    await user.click(screen.getByLabelText('All applications'));
+    await user.click(screen.getByRole('button', { name: 'Issue' }));
+
+    await waitFor(() => {
+      expect(onIssue).toHaveBeenCalledWith({
+        apps: undefined,
+        all_apps: true,
+        description: undefined,
+        expires_in_days: undefined,
+      });
+    });
+  });
+
+  it('disables the application list under the wildcard', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText('All applications'));
+
+    expect(screen.getByLabelText(/^Applications/)).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeEnabled();
+  });
+
+  it('passes a requested expiry through', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText('All applications'));
+    await user.type(screen.getByLabelText(/^Expires in/), '30');
+    await user.click(screen.getByRole('button', { name: 'Issue' }));
+
+    await waitFor(() => {
+      expect(onIssue).toHaveBeenCalledWith(expect.objectContaining({ expires_in_days: 30 }));
+    });
+  });
+
+  it.each([['4000'], ['-1'], ['1.5'], ['abc']])('blocks submission on an expiry of %s', async input => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText('All applications'));
+    await user.type(screen.getByLabelText(/^Expires in/), input);
+
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeDisabled();
+    expect(onIssue).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dialog open and shows why a request was refused', async () => {
+    const user = userEvent.setup();
+    onIssue.mockRejectedValue(new Error('a token must not list more than 200 applications'));
+    renderDialog();
+
+    await user.click(screen.getByLabelText('All applications'));
+    await user.click(screen.getByRole('button', { name: 'Issue' }));
+
+    expect(await screen.findByText(/not list more than 200 applications/)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears the form when cancelled', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/^Applications/), 'app1');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(screen.getByLabelText(/^Applications/)).toHaveValue('');
+  });
+});

--- a/web/src/features/appTokens/IssueTokenDialog.test.tsx
+++ b/web/src/features/appTokens/IssueTokenDialog.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { IssueTokenDialog, parseApps } from './IssueTokenDialog';
+import { IssueTokenDialog, parseApps, scopeError } from './IssueTokenDialog';
 
 vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 
@@ -130,5 +130,66 @@ describe('IssueTokenDialog', () => {
 
     expect(onClose).toHaveBeenCalled();
     expect(screen.getByLabelText(/^Applications/)).toHaveValue('');
+  });
+});
+
+// The server caps an explicit scope at 200 names of 255 characters and answers 406.
+// The dialog must refuse first rather than round-tripping a request it knows is bad.
+describe('scope caps', () => {
+  const onIssue = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    onIssue.mockResolvedValue(undefined);
+  });
+
+  const names = (count: number) => Array.from({ length: count }, (_, i) => `app-${i}`).join(',');
+
+  it.each([
+    ['more names than the cap', names(201), /At most 200 applications/],
+    ['a name longer than the cap', 'a'.repeat(256), /at most 255 characters/],
+  ])('refuses %s without submitting', async (_name, input, message) => {
+    render(<IssueTokenDialog open onClose={onClose} onIssue={onIssue} />);
+
+    fireEvent.change(screen.getByLabelText(/^Applications/), { target: { value: input } });
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeDisabled();
+    expect(onIssue).not.toHaveBeenCalled();
+  });
+
+  it('accepts the boundary values', async () => {
+    render(<IssueTokenDialog open onClose={onClose} onIssue={onIssue} />);
+
+    fireEvent.change(screen.getByLabelText(/^Applications/), { target: { value: names(200) } });
+
+    expect(screen.getByText('200 applications')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeEnabled();
+  });
+
+  it('a wildcard is unaffected by a stale over-cap list', async () => {
+    const user = userEvent.setup();
+    render(<IssueTokenDialog open onClose={onClose} onIssue={onIssue} />);
+
+    fireEvent.change(screen.getByLabelText(/^Applications/), { target: { value: names(201) } });
+    await user.click(screen.getByLabelText('All applications'));
+
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeEnabled();
+  });
+});
+
+describe('scopeError', () => {
+  it('accepts an acceptable scope', () => {
+    expect(scopeError(['app1', 'app2'])).toBeNull();
+    expect(scopeError([])).toBeNull();
+    expect(scopeError(Array.from({ length: 200 }, (_, i) => `app-${i}`))).toBeNull();
+    expect(scopeError(['a'.repeat(255)])).toBeNull();
+  });
+
+  it('names why a scope is refused', () => {
+    expect(scopeError(Array.from({ length: 201 }, (_, i) => `app-${i}`))).toMatch(/At most 200/);
+    expect(scopeError(['ok', 'a'.repeat(256)])).toMatch(/at most 255 characters/);
   });
 });

--- a/web/src/features/appTokens/IssueTokenDialog.tsx
+++ b/web/src/features/appTokens/IssueTokenDialog.tsx
@@ -26,6 +26,26 @@ export const parseApps = (value: string): string[] =>
     .map(app => app.trim())
     .filter(app => app.length > 0);
 
+/** Mirrors the server's caps on an explicit scope, so it refuses before the request. */
+const MAX_APPS = 200;
+const MAX_APP_NAME_LENGTH = 255;
+const MAX_EXPIRY_DAYS = 3650;
+const MAX_DESCRIPTION_LENGTH = 255;
+
+/** Names why a parsed scope would be refused, or null when it is acceptable. */
+export const scopeError = (apps: string[]): string | null => {
+  if (apps.length > MAX_APPS) {
+    return `At most ${MAX_APPS} applications; scope the token to all applications instead.`;
+  }
+
+  const tooLong = apps.find(app => app.length > MAX_APP_NAME_LENGTH);
+  if (tooLong) {
+    return `An application name must be at most ${MAX_APP_NAME_LENGTH} characters.`;
+  }
+
+  return null;
+};
+
 /**
  * Collects the scope of a new token. All applications is a deliberate second
  * choice rather than the default, since it is the credential that authorizes the
@@ -40,9 +60,16 @@ export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogPro
   const [error, setError] = useState<string | null>(null);
 
   const apps = useMemo(() => parseApps(appsInput), [appsInput]);
+  const invalidScope = allApps ? null : scopeError(apps);
+  const appsHelperText =
+    allApps ? 'This token will authorize every application, present and future.'
+      : invalidScope ?? `${apps.length} ${apps.length === 1 ? 'application' : 'applications'}`;
   const expiryDays = Number(expiresInDays);
-  const expiryValid = expiresInDays === '' || (Number.isInteger(expiryDays) && expiryDays >= 0 && expiryDays <= 3650);
-  const canSubmit = (allApps || apps.length > 0) && expiryValid && !submitting;
+  const expiryValid =
+    expiresInDays === '' ||
+    (Number.isInteger(expiryDays) && expiryDays >= 0 && expiryDays <= MAX_EXPIRY_DAYS);
+  const canSubmit =
+    (allApps || apps.length > 0) && invalidScope === null && expiryValid && !submitting;
 
   const reset = useCallback(() => {
     setAppsInput('');
@@ -109,11 +136,8 @@ export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogPro
             disabled={allApps}
             multiline
             minRows={3}
-            helperText={
-              allApps
-                ? 'This token will authorize every application, present and future.'
-                : `${apps.length} application${apps.length === 1 ? '' : 's'}`
-            }
+            error={invalidScope !== null}
+            helperText={appsHelperText}
             fullWidth
           />
 
@@ -122,7 +146,7 @@ export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogPro
             placeholder="which pipeline holds this token"
             value={description}
             onChange={event => setDescription(event.target.value)}
-            slotProps={{ htmlInput: { maxLength: 255 } }}
+            slotProps={{ htmlInput: { maxLength: MAX_DESCRIPTION_LENGTH } }}
             fullWidth
           />
 
@@ -132,7 +156,11 @@ export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogPro
             value={expiresInDays}
             onChange={event => setExpiresInDays(event.target.value)}
             error={!expiryValid}
-            helperText={expiryValid ? 'Empty means the token never expires.' : 'Enter a whole number of days, up to 3650.'}
+            helperText={
+              expiryValid
+                ? 'Empty means the token never expires.'
+                : `Enter a whole number of days, up to ${MAX_EXPIRY_DAYS}.`
+            }
             fullWidth
           />
         </Stack>

--- a/web/src/features/appTokens/IssueTokenDialog.tsx
+++ b/web/src/features/appTokens/IssueTokenDialog.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+} from '@mui/material';
+import type { IssueAppTokenRequest } from './appTokensService';
+
+interface IssueTokenDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onIssue: (request: IssueAppTokenRequest) => Promise<void>;
+}
+
+/** Splits the textarea into application names, dropping blank entries. */
+export const parseApps = (value: string): string[] =>
+  value
+    .split(/[\n,]/)
+    .map(app => app.trim())
+    .filter(app => app.length > 0);
+
+/**
+ * Collects the scope of a new token. All applications is a deliberate second
+ * choice rather than the default, since it is the credential that authorizes the
+ * whole estate.
+ */
+export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogProps) => {
+  const [appsInput, setAppsInput] = useState('');
+  const [allApps, setAllApps] = useState(false);
+  const [description, setDescription] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apps = useMemo(() => parseApps(appsInput), [appsInput]);
+  const expiryDays = Number(expiresInDays);
+  const expiryValid = expiresInDays === '' || (Number.isInteger(expiryDays) && expiryDays >= 0 && expiryDays <= 3650);
+  const canSubmit = (allApps || apps.length > 0) && expiryValid && !submitting;
+
+  const reset = useCallback(() => {
+    setAppsInput('');
+    setAllApps(false);
+    setDescription('');
+    setExpiresInDays('');
+    setError(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (submitting) {
+      return;
+    }
+    reset();
+    onClose();
+  }, [onClose, reset, submitting]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onIssue({
+        apps: allApps ? undefined : apps,
+        all_apps: allApps || undefined,
+        description: description.trim() || undefined,
+        expires_in_days: expiresInDays === '' ? undefined : expiryDays,
+      });
+      reset();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error && err.message ? err.message : 'Failed to issue the token.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [allApps, apps, canSubmit, description, expiresInDays, expiryDays, onClose, onIssue, reset]);
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+      <DialogTitle>Issue a deploy token</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={allApps}
+                onChange={event => setAllApps(event.target.checked)}
+                slotProps={{ input: { 'aria-label': 'All applications' } }}
+              />
+            }
+            label="All applications"
+          />
+
+          <TextField
+            label="Applications"
+            placeholder="one per line, or comma separated"
+            value={appsInput}
+            onChange={event => setAppsInput(event.target.value)}
+            disabled={allApps}
+            multiline
+            minRows={3}
+            helperText={
+              allApps
+                ? 'This token will authorize every application, present and future.'
+                : `${apps.length} application${apps.length === 1 ? '' : 's'}`
+            }
+            fullWidth
+          />
+
+          <TextField
+            label="Description"
+            placeholder="which pipeline holds this token"
+            value={description}
+            onChange={event => setDescription(event.target.value)}
+            slotProps={{ htmlInput: { maxLength: 255 } }}
+            fullWidth
+          />
+
+          <TextField
+            label="Expires in (days)"
+            placeholder="leave empty for no expiry"
+            value={expiresInDays}
+            onChange={event => setExpiresInDays(event.target.value)}
+            error={!expiryValid}
+            helperText={expiryValid ? 'Empty means the token never expires.' : 'Enter a whole number of days, up to 3650.'}
+            fullWidth
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} size="small" disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" size="small" disabled={!canSubmit}>
+          Issue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/web/src/features/appTokens/IssueTokenDialog.tsx
+++ b/web/src/features/appTokens/IssueTokenDialog.tsx
@@ -38,12 +38,25 @@ export const scopeError = (apps: string[]): string | null => {
     return `At most ${MAX_APPS} applications; scope the token to all applications instead.`;
   }
 
-  const tooLong = apps.find(app => app.length > MAX_APP_NAME_LENGTH);
-  if (tooLong) {
+  if (apps.some(app => app.length > MAX_APP_NAME_LENGTH)) {
     return `An application name must be at most ${MAX_APP_NAME_LENGTH} characters.`;
   }
 
   return null;
+};
+
+/** Describes the scope under the Applications field: the wildcard, why the list is
+ * refused, or how many names it holds. */
+const describeAppsField = (allApps: boolean, apps: string[], invalidScope: string | null): string => {
+  if (allApps) {
+    return 'This token will authorize every application, present and future.';
+  }
+
+  if (invalidScope) {
+    return invalidScope;
+  }
+
+  return `${apps.length} ${apps.length === 1 ? 'application' : 'applications'}`;
 };
 
 /**
@@ -61,9 +74,7 @@ export const IssueTokenDialog = ({ open, onClose, onIssue }: IssueTokenDialogPro
 
   const apps = useMemo(() => parseApps(appsInput), [appsInput]);
   const invalidScope = allApps ? null : scopeError(apps);
-  const appsHelperText =
-    allApps ? 'This token will authorize every application, present and future.'
-      : invalidScope ?? `${apps.length} ${apps.length === 1 ? 'application' : 'applications'}`;
+  const appsHelperText = describeAppsField(allApps, apps, invalidScope);
   const expiryDays = Number(expiresInDays);
   const expiryValid =
     expiresInDays === '' ||

--- a/web/src/features/appTokens/SecretRevealDialog.test.tsx
+++ b/web/src/features/appTokens/SecretRevealDialog.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SecretRevealDialog } from './SecretRevealDialog';
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+/**
+ * Copying is how an operator captures a secret that is displayed once and cannot be
+ * recovered. A silent regression here loses the credential and leaves a live token
+ * in Postgres that nobody holds.
+ */
+describe('SecretRevealDialog', () => {
+  const writeText = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    writeText.mockResolvedValue(undefined);
+  });
+
+  // userEvent.setup() installs its own navigator.clipboard, so the stub has to be
+  // put in place afterwards or it is silently replaced.
+  const setupWithClipboard = () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+    return user;
+  };
+
+  it('renders nothing without a secret', () => {
+    render(<SecretRevealDialog secret={null} onClose={onClose} />);
+
+    expect(screen.queryByLabelText('Deploy token secret')).not.toBeInTheDocument();
+  });
+
+  it('copies the secret verbatim and confirms it', async () => {
+    const user = setupWithClipboard();
+    render(<SecretRevealDialog secret="awt_theOneAndOnlyCopy" onClose={onClose} />);
+
+    const button = screen.getByRole('button', { name: 'Copy deploy token' });
+    await user.click(button);
+
+    expect(writeText).toHaveBeenCalledWith('awt_theOneAndOnlyCopy');
+
+    // The confirmation lives in the tooltip, which MUI only mounts on hover.
+    await user.hover(button);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Copied');
+  });
+
+  it('shows the secret read-only so it cannot be edited before copying', () => {
+    render(<SecretRevealDialog secret="awt_readOnly" onClose={onClose} />);
+
+    const field = screen.getByLabelText('Deploy token secret');
+    expect(field).toHaveValue('awt_readOnly');
+    expect(field).toHaveAttribute('readonly');
+  });
+
+  it('survives a denied clipboard permission without losing the dialog', async () => {
+    const user = setupWithClipboard();
+    writeText.mockRejectedValue(new Error('permission denied'));
+    render(<SecretRevealDialog secret="awt_stillVisible" onClose={onClose} />);
+
+    const button = screen.getByRole('button', { name: 'Copy deploy token' });
+    await user.click(button);
+
+    // The secret stays on screen and selectable; nothing claims it was copied.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Deploy token secret')).toHaveValue('awt_stillVisible');
+    });
+    await user.hover(button);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Copy to clipboard');
+  });
+
+  it('closes on Done', async () => {
+    const user = setupWithClipboard();
+    render(<SecretRevealDialog secret="awt_done" onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not carry a stale confirmation to the next token', async () => {
+    const user = setupWithClipboard();
+    // One instance throughout, as AppTokensPage drives it: the dialog is rendered
+    // unconditionally and only MUI's Dialog unmounts its children, so the copied
+    // flag lives across close and reopen. handleClose's reset is the only thing
+    // stopping the next token from opening on a "Copied" it never earned.
+    const { rerender } = render(<SecretRevealDialog secret="awt_first" onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy deploy token' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    rerender(<SecretRevealDialog secret={null} onClose={onClose} />);
+    rerender(<SecretRevealDialog secret="awt_second" onClose={onClose} />);
+
+    await user.hover(screen.getByRole('button', { name: 'Copy deploy token' }));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Copy to clipboard');
+  });
+});

--- a/web/src/features/appTokens/SecretRevealDialog.tsx
+++ b/web/src/features/appTokens/SecretRevealDialog.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useState } from 'react';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+} from '@mui/material';
+
+interface SecretRevealDialogProps {
+  secret: string | null;
+  onClose: () => void;
+}
+
+/**
+ * Shows a freshly issued token once. Nothing persists the secret, so closing this
+ * dialog is the point past which it cannot be recovered — the copy affordance and
+ * the warning are the whole reason it exists.
+ */
+export const SecretRevealDialog = ({ secret, onClose }: SecretRevealDialogProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    if (!secret) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(secret);
+      setCopied(true);
+    } catch {
+      // A denied clipboard permission is not an error worth interrupting for: the
+      // secret is on screen and selectable.
+      setCopied(false);
+    }
+  }, [secret]);
+
+  const handleClose = useCallback(() => {
+    setCopied(false);
+    onClose();
+  }, [onClose]);
+
+  return (
+    <Dialog open={Boolean(secret)} onClose={handleClose} fullWidth maxWidth="sm">
+      <DialogTitle>Copy your deploy token</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="warning">
+            This is the only time the token is shown. Store it in your pipeline&apos;s secret
+            manager now — if you lose it, revoke it and issue a new one.
+          </Alert>
+
+          <Stack direction="row" spacing={1} alignItems="flex-start">
+            <TextField
+              label="Token"
+              value={secret ?? ''}
+              slotProps={{ htmlInput: { readOnly: true, 'aria-label': 'Deploy token secret' } }}
+              multiline
+              fullWidth
+            />
+            <Tooltip title={copied ? 'Copied' : 'Copy to clipboard'}>
+              <IconButton onClick={handleCopy} aria-label="Copy deploy token">
+                <ContentCopyIcon />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} variant="contained" size="small">
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/web/src/features/appTokens/appTokensService.test.ts
+++ b/web/src/features/appTokens/appTokensService.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type AppToken,
+  describeScope,
+  isTokenActive,
+  issueAppToken,
+  listAppTokens,
+  revokeAppToken,
+} from './appTokensService';
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const token = (overrides: Partial<AppToken> = {}): AppToken => ({
+  id: 'a1',
+  all_apps: false,
+  apps: ['app1'],
+  hint: '3f9a',
+  created_by: 'alice',
+  created_at: 1_700_000_000_000,
+  ...overrides,
+});
+
+describe('appTokensService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listAppTokens', () => {
+    it('returns the tokens the server reports', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse([token()]));
+
+      await expect(listAppTokens()).resolves.toEqual([token()]);
+    });
+
+    it('refuses a bodiless 200 rather than reporting no tokens', async () => {
+      // writeJSON always marshals a body, so an absent one means something other
+      // than the API answered.
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+
+      await expect(listAppTokens()).rejects.toThrow(/did not answer/);
+    });
+
+    it('propagates a rejection so the page can surface it', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({ status: 'unauthorized' }, 401),
+      );
+
+      await expect(listAppTokens()).rejects.toThrow(/unauthorized/);
+    });
+  });
+
+  describe('issueAppToken', () => {
+    it('posts the requested scope and returns the secret', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse(token({ secret: 'awt_secret' }), 201));
+
+      const issued = await issueAppToken({ apps: ['app1', 'app2'], expires_in_days: 30 });
+
+      expect(issued.secret).toBe('awt_secret');
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({
+        apps: ['app1', 'app2'],
+        expires_in_days: 30,
+      });
+    });
+
+    it('fails loudly when the server returns no payload', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 201 }));
+
+      await expect(issueAppToken({ all_apps: true })).rejects.toThrow(/no payload/);
+    });
+  });
+
+  describe('revokeAppToken', () => {
+    it('deletes by id', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse('revoked'));
+
+      await revokeAppToken('a1');
+
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/v1/app-tokens/a1');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('encodes an id that would otherwise change the path', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse('revoked'));
+
+      await revokeAppToken('a/../b');
+
+      const [url] = fetchSpy.mock.calls[0] as [string];
+      expect(url).toContain('a%2F..%2Fb');
+    });
+  });
+
+  describe('isTokenActive', () => {
+    const now = 1_700_000_000_000;
+
+    it.each([
+      ['a token without an expiry', token(), true],
+      ['a token expiring later', token({ expires_at: now + 1000 }), true],
+      ['a token expiring now', token({ expires_at: now }), false],
+      ['an expired token', token({ expires_at: now - 1000 }), false],
+      ['a revoked token', token({ revoked_at: now - 1000 }), false],
+      ['a revoked token with a future expiry', token({ revoked_at: now, expires_at: now + 1000 }), false],
+    ])('%s', (_name, subject, expected) => {
+      expect(isTokenActive(subject as AppToken, now)).toBe(expected);
+    });
+  });
+
+  describe('describeScope', () => {
+    it('names the wildcard', () => {
+      expect(describeScope(token({ all_apps: true, apps: undefined }))).toBe('All applications');
+    });
+
+    it('lists the applications', () => {
+      expect(describeScope(token({ apps: ['app1', 'app2'] }))).toBe('app1, app2');
+    });
+
+    it('does not pretend an empty scope covers something', () => {
+      expect(describeScope(token({ apps: [] }))).toBe('No applications');
+    });
+  });
+});
+
+describe('the SPA catch-all must never read as success', () => {
+  // Where the token endpoints are not registered the request falls through to the
+  // Web UI's HTML handler, which answers 200. Reporting that as a completed
+  // revocation would tell an operator a leaked credential is dead while it deploys.
+  const htmlResponse = () =>
+    new Response('<!doctype html><title>Argo Watcher</title>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fails a revocation the API did not confirm', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(htmlResponse());
+
+    await expect(revokeAppToken('a1')).rejects.toThrow(/did not answer the deploy token revoke/);
+  });
+
+  it('fails a listing the API did not answer, rather than reporting no tokens', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(htmlResponse());
+
+    await expect(listAppTokens()).rejects.toThrow(/did not answer the deploy token list/);
+  });
+
+  it('still accepts a genuine JSON answer', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify('application deploy token revoked'), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(revokeAppToken('a1')).resolves.toBeUndefined();
+  });
+
+  it('still accepts an empty list from the API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    await expect(listAppTokens()).resolves.toEqual([]);
+  });
+});

--- a/web/src/features/appTokens/appTokensService.ts
+++ b/web/src/features/appTokens/appTokensService.ts
@@ -1,0 +1,99 @@
+import { httpClient } from '../../data/httpClient';
+
+const ENDPOINT = '/api/v1/app-tokens';
+
+/**
+ * An application deploy token as the server describes it. `secret` is present
+ * only in the response that created the token — it is never stored, so this is
+ * the one chance to show it.
+ */
+export interface AppToken {
+  id: string;
+  apps?: string[];
+  all_apps: boolean;
+  hint: string;
+  description?: string;
+  created_by: string;
+  /** Unix milliseconds; 0 or absent where the server has no timestamp. */
+  created_at: number;
+  expires_at?: number;
+  revoked_at?: number;
+  last_used_at?: number;
+  secret?: string;
+}
+
+/**
+ * The scope a new token is asked for. `all_apps` and `apps` are mutually
+ * exclusive; the server rejects a request setting both.
+ */
+export interface IssueAppTokenRequest {
+  apps?: string[];
+  all_apps?: boolean;
+  description?: string;
+  /** Omit or pass 0 for a token that never expires. */
+  expires_in_days?: number;
+}
+
+/**
+ * Guards against the Web UI's HTML catch-all being mistaken for the API.
+ *
+ * Where the token endpoints are not registered the request falls through to it,
+ * which answers 200 with `text/html`; httpClient then yields `undefined` rather
+ * than throwing. Treating that as success would report a revocation that never
+ * happened, so an absent body is an error here, not an empty result.
+ */
+const assertAnswered = <T>(data: T | undefined, action: string): T => {
+  if (data === undefined) {
+    throw new Error(
+      `The server did not answer the deploy token ${action}. Token management may not be available on this instance.`,
+    );
+  }
+
+  return data;
+};
+
+/**
+ * Lists every token, revoked ones included. Never carries a secret.
+ *
+ * An absent body means the SPA catch-all answered, not the API — see assertAnswered.
+ */
+export const listAppTokens = async (): Promise<AppToken[]> => {
+  const response = await httpClient<AppToken[]>(ENDPOINT);
+  return assertAnswered(response.data, 'list');
+};
+
+/** Mints a token. The returned `secret` is the only copy that will ever exist. */
+export const issueAppToken = async (request: IssueAppTokenRequest): Promise<AppToken> => {
+  const response = await httpClient<AppToken>(ENDPOINT, { method: 'POST', body: request });
+  if (!response.data) {
+    throw new Error('The server issued a token but returned no payload.');
+  }
+  return response.data;
+};
+
+/**
+ * Withdraws a token, effective on its next use.
+ *
+ * Confirming the API answered matters most here: reporting a revocation that did not
+ * happen would tell an operator a leaked credential is dead while it still deploys.
+ */
+export const revokeAppToken = async (id: string): Promise<void> => {
+  const response = await httpClient(`${ENDPOINT}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  assertAnswered(response.data, 'revoke');
+};
+
+/** True while the token still authorizes deployments. */
+export const isTokenActive = (token: AppToken, now: number = Date.now()): boolean => {
+  if (token.revoked_at) {
+    return false;
+  }
+  return !token.expires_at || token.expires_at > now;
+};
+
+/** Human-readable scope: the wildcard, or the application list. */
+export const describeScope = (token: AppToken): string => {
+  if (token.all_apps) {
+    return 'All applications';
+  }
+  return token.apps?.length ? token.apps.join(', ') : 'No applications';
+};

--- a/web/src/features/appTokens/useAppTokens.ts
+++ b/web/src/features/appTokens/useAppTokens.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  type AppToken,
+  type IssueAppTokenRequest,
+  issueAppToken,
+  listAppTokens,
+  revokeAppToken,
+} from './appTokensService';
+
+interface UseAppTokens {
+  tokens: AppToken[];
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+  issue: (request: IssueAppTokenRequest) => Promise<AppToken>;
+  revoke: (id: string) => Promise<void>;
+}
+
+const messageOf = (err: unknown, fallback: string): string =>
+  err instanceof Error && err.message ? err.message : fallback;
+
+/**
+ * Loads the token list and exposes the two mutations, reloading after each so the
+ * table reflects what the server holds rather than an optimistic guess.
+ *
+ * `issue` returns the created token because its `secret` is shown once and never
+ * appears in a later list.
+ */
+export const useAppTokens = (): UseAppTokens => {
+  const [tokens, setTokens] = useState<AppToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      setTokens(await listAppTokens());
+      setError(null);
+    } catch (err) {
+      setError(messageOf(err, 'Failed to load deploy tokens.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const issue = useCallback(
+    async (request: IssueAppTokenRequest) => {
+      const created = await issueAppToken(request);
+      await reload();
+      return created;
+    },
+    [reload],
+  );
+
+  const revoke = useCallback(
+    async (id: string) => {
+      await revokeAppToken(id);
+      await reload();
+    },
+    [reload],
+  );
+
+  return { tokens, loading, error, reload, issue, revoke };
+};

--- a/web/src/layout/components/AppTopBar.test.tsx
+++ b/web/src/layout/components/AppTopBar.test.tsx
@@ -33,6 +33,10 @@ vi.mock('../../shared/hooks/useOidcEnabled', () => ({
   useOidcEnabled: () => oidcEnabledMock(),
 }));
 
+vi.mock('../../shared/hooks/useAppTokensAvailable', () => ({
+  useAppTokensAvailable: () => false,
+}));
+
 vi.mock('react-admin', async () => {
   const actual = await vi.importActual<typeof import('react-admin')>('react-admin');
   return {

--- a/web/src/layout/components/ConfigDrawer.test.tsx
+++ b/web/src/layout/components/ConfigDrawer.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HttpResponse } from '../../data/httpClient';
 import { ThemeModeProvider, useThemeMode } from '../../theme/ThemeModeProvider';
@@ -12,6 +19,7 @@ vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 
 const notifyMock = vi.fn();
 const oidcEnabledMock = vi.fn();
+const appTokensAvailableMock = vi.fn();
 const permissionsMock = vi.fn();
 const identityMock = vi.fn();
 
@@ -25,6 +33,10 @@ vi.mock('../../features/deployLock/deployLockService', () => ({
 
 vi.mock('../../shared/hooks/useOidcEnabled', () => ({
   useOidcEnabled: () => oidcEnabledMock(),
+}));
+
+vi.mock('../../shared/hooks/useAppTokensAvailable', () => ({
+  useAppTokensAvailable: () => appTokensAvailableMock(),
 }));
 
 vi.mock('react-admin', async () => {
@@ -45,6 +57,7 @@ const ThemeModeConsumer = () => {
 
 const renderDrawer = () =>
   render(
+    <MemoryRouter>
     <ThemeModeProvider>
       <TimezoneProvider>
         <DeployLockProvider>
@@ -52,7 +65,8 @@ const renderDrawer = () =>
           <ConfigDrawer open onClose={() => undefined} version="1.0.0" />
         </DeployLockProvider>
       </TimezoneProvider>
-    </ThemeModeProvider>,
+    </ThemeModeProvider>
+    </MemoryRouter>,
   );
 
 describe('ConfigDrawer', () => {
@@ -70,6 +84,7 @@ describe('ConfigDrawer', () => {
       isPending: false,
     });
     oidcEnabledMock.mockReturnValue(true);
+    appTokensAvailableMock.mockReturnValue(true);
     permissionsMock.mockReturnValue({
       permissions: { groups: ['devops'], privilegedGroups: ['devops'] },
       isLoading: false,
@@ -195,5 +210,89 @@ describe('ConfigDrawer', () => {
     renderDrawer();
     expect(screen.queryByText(/Backend Configuration/i)).toBeNull();
     expect(screen.queryByRole('button', { name: /copy configuration/i })).toBeNull();
+  });
+});
+
+describe('ConfigDrawer deploy tokens section', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    (deployLockService.subscribe as ReturnType<typeof vi.fn>).mockReturnValue(() => undefined);
+    identityMock.mockReturnValue({ identity: { id: 'user-id' }, isPending: false });
+    oidcEnabledMock.mockReturnValue(true);
+    notifyMock.mockReset();
+  });
+
+  const privileged = { permissions: { groups: ['devops'], privilegedGroups: ['devops'] }, isLoading: false };
+
+  it('offers the section to a privileged user on a server that has the feature', async () => {
+    appTokensAvailableMock.mockReturnValue(true);
+    permissionsMock.mockReturnValue(privileged);
+
+    renderDrawer();
+
+    expect(await screen.findByText('Deploy Tokens')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Manage' })).toBeInTheDocument();
+  });
+
+  it.each([
+    ['the feature is unavailable', false, privileged],
+    ['availability is still unknown', null, privileged],
+    [
+      'the user is not privileged',
+      true,
+      { permissions: { groups: ['devs'], privilegedGroups: ['devops'] }, isLoading: false },
+    ],
+  ])('hides the section when %s', async (_name, available, permissions) => {
+    // The endpoints fall through to the HTML catch-all when the server lacks them,
+    // which answers 200 — so an ungated entry point would lead to a page claiming
+    // no tokens exist rather than failing.
+    appTokensAvailableMock.mockReturnValue(available);
+    permissionsMock.mockReturnValue(permissions);
+
+    renderDrawer();
+
+    expect(await screen.findByText('Workspace Controls')).toBeInTheDocument();
+    expect(screen.queryByText('Deploy Tokens')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument();
+  });
+});
+
+// The '/app-tokens' path is written in both ConfigDrawer and App.tsx's route table.
+// App.test.tsx pins the route list and this pins the button, so a typo in either
+// can no longer leave both suites green with a dead entry point.
+describe('ConfigDrawer Manage navigation', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    (deployLockService.subscribe as ReturnType<typeof vi.fn>).mockReturnValue(() => undefined);
+    identityMock.mockReturnValue({ identity: { id: 'user-id' }, isPending: false });
+    oidcEnabledMock.mockReturnValue(true);
+    appTokensAvailableMock.mockReturnValue(true);
+    permissionsMock.mockReturnValue({
+      permissions: { groups: ['devops'], privilegedGroups: ['devops'] },
+      isLoading: false,
+    });
+  });
+
+  it('navigates to the token page and closes the drawer', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <MemoryRouter>
+        <ThemeModeProvider>
+          <TimezoneProvider>
+            <DeployLockProvider>
+              <ConfigDrawer open onClose={onClose} version="1.0.0" />
+            </DeployLockProvider>
+          </TimezoneProvider>
+        </ThemeModeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Manage' }));
+
+    expect(navigateMock).toHaveBeenCalledWith('/app-tokens');
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/web/src/layout/components/ConfigDrawer.tsx
+++ b/web/src/layout/components/ConfigDrawer.tsx
@@ -2,6 +2,7 @@ import LightModeIcon from '@mui/icons-material/LightMode';
 import NightlightIcon from '@mui/icons-material/Nightlight';
 import LockIcon from '@mui/icons-material/Lock';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
+import KeyIcon from '@mui/icons-material/Key';
 import {
   Box,
   Button,
@@ -14,10 +15,12 @@ import {
   Typography,
 } from '@mui/material';
 import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useNotify, usePermissions } from 'react-admin';
 import { useThemeMode } from '../../theme';
 import { useDeployLock } from '../../features/deployLock/DeployLockProvider';
 import { useOidcEnabled } from '../../shared/hooks/useOidcEnabled';
+import { useAppTokensAvailable } from '../../shared/hooks/useAppTokensAvailable';
 import { hasPrivilegedAccess } from '../../shared/utils/permissions';
 import { useTimezone } from '../../shared/providers/TimezoneProvider';
 import { UserBadge } from './UserBadge';
@@ -34,8 +37,10 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
   const { timezone, setTimezone } = useTimezone();
   const browserZone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'local', []);
   const notify = useNotify();
+  const navigate = useNavigate();
   const { locked: deployLock, setLock, releaseLock } = useDeployLock();
   const oidcEnabled = useOidcEnabled();
+  const appTokensAvailable = useAppTokensAvailable();
   const { permissions } = usePermissions();
 
   const groups: readonly string[] = (permissions as { groups?: string[] })?.groups ?? [];
@@ -48,6 +53,10 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
   // oidcEnabled is unknown (null = config still loading or the request failed).
   const showLockToggle = oidcEnabled === true;
   const canToggleLock = oidcEnabled === true && privileged;
+  // The token endpoints need Postgres as well as OIDC, and answer privileged
+  // callers only. Where they are absent the request falls through to the HTML
+  // catch-all, so an ungated entry point would show an empty list rather than fail.
+  const canManageTokens = appTokensAvailable === true && privileged;
   let lockHelperText: string | null = null;
   if (oidcEnabled === null) {
     lockHelperText = 'Checking permissions…';
@@ -78,6 +87,11 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
       setLockUpdating(false);
     }
   }, [canToggleLock, deployLock, notify, releaseLock, setLock]);
+
+  const handleManageTokens = useCallback(() => {
+    onClose();
+    navigate('/app-tokens');
+  }, [navigate, onClose]);
 
   return (
     <Drawer
@@ -190,6 +204,36 @@ export const ConfigDrawer = ({ open, onClose, version }: ConfigDrawerProps) => {
               </Typography>
             )}
           </Stack>
+
+          {canManageTokens && (
+            <>
+              <Divider />
+
+              <Stack spacing={1.5} component="section" aria-labelledby="drawer-tokens">
+                <Typography variant="subtitle2" sx={{
+                  color: 'text.secondary'
+                }}>
+                  <span id="drawer-tokens">Deploy Tokens</span>
+                </Typography>
+                <Stack
+                  direction="row"
+                  sx={{
+                    alignItems: 'center',
+                    justifyContent: 'space-between'
+                  }}>
+                  <Stack direction="row" spacing={1} sx={{
+                    alignItems: 'center'
+                  }}>
+                    <KeyIcon fontSize="small" />
+                    <Typography variant="body2">Issue and revoke</Typography>
+                  </Stack>
+                  <Button variant="outlined" size="small" onClick={handleManageTokens}>
+                    Manage
+                  </Button>
+                </Stack>
+              </Stack>
+            </>
+          )}
         </Stack>
 
         <Box

--- a/web/src/shared/hooks/useAppTokensAvailable.test.tsx
+++ b/web/src/shared/hooks/useAppTokensAvailable.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppTokensAvailable } from './useAppTokensAvailable';
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('useAppTokensAvailable', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts unknown so callers deny before the config arrives', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAppTokensAvailable());
+
+    expect(result.current).toBeNull();
+  });
+
+  it.each([
+    ['OIDC and Postgres', { oidc: { enabled: true }, state_type: 'postgres' }, true],
+    ['Postgres but no OIDC', { oidc: { enabled: false }, state_type: 'postgres' }, false],
+    ['OIDC but in-memory state', { oidc: { enabled: true }, state_type: 'in-memory' }, false],
+    ['neither', { oidc: { enabled: false }, state_type: 'in-memory' }, false],
+    ['a payload missing both fields', {}, false],
+  ])('reports %s', async (_name, config, expected) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(config));
+
+    const { result } = renderHook(() => useAppTokensAvailable());
+
+    await waitFor(() => {
+      expect(result.current).toBe(expected);
+    });
+  });
+
+  it('stays unknown when the config request fails', async () => {
+    // Collapsing to false would hide the feature on a blip; to true would offer a
+    // page that cannot work.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useAppTokensAvailable());
+
+    // Settle on the request having been made and rejected, not on a fixed delay:
+    // a sleep would pass for the wrong reason on a loaded runner.
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+});

--- a/web/src/shared/hooks/useAppTokensAvailable.ts
+++ b/web/src/shared/hooks/useAppTokensAvailable.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { httpClient } from '../../data/httpClient';
+
+interface ServerConfigResponse {
+  oidc?: {
+    enabled?: boolean;
+  };
+  state_type?: string;
+}
+
+/**
+ * Reports whether the server exposes the application deploy token endpoints,
+ * which need both OIDC and the Postgres state backend.
+ *
+ * Without this the endpoints are not routes at all, and a request for them falls
+ * through to the Web UI's HTML catch-all — which answers 200, so the token list
+ * would render empty rather than failing, claiming no tokens exist on a server
+ * that cannot hold any. `null` means "not known yet", and callers deny on it.
+ */
+export const useAppTokensAvailable = (): boolean | null => {
+  const [available, setAvailable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let subscribed = true;
+
+    httpClient<ServerConfigResponse>('/api/v1/config')
+      .then(response => {
+        if (subscribed) {
+          const config = response.data;
+          setAvailable(Boolean(config?.oidc?.enabled) && config?.state_type === 'postgres');
+        }
+      })
+      .catch(() => {
+        // Left null on failure: collapsing to false would hide the feature on a
+        // transient error, and to true would offer a broken page.
+      });
+
+    return () => {
+      subscribed = false;
+    };
+  }, []);
+
+  return available;
+};


### PR DESCRIPTION
Opaque `awt_`-prefixed credentials scoped to named applications or to a wildcard, issued and revoked from the Web UI by a member of `OIDC_PRIVILEGED_GROUPS` and stored as SHA-256 in Postgres. They ride `BEARER_TOKEN` like a JWT and the server routes on the prefix, so pipelines need no other change.

Requires `OIDC_ENABLED=true` and `STATE_TYPE=postgres`; without both, a presented token is rejected `401` naming the missing setting rather than being ignored. There is no in-memory store by design — a token has to outlive the process and be honoured by every replica.

Two behaviour changes worth flagging:

- The `allowed_apps` JWT claim is now enforced. A token carrying it is confined to the applications it names; one omitting it still authorizes every application, so a fleet that never set it is unaffected. A pipeline that set the claim while it was documented as unenforced, and relies on deploying outside it, will start being rejected.
- `POST /api/v1/tasks` answers `503` instead of `401` when a credential cannot be checked at all, so a provider or database blip no longer tells a client its credential is bad.

Adds migration `000009_app_tokens`.