### PR TITLE
fix(web): show why a read failed instead of an empty task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   judged at all, such as an unreachable OIDC provider or state backend. A blip no longer
   tells a pipeline its credential is bad, and the client can retry.
 
+### Fixed
+
+- The Web UI now names why a read failed instead of implying there is nothing to show. A
+  failed task-list load rendered as an endless loading skeleton or "No recent tasks so
+  far…", and a task page reported "Task not found" for any read error at all. Both now
+  show the actual cause — an unreachable identity provider, a rejected session, an
+  unreachable server — together with the remedy. A page that already loaded keeps its
+  content when a background refresh fails, rather than blanking.
+
 ## [1.0.0] - 2026-08-23
 
 ### Added

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -168,6 +168,8 @@ The server negotiates `argo-watcher.v1` and never echoes the token entry. Client
 
 A read whose credential could not be checked returns **503 Service Unavailable**, never 401. The Web UI treats a 401 as a dead session and signs the user out, so a brief provider outage must not look like an authentication failure. Cached decisions keep working throughout.
 
+The symptom to recognise: both the task list and a task's own page show **"Argo Watcher cannot verify your session"**, with a hint to check that the issuer is reachable from the Argo Watcher server. Neither reports an empty task list nor a missing task, and a page that already loaded keeps its content. The server log names the failing discovery request.
+
 ## Migrating from `KEYCLOAK_*`
 
 Earlier releases were Keycloak-specific. Those variables were **removed in 1.0.0**, and the server refuses to start while any of them is set, naming each one and its replacement. Rename them:

--- a/web/README.md
+++ b/web/README.md
@@ -45,7 +45,7 @@ Everything runtime comes from the backend's `/api/v1/config` — issuer URL, cli
 | `src/main.tsx` | Mounts `AppSplash` immediately, awaits `bootstrapAuth()` to consume any OIDC callback, then mounts React-admin with the shared providers. |
 | `src/App.tsx` | The React-admin shell: the `tasks` resource plus custom routes for history and task detail. |
 | `src/auth/` | `authProvider.ts` (OIDC via `oidc-client-ts`, configured from `/api/v1/config`), `authFailure.ts` (the `AuthFailure` the splash screen renders), `tokenStore.ts` (token in memory only). |
-| `src/data/` | `httpClient.ts`, the React-admin `dataProvider`, and `wsStatusService.ts` — the shared REST-bootstrap + `/ws` protocol. |
+| `src/data/` | `httpClient.ts`, the React-admin `dataProvider`, `readFailure.ts` (turns a failed read's status and body into the message the UI shows), and `wsStatusService.ts` — the shared REST-bootstrap + `/ws` protocol. |
 | `src/features/` | Feature modules: `tasks/`, `deployLock/`, `argocdStatus/`. Each owns its components, hooks and services. |
 | `src/layout/` | Layout primitives (top bar, nav, notifications) and `AppSplash.tsx`, the pre-mount loading screen. |
 | `src/shared/` | Cross-cutting hooks, providers (theme mode, timezone) and utilities. |

--- a/web/src/data/dataProvider.test.ts
+++ b/web/src/data/dataProvider.test.ts
@@ -246,6 +246,20 @@ describe('dataProvider', () => {
     expect(result.data.status).toBe('in progress');
   });
 
+  // Reachable only on a 2xx with no parseable JSON — a proxy sign-in page, say.
+  // httpClient throws on a real 404, so this must not be labelled "task not found".
+  it('reports a body-less success as a transport failure, not a missing task', async () => {
+    mockFetch().mockResolvedValue(new Response('<html>login</html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html' },
+    }));
+
+    await expect(dataProvider.getOne('tasks', { id: '123' })).rejects.toMatchObject({
+      status: 0,
+      message: 'The server returned no task data',
+    });
+  });
+
   it('throws HttpError when task detail contains error', async () => {
     mockFetch().mockResolvedValue(
       jsonResponse({

--- a/web/src/data/dataProvider.test.ts
+++ b/web/src/data/dataProvider.test.ts
@@ -260,7 +260,7 @@ describe('dataProvider', () => {
     });
   });
 
-  it('throws HttpError when task detail contains error', async () => {
+  it('throws with the real response status when task detail contains error', async () => {
     mockFetch().mockResolvedValue(
       jsonResponse({
         id: 'missing',
@@ -268,7 +268,12 @@ describe('dataProvider', () => {
       }),
     );
 
-    await expect(dataProvider.getOne('tasks', { id: 'missing' })).rejects.toThrow(HttpError);
+    // Not a synthesized 404: the response succeeded and its body reports the error,
+    // so the UI must not present it as a task that does not exist.
+    await expect(dataProvider.getOne('tasks', { id: 'missing' })).rejects.toMatchObject({
+      status: 200,
+      message: 'task not found',
+    });
   });
 
   it('creates a task and returns accepted status', async () => {

--- a/web/src/data/dataProvider.ts
+++ b/web/src/data/dataProvider.ts
@@ -118,8 +118,10 @@ const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
 
 const getOne = async (params: GetOneParams): Promise<GetOneResult<TaskStatus>> => {
   const { data } = await httpClient<TaskStatus>(`/api/v1/${RESOURCE_TASKS}/${params.id}`);
+  // httpClient throws on a real 404, so an empty body here is a 2xx that carried no
+  // JSON — an intermediary answering, not a missing task. Status 0 says transport.
   if (!data) {
-    throw new HttpError('Task not found', 404);
+    throw new HttpError('The server returned no task data', 0);
   }
   if (data.error) {
     throw new HttpError(data.error, 404, data);

--- a/web/src/data/dataProvider.ts
+++ b/web/src/data/dataProvider.ts
@@ -117,14 +117,16 @@ const getList = async (params: GetListParams): Promise<GetListResult<Task>> => {
 };
 
 const getOne = async (params: GetOneParams): Promise<GetOneResult<TaskStatus>> => {
-  const { data } = await httpClient<TaskStatus>(`/api/v1/${RESOURCE_TASKS}/${params.id}`);
+  const { data, status } = await httpClient<TaskStatus>(`/api/v1/${RESOURCE_TASKS}/${params.id}`);
   // httpClient throws on a real 404, so an empty body here is a 2xx that carried no
   // JSON — an intermediary answering, not a missing task. Status 0 says transport.
   if (!data) {
     throw new HttpError('The server returned no task data', 0);
   }
+  // The real response status, never a synthesized 404: this body reports an error on a
+  // success, and describeReadFailure names it as such rather than as a missing task.
   if (data.error) {
-    throw new HttpError(data.error, 404, data);
+    throw new HttpError(data.error, status, data);
   }
 
   return {

--- a/web/src/data/readFailure.test.ts
+++ b/web/src/data/readFailure.test.ts
@@ -1,0 +1,87 @@
+import { HttpError } from 'react-admin';
+import { describe, expect, it } from 'vitest';
+import { describeReadFailure } from './readFailure';
+
+const providerUnavailable = () =>
+  new HttpError('authentication provider unavailable', 503, {
+    status: 'authentication provider unavailable',
+    error: 'token validation failed',
+  });
+
+describe('describeReadFailure', () => {
+  it('names the identity provider when the server could not validate the token', () => {
+    const failure = describeReadFailure(providerUnavailable());
+
+    expect(failure.title).toBe('Argo Watcher cannot verify your session');
+    expect(failure.detail).toContain('identity provider');
+    // The server never judged the token, so the copy must not claim it is valid.
+    expect(failure.hint).toContain('has not been rejected');
+    expect(failure.hint).not.toContain('still valid');
+  });
+
+  it('passes server text through untouched at the length limit', () => {
+    const failure = describeReadFailure(new HttpError('x'.repeat(300), 500));
+
+    expect(failure.detail).toBe(`${'x'.repeat(300)} (HTTP 500)`);
+  });
+
+  it('trims server text one character over the limit', () => {
+    const failure = describeReadFailure(new HttpError('x'.repeat(301), 500));
+
+    expect(failure.detail).toBe(`${'x'.repeat(300)}… (HTTP 500)`);
+  });
+
+  it('does not blame the identity provider for a 503 the server did not attribute to it', () => {
+    const failure = describeReadFailure(
+      new HttpError('down', 503, { status: 'down', error: 'state backend unreachable' }),
+    );
+
+    expect(failure.title).toBe('Argo Watcher is unavailable');
+    expect(failure.detail).toBe('down');
+    expect(failure.hint).not.toContain('identity provider');
+  });
+
+  it.each([401, 403])('reports a credential rejected with %i as a session problem', status => {
+    const failure = describeReadFailure(new HttpError('You are not authorized', status));
+
+    expect(failure.title).toBe('This session is no longer accepted');
+    expect(failure.detail).toBe('You are not authorized');
+    expect(failure.hint).toContain('sign in again');
+  });
+
+  it('reports a request that never reached the server as unreachable', () => {
+    // httpClient reports both a network drop and its 30s abort with status 0.
+    const timedOut = describeReadFailure(new HttpError('Request timed out', 0));
+    expect(timedOut.title).toBe('Could not reach the Argo Watcher server');
+    // The detail already says it timed out; the hint must not repeat it.
+    expect(timedOut.hint).toBe('Check that the server is reachable, then retry.');
+    expect(describeReadFailure(new Error('boom')).title).toBe('Could not reach the Argo Watcher server');
+  });
+
+  it('carries the status code for any other server error', () => {
+    const failure = describeReadFailure(new HttpError('internal server error', 500));
+
+    expect(failure.title).toBe('The Argo Watcher server returned an error');
+    expect(failure.detail).toBe('internal server error (HTTP 500)');
+  });
+
+  it('carries the status code for a rejected request', () => {
+    const failure = describeReadFailure(new HttpError('unsupported status filter', 400));
+
+    expect(failure.title).toBe('The request was rejected');
+    expect(failure.detail).toBe('unsupported status filter (HTTP 400)');
+  });
+
+  // A 503 from a proxy carries no JSON body at all, and a non-conformant one can put
+  // anything in `status`. Neither may be read as an identity-provider outage.
+  it.each([
+    ['a body that is not an object', new HttpError('nope', 503, 'not an object')],
+    ['a non-string status field', new HttpError('nope', 503, { status: 503 })],
+    ['no body at all', new HttpError('Service Unavailable', 503)],
+  ])('does not blame the provider for %s', (_label, error) => {
+    const failure = describeReadFailure(error);
+
+    expect(failure.title).toBe('Argo Watcher is unavailable');
+    expect(failure.hint).not.toContain('identity provider');
+  });
+});

--- a/web/src/data/readFailure.test.ts
+++ b/web/src/data/readFailure.test.ts
@@ -77,6 +77,15 @@ describe('describeReadFailure', () => {
     expect(failure.detail).not.toContain('HTTP');
   });
 
+  // Only reached for a task that vanished under a loaded page; a first-load 404 is the
+  // not-found card, which TaskShow renders instead of calling this.
+  it('reports a 404 as a task that is gone, not a rejected request', () => {
+    const failure = describeReadFailure(new HttpError('task not found', 404));
+
+    expect(failure.title).toBe('This task is no longer available');
+    expect(failure.detail).toBe('task not found');
+  });
+
   it('carries the status code for a rejected request', () => {
     const failure = describeReadFailure(new HttpError('unsupported status filter', 400));
 

--- a/web/src/data/readFailure.test.ts
+++ b/web/src/data/readFailure.test.ts
@@ -65,6 +65,18 @@ describe('describeReadFailure', () => {
     expect(failure.detail).toBe('internal server error (HTTP 500)');
   });
 
+  // dataProvider.getOne throws with the real response status, so a body that reports an
+  // error on a 2xx must not be dressed up as a missing task or an unreachable server.
+  it('reports a success whose body carries an error as a server-reported error', () => {
+    const failure = describeReadFailure(
+      new HttpError('task not found', 200, { id: 'task-1', error: 'task not found' }),
+    );
+
+    expect(failure.title).toBe('The Argo Watcher server reported an error');
+    expect(failure.detail).toBe('task not found');
+    expect(failure.detail).not.toContain('HTTP');
+  });
+
   it('carries the status code for a rejected request', () => {
     const failure = describeReadFailure(new HttpError('unsupported status filter', 400));
 

--- a/web/src/data/readFailure.ts
+++ b/web/src/data/readFailure.ts
@@ -1,0 +1,78 @@
+import { normalizeError } from '../shared/utils';
+
+/** A failed read, in the words the UI shows. */
+export interface ReadFailure {
+  /** One-line headline naming what failed. */
+  readonly title: string;
+  /** What the server (or the transport) reported. */
+  readonly detail?: string;
+  /** Argo Watcher's own suggested remedy — never server-supplied. */
+  readonly hint?: string;
+}
+
+/**
+ * The 503 `status` set by internal/server/handlers.go providerUnavailableMessage.
+ * Keying on it, not the code alone, keeps the other 503 the API returns off this tab.
+ */
+const PROVIDER_UNAVAILABLE = 'authentication provider unavailable';
+
+/** Server text lands in a fixed-width panel, so it is trimmed like authFailure's. */
+const MAX_DETAIL_LENGTH = 300;
+
+const clamp = (text: string): string =>
+  text.length > MAX_DETAIL_LENGTH ? `${text.slice(0, MAX_DETAIL_LENGTH)}…` : text;
+
+/** Reads the server's `status` field from an error body of unvalidated shape. */
+const serverStatus = (body: unknown): string | undefined => {
+  if (typeof body !== 'object' || body === null || !('status' in body)) {
+    return undefined;
+  }
+  const { status } = body as { status: unknown };
+  return typeof status === 'string' ? status : undefined;
+};
+
+/** @param error - anything thrown by the data provider. */
+export const describeReadFailure = (error: unknown): ReadFailure => {
+  const { message, status, details } = normalizeError(error);
+
+  if (status === 503) {
+    if (serverStatus(details) === PROVIDER_UNAVAILABLE) {
+      return {
+        title: 'Argo Watcher cannot verify your session',
+        detail:
+          'The server could not reach the identity provider to validate your token, so it is refusing every read.',
+        hint: 'Your sign-in has not been rejected — this is a server-side outage. Check that the OIDC issuer is reachable from the Argo Watcher server (DNS and egress), then retry.',
+      };
+    }
+
+    return {
+      title: 'Argo Watcher is unavailable',
+      detail: clamp(message),
+      hint: 'The server reported itself as unavailable. Retry once it recovers.',
+    };
+  }
+
+  if (status === 401 || status === 403) {
+    return {
+      title: 'This session is no longer accepted',
+      detail: clamp(message),
+      hint: 'Reload the page to sign in again.',
+    };
+  }
+
+  // status 0 is what httpClient reports for a network drop and for its own
+  // request-timeout abort; undefined means the throw carried no HTTP status.
+  if (status === undefined || status === 0) {
+    return {
+      title: 'Could not reach the Argo Watcher server',
+      detail: clamp(message),
+      hint: 'Check that the server is reachable, then retry.',
+    };
+  }
+
+  return {
+    title: status >= 500 ? 'The Argo Watcher server returned an error' : 'The request was rejected',
+    detail: `${clamp(message)} (HTTP ${status})`,
+    hint: 'Retry, and check the Argo Watcher server logs if it keeps failing.',
+  };
+};

--- a/web/src/data/readFailure.ts
+++ b/web/src/data/readFailure.ts
@@ -70,6 +70,16 @@ export const describeReadFailure = (error: unknown): ReadFailure => {
     };
   }
 
+  // A 2xx whose body reports an error. The server answered, so no status code is
+  // appended: the response was a success and saying "(HTTP 200)" would only confuse.
+  if (status >= 200 && status < 300) {
+    return {
+      title: 'The Argo Watcher server reported an error',
+      detail: clamp(message),
+      hint: 'Retry, and check the Argo Watcher server logs if it keeps failing.',
+    };
+  }
+
   return {
     title: status >= 500 ? 'The Argo Watcher server returned an error' : 'The request was rejected',
     detail: `${clamp(message)} (HTTP ${status})`,

--- a/web/src/data/readFailure.ts
+++ b/web/src/data/readFailure.ts
@@ -70,6 +70,14 @@ export const describeReadFailure = (error: unknown): ReadFailure => {
     };
   }
 
+  if (status === 404) {
+    return {
+      title: 'This task is no longer available',
+      detail: clamp(message),
+      hint: 'It may have been removed since the page loaded.',
+    };
+  }
+
   // A 2xx whose body reports an error. The server answered, so no status code is
   // appended: the response was a success and saying "(HTTP 200)" would only confuse.
   if (status >= 200 && status < 300) {

--- a/web/src/features/tasks/components/EmptyState.test.tsx
+++ b/web/src/features/tasks/components/EmptyState.test.tsx
@@ -9,6 +9,20 @@ describe('EmptyState', () => {
     expect(screen.getByText('Kick something off')).toBeInTheDocument();
   });
 
+  it('sets the hint apart from the description instead of running the two together', () => {
+    const { container } = render(
+      <EmptyState title="Broken" description="The server refused the read." hint="Retry shortly." />,
+    );
+
+    const paragraphs = [...container.querySelectorAll('p')].map(node => node.textContent);
+    expect(paragraphs).toEqual(['The server refused the read.', 'Retry shortly.']);
+  });
+
+  it('omits the hint paragraph when no hint is provided', () => {
+    const { container } = render(<EmptyState title="Broken" description="Only this." />);
+    expect(container.querySelectorAll('p')).toHaveLength(1);
+  });
+
   it('omits description when not provided', () => {
     const { container } = render(<EmptyState title="Empty" />);
     expect(screen.getByText('Empty')).toBeInTheDocument();

--- a/web/src/features/tasks/components/EmptyState.tsx
+++ b/web/src/features/tasks/components/EmptyState.tsx
@@ -10,6 +10,8 @@ interface EmptyStateProps {
   readonly icon?: EmptyStateIcon;
   readonly title: string;
   readonly description?: string;
+  /** Suggested remedy, set apart from `description` so neither runs into the other. */
+  readonly hint?: string;
   readonly cta?: ReactNode;
 }
 
@@ -23,7 +25,7 @@ const ICONS: Record<EmptyStateIcon, ReactNode> = {
  * Static empty-state placeholder shown when the task list returns zero rows.
  * No spinner — initial-load skeletons are owned by react-admin's <Datagrid>.
  */
-export const EmptyState = ({ icon = 'inbox', title, description, cta }: EmptyStateProps) => (
+export const EmptyState = ({ icon = 'inbox', title, description, hint, cta }: EmptyStateProps) => (
   <Box
     sx={{
       minHeight: 320,
@@ -47,6 +49,13 @@ export const EmptyState = ({ icon = 'inbox', title, description, cta }: EmptySta
           color: 'text.secondary'
         }}>
           {description}
+        </Typography>
+      )}
+      {hint && (
+        <Typography variant="body2" sx={{
+          color: 'text.secondary'
+        }}>
+          {hint}
         </Typography>
       )}
       {cta}

--- a/web/src/features/tasks/components/TaskListLayout.integration.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.integration.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { AdminContext, HttpError, testDataProvider, useListContext, useRefresh } from 'react-admin';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskListLayout } from './TaskListLayout';
+
+const providerUnavailable = () =>
+  new HttpError('authentication provider unavailable', 503, {
+    status: 'authentication provider unavailable',
+    error: 'token validation failed',
+  });
+
+/** Marks the moment the list query has actually observed a failure. */
+const ErrorProbe = () => {
+  const { error } = useListContext();
+  return error ? <div data-testid="list-error" /> : null;
+};
+
+/** Stands in for the toolbar's auto-refresh, which reloads through this same hook. */
+const RefreshButton = () => {
+  const refresh = useRefresh();
+  return (
+    <button type="button" onClick={refresh}>
+      refresh now
+    </button>
+  );
+};
+
+/**
+ * @description Drives the real react-admin list plumbing, whose `total` is left
+ * undefined on a failed query and whose rows survive a failed refetch. The sibling
+ * suite stubs useListContext, so only this one can hold those two facts honest.
+ */
+const renderList = (getList: () => Promise<unknown>) =>
+  render(
+    <MemoryRouter>
+      <AdminContext dataProvider={testDataProvider({ getList: vi.fn(getList) })}>
+        <TaskListLayout
+          perPageStorageKey="test.perPage"
+          header={[<ErrorProbe key="probe" />, <RefreshButton key="refresh" />]}
+          emptyComponent={<div data-testid="empty-state" />}
+        >
+          <div data-testid="datagrid">Rows</div>
+        </TaskListLayout>
+      </AdminContext>
+    </MemoryRouter>,
+  );
+
+describe('TaskListLayout against react-admin', () => {
+  it('names the identity-provider outage when the server refuses every read with 503', async () => {
+    renderList(() => Promise.reject(providerUnavailable()));
+
+    await waitFor(() =>
+      expect(screen.getByText('Argo Watcher cannot verify your session')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/could not reach the identity provider/)).toBeInTheDocument();
+    expect(screen.getByText(/OIDC issuer is reachable/)).toBeInTheDocument();
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('reports an aborted request as an unreachable server', async () => {
+    renderList(() => Promise.reject(new HttpError('Request timed out', 0)));
+
+    await waitFor(() =>
+      expect(screen.getByText('Could not reach the Argo Watcher server')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  // The gate keys on absent rows, which is only safe because react-admin retains the
+  // loaded page across a failed refetch. Asserted here rather than assumed.
+  it('keeps the loaded grid when a refresh fails', async () => {
+    let attempt = 0;
+    renderList(() => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.resolve({ data: [{ id: 'task-1' }], total: 1 })
+        : Promise.reject(providerUnavailable());
+    });
+
+    await waitFor(() => expect(screen.getByTestId('datagrid')).toBeInTheDocument());
+
+    screen.getByRole('button', { name: 'refresh now' }).click();
+
+    // Wait for the failure to be observed, not merely started, so the assertions
+    // below cannot pass while the query is still in flight.
+    await waitFor(() => expect(screen.getByTestId('list-error')).toBeInTheDocument());
+
+    expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+    expect(screen.queryByText('Argo Watcher cannot verify your session')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/tasks/components/TaskListLayout.integration.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.integration.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { AdminContext, HttpError, testDataProvider, useListContext, useRefresh } from 'react-admin';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
@@ -50,9 +50,7 @@ describe('TaskListLayout against react-admin', () => {
   it('names the identity-provider outage when the server refuses every read with 503', async () => {
     renderList(() => Promise.reject(providerUnavailable()));
 
-    await waitFor(() =>
-      expect(screen.getByText('Argo Watcher cannot verify your session')).toBeInTheDocument(),
-    );
+    await screen.findByText('Argo Watcher cannot verify your session');
     expect(screen.getByText(/could not reach the identity provider/)).toBeInTheDocument();
     expect(screen.getByText(/OIDC issuer is reachable/)).toBeInTheDocument();
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
@@ -62,9 +60,7 @@ describe('TaskListLayout against react-admin', () => {
   it('reports an aborted request as an unreachable server', async () => {
     renderList(() => Promise.reject(new HttpError('Request timed out', 0)));
 
-    await waitFor(() =>
-      expect(screen.getByText('Could not reach the Argo Watcher server')).toBeInTheDocument(),
-    );
+    await screen.findByText('Could not reach the Argo Watcher server');
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
@@ -80,13 +76,13 @@ describe('TaskListLayout against react-admin', () => {
         : Promise.reject(providerUnavailable());
     });
 
-    await waitFor(() => expect(screen.getByTestId('datagrid')).toBeInTheDocument());
+    await screen.findByTestId('datagrid');
 
     screen.getByRole('button', { name: 'refresh now' }).click();
 
     // Wait for the failure to be observed, not merely started, so the assertions
     // below cannot pass while the query is still in flight.
-    await waitFor(() => expect(screen.getByTestId('list-error')).toBeInTheDocument());
+    await screen.findByTestId('list-error');
 
     expect(screen.getByTestId('datagrid')).toBeInTheDocument();
     expect(screen.queryByText('Argo Watcher cannot verify your session')).not.toBeInTheDocument();

--- a/web/src/features/tasks/components/TaskListLayout.test.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.test.tsx
@@ -192,7 +192,7 @@ describe('TaskListLayout', () => {
     );
 
     expect(screen.getByText('Date filter')).toBeInTheDocument();
-    expect(screen.getByText('Couldn’t load tasks')).toBeInTheDocument();
+    expect(screen.getByText('Could not reach the Argo Watcher server')).toBeInTheDocument();
     expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
 
@@ -200,6 +200,60 @@ describe('TaskListLayout', () => {
     // from their own query, and a list-only refetch would leave them stuck.
     screen.getByRole('button', { name: 'Retry' }).click();
     expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  // react-admin leaves `total` undefined on an errored query, so a gate on
+  // `total === 0` fell through to the datagrid and read as an empty task list.
+  it('shows the error state when a failed query reports no total at all', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    listContextRef.current = {
+      data: undefined as unknown as unknown[],
+      total: undefined,
+      isPending: false,
+      filterValues: {},
+      error: Object.assign(new Error('authentication provider unavailable'), {
+        status: 503,
+        body: { status: 'authentication provider unavailable', error: 'token validation failed' },
+      }),
+    };
+
+    render(
+      <TaskListLayout perPageStorageKey="history.perPage" emptyComponent={<div data-testid="empty-state" />}>
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    expect(screen.getByText('Argo Watcher cannot verify your session')).toBeInTheDocument();
+    expect(screen.getByText(/could not reach the identity provider/)).toBeInTheDocument();
+    // The remedy is the half that stops a pointless re-login, so pin it too.
+    expect(screen.getByText(/OIDC issuer is reachable/)).toBeInTheDocument();
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  // History persists its filters, so a returning user hits an outage with filters set.
+  // The outage must win over the datagrid's "adjust your filters" empty state.
+  it('shows the error state even when filters are active', () => {
+    readPersistentPerPageMock.mockReturnValue(25);
+    listContextRef.current = {
+      data: undefined as unknown as unknown[],
+      total: undefined,
+      isPending: false,
+      filterValues: { app: 'demo', start: 1, end: 2 },
+      error: Object.assign(new Error('authentication provider unavailable'), {
+        status: 503,
+        body: { status: 'authentication provider unavailable', error: 'token validation failed' },
+      }),
+    };
+
+    render(
+      <TaskListLayout perPageStorageKey="history.perPage" emptyComponent={<div data-testid="empty-state" />}>
+        <div data-testid="datagrid">Rows</div>
+      </TaskListLayout>,
+    );
+
+    expect(screen.getByText('Argo Watcher cannot verify your session')).toBeInTheDocument();
+    expect(screen.queryByTestId('datagrid')).not.toBeInTheDocument();
   });
 
   it('keeps the populated grid (not the error panel) when a refetch fails with rows already loaded', () => {
@@ -225,7 +279,7 @@ describe('TaskListLayout', () => {
     );
 
     expect(screen.getByTestId('datagrid')).toBeInTheDocument();
-    expect(screen.queryByText('Couldn’t load tasks')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Could not reach/)).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 
@@ -249,7 +303,7 @@ describe('TaskListLayout', () => {
     );
 
     expect(screen.getByTestId('datagrid')).toBeInTheDocument();
-    expect(screen.queryByText('Couldn’t load tasks')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Could not reach/)).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 

--- a/web/src/features/tasks/components/TaskListLayout.tsx
+++ b/web/src/features/tasks/components/TaskListLayout.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement, type ReactNode } from 'react';
 import { Box, Stack } from '@mui/material';
 import { List, Pagination, useListContext, useRefresh, type ListProps } from 'react-admin';
+import { describeReadFailure } from '../../../data/readFailure';
 import { PerPagePersistence, readPersistentPerPage } from '../../../shared/hooks/usePersistentPerPage';
 import { EmptyState, EmptyStateCta } from './EmptyState';
 import { SearchFilteredView } from './SearchFilteredView';
@@ -18,23 +19,8 @@ interface TaskListLayoutProps {
 }
 
 /**
- * The empty gate lives here — inside <List> — rather than on <List empty>,
- * because react-admin renders the `empty` element *instead of* the entire list,
- * which drops the filter toolbar with it. Users would then land on an empty
- * history page with no way to widen the date range. When filters are active we
- * defer to the datagrid's own filtered empty state (with its "Clear filters"
- * CTA), matching react-admin's original `shouldRenderEmptyPage` condition
- * (`!error && !isPending && total === 0 && !filterValues`).
- *
- * A fetch error (a 5xx, a network drop, or the request timing out — see
- * REQUEST_TIMEOUT_MS in httpClient) is rendered as an explicit error state with
- * a retry, NOT as the empty placeholder or the datagrid's "no tasks" message: a
- * load failure must never masquerade as genuine emptiness.
- *
- * The error panel is gated on `total === 0` so it only replaces the body when
- * there is nothing to show. react-admin keeps the previously loaded rows across
- * a refetch, so a transient auto-refresh failure keeps the populated grid (the
- * error is surfaced via react-admin's notification) instead of blanking it.
+ * Gates inside <List>: <List empty> renders instead of the list, dropping the filter
+ * toolbar. The error panel keys on absent rows — an errored query sets no `total`.
  */
 const ListBody = ({
   emptyComponent,
@@ -43,19 +29,21 @@ const ListBody = ({
   emptyComponent: ReactNode | false;
   children: ReactNode;
 }) => {
-  const { isPending, total, filterValues, error } = useListContext();
+  const { isPending, total, data, filterValues, error } = useListContext();
   const hasFilters = Object.keys(filterValues ?? {}).length > 0;
   // Retry has to reload every active query, not just the list: the toolbar's
   // status counts come from their own query, and a list-only refetch would
   // repopulate the grid while the pills stayed stuck on the failed fetch.
   const refresh = useRefresh();
 
-  if (error && !isPending && total === 0) {
+  if (error && !isPending && !data?.length) {
+    const failure = describeReadFailure(error);
     return (
       <EmptyState
         icon="error"
-        title="Couldn’t load tasks"
-        description="The request failed or timed out. Check that the server is reachable, then try again."
+        title={failure.title}
+        description={failure.detail}
+        hint={failure.hint}
         cta={<EmptyStateCta label="Retry" onClick={refresh} />}
       />
     );

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -283,7 +283,73 @@ describe('TaskShow', () => {
     });
 
     await renderWithRouter('/task/task-1');
-    expect(mockUseNotify).toHaveBeenCalledWith('Failed to load task details.', { type: 'error' });
+    expect(mockUseNotify).toHaveBeenCalledWith('Could not reach the Argo Watcher server', {
+      type: 'error',
+    });
+  });
+
+  // A 503 means the server refused to read, not that the task is gone. Claiming
+  // "not found" for a deep link sends the reader hunting for a deleted task.
+  it('names the read failure instead of claiming the task is missing', async () => {
+    mockUseGetOne.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: Object.assign(new Error('authentication provider unavailable'), {
+        status: 503,
+        body: { status: 'authentication provider unavailable', error: 'token validation failed' },
+      }),
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    expect(screen.getByText('Argo Watcher cannot verify your session')).toBeInTheDocument();
+    expect(screen.getByText(/could not reach the identity provider/i)).toBeInTheDocument();
+    expect(screen.getByText(/OIDC issuer is reachable/)).toBeInTheDocument();
+    expect(screen.queryByText(/Task not found/i)).not.toBeInTheDocument();
+  });
+
+  // The page polls every 10s while a task is in progress. Discarding a loaded task
+  // over one failed poll is the blanking the task list deliberately avoids.
+  it('keeps a loaded task on screen when a poll fails, and only toasts the cause', async () => {
+    mockUseGetOne.mockReturnValue({
+      data: buildTask(),
+      isLoading: false,
+      isError: true,
+      error: Object.assign(new Error('authentication provider unavailable'), {
+        status: 503,
+        body: { status: 'authentication provider unavailable', error: 'token validation failed' },
+      }),
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    expect(screen.getByText('demo-app')).toBeInTheDocument();
+    expect(screen.queryByText('Argo Watcher cannot verify your session')).not.toBeInTheDocument();
+    expect(mockUseNotify).toHaveBeenCalledWith('Argo Watcher cannot verify your session', {
+      type: 'error',
+    });
+  });
+
+  it('still reports a genuinely missing task as not found, without an error toast', async () => {
+    mockUseGetOne.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: Object.assign(new Error('task not found'), {
+        status: 404,
+        body: { id: 'task-1', error: 'task not found' },
+      }),
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    expect(screen.getByText(/Task not found/i)).toBeInTheDocument();
+    // The card already says it; a toast repeating it would be noise.
+    expect(mockUseNotify).not.toHaveBeenCalledWith(expect.anything(), { type: 'error' });
   });
 
   it('warns when configuration request fails', async () => {

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -333,6 +333,26 @@ describe('TaskShow', () => {
     });
   });
 
+  // dataProvider.getOne throws with the response's own status, so a body reporting an
+  // error on a 2xx reaches here as 200 and must show the server's text, not "not found".
+  it('shows the server text when a successful response reports an error', async () => {
+    mockUseGetOne.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: Object.assign(new Error('task not found'), {
+        status: 200,
+        body: { id: 'task-1', error: 'task not found' },
+      }),
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    expect(screen.getByText('The Argo Watcher server reported an error')).toBeInTheDocument();
+    expect(screen.queryByText(/could not be located/i)).not.toBeInTheDocument();
+  });
+
   it('still reports a genuinely missing task as not found, without an error toast', async () => {
     mockUseGetOne.mockReturnValue({
       data: undefined,

--- a/web/src/features/tasks/show/TaskShow.test.tsx
+++ b/web/src/features/tasks/show/TaskShow.test.tsx
@@ -353,6 +353,28 @@ describe('TaskShow', () => {
     expect(screen.queryByText(/could not be located/i)).not.toBeInTheDocument();
   });
 
+  // react-query keeps the loaded task, so nothing on screen changes — without the toast
+  // the reader would go on trusting a task that has since disappeared.
+  it('toasts when a loaded task starts returning 404 on refresh', async () => {
+    mockUseGetOne.mockReturnValue({
+      data: buildTask(),
+      isLoading: false,
+      isError: true,
+      error: Object.assign(new Error('task not found'), {
+        status: 404,
+        body: { id: 'task-1', error: 'task not found' },
+      }),
+      refetch: vi.fn(),
+    });
+
+    await renderWithRouter('/task/task-1');
+
+    expect(screen.getByText('demo-app')).toBeInTheDocument();
+    expect(mockUseNotify).toHaveBeenCalledWith('This task is no longer available', {
+      type: 'error',
+    });
+  });
+
   it('still reports a genuinely missing task as not found, without an error toast', async () => {
     mockUseGetOne.mockReturnValue({
       data: undefined,

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -23,7 +23,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useGetIdentity, useGetOne, useNotify, usePermissions } from 'react-admin';
 import { Link as RouterLink, useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -33,8 +33,9 @@ import { describeTaskStatus } from '../utils/statusPresentation';
 import { RollbackIndicator } from '../components/RollbackIndicator';
 import { useDeployLockState } from '../../deployLock/useDeployLockState';
 import { useOidcEnabled } from '../../../shared/hooks/useOidcEnabled';
-import { getBrowserWindow, hasPrivilegedAccess } from '../../../shared/utils';
+import { getBrowserWindow, hasPrivilegedAccess, normalizeError } from '../../../shared/utils';
 import { httpClient } from '../../../data/httpClient';
+import { describeReadFailure } from '../../../data/readFailure';
 import { getAccessToken } from '../../../auth/tokenStore';
 import { useTimezone } from '../../../shared/providers/TimezoneProvider';
 
@@ -195,11 +196,19 @@ export const TaskShow = () => {
     refetch,
   } = useGetOne<TaskStatus>('tasks', { id: id ?? '' }, { retry: false, enabled: Boolean(id) });
 
+  // 404 is the one failure that really means "no such task", so it keeps the
+  // not-found card below; every other read failure is named for what it was.
+  // Memoised because it drives a notify effect that must not fire per render.
+  const readFailure = useMemo(
+    () => (isError && error && normalizeError(error).status !== 404 ? describeReadFailure(error) : null),
+    [isError, error],
+  );
+
   useEffect(() => {
-    if (isError && error) {
-      notify('Failed to load task details.', { type: 'error' });
+    if (readFailure) {
+      notify(readFailure.title, { type: 'error' });
     }
-  }, [error, isError, notify]);
+  }, [readFailure, notify]);
 
   useEffect(() => {
     let cancelled = false;
@@ -363,6 +372,24 @@ export const TaskShow = () => {
         <CircularProgress />
         <Typography variant="body1">Loading task details…</Typography>
       </Stack>
+    );
+  }
+
+  // Only when there is nothing to show. A poll failure over a loaded task keeps the
+  // detail view and reports itself through the toast, as the task list does.
+  if (readFailure && !data) {
+    return (
+      <Card>
+        <CardContent>
+          <Typography variant="h6">{readFailure.title}</Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            {readFailure.detail}
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
+            {readFailure.hint}
+          </Typography>
+        </CardContent>
+      </Card>
     );
   }
 

--- a/web/src/features/tasks/show/TaskShow.tsx
+++ b/web/src/features/tasks/show/TaskShow.tsx
@@ -196,12 +196,14 @@ export const TaskShow = () => {
     refetch,
   } = useGetOne<TaskStatus>('tasks', { id: id ?? '' }, { retry: false, enabled: Boolean(id) });
 
-  // 404 is the one failure that really means "no such task", so it keeps the
-  // not-found card below; every other read failure is named for what it was.
+  // A 404 with nothing loaded is the not-found card below, which names the id itself, so
+  // it needs no toast. Every other failure — a 404 over a loaded task included — is named.
+  const isMissingTask = isError && !data && normalizeError(error).status === 404;
+
   // Memoised because it drives a notify effect that must not fire per render.
   const readFailure = useMemo(
-    () => (isError && error && normalizeError(error).status !== 404 ? describeReadFailure(error) : null),
-    [isError, error],
+    () => (isError && error && !isMissingTask ? describeReadFailure(error) : null),
+    [isError, error, isMissingTask],
   );
 
   useEffect(() => {


### PR DESCRIPTION
When the server cannot reach its OIDC issuer it answers every read with 503, and the UI reported that as nothing to show: the task list rendered an endless skeleton or "No recent tasks so far…", and a task page said "Task not found". Both now name the actual cause with a remedy beside it.

The list's error panel was gated on `total === 0`, which react-admin never sets on an errored query — it keys on the absence of rows now. `getOne` also stopped synthesizing a 404 for a body-level error, so a task page shows what the server said rather than claiming the task is gone.

A page that already loaded keeps its content when a background refresh fails, on both surfaces. The existing component tests stub `useListContext` and so could not catch the original bug; there is a small integration suite against real react-admin for the gates that depend on library behaviour.