### PR TITLE
test(e2e): cover application deploy tokens against a real Keycloak

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,8 @@ jobs:
     # Label path: run only when the `e2e` label is the one just added.
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'e2e'
     runs-on: ubuntu-latest
-    # A measured full run is ~38m (13m boot + 25m phases) on a local machine; hosted
-    # runners are slower, so 45 left almost no headroom.
+    # A measured full run is ~41m (8m boot + 33m phases) on a local machine; hosted
+    # runners are slower, so 45 would leave almost no headroom.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -102,7 +102,7 @@ go test -v -run TestArgoStatusUpdaterCheck ./...
 
 **Browser tests** (`task test-web-e2e`) cover what jsdom cannot: the top-level OIDC redirect and the path it returns to, session recovery across a reload, the server's SPA fallback for deep-linked task URLs, the live WebSocket behind the deploy-lock banner, and the privileged write flows for a privileged versus a regular user. The task builds `web/dist`, brings Keycloak up, and lets Playwright start two servers (`8100` without OIDC, `8101` with) plus the mock Argo CD. Specs live in `web/e2e/`.
 
-**The end-to-end lab** in [`test/e2e/`](https://github.com/shini4i/argo-watcher/tree/main/test/e2e) runs real Argo CD, Gitea and a race-detector build on a kind cluster, once per release. Its README covers the phases and how to add one.
+**The end-to-end lab** in [`test/e2e/`](https://github.com/shini4i/argo-watcher/tree/main/test/e2e) runs real Argo CD, Gitea, Keycloak and a race-detector build on a kind cluster, once per release. Its README covers the phases and how to add one.
 
 ## Swagger spec
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,7 +1,8 @@
 # argo-watcher end-to-end lab
 
-A disposable lab that runs **real** ArgoCD, Gitea, and argo-rollouts (the last
-only for the `accept-suspended` phase) on a single-node
+A disposable lab that runs **real** ArgoCD, Gitea, Keycloak (the OIDC provider the
+`app-tokens` phase authenticates against) and argo-rollouts (the last only for the
+`accept-suspended` phase) on a single-node
 [kind](https://kind.sigs.k8s.io/) cluster, with argo-watcher built under the Go
 **race detector**. Nothing is mocked here, which is the point: it covers the real
 ArgoCD polling loop, the real git push path, and data races under sustained
@@ -74,6 +75,7 @@ task load                 # git-conflict soak: competitor + concurrent deploys, 
 task batch-writeback      # toggle GIT_BATCH_WRITEBACK on, re-run the contention soak: assert 0 lost updates + real coalescing (mean batch size > 1), then revert
 task race                 # same-app supersession: a newer deploy must win over an older retrying one
 task state-postgres       # flip the release to Postgres state: assert migration, deploy loop, task survives a pod restart, the shared deploy lock, supersession under contention
+task app-tokens           # application deploy tokens end to end: issue through the Keycloak-authenticated API, enforce the per-application scope on a real deploy, revoke, expire
 task failure-diagnostics  # assert failure reasons carry the real cause (pod ImagePullBackOff, failed hooks, a degraded migration Job, a stuck rollout)
 task argocd-unreachable   # scale ArgoCD down: assert /reachability flips (reason "argocd") + the watcher broadcasts "argocd_down:argocd" + POST fast-fails 503, then recovers
 task shutdown-drain       # assert graceful shutdown drains in-flight WebSocket connections (GoingAway) with no race/panic
@@ -97,11 +99,11 @@ podman `ctr import` locally, so the lab runs unchanged in both places.
 
 ## Reaching the lab
 
-Four services are published on fixed **localhost** ports (no ingress, no
+Five services are published on fixed **localhost** ports (no ingress, no
 port-forward): argo-watcher `30080`, webhook-tester `30081`, Gitea `30300`, ArgoCD
-`30443`. `fixtures/nodeports/` assigns the node ports and `kind-config.yaml`
-maps them to the host; kind requires the two to use the same number, which
-`ports.bats` asserts. The URLs are exported by `scripts/lib.sh` (`AW_URL`,
+`30443`, Keycloak `30500`. `fixtures/nodeports/` assigns the node ports and
+`kind-config.yaml` maps them to the host; kind requires the two to use the same
+number, which `ports.bats` asserts. The URLs are exported by `scripts/lib.sh` (`AW_URL`,
 `GITEA_URL`, …), so a phase that restarts the server just waits for it to answer
 again instead of re-establishing a forward.
 
@@ -111,7 +113,7 @@ again instead of re-establishing a forward.
 |---|---|
 | `Dockerfile.server.race` | argo-watcher built with `-race` on a glibc distroless base |
 | `kind-config.yaml` | single-node cluster + the host port mappings for the NodePorts below |
-| `fixtures/nodeports/` | fixed NodePort Services for the four components phases talk to from the host (one per file, matching `fixtures/postgres/`) |
+| `fixtures/nodeports/` | fixed NodePort Services for the five components phases talk to from the host (one per file, matching `fixtures/postgres/`) |
 | `phases.bats` | the per-release phase suite: one test per phase, with the ordering constraints |
 | `ports.bats` | offline assertions on the kind-config ↔ nodeports port coupling |
 | `scripts/lib.sh` | shared phase helpers: endpoint URLs, `retry`/`wait_*`, `req`, `run_client`, `metric_sum`/`metric_label_sum`, `helm_apply_aw`, `ok`/`bad`/`phase_end` |
@@ -123,6 +125,8 @@ again instead of re-establishing a forward.
 | `scripts/mint-argo-token.sh` | mint `ARGO_TOKEN` into `argo-watcher-secret` |
 | `scripts/failure-diagnostics.sh` | table-driven failure-reason assertions, driven through the real client (add a case = one table entry) |
 | `scripts/race-supersede.sh` | same-app supersession assertion: real client, newer deploy wins, older is superseded |
+| `scripts/app-tokens.sh` | assert application deploy tokens end to end against the lab's real Keycloak: the endpoints are unregistered and a token refused by name while the feature is off; issuing is restricted to a privileged operator (an unprivileged user and a token minted for another client of the realm are both 401); an issued token records its scope, hint and creator and returns its secret exactly once, with `Cache-Control: no-store`; a scope matching nothing is 406 and one with duplicates/whitespace is normalized; the per-application scope authorizes a REAL deploy of `app4` (write-back committed) while refusing `app2` and near-miss names; a multi-application token covers each of its apps and an all-applications one covers any; `last_used_at` moves on a deployment but never on a read; revocation takes effect on the next request and keeps the audit row; an expired token is refused; the token opens a `/ws` handshake and a CI JWT still works on the same header; and the token survives a pod restart |
+| `values/keycloak.yaml` | the in-cluster OIDC provider (generic `app` chart) serving the SAME realm the docker-compose `integration` profile imports, from `test/keycloak/argo-watcher-e2e-realm.json` mounted as a ConfigMap. `KC_HOSTNAME` pins the issuer to the in-cluster Service URL so a token minted from the host over the NodePort is still accepted at the userinfo endpoint the server calls from inside the cluster |
 | `scripts/state-postgres.sh` | flip the release to `STATE_TYPE=postgres` and assert the Postgres-only path: schema migration Job, real deploy loop, task history surviving a pod restart (in-memory loses it), the shared deploy lock (a lock row written by another writer rejects deploys here), and supersession under contention (the hand-written `CancelInProgressTasks` SQL) |
 | `scripts/batch-writeback.sh` | toggle `GIT_BATCH_WRITEBACK=true` on the release, re-run the contention soak, and revert; reuses `collect.sh` (with `BATCH_MODE`) to gate on zero lost updates and real coalescing (`gitops_batch_size` mean > 1) |
 | `fixtures/postgres/` | in-cluster Postgres (Secret + Service + StatefulSet, one resource per file) the `state-postgres` phase points the release at; the chart bundles no database |
@@ -132,8 +136,8 @@ again instead of re-establishing a forward.
 | `scripts/api-surface.sh` | assert the read-only HTTP surface to contract: the `/livez` + `/readyz` probes, version/config (secrets redacted), task-list filters + invalid-status 400, unknown-task 404, deploy-lock POST/DELETE 404 when OIDC auth is off |
 | `scripts/read-auth.sh` | assert OIDC read protection: toggles `OIDC_ENABLED` on the release with the issuer pointed at a closed port and reverts, asserting 401 without a credential, 503 (never 401) when the provider cannot be consulted — including with a rejected JWT alongside, 15× because strategy order is randomized — 200 for a deploy token / JWT, the `/tasks/:id`, `/config`, `/livez`, `/readyz`, `/metrics` and `POST /tasks` exemptions, and the `unauthenticated_reads` counter semantics. Also asserts the /ws handshake: 401 with no credential, accepted with a deploy token, and 503 for a subprotocol-borne token whose provider is unreachable. Needs no identity provider; group-based authorization is covered by the Keycloak integration suite instead |
 | `scripts/client-knobs.sh` | assert client env knobs via the real client: `TASK_REFRESH=false` still deploys, `DEBUG=true` cURL log redacts the deploy token |
-| `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed. Then sets `JWT_ISSUER` + `JWT_AUDIENCE` on the release and reverts, asserting a claimless token turns 401, a matching one 202, one from another issuer 401, and that unsetting them restores the claimless token |
-| `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency). `JWT_ISS` / `JWT_AUD` add those claims |
+| `scripts/jwt-auth.sh` | assert the JWT (`BEARER_TOKEN`) auth path: mint an HS256 token, deploy with no deploy token, prove the authenticated write-back reaches deployed. Then sets `JWT_ISSUER` + `JWT_AUDIENCE` on the release and reverts, asserting a claimless token turns 401, a matching one 202, one from another issuer 401, and that unsetting them restores the claimless token. Finally asserts the `allowed_apps` claim: a token carrying it deploys only the applications it names (401 elsewhere, naming the claim), while one omitting it still authorizes every application |
+| `tools/mintjwt/` | tiny Go HS256 JWT minter (signs with the server's own jwt library; avoids an openssl dependency). `JWT_ISS` / `JWT_AUD` / `JWT_ALLOWED_APPS` add those claims |
 | `scripts/fire-and-forget.sh` | assert `argo-watcher/fire-and-forget` on a managed CronJob app: the write-back updates the CronJob's image and the deploy reports "deployed" even though the image never rolls out (no pod until the schedule fires) |
 | `fixtures/fire-and-forget-app.yaml` + `fixtures/fire-and-forget-chart/` | dedicated `ffapp` Argo Application (managed) and its CronJob chart (image tag a write-back target, effectively-never schedule), outside the app1..N soak range |
 | `scripts/commit-format.sh` | assert `COMMIT_MESSAGE_FORMAT` renders into the real write-back commit message (reads the commit back from the gitops repo) |
@@ -201,6 +205,23 @@ again instead of re-establishing a forward.
   on Postgres for free. Multi-replica is out of scope — the chart requires
   postgres for `replicaCount > 1`, and shared-state / cross-replica handoff is
   deliberately not exercised.
+- **`app-tokens` needs BOTH OIDC and Postgres, so it runs after `state-postgres`.**
+  Application deploy tokens are registered only when `OIDC_ENABLED=true` *and*
+  `STATE_TYPE=postgres` — a token outlives the process holding it, so there is no
+  in-memory store. The phase therefore inherits the Postgres release the previous
+  phase left, layers `OIDC_ENABLED` + the lab's Keycloak on top for its own
+  duration, and reverts to Postgres-without-OIDC (`AW_EXTRA_VALUES` in `lib.sh` is
+  what keeps `helm_apply_aw`'s revert from silently dropping the overlay). The
+  complementary case — OIDC on but in-memory state, where the endpoints must still
+  be absent — is asserted in `read-auth.sh`, the lab's only OIDC-on in-memory
+  server.
+- **Keycloak's issuer is pinned to its in-cluster URL, not the NodePort.** The
+  phase mints tokens from the host over `localhost:30500` while argo-watcher runs
+  discovery and userinfo from inside the cluster. Left to derive the issuer per
+  request, Keycloak would mint a token on one hostname that the userinfo endpoint
+  rejects on the other; `KC_HOSTNAME=http://keycloak.keycloak` with
+  `KC_HOSTNAME_STRICT=false` makes both paths agree. The token request also asks
+  for the `openid` scope — Keycloak 26 answers userinfo `403` without it.
 - **`shutdown-drain` follows the pod's logs before deleting it.** A recreated
   StatefulSet pod is a new object, so `kubectl logs --previous` would not have the
   terminated instance's shutdown logs; the script streams `logs -f` to a file

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -64,10 +64,11 @@ tasks:
       - task: gitea
       # NodePorts come before `seed`, which is the first step to reach a service
       # (Gitea) from the host. A Service may exist before it has any endpoints, so
-      # publishing all four up front is safe and keeps them in one place.
+      # publishing them all up front is safe and keeps them in one place.
       - task: nodeports
       - task: seed
       - task: webhook-tester
+      - task: keycloak
       - task: argo-watcher
       - task: apply-apps
       - task: verify
@@ -126,7 +127,7 @@ tasks:
       - ./scripts/load-race-image.sh {{.RACE_IMAGE}} {{.CLUSTER}}
 
   nodeports:
-    desc: "Publish argo-watcher / gitea / argocd / webhook-tester on the fixed NodePorts kind maps to localhost"
+    desc: "Publish argo-watcher / gitea / argocd / webhook-tester / keycloak on the fixed NodePorts kind maps to localhost"
     cmds:
       # The namespaces are created up front so the Services can be applied in one
       # shot, before the releases that will eventually back them exist. Each is
@@ -135,6 +136,7 @@ tasks:
       - kubectl create namespace gitea --dry-run=client -o yaml | kubectl apply -f -
       - kubectl create namespace argo-watcher --dry-run=client -o yaml | kubectl apply -f -
       - kubectl create namespace webhook-tester --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl create namespace keycloak --dry-run=client -o yaml | kubectl apply -f -
       - kubectl apply -f fixtures/nodeports/
 
   argocd:
@@ -172,6 +174,19 @@ tasks:
         -f values/webhook-tester.yaml
       - kubectl -n webhook-tester rollout status deploy/webhook-tester --timeout=120s
 
+  keycloak:
+    desc: "Install the in-cluster OIDC provider (generic app chart) used by the app-tokens phase"
+    cmds:
+      # The realm is the one the docker-compose `integration` profile imports, so
+      # both suites run against the same provider definition.
+      - kubectl create namespace keycloak --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl -n keycloak create configmap keycloak-realm
+        --from-file=../keycloak/argo-watcher-e2e-realm.json
+        --dry-run=client -o yaml | kubectl apply -f -
+      - helm upgrade --install keycloak app --repo {{.AW_CHART_REPO}}
+        --version {{.APP_CHART_VERSION}} -n keycloak -f values/keycloak.yaml
+      - kubectl -n keycloak rollout status deploy/keycloak --timeout=300s
+
   seed:
     desc: "Seed Gitea (fixture repo + deploy key) and wire argo-watcher SSH"
     cmds:
@@ -204,7 +219,7 @@ tasks:
       - DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/client-knobs.sh
 
   jwt-auth:
-    desc: "Assert the JWT (BEARER_TOKEN) auth path: JWT-authenticated write-back reaches deployed"
+    desc: "Assert the JWT (BEARER_TOKEN) auth path: authenticated write-back, iss/aud binding, allowed_apps scope"
     cmds:
       - JWT_SECRET={{.JWT_SECRET}} ./scripts/jwt-auth.sh
 
@@ -297,6 +312,13 @@ tasks:
     cmds:
       - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
         DEPLOY_TOKEN={{.DEPLOY_TOKEN}} ./scripts/state-postgres.sh
+
+  app-tokens:
+    desc: "Assert application deploy tokens end to end: issue via Keycloak-authenticated API, per-app scope, revoke, expiry"
+    deps: [apply-apps]
+    cmds:
+      - AW_CHART_REPO={{.AW_CHART_REPO}} AW_CHART_VERSION={{.AW_CHART_VERSION}}
+        DEPLOY_TOKEN={{.DEPLOY_TOKEN}} JWT_SECRET={{.JWT_SECRET}} ./scripts/app-tokens.sh
 
   race:
     desc: "Same-app supersession race: a newer deploy must win over an older retrying one"

--- a/test/e2e/fixtures/nodeports/keycloak.yaml
+++ b/test/e2e/fixtures/nodeports/keycloak.yaml
@@ -1,0 +1,20 @@
+# Fixed NodePort for Keycloak: the app-tokens phase mints OIDC access tokens from
+# the host over it. nodePort MUST equal the matching containerPort in
+# kind-config.yaml. See nodeports/argo-watcher.yaml for why these are standalone.
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-nodeport
+  namespace: keycloak
+spec:
+  type: NodePort
+  # Keycloak runs under the generic `app` chart, hence name=app.
+  selector:
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: keycloak
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30500
+      protocol: TCP

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -38,3 +38,8 @@ nodes:
         hostPort: 30443
         listenAddress: "127.0.0.1"
         protocol: TCP
+      # Keycloak (the app-tokens phase mints OIDC access tokens over it)
+      - containerPort: 30500
+        hostPort: 30500
+        listenAddress: "127.0.0.1"
+        protocol: TCP

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -81,7 +81,7 @@ phase() {
   phase client-knobs.sh
 }
 
-@test "jwt-auth: the BEARER_TOKEN path drives a write-back, and iss/aud bind it" {
+@test "jwt-auth: the BEARER_TOKEN path drives a write-back; iss/aud and allowed_apps bind it" {
   phase jwt-auth.sh
 }
 
@@ -147,6 +147,14 @@ phase() {
   # failure-diagnostics so it deploys against pristine apps. Everything after runs on
   # Postgres — both remaining phases are backend-agnostic, so that is a free bonus.
   phase state-postgres.sh
+}
+
+@test "app-tokens: issue via the OIDC API, per-app scope, revoke, expiry" {
+  # Must follow state-postgres: the tokens require STATE_TYPE=postgres, and this
+  # phase reverts to the Postgres release it inherits rather than the in-memory one.
+  # It enables OIDC against the lab's real Keycloak for its own duration, deploys
+  # app4 and reverts, so it must also precede failure-diagnostics.
+  phase app-tokens.sh
 }
 
 @test "failure-diagnostics: failure reasons carry the real cause" {

--- a/test/e2e/ports.bats
+++ b/test/e2e/ports.bats
@@ -51,7 +51,7 @@ service_nodeports() {
 @test "lib.sh endpoint URLs use the published nodePorts" {
   # shellcheck source=./scripts/lib.sh
   . "${BATS_TEST_DIRNAME}/scripts/lib.sh"
-  for url in "$AW_URL" "$AW_WS_URL" "$WHT_URL" "$GITEA_URL" "$ARGOCD_URL" "$GITOPS_REPO_URL"; do
+  for url in "$AW_URL" "$AW_WS_URL" "$WHT_URL" "$GITEA_URL" "$ARGOCD_URL" "$GITOPS_REPO_URL" "$KEYCLOAK_URL"; do
     port="${url##*:}"; port="${port%%/*}"
     run grep -rqE "nodePort: ${port}\$" "$NODEPORTS_DIR"
     assert_success

--- a/test/e2e/scripts/app-tokens.sh
+++ b/test/e2e/scripts/app-tokens.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+# Prove application deploy tokens end to end against a REAL OIDC provider: issue one
+# through the Keycloak-authenticated API, enforce its per-application scope on a real
+# deploy, then revoke and expire it. See README.md for placement and rationale.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+: "${AW_CHART_REPO:?AW_CHART_REPO is required}" "${AW_CHART_VERSION:?AW_CHART_VERSION is required}"
+VALUES="${E2E_DIR}/values/argo-watcher.yaml"
+PG_VALUES="${E2E_DIR}/values/argo-watcher-postgres.yaml"
+
+# The tokens live in Postgres, so every helm apply here — the revert included — must
+# keep that overlay layered on the base values.
+AW_EXTRA_VALUES=("$PG_VALUES")
+
+# MUST match KC_HOSTNAME in values/keycloak.yaml: this is the issuer as the SERVER
+# reaches it, while the token endpoint below is the same realm as the HOST sees it.
+REALM="argo-watcher-e2e"
+KC_ISSUER="http://keycloak.keycloak/realms/${REALM}"
+KC_TOKEN_URL="${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token"
+KC_CLIENT="argo-watcher"
+# A second client of the same realm, standing in for another application registered
+# with the same provider (issue #577's credential binding).
+KC_FOREIGN_CLIENT="other-app"
+PRIV_GROUP="privileged"
+
+# MUST match JWT_SECRET in values/argo-watcher.yaml (the prefix-routing assertion
+# mints a CI JWT for the same header the tokens arrive in).
+JWT_SECRET="${JWT_SECRET:-e2e-jwt-secret}"
+
+# The one app deployed for real, and one the scoped token must NOT cover.
+APP="${APP:-app4}"
+DENIED_APP="app2"
+
+# Names no Argo Application carries. An accepted task IS validated, so one naming a
+# real fixture app would write its (bogus) tag back to the shared gitops repo; for
+# these the task fails "app not found" in seconds, before any write-back.
+SCOPE_A="scope-alpha"
+SCOPE_B="scope-beta"
+
+UNKNOWN_ID="00000000-0000-0000-0000-000000000000"
+
+bin_dir="$(mktemp -d)"
+work="$(mktemp -d)"
+probe_out="$(mktemp)"
+
+revert() {
+  echo "reverting OIDC_ENABLED (the Postgres overlay stays)"
+  helm_apply_aw || true
+  wait_service || true
+  rm -rf "$bin_dir" "$work" "$probe_out"
+  return
+}
+trap revert EXIT
+
+# --- helpers ------------------------------------------------------------------
+# kc_token <client> <user> <password>: an access token from the lab realm's direct
+# access grant. The openid scope is required — Keycloak 26 answers userinfo 403
+# without it, and argo-watcher validates by calling userinfo.
+kc_token() {
+  curl -s -m 10 -X POST "$KC_TOKEN_URL" \
+    -d grant_type=password -d "client_id=$1" -d "username=$2" -d "password=$3" \
+    -d scope=openid | jq -r '.access_token // empty'
+  return
+}
+
+# as_priv <method> <path> [curl args...]: a request carrying the privileged
+# operator's OIDC token, which is what the token endpoints demand.
+as_priv() {
+  local method="$1" path="$2"
+  shift 2
+  req "$method" "${AW_API}${path}" -H "Oidc-Authorization: Bearer ${PRIV_TOKEN}" "$@"
+  return
+}
+
+# issue <json>: POST a token request as the privileged operator.
+issue() {
+  as_priv POST /app-tokens -H 'Content-Type: application/json' -d "$1"
+  return
+}
+
+# issue_secret <json> <description>: issue a token, aborting the phase if it is
+# refused, and leave its secret in TOKEN_SECRET and its id in TOKEN_ID. Values are
+# returned in variables, not echoed: a die() inside $(...) would kill only the
+# subshell and the caller would carry on with an empty secret.
+issue_secret() {
+  local json="$1" what="$2"
+  issue "$json"
+  [[ "$CODE" == "201" ]] || die "could not issue the ${what} token: code=${CODE} body=${BODY}"
+  TOKEN_ID="$(jq -r '.id' <<<"$BODY")"
+  TOKEN_SECRET="$(jq -r '.secret' <<<"$BODY")"
+  return
+}
+
+# token_field <id> <jq-filter>: read one field of a token from the API listing, so
+# the assertions go through the endpoint operators actually use.
+token_field() {
+  as_priv GET /app-tokens
+  jq -r --arg id "$1" ".[] | select(.id == \$id) | $2" <<<"$BODY"
+  return
+}
+
+# token_moved <id> <field>: true when the token's timestamp field carries a real
+# instant. A bare `!= 0` would also pass on NO output, which is what a listing that
+# is not an array prints — the failure this is most likely to face.
+token_moved() {
+  local value
+  value="$(token_field "$1" "$2 // 0")"
+  [[ "$value" =~ ^[0-9]+$ ]] && (( value > 0 ))
+  return
+}
+
+build_client "$bin_dir" || die "client build failed"
+build_bin "$bin_dir" ./test/e2e/tools/wsprobe || die "wsprobe build failed"
+wsprobe="$BIN"
+
+wait_service || die "argo-watcher never answered on ${AW_URL}"
+
+# --- 0. The feature is refused by name while it is unavailable ----------------
+# Without this the phase could pass against a server that accepts anything: the
+# endpoints must not exist, and a token must be rejected with the reason rather
+# than ignored as an unreadable header (which would skip the write-back silently).
+req GET "${AW_API}/app-tokens"
+if [[ "$CODE" == "200" ]] && ! jq -e 'type == "array"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /app-tokens is not a route with OIDC disabled (falls through to the SPA)"
+else
+  bad "GET /app-tokens with OIDC disabled: code=${CODE} body=$(head -c 120 <<<"$BODY")"
+fi
+
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: awt_unavailable"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("OIDC_ENABLED and STATE_TYPE=postgres")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "an app token is refused by name while the feature is unavailable"
+else
+  bad "app token with the feature off: code=${CODE} body=${BODY} (want 401 naming the requirements)"
+fi
+
+# --- 1. Bring up Postgres + OIDC ----------------------------------------------
+echo "=== provisioning Postgres and pointing the release at Keycloak ==="
+kubectl apply -f "${E2E_DIR}/fixtures/postgres/" >/dev/null
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher-db --timeout=180s >/dev/null
+
+wait_url "${KEYCLOAK_URL}/realms/${REALM}/.well-known/openid-configuration" 60 \
+  || die "keycloak never answered on ${KEYCLOAK_URL}"
+
+idx=$(extra_envs_index "$VALUES")
+helm_apply_aw --set-string "extraEnvs[${idx}].name=OIDC_ENABLED" \
+              --set-string "extraEnvs[${idx}].value=true" \
+              --set-string "extraEnvs[$((idx + 1))].name=OIDC_ISSUER_URL" \
+              --set-string "extraEnvs[$((idx + 1))].value=${KC_ISSUER}" \
+              --set-string "extraEnvs[$((idx + 2))].name=OIDC_CLIENT_ID" \
+              --set-string "extraEnvs[$((idx + 2))].value=${KC_CLIENT}" \
+              --set-string "extraEnvs[$((idx + 3))].name=OIDC_PRIVILEGED_GROUPS" \
+              --set-string "extraEnvs[$((idx + 3))].value=${PRIV_GROUP}" \
+              --wait --timeout 5m
+wait_service || die "argo-watcher never came back with OIDC enabled"
+
+# Minted only now, and re-minted before the long sections below: the realm pins no
+# access-token lifespan, so it inherits Keycloak's default of a few minutes — less
+# than a helm rollout plus a real deploy. An expired token 401s every privileged
+# call and would read as a token-management regression.
+mint_operators() {
+  PRIV_TOKEN="$(kc_token "$KC_CLIENT" priv-user priv-pass)"
+  REGULAR_TOKEN="$(kc_token "$KC_CLIENT" regular-user regular-pass)"
+  FOREIGN_TOKEN="$(kc_token "$KC_FOREIGN_CLIENT" priv-user priv-pass)"
+  [[ -n "$PRIV_TOKEN" && -n "$REGULAR_TOKEN" && -n "$FOREIGN_TOKEN" ]] \
+    || die "could not mint the realm's access tokens from ${KC_TOKEN_URL}"
+  return
+}
+mint_operators
+
+req GET "${AW_API}/config"
+jq -e '.oidc.enabled == true and .state_type == "postgres"' <<<"$BODY" >/dev/null 2>&1 \
+  || die "server did not come back on OIDC + Postgres (config=${BODY})"
+ok "server reports oidc.enabled=true and state_type=postgres"
+
+# --- 2. Only a privileged operator may manage tokens --------------------------
+req GET "${AW_API}/app-tokens"
+if [[ "$CODE" == "401" ]]; then
+  ok "GET /app-tokens -> 401 without a credential"
+else
+  bad "GET /app-tokens uncredentialed: code=${CODE} body=${BODY} (want 401)"
+fi
+
+req GET "${AW_API}/app-tokens" -H "Oidc-Authorization: Bearer ${REGULAR_TOKEN}"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("privileged groups")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /app-tokens -> 401 for an authenticated but unprivileged user"
+else
+  bad "GET /app-tokens as regular-user: code=${CODE} body=${BODY} (want 401 naming the groups)"
+fi
+
+# The list names who holds a credential for which applications, so it is as
+# restricted as issuing. A token minted for another client of the same realm must
+# not reach it either.
+req GET "${AW_API}/app-tokens" -H "Oidc-Authorization: Bearer ${FOREIGN_TOKEN}"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("not issued to")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /app-tokens -> 401 for a token issued to another client of the realm"
+else
+  bad "GET /app-tokens with a foreign-client token: code=${CODE} body=${BODY} (want 401)"
+fi
+
+as_priv GET /app-tokens
+if [[ "$CODE" == "200" ]] && jq -e 'type == "array"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /app-tokens -> 200 for a privileged operator"
+else
+  bad "GET /app-tokens as priv-user: code=${CODE} body=${BODY} (want a 200 array)"
+fi
+
+# --- 3. Issuing a token --------------------------------------------------------
+echo "=== issuing a token scoped to ${APP} ==="
+issue "{\"apps\":[\"${APP}\"],\"description\":\"e2e ${APP} pipeline\"}"
+if [[ "$CODE" != "201" ]]; then
+  die "issuing failed: code=${CODE} body=${BODY}"
+fi
+
+SCOPED_ID="$(jq -r '.id' <<<"$BODY")"
+SCOPED_SECRET="$(jq -r '.secret' <<<"$BODY")"
+if jq -e --arg app "$APP" --arg desc "e2e ${APP} pipeline" \
+     '.apps == [$app] and .all_apps == false and .created_by == "priv-user" and .description == $desc' \
+     <<<"$BODY" >/dev/null 2>&1; then
+  ok "the issued token records its scope, description and the operator who created it"
+else
+  bad "issued token metadata: $(jq -c '{apps,all_apps,created_by,description}' <<<"$BODY")"
+fi
+
+if [[ "$SCOPED_SECRET" == awt_* ]] && [[ "$(jq -r '.hint' <<<"$BODY")" == "${SCOPED_SECRET: -4}" ]]; then
+  ok "the secret carries the awt_ prefix and the hint names its last four characters"
+else
+  bad "secret/hint mismatch: secret=${SCOPED_SECRET:0:8}... hint=$(jq -r '.hint' <<<"$BODY")"
+fi
+
+# The one response that carries a secret must not be cached by anything in front
+# of the server.
+if curl -s -m 10 -D - -o /dev/null -X POST "${AW_API}/app-tokens" \
+     -H "Oidc-Authorization: Bearer ${PRIV_TOKEN}" -H 'Content-Type: application/json' \
+     -d "{\"apps\":[\"${SCOPE_A}\"]}" | grep -qi '^cache-control: no-store'; then
+  ok "the issue response is marked Cache-Control: no-store"
+else
+  bad "the issue response is missing Cache-Control: no-store"
+fi
+
+# The secret exists in clear exactly once: the listing can only ever show the hint.
+if [[ "$(token_field "$SCOPED_ID" '.secret // "absent"')" == "absent" ]]; then
+  ok "the listing never returns a token's secret"
+else
+  bad "the listing returned a secret for token ${SCOPED_ID}"
+fi
+
+# --- 4. A scope that matches nothing is refused --------------------------------
+while read -r label json; do
+  issue "$json"
+  if [[ "$CODE" == "406" ]]; then
+    ok "invalid scope refused (406): ${label}"
+  else
+    bad "invalid scope ${label}: code=${CODE} body=${BODY} (want 406)"
+  fi
+done <<'EOF'
+neither-apps-nor-all {}
+bounded-and-unbounded {"apps":["a"],"all_apps":true}
+empty-application-name {"apps":["  "]}
+expiry-beyond-ten-years {"apps":["a"],"expires_in_days":4000}
+EOF
+
+# The bounds on the list. Both are refused by the request validator before
+# Scope.Validate runs, so these pin the API contract, not apptoken's own caps —
+# those are killed by TestScopeValidate.
+issue "$(jq -nc '{apps: [range(201) | "bulk-app-\(.)"]}')"
+if [[ "$CODE" == "406" ]]; then
+  ok "invalid scope refused (406): more applications than the cap"
+else
+  bad "201-application scope: code=${CODE} body=${BODY} (want 406)"
+fi
+
+issue "$(jq -nc --arg name "$(printf 'a%.0s' {1..256})" '{apps: [$name]}')"
+if [[ "$CODE" == "406" ]]; then
+  ok "invalid scope refused (406): an application name past 255 characters"
+else
+  bad "over-long application name: code=${CODE} body=${BODY} (want 406)"
+fi
+
+# Whitespace and duplicates are normalized at issue time, so the stored scope is
+# the one Allows() compares against later.
+issue "{\"apps\":[\"  ${SCOPE_A} \",\"${SCOPE_A}\",\"${SCOPE_B}\"]}"
+PAIR_ID="$(jq -r '.id' <<<"$BODY")"
+if [[ "$CODE" == "201" ]] && jq -e --arg a "$SCOPE_A" --arg b "$SCOPE_B" '.apps == [$a,$b]' <<<"$BODY" >/dev/null 2>&1; then
+  ok "the scope is trimmed and deduplicated on the way in"
+else
+  bad "scope normalization: code=${CODE} apps=$(jq -c '.apps' <<<"$BODY")"
+fi
+PAIR_SECRET="$(jq -r '.secret' <<<"$BODY")"
+
+# --- 5. The scope is what authorizes a deployment ------------------------------
+echo "=== deploying ${APP} with the scoped token (BEARER_TOKEN, no deploy token) ==="
+require_app_synced "$APP"
+TAG="$(other_tag "$APP")"
+
+# Reaching "deployed" on a tag the app is not on takes a write-back, which only a
+# validated task gets — so the token was accepted for THIS application.
+if run_client "$APP" "$TAG" BEARER_TOKEN="$SCOPED_SECRET"; then
+  ok "the scoped token drove a deploy of ${APP} to 'deployed' on ${TAG}"
+else
+  bad "client exited non-zero — the app token was likely rejected for ${APP}"
+fi
+
+gitops_clone "${work}/repo"
+got="$(override_param "${work}/repo/chart/.argocd-source-${APP}.yaml" app.image.tag)"
+if [[ "$got" == "$TAG" ]]; then
+  ok "the write-back committed ${APP} -> ${TAG} (the task was validated)"
+else
+  bad "write-back override for ${APP}: got '${got}', want '${TAG}'"
+fi
+
+# The deploy above can run for minutes; refresh before the privileged calls resume.
+mint_operators
+
+post_task "$(task_json "$DENIED_APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
+reason="$(jq -r '.error // empty' <<<"$BODY")"
+if [[ "$CODE" == "401" ]] && [[ "$reason" == *"$DENIED_APP"* ]] && [[ "$reason" == *"$APP"* ]]; then
+  ok "the same token is refused for ${DENIED_APP}, and the reason names both the app and the scope"
+else
+  bad "scope enforcement for ${DENIED_APP}: code=${CODE} reason=${reason} (want 401 naming app and scope)"
+fi
+
+# Application names are Kubernetes object names, so the comparison is exact: neither
+# a different case nor a longer name sharing the prefix may pass.
+for near in "${APP^^}" "${APP}4"; do
+  post_task "$(task_json "$near" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
+  if [[ "$CODE" == "401" ]]; then
+    ok "the scope does not stretch to ${near}"
+  else
+    bad "near-miss application ${near}: code=${CODE} body=${BODY} (want 401)"
+  fi
+done
+
+# A token listing several applications covers each of them.
+for app in "$SCOPE_A" "$SCOPE_B"; do
+  post_task "$(task_json "$app" v0.0.1)" -H "Authorization: ${PAIR_SECRET}"
+  if [[ "$CODE" == "202" ]]; then
+    ok "the two-application token authorizes ${app}"
+  else
+    bad "two-application token for ${app}: code=${CODE} body=${BODY} (want 202)"
+  fi
+done
+post_task "$(task_json "$DENIED_APP" v0.0.1)" -H "Authorization: ${PAIR_SECRET}"
+if [[ "$CODE" == "401" ]]; then
+  ok "the two-application token stops at the applications it lists"
+else
+  bad "two-application token for ${DENIED_APP}: code=${CODE} (want 401)"
+fi
+if token_moved "$PAIR_ID" .last_used_at; then
+  ok "the two-application token authorized those tasks, rather than them being accepted uncredentialed"
+else
+  bad "the two-application token's use was never recorded, so its 202s prove nothing"
+fi
+
+# all_apps is a wildcard over applications that need not exist yet, which is why it
+# is a column of its own rather than an entry in the list. The names are fictional
+# on purpose: an accepted task IS validated, so one naming a real fixture app would
+# write its bogus tag back to the gitops repo.
+issue_secret '{"all_apps":true,"description":"e2e fleet"}' all-apps
+ALL_SECRET="$TOKEN_SECRET"
+ALL_ID="$TOKEN_ID"
+for app in "$SCOPE_A" "$SCOPE_B" "never-registered-app"; do
+  post_task "$(task_json "$app" v0.0.1)" -H "Authorization: ${ALL_SECRET}"
+  if [[ "$CODE" == "202" ]]; then
+    ok "the all-applications token authorizes ${app}"
+  else
+    bad "all-applications token for ${app}: code=${CODE} body=${BODY} (want 202)"
+  fi
+done
+if token_moved "$ALL_ID" .last_used_at; then
+  ok "the all-applications token authorized those tasks (the wildcard branch really ran)"
+else
+  bad "the all-applications token's use was never recorded, so its 202s prove nothing"
+fi
+
+# --- 6. Use is recorded on deployments, never on reads -------------------------
+issue_secret "{\"apps\":[\"${SCOPE_A}\"]}" last-used
+USED_SECRET="$TOKEN_SECRET"
+USED_ID="$TOKEN_ID"
+if [[ "$(token_field "$USED_ID" '.last_used_at // 0')" == "0" ]]; then
+  ok "a fresh token reports no last use"
+else
+  bad "a freshly issued token already carries last_used_at"
+fi
+
+req GET "${AW_API}/tasks?from_timestamp=0" -H "Authorization: ${USED_SECRET}"
+if [[ "$CODE" == "200" ]]; then
+  ok "an app token authenticates a protected read"
+else
+  bad "read with an app token: code=${CODE} body=${BODY} (want 200)"
+fi
+if [[ "$(token_field "$USED_ID" '.last_used_at // 0')" == "0" ]]; then
+  ok "the read left last_used_at unset (a polled endpoint stays read-only)"
+else
+  bad "a read recorded a use, turning every status poll into a write"
+fi
+
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: ${USED_SECRET}"
+[[ "$CODE" == "202" ]] || bad "the last-used token was refused for its own app: code=${CODE}"
+if token_moved "$USED_ID" .last_used_at; then
+  ok "authorizing a deployment recorded the token's use"
+else
+  bad "last_used_at is still unset after the token authorized a deployment"
+fi
+
+# --- 7. Unknown, revoked and expired tokens ------------------------------------
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: awt_dGhpcy1zZWNyZXQtd2FzLW5ldmVyLWlzc3VlZA"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("not a known application deploy token")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "a well-formed token that was never issued -> 401"
+else
+  bad "unknown app token: code=${CODE} body=${BODY} (want 401)"
+fi
+
+echo "=== revoking ==="
+req DELETE "${AW_API}/app-tokens/${SCOPED_ID}"
+anon_code="$CODE"
+req DELETE "${AW_API}/app-tokens/${SCOPED_ID}" -H "Oidc-Authorization: Bearer ${REGULAR_TOKEN}"
+# The reason matters as much as the code here: any 401 would satisfy a code-only
+# check, including one caused by a token this phase mismanaged.
+if [[ "$anon_code" == "401" && "$CODE" == "401" ]] &&
+   jq -e '.error | test("privileged groups")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "revocation is restricted to a privileged operator"
+else
+  bad "DELETE uncredentialed=${anon_code} unprivileged=${CODE} body=${BODY} (want 401 naming the groups)"
+fi
+
+as_priv DELETE "/app-tokens/${SCOPED_ID}"
+if [[ "$CODE" == "200" ]]; then
+  ok "the privileged operator revoked the token"
+else
+  bad "DELETE /app-tokens/${SCOPED_ID}: code=${CODE} body=${BODY} (want 200)"
+fi
+
+# The point of the store being a database read on every request: revocation takes
+# effect on the next one, with nothing to restart or expire first.
+post_task "$(task_json "$APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
+reason="$(jq -r '.error // empty' <<<"$BODY")"
+if [[ "$CODE" == "401" ]] && [[ "$reason" == *revoked* ]]; then
+  ok "the revoked token is refused on its very next use, and told it was revoked"
+else
+  bad "revoked token: code=${CODE} reason=${reason} (want 401 naming the revocation)"
+fi
+
+req GET "${AW_API}/tasks?from_timestamp=0" -H "Authorization: ${SCOPED_SECRET}"
+if [[ "$CODE" == "401" ]]; then
+  ok "the revoked token cannot read either"
+else
+  bad "read with a revoked token: code=${CODE} (want 401)"
+fi
+
+revoked_at="$(token_field "$SCOPED_ID" '.revoked_at // 0')"
+if token_moved "$SCOPED_ID" .revoked_at; then
+  ok "the revoked token keeps its row, stamped with when it was withdrawn"
+else
+  bad "the revoked token lost its audit row (revoked_at=${revoked_at})"
+fi
+
+# Revoking twice is a no-op rather than a re-stamp, and must be told apart from an
+# id that never existed.
+as_priv DELETE "/app-tokens/${SCOPED_ID}"
+if [[ "$CODE" == "200" ]] && [[ "$(token_field "$SCOPED_ID" '.revoked_at')" == "$revoked_at" ]]; then
+  ok "revoking an already-revoked token leaves the original revocation time"
+else
+  bad "second revocation: code=${CODE} revoked_at=$(token_field "$SCOPED_ID" '.revoked_at')"
+fi
+
+as_priv DELETE "/app-tokens/${UNKNOWN_ID}"
+if [[ "$CODE" == "404" ]]; then
+  ok "revoking an unknown id -> 404"
+else
+  bad "DELETE unknown id: code=${CODE} body=${BODY} (want 404)"
+fi
+
+as_priv DELETE "/app-tokens/not-a-uuid"
+if [[ "$CODE" == "400" ]]; then
+  ok "a malformed token id -> 400"
+else
+  bad "DELETE malformed id: code=${CODE} body=${BODY} (want 400)"
+fi
+
+echo "=== expiry ==="
+issue_secret "{\"apps\":[\"${SCOPE_A}\"],\"expires_in_days\":1}" expiring
+EXPIRING_SECRET="$TOKEN_SECRET"
+EXPIRING_ID="$TOKEN_ID"
+if token_moved "$EXPIRING_ID" .expires_at; then
+  ok "expires_in_days stored an expiry"
+else
+  bad "expires_in_days did not store an expiry"
+fi
+
+# Waiting a day is not an option, so move the stored deadline into the past: the
+# boundary Usable() applies is the row's, and this is the row.
+psql_db "UPDATE app_tokens SET expires_at = now() - interval '1 hour' WHERE id = '${EXPIRING_ID}'" >/dev/null
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: ${EXPIRING_SECRET}"
+reason="$(jq -r '.error // empty' <<<"$BODY")"
+if [[ "$CODE" == "401" ]] && [[ "$reason" == *expired* ]]; then
+  ok "a token past its expiry is refused, and told it expired"
+else
+  bad "expired token: code=${CODE} reason=${reason} (want 401 naming the expiry)"
+fi
+
+# --- 8. The WebSocket and the JWT sharing the header ---------------------------
+WS_URL="$AW_WS_URL" DURATION=3s "$wsprobe" >"$probe_out" 2>/dev/null || true
+if grep -q '^OPEN$' "$probe_out"; then
+  bad "an uncredentialed /ws handshake was accepted while OIDC is on"
+else
+  ok "WS handshake refused without a credential (the control for the next assertion)"
+fi
+
+WS_URL="$AW_WS_URL" DURATION=3s WSPROBE_BEARER_TOKEN="$ALL_SECRET" "$wsprobe" >"$probe_out" 2>/dev/null || true
+if wait_ws_open "$probe_out"; then
+  ok "WS handshake accepted with an app token"
+else
+  bad "WS handshake with an app token: $(tr '\n' ',' <"$probe_out") (want OPEN)"
+fi
+
+# Both credential types arrive in Authorization and are told apart by the token's
+# own shape, so registering the tokens must not have displaced the JWT strategy.
+jwt="$(cd "$E2E_ROOT" && JWT_SECRET="$JWT_SECRET" go run ./test/e2e/tools/mintjwt)" \
+  || die "could not mint a JWT"
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: ${jwt}"
+if [[ "$CODE" == "202" ]]; then
+  ok "a CI JWT still authorizes on the same header the app tokens use"
+else
+  bad "JWT alongside app tokens: code=${CODE} body=${BODY} (want 202)"
+fi
+
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: not-a-credential"
+if [[ "$CODE" == "401" ]]; then
+  ok "a non-prefixed value still reaches the JWT strategy and is rejected"
+else
+  bad "garbage on Authorization: code=${CODE} body=${BODY} (want 401)"
+fi
+
+# --- 9. Tokens outlive the process that issued them ----------------------------
+# The whole reason there is no in-memory store: an issued token must survive a
+# restart and be honored by every replica.
+echo "=== restarting the server; the token must still authorize ==="
+kubectl -n "$NS_AW" delete pod argo-watcher-0 --wait=true >/dev/null
+kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
+wait_service || die "argo-watcher never came back after the restart"
+
+post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: ${ALL_SECRET}"
+if [[ "$CODE" == "202" ]]; then
+  ok "the token still authorizes after a restart"
+else
+  bad "token after a restart: code=${CODE} body=${BODY} (want 202)"
+fi
+post_task "$(task_json "$APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
+reason="$(jq -r '.error // empty' <<<"$BODY")"
+if [[ "$CODE" == "401" ]] && [[ "$reason" == *revoked* ]]; then
+  ok "the revocation survived the restart too"
+else
+  bad "revoked token after a restart: code=${CODE} reason=${reason} (want 401)"
+fi
+
+# --- 10. Revert ----------------------------------------------------------------
+revert
+trap - EXIT
+
+req GET "${AW_API}/app-tokens"
+if [[ "$CODE" == "200" ]] && ! jq -e 'type == "array"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "the token endpoints are gone again with OIDC disabled"
+else
+  bad "after revert GET /app-tokens: code=${CODE} body=$(head -c 120 <<<"$BODY")"
+fi
+
+phase_end APP-TOKENS

--- a/test/e2e/scripts/app-tokens.sh
+++ b/test/e2e/scripts/app-tokens.sh
@@ -42,6 +42,8 @@ SCOPE_A="scope-alpha"
 SCOPE_B="scope-beta"
 
 UNKNOWN_ID="00000000-0000-0000-0000-000000000000"
+# The rejection reason every 401 assertion below reads out of the response body.
+ERROR_FILTER='.error // empty'
 
 bin_dir="$(mktemp -d)"
 work="$(mktemp -d)"
@@ -61,9 +63,10 @@ trap revert EXIT
 # access grant. The openid scope is required — Keycloak 26 answers userinfo 403
 # without it, and argo-watcher validates by calling userinfo.
 kc_token() {
+  local client="$1" user="$2" password="$3"
   curl -s -m 10 -X POST "$KC_TOKEN_URL" \
-    -d grant_type=password -d "client_id=$1" -d "username=$2" -d "password=$3" \
-    -d scope=openid | jq -r '.access_token // empty'
+    -d grant_type=password -d "client_id=${client}" -d "username=${user}" \
+    -d "password=${password}" -d scope=openid | jq -r '.access_token // empty'
   return
 }
 
@@ -78,7 +81,8 @@ as_priv() {
 
 # issue <json>: POST a token request as the privileged operator.
 issue() {
-  as_priv POST /app-tokens -H 'Content-Type: application/json' -d "$1"
+  local json="$1"
+  as_priv POST /app-tokens -H 'Content-Type: application/json' -d "$json"
   return
 }
 
@@ -98,8 +102,9 @@ issue_secret() {
 # token_field <id> <jq-filter>: read one field of a token from the API listing, so
 # the assertions go through the endpoint operators actually use.
 token_field() {
+  local id="$1" filter="$2"
   as_priv GET /app-tokens
-  jq -r --arg id "$1" ".[] | select(.id == \$id) | $2" <<<"$BODY"
+  jq -r --arg id "$id" ".[] | select(.id == \$id) | ${filter}" <<<"$BODY"
   return
 }
 
@@ -107,8 +112,8 @@ token_field() {
 # instant. A bare `!= 0` would also pass on NO output, which is what a listing that
 # is not an array prints — the failure this is most likely to face.
 token_moved() {
-  local value
-  value="$(token_field "$1" "$2 // 0")"
+  local id="$1" field="$2" value
+  value="$(token_field "$id" "${field} // 0")"
   [[ "$value" =~ ^[0-9]+$ ]] && (( value > 0 ))
   return
 }
@@ -316,7 +321,7 @@ fi
 mint_operators
 
 post_task "$(task_json "$DENIED_APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
-reason="$(jq -r '.error // empty' <<<"$BODY")"
+reason="$(jq -r "$ERROR_FILTER" <<<"$BODY")"
 if [[ "$CODE" == "401" ]] && [[ "$reason" == *"$DENIED_APP"* ]] && [[ "$reason" == *"$APP"* ]]; then
   ok "the same token is refused for ${DENIED_APP}, and the reason names both the app and the scope"
 else
@@ -437,7 +442,7 @@ fi
 # The point of the store being a database read on every request: revocation takes
 # effect on the next one, with nothing to restart or expire first.
 post_task "$(task_json "$APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
-reason="$(jq -r '.error // empty' <<<"$BODY")"
+reason="$(jq -r "$ERROR_FILTER" <<<"$BODY")"
 if [[ "$CODE" == "401" ]] && [[ "$reason" == *revoked* ]]; then
   ok "the revoked token is refused on its very next use, and told it was revoked"
 else
@@ -495,7 +500,7 @@ fi
 # boundary Usable() applies is the row's, and this is the row.
 psql_db "UPDATE app_tokens SET expires_at = now() - interval '1 hour' WHERE id = '${EXPIRING_ID}'" >/dev/null
 post_task "$(task_json "$SCOPE_A" v0.0.1)" -H "Authorization: ${EXPIRING_SECRET}"
-reason="$(jq -r '.error // empty' <<<"$BODY")"
+reason="$(jq -r "$ERROR_FILTER" <<<"$BODY")"
 if [[ "$CODE" == "401" ]] && [[ "$reason" == *expired* ]]; then
   ok "a token past its expiry is refused, and told it expired"
 else
@@ -550,7 +555,7 @@ else
   bad "token after a restart: code=${CODE} body=${BODY} (want 202)"
 fi
 post_task "$(task_json "$APP" v0.0.1)" -H "Authorization: ${SCOPED_SECRET}"
-reason="$(jq -r '.error // empty' <<<"$BODY")"
+reason="$(jq -r "$ERROR_FILTER" <<<"$BODY")"
 if [[ "$CODE" == "401" ]] && [[ "$reason" == *revoked* ]]; then
   ok "the revocation survived the restart too"
 else

--- a/test/e2e/scripts/jwt-auth.sh
+++ b/test/e2e/scripts/jwt-auth.sh
@@ -104,4 +104,37 @@ else
   bad "after revert, token without iss/aud: code=${CODE} body=${BODY} (want 202)"
 fi
 
+# --- 4. allowed_apps confines a token to the applications it names -------------
+# The other half of the claim policy, and the JWT counterpart of an application
+# deploy token's scope. The accepted names are fictional on purpose: the task IS
+# validated, so a real fixture app would take its bogus tag through a write-back.
+SCOPED_A="jwt-scope-alpha"
+SCOPED_B="jwt-scope-beta"
+scoped_jwt="$(mint JWT_ALLOWED_APPS="${SCOPED_A},${SCOPED_B}")"
+
+for app in "$SCOPED_A" "$SCOPED_B"; do
+  post_task "$(task_json "$app" v0.0.1)" -H "Authorization: ${scoped_jwt}"
+  if [[ "$CODE" == "202" ]]; then
+    ok "allowed_apps authorizes ${app}"
+  else
+    bad "allowed_apps token for ${app}: code=${CODE} body=${BODY} (want 202)"
+  fi
+done
+
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${scoped_jwt}"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("allowed_apps")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "allowed_apps refuses ${APP}, naming the claim that confined the token"
+else
+  bad "allowed_apps token for ${APP}: code=${CODE} body=${BODY} (want 401 naming the claim)"
+fi
+
+# Section 1 already deployed with a claimless token; this states the compatibility
+# rule outright, since a fleet that never set the claim depends on it.
+post_task "$(task_json "$APP" "$TAG")" -H "Authorization: ${plain_jwt}"
+if [[ "$CODE" == "202" ]]; then
+  ok "a token omitting allowed_apps still authorizes any application"
+else
+  bad "claimless token after the scoped one: code=${CODE} (want 202)"
+fi
+
 phase_end JWT-AUTH

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -381,7 +381,8 @@ helm_apply_aw() {
 # bare values (no headers or padding). Only meaningful once fixtures/postgres/ is
 # applied — the state-postgres and app-tokens phases both do that.
 psql_db() {
+  local sql="$1"
   kubectl -n "$NS_AW" exec argo-watcher-db-0 -- \
-    psql -qtAX -U argo_watcher -d argo_watcher -c "$1"
+    psql -qtAX -U argo_watcher -d argo_watcher -c "$sql"
   return
 }

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -33,6 +33,9 @@ AW_API="${AW_URL}/api/v1"
 AW_WS_URL="${AW_WS_URL:-ws://localhost:30080/ws}"
 WHT_URL="${WHT_URL:-http://localhost:30081}"
 GITEA_URL="${GITEA_URL:-http://localhost:30300}"
+# Keycloak as the HOST reaches it. The issuer argo-watcher is configured with is the
+# in-cluster URL instead (KC_HOSTNAME in values/keycloak.yaml) — see app-tokens.sh.
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:30500}"
 # Self-signed cert; callers pass -k.
 ARGOCD_URL="${ARGOCD_URL:-https://localhost:30443}"
 
@@ -331,10 +334,9 @@ other_tag() {
 
 # --- helm --------------------------------------------------------------------
 # extra_envs_index <values-file>: the index of the next free extraEnvs entry, so a
-# phase can append one with `--set extraEnvs[N]...`. Counted from the values FILE,
-# not the live release, so it does not depend on release state. The awk scopes the
-# count to the extraEnvs block (between "extraEnvs:" and the next top-level key),
-# so a same-indented "- name:" added to another section cannot silently shift it.
+# phase can append one with `--set extraEnvs[N]...`. Counted from ONE file, so no
+# file layered by AW_EXTRA_VALUES may define extraEnvs: helm replaces lists across
+# -f files rather than merging them, which would leave this index pointing wrong.
 extra_envs_index() {
   local file="$1"
   awk '
@@ -356,14 +358,30 @@ extra_envs_index() {
 # alone: without it helm carries a prior `--set extraEnvs[N]` forward, so the
 # revert (values file only) would NOT drop the injected variable.
 #
+# AW_EXTRA_VALUES layers further values files on top, so a phase whose release the
+# base file alone does not describe (app-tokens, on Postgres) can still revert here.
 # Requires AW_CHART_REPO and AW_CHART_VERSION (passed from the Taskfile, which pins
 # the chart version).
 helm_apply_aw() {
+  local overlays=() file
+  for file in "${AW_EXTRA_VALUES[@]:-}"; do
+    [[ -n "$file" ]] && overlays+=(-f "$file")
+  done
+
   helm upgrade --install argo-watcher argo-watcher \
     --repo "${AW_CHART_REPO:?AW_CHART_REPO is required}" \
     --version "${AW_CHART_VERSION:?AW_CHART_VERSION is required}" \
-    -n "$NS_AW" -f "${E2E_DIR}/values/argo-watcher.yaml" --reset-values \
+    -n "$NS_AW" -f "${E2E_DIR}/values/argo-watcher.yaml" "${overlays[@]}" --reset-values \
     --set image.tag=race "$@" >/dev/null
   kubectl -n "$NS_AW" rollout status statefulset/argo-watcher --timeout=180s >/dev/null
+  return
+}
+
+# psql_db <sql>: run one statement against the lab's in-cluster Postgres, printing
+# bare values (no headers or padding). Only meaningful once fixtures/postgres/ is
+# applied — the state-postgres and app-tokens phases both do that.
+psql_db() {
+  kubectl -n "$NS_AW" exec argo-watcher-db-0 -- \
+    psql -qtAX -U argo_watcher -d argo_watcher -c "$1"
   return
 }

--- a/test/e2e/scripts/read-auth.sh
+++ b/test/e2e/scripts/read-auth.sh
@@ -158,6 +158,23 @@ else
   bad "GET /tasks with a valid JWT: code=${CODE} body=${BODY} (want 200)"
 fi
 
+# Application deploy tokens need a store that outlives the process, so OIDC alone
+# does not turn them on: the endpoints must stay unregistered and a token be refused
+# by name. Covered here because this is the lab's only OIDC-on, in-memory server.
+req GET "${AW_API}/app-tokens"
+if [[ "$CODE" == "200" ]] && ! jq -e 'type == "array"' <<<"$BODY" >/dev/null 2>&1; then
+  ok "GET /app-tokens is not a route on in-memory state (falls through to the SPA)"
+else
+  bad "GET /app-tokens on in-memory state: code=${CODE} (want the SPA fallthrough, not an array)"
+fi
+
+post_task "$(task_json app1 v0.0.1)" -H "Authorization: awt_no-store-for-this"
+if [[ "$CODE" == "401" ]] && jq -e '.error | test("STATE_TYPE=postgres")' <<<"$BODY" >/dev/null 2>&1; then
+  ok "an app token is refused by name on in-memory state"
+else
+  bad "app token on in-memory state: code=${CODE} body=${BODY} (want 401 naming the requirement)"
+fi
+
 # --- 5. The deliberate exemptions stay reachable -------------------------------
 # Breaking any of these breaks either every pipeline (the task lookup), the Web UI's
 # ability to log in at all (/config), or the probes and the scrape.

--- a/test/e2e/scripts/state-postgres.sh
+++ b/test/e2e/scripts/state-postgres.sh
@@ -53,11 +53,6 @@ probe_pid=""
 # Set to 1 while the deploy-lock assertion holds the shared lock (see below).
 lock_set=0
 
-psql_db() {
-  local sql="$1"
-  kubectl -n "$NS_AW" exec argo-watcher-db-0 -- psql -qtAX -U argo_watcher -d argo_watcher -c "$sql"
-}
-
 cleanup() {
   # The deploy lock lives in the shared database, so a lock left set by an
   # aborted run would 406 every deploy in the phases that follow. Always drop it.

--- a/test/e2e/tools/mintjwt/main.go
+++ b/test/e2e/tools/mintjwt/main.go
@@ -1,17 +1,13 @@
-// Command mintjwt prints a short-lived HS256 JSON Web Token signed with the
-// value of the JWT_SECRET environment variable. It exists so the e2e lab can
-// exercise argo-watcher's BEARER_TOKEN auth path without depending on an external
-// tool (openssl is not guaranteed on the lab host); it signs with the very
-// library the server validates with (golang-jwt/jwt/v5), so the token is
-// guaranteed compatible. The token carries the iat and exp claims the server
-// requires and is valid for one hour — long enough for a single deploy phase.
-// JWT_ISS and JWT_AUD add the iss and aud claims a server configured with
-// JWT_ISSUER / JWT_AUDIENCE requires.
+// Command mintjwt prints a one-hour HS256 token signed with JWT_SECRET, using the
+// very library the server validates with, so the lab needs no openssl. JWT_ISS,
+// JWT_AUD and JWT_ALLOWED_APPS (comma-separated) add the iss, aud and allowed_apps
+// claims; iat and exp are always set, because the server requires them.
 package main
 
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -37,6 +33,11 @@ func main() {
 	}
 	if audience := os.Getenv("JWT_AUD"); audience != "" {
 		claims["aud"] = audience
+	}
+	// A list, not a string: the claim is read back as one, and a token omitting it
+	// keeps authorizing every application.
+	if apps := os.Getenv("JWT_ALLOWED_APPS"); apps != "" {
+		claims["allowed_apps"] = strings.Split(apps, ",")
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/test/e2e/tools/wsprobe/main.go
+++ b/test/e2e/tools/wsprobe/main.go
@@ -52,6 +52,7 @@ func env(k, def string) string {
 type credentials struct {
 	oidc        string
 	deploy      string
+	bearer      string
 	subprotocol string
 }
 
@@ -66,6 +67,11 @@ func dialOptions(creds credentials) *websocket.DialOptions {
 	}
 	if creds.deploy != "" {
 		opts.HTTPHeader.Set("ARGO_WATCHER_DEPLOY_TOKEN", creds.deploy)
+	}
+	// The header a CI JWT and an application deploy token share; the server routes
+	// between them on the token's own shape.
+	if creds.bearer != "" {
+		opts.HTTPHeader.Set("Authorization", creds.bearer)
 	}
 	if creds.subprotocol != "" {
 		opts.Subprotocols = []string{"argo-watcher.v1", "argo-watcher.token." + creds.subprotocol}
@@ -88,6 +94,7 @@ func main() {
 	creds := credentials{
 		oidc:        env("WSPROBE_OIDC_TOKEN", ""),
 		deploy:      env("WSPROBE_DEPLOY_TOKEN", ""),
+		bearer:      env("WSPROBE_BEARER_TOKEN", ""),
 		subprotocol: env("WSPROBE_SUBPROTOCOL_TOKEN", ""),
 	}
 

--- a/test/e2e/values/keycloak.yaml
+++ b/test/e2e/values/keycloak.yaml
@@ -1,0 +1,62 @@
+# In-cluster Keycloak for the app-tokens phase, on the generic shini4i `app` chart.
+# It serves the realm the docker-compose `integration` profile imports
+# (test/keycloak/argo-watcher-e2e-realm.json, mounted as a ConfigMap by the Taskfile).
+fullnameOverride: keycloak
+
+image:
+  repository: quay.io/keycloak/keycloak
+  # Pinned to the version docker-compose runs, so both suites exercise one provider.
+  tag: "26.7.0"
+
+service:
+  type: ClusterIP
+  ports:
+    - port: 80
+      containerPort: 8080
+      name: http
+
+volumes:
+  - name: realm
+    configMap:
+      name: keycloak-realm
+
+app:
+  # Development mode: HTTP with no certificate and no build step. The realm is
+  # re-imported on every boot, which is what makes the pod disposable.
+  args:
+    - start-dev
+    - --import-realm
+  env:
+    - name: KC_BOOTSTRAP_ADMIN_USERNAME
+      value: admin
+    - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+      value: admin
+    # The phase mints tokens from the HOST over the NodePort while argo-watcher calls
+    # discovery and userinfo from INSIDE the cluster. Without a fixed hostname Keycloak
+    # derives the issuer per request, so a token minted on one path is rejected on the
+    # other. MUST match the OIDC_ISSUER_URL prefix in scripts/app-tokens.sh.
+    - name: KC_HOSTNAME
+      value: http://keycloak.keycloak
+    # Keep answering under any other name (the phase calls it localhost:30500) while
+    # still minting the fixed issuer above.
+    - name: KC_HOSTNAME_STRICT
+      value: "false"
+  additionalVolumeMounts:
+    - name: realm
+      mountPath: /opt/keycloak/data/import
+      readOnly: true
+  # The realm's own discovery document, which answers only once the import has
+  # finished — exactly what the phase waits for. Keycloak needs ~15s to get there.
+  readinessProbe:
+    httpGet:
+      path: /realms/argo-watcher-e2e/.well-known/openid-configuration
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 3
+    failureThreshold: 40
+  livenessProbe:
+    httpGet:
+      path: /realms/argo-watcher-e2e/.well-known/openid-configuration
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 15


### PR DESCRIPTION
Adds an `app-tokens` e2e phase covering the deploy-token lifecycle — issuing, the per-application scope on a real deploy, revocation, expiry — and brings Keycloak into the kind lab, since issuing and revoking are gated on a privileged OIDC session the lab could not produce.

Worth knowing:
- The phase runs after `state-postgres` and reverts to that release, because the tokens need `STATE_TYPE=postgres`.
- Its operator tokens are re-minted around the long steps: Keycloak expires them in minutes, which is shorter than a rollout plus a deploy.
- Every task the scope matrix expects to be accepted names an application no Argo Application carries — an accepted task is validated, so a real fixture app would take a bogus tag through the write-back.
- Also covers `allowed_apps`, the JWT counterpart of a token's scope.