### PR TITLE
fix(e2e): derive the race image Go version from go.mod

### DIFF
--- a/test/e2e/Dockerfile.server.race
+++ b/test/e2e/Dockerfile.server.race
@@ -1,8 +1,10 @@
-# Lab-only argo-watcher image built with the Go race detector. Not the shipped
-# image. Build from the repo root: web/dist must already exist there (the
-# build-race-image task runs `task build-ui` first).
+# Lab-only argo-watcher image built with -race, not the shipped image. Build from the repo root;
+# the build-race-image task runs `task build-ui` first so web/dist exists.
 
-FROM golang:1.26.5-bookworm AS build
+# GO_VERSION comes from go.mod via the build-race-image task. The golang image
+# sets GOTOOLCHAIN=local, so a base older than the go directive fails outright.
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-bookworm AS build
 
 WORKDIR /src
 

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -119,7 +119,9 @@ tasks:
       # uses) so web/dist exists before the image build — it is a generated
       # artifact, absent on a fresh checkout.
       - task build-ui
-      - docker build -f test/e2e/Dockerfile.server.race -t {{.RACE_IMAGE}} .
+      # The base image tag follows go.mod so it cannot drift behind a Go bump.
+      # A toolchain directive wins over the go directive: it is the higher floor.
+      - docker build --build-arg GO_VERSION="$(awk '/^go [0-9]/{v=$2} /^toolchain go/{v=substr($2,3)} END{print v}' go.mod)" -f test/e2e/Dockerfile.server.race -t {{.RACE_IMAGE}} .
 
   load-race-image:
     desc: "Load the race image into the kind node"

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -120,8 +120,7 @@ tasks:
       # artifact, absent on a fresh checkout.
       - task build-ui
       # The base image tag follows go.mod so it cannot drift behind a Go bump.
-      # A toolchain directive wins over the go directive: it is the higher floor.
-      - docker build --build-arg GO_VERSION="$(awk '/^go [0-9]/{v=$2} /^toolchain go/{v=substr($2,3)} END{print v}' go.mod)" -f test/e2e/Dockerfile.server.race -t {{.RACE_IMAGE}} .
+      - docker build --build-arg GO_VERSION="$(. test/e2e/scripts/lib.sh && go_version go.mod)" -f test/e2e/Dockerfile.server.race -t {{.RACE_IMAGE}} .
 
   load-race-image:
     desc: "Load the race image into the kind node"

--- a/test/e2e/scripts/lib.bats
+++ b/test/e2e/scripts/lib.bats
@@ -244,6 +244,61 @@ PROM
   assert_equal "$(jq -r '.images[0].image' <<<"$json")" "custom/img"
 }
 
+# --- go_version ---------------------------------------------------------------
+# The -race image's base tag is built from this, and the golang image refuses a
+# toolchain older than the module's floor, so a wrong answer here breaks the lab
+# build with a message that points at Docker rather than at go.mod.
+
+gomod_fixture() {
+  printf '%s\n' "$@" >"${BATS_TEST_TMPDIR}/go.mod"
+  printf '%s' "${BATS_TEST_TMPDIR}/go.mod"
+}
+
+@test "go_version reads the go directive" {
+  run go_version "$(gomod_fixture 'module x' '' 'go 1.26.7' '' 'require (' ')')"
+  assert_success
+  assert_output "1.26.7"
+}
+
+@test "go_version prefers a toolchain directive over the go directive" {
+  run go_version "$(gomod_fixture 'module x' '' 'go 1.26.0' '' 'toolchain go1.26.9')"
+  assert_success
+  assert_output "1.26.9"
+}
+
+@test "go_version accepts a two-part go directive" {
+  run go_version "$(gomod_fixture 'module x' '' 'go 1.25')"
+  assert_success
+  assert_output "1.25"
+}
+
+@test "go_version ignores 'toolchain default' and keeps the go directive" {
+  run go_version "$(gomod_fixture 'module x' '' 'go 1.26.7' '' 'toolchain default')"
+  assert_success
+  assert_output "1.26.7"
+}
+
+@test "go_version ignores a go directive that is not at the start of a line" {
+  run go_version "$(gomod_fixture 'module x' '' 'go 1.26.7' '' 'require (' '	rsc.io/go 1.0.0' ')')"
+  assert_success
+  assert_output "1.26.7"
+}
+
+@test "go_version fails loudly when no version is declared" {
+  run ! go_version "$(gomod_fixture 'module x' '' 'require (' ')')"
+  assert_output --partial "no go or toolchain directive"
+}
+
+@test "go_version reads the repository's own go.mod" {
+  run go_version "${BATS_TEST_DIRNAME}/../../../go.mod"
+  assert_success
+  assert_output --regexp '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}
+
+@test "go_version fails when handed no path" {
+  run ! go_version
+}
+
 # --- retry -------------------------------------------------------------------
 # These counters are deliberately named `attempts` and `delay` — the same names
 # retry takes as parameters. A command retry runs executes in the same shell, so if

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -294,7 +294,7 @@ run_client() {
 go_version() {
   local gomod="$1" v
   v="$(awk '/^go [0-9]/{v=$2} /^toolchain go/{v=substr($2,3)} END{print v}' "$gomod")" || return 1
-  if [ -z "$v" ]; then
+  if [[ -z "$v" ]]; then
     echo "go_version: no go or toolchain directive in ${gomod}" >&2
     return 1
   fi

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -287,6 +287,20 @@ run_client() {
   return
 }
 
+# go_version <go.mod>: the Go version the module requires, for the -race image's
+# golang base tag. A toolchain directive outranks the go directive. That image sets
+# GOTOOLCHAIN=local, so a stale tag fails the build rather than downgrading. The
+# path is explicit: Task's shell defines no BASH_SOURCE, so E2E_ROOT is bash-only.
+go_version() {
+  local gomod="$1" v
+  v="$(awk '/^go [0-9]/{v=$2} /^toolchain go/{v=substr($2,3)} END{print v}' "$gomod")" || return 1
+  if [ -z "$v" ]; then
+    echo "go_version: no go or toolchain directive in ${gomod}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
 # --- gitops repo -------------------------------------------------------------
 # gitops_clone <dir>: clone the lab's shared gitops repo (every fixture app renders
 # from it, which is what makes their write-back pushes contend) into <dir>.


### PR DESCRIPTION
The e2e lab's race image pinned its own `golang` base tag, which fell behind when go.mod moved to 1.26.7 — and since the official image sets `GOTOOLCHAIN=local`, the mismatch failed `go mod download` outright rather than downgrading. The tag is now passed as a build arg read from go.mod, preferring a `toolchain` directive over the `go` directive so either shape works.

Not verifiable locally: the image build needs a container runtime, so the next e2e run is the real check.