### PR TITLE
fix(server): discard server-owned fields from a task submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sparse. The `Application` variable no longer assumes the scrape job is named
   `argo-watcher`, so the dashboard works unmodified across environments.
 
+### Security
+
+- A task submission can no longer set the fields the server owns. `status_reason` and
+  `updated` are written by the server as a deployment progresses, but both were ordinary
+  JSON fields on the submission payload, and `POST /api/v1/tasks` takes no credential by
+  design. A crafted `status_reason` was stored verbatim by the in-memory backend and
+  re-served to every reader of the task, and on both backends it reached the webhook and
+  Mattermost start notification, whose message format is an operator-supplied template
+  over the whole task. A submitted `updated` likewise rendered a fabricated timestamp
+  there. Both fields are now cleared when the deployment is accepted, alongside the
+  existing server-side overwrite of the rollback fields.
+
 ## [1.1.0] - 2026-08-31
 
 ### Added

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -163,7 +163,8 @@ func (argo *Argo) StartLivenessProbe(ctx context.Context, interval time.Duration
 	}
 }
 
-// AddTask validates a new deployment task and adds it to the task repository.
+// AddTask validates a new deployment task, overwrites the fields a client must not
+// set, and adds it to the task repository.
 func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// Gate on the cached reachability instead of a live Check(): a deploy
 	// attempted during an ArgoCD outage then fails fast with a clear error
@@ -188,6 +189,12 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// action) can never influence the stored result.
 	task.RollbackTargetId = argo.detectRollback(task)
 	task.IsRollback = task.RollbackTargetId != ""
+
+	// StatusReason and Updated are server-owned but JSON-bindable, and submission takes
+	// no credential. Clearing them keeps a client-supplied value out of the in-memory
+	// store and out of the task the start notification renders.
+	task.StatusReason = ""
+	task.Updated = 0
 
 	// Superseding stops the watcher polling ArgoCD for a rollout nobody is waiting
 	// on anymore (issue #353). Matching on image name

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -435,6 +435,40 @@ func TestArgoAddTask(t *testing.T) {
 		assert.False(t, captured.IsRollback)
 		assert.Empty(t, captured.RollbackTargetId)
 	})
+
+	t.Run("Argo - Client-supplied server-owned fields are discarded", func(t *testing.T) {
+		api := newArgoApiMock(ctrl)
+		metrics := mocks.NewMockMetricsInterface(ctrl)
+		state := newTaskRepositoryMock(ctrl)
+
+		metrics.EXPECT().AddAcceptedDeployment()
+
+		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0))
+
+		var captured models.Task
+		state.EXPECT().CancelInProgressTasks("test-app", gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(0), nil)
+		state.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+			captured = task
+			task.Id = uuid.NewString()
+			return &task, nil
+		})
+
+		argo := &Argo{}
+		argo.Init(state, api, metrics)
+		newTask, err := argo.AddTask(models.Task{
+			App:          "test-app",
+			Images:       []models.Image{{Image: "app", Tag: "v1"}},
+			StatusReason: "attacker-controlled",
+			Updated:      4102444800,
+		})
+
+		assert.NoError(t, err)
+		assert.Empty(t, captured.StatusReason, "the stored task must not carry a client-supplied status reason")
+		assert.Zero(t, captured.Updated, "the stored task must not carry a client-supplied update time")
+		require.NotNil(t, newTask)
+		assert.Empty(t, newTask.StatusReason, "the accepted task must not reach the start notification with it")
+		assert.Zero(t, newTask.Updated, "the accepted task must not reach the start notification with it")
+	})
 }
 
 func TestArgoDetectRollback(t *testing.T) {

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -26,15 +26,20 @@ const MaxTaskImages = 50
 const MaxTaskFieldLength = 255
 
 type Task struct {
-	Id           string  `json:"id,omitempty"`
-	Created      float64 `json:"created,omitempty"`
-	Updated      float64 `json:"updated,omitempty"`
-	App          string  `json:"app" binding:"required,max=255" example:"argo-watcher"`
-	Author       string  `json:"author" binding:"required,max=255" example:"John Doe"`
-	Project      string  `json:"project" binding:"required,max=255" example:"Demo"`
-	Images       []Image `json:"images" binding:"required,max=50,dive"`
-	Status       string  `json:"status,omitempty"`
-	StatusReason string  `json:"status_reason,omitempty"`
+	// Id, Created and Updated are server-owned: the state backend stamps all three,
+	// and AddTask additionally clears Updated, which the backend would otherwise leave
+	// carrying a submitted value into the start notification.
+	Id      string  `json:"id,omitempty"`
+	Created float64 `json:"created,omitempty"`
+	Updated float64 `json:"updated,omitempty"`
+	App     string  `json:"app" binding:"required,max=255" example:"argo-watcher"`
+	Author  string  `json:"author" binding:"required,max=255" example:"John Doe"`
+	Project string  `json:"project" binding:"required,max=255" example:"Demo"`
+	Images  []Image `json:"images" binding:"required,max=50,dive"`
+	Status  string  `json:"status,omitempty"`
+	// StatusReason is server-owned: it is written when a deployment reaches a terminal
+	// state, so AddTask discards a submitted value before the task is stored or notified.
+	StatusReason string `json:"status_reason,omitempty"`
 	// Validated records whether the request that created this task presented a valid
 	// credential. It gates the git write-back and, since it also decides what a task
 	// may supersede, it is never accepted from or served over the API.

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1937,6 +1937,49 @@ func TestAddTaskEndpoint(t *testing.T) {
 		assert.False(t, stored.Validated, "a body-supplied validated flag must not grant authority")
 	})
 
+	// status_reason and updated are written by the server as a deployment progresses,
+	// but both bind from the request body and submission takes no credential. This
+	// pins the clearing at the HTTP boundary, so moving task normalisation out of
+	// argo.AddTask cannot reopen the hole with the argocd unit test still green.
+	t.Run("body-supplied server-owned fields are ignored", func(t *testing.T) {
+		lockdown, _ := NewLockdown("", lock.NewInMemoryDeployLockStore())
+		strategies := make(map[string]auth.AuthStrategy)
+
+		ctrl := gomock.NewController(t)
+		repo, _ := newRepo(ctrl)
+		repo.EXPECT().Check().Return(true).AnyTimes()
+
+		var stored models.Task
+		repo.EXPECT().AddTask(gomock.Any()).DoAndReturn(func(task models.Task) (*models.Task, error) {
+			stored = task
+			return nil, fmt.Errorf("stop before the rollout goroutine")
+		})
+		argo := &argocd.Argo{}
+		argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+		env := &Env{
+			lockdown:      lockdown,
+			strategies:    strategies,
+			authenticator: auth.NewAuthenticator(strategies),
+			argo:          argo,
+			config:        &config.ServerConfig{DeploymentTimeout: 900},
+		}
+
+		router := chi.NewRouter()
+		router.Post("/api/v1/tasks", env.addTask)
+
+		taskJSON := `{"app": "test-app", "author": "test-author", "project": "test-project", "images": [{"image": "test", "tag": "v1"}], "status_reason": "attacker-controlled", "updated": 4102444800}`
+		req, _ := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(taskJSON))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		// Only these two: id, created and status are stamped by the state backend, so
+		// at a mock repo they legitimately still carry whatever the body sent.
+		assert.Empty(t, stored.StatusReason, "a body-supplied status reason must not be stored")
+		assert.Zero(t, stored.Updated, "a body-supplied update time must not be stored")
+	})
+
 	// The mirrored positive case. Without it, mutating the assignment to
 	// `task.Validated = false` keeps the whole Go suite green: the state and argocd
 	// tests set Validated directly, so this handler line is the only place the

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -58,10 +58,22 @@ func TestImageNamesOverlap(t *testing.T) {
 func TestInMemoryState_AddTask(t *testing.T) {
 	state := InMemoryState{}
 
-	firstTask, err := state.AddTask(createTestTask("Test"))
+	// The web UI derives a task's duration from created/updated, so the store stamps
+	// both itself. Poisoned here so the assertions below pin the overwrite, not just
+	// that a value ended up non-zero.
+	const farFuture = 4102444800
+	poisoned := createTestTask("Test")
+	poisoned.Created = farFuture
+	poisoned.Updated = farFuture
+
+	firstTask, err := state.AddTask(poisoned)
 	require.NoError(t, err)
 	assert.NotEmpty(t, firstTask.Id)
 	assert.Equal(t, models.StatusInProgressMessage, firstTask.Status)
+	assert.NotZero(t, firstTask.Created)
+	assert.NotZero(t, firstTask.Updated)
+	assert.NotEqual(t, float64(farFuture), firstTask.Created)
+	assert.NotEqual(t, float64(farFuture), firstTask.Updated)
 
 	secondTask, err := state.AddTask(createTestTask("Test2"))
 	require.NoError(t, err)


### PR DESCRIPTION
The `status_reason` and `updated` fields are written by the server as a deployment progresses, but both bind from the `POST /api/v1/tasks` body, which takes no credential by design. The in-memory backend stored a submitted `status_reason` verbatim and re-served it to every reader of the task; on both backends it also reached the webhook and Mattermost start notification, whose message format is an operator-supplied template over the whole task.

Both are cleared in `argo.AddTask` rather than in the state backends, alongside the existing overwrite of the rollback fields. It is the only non-test caller of `State.AddTask` and the only producer of the accepted task the start notification renders, so one clear covers both backends and the notification path.

No change to what the API serves or the UI shows: both backends already stamp `created` and `updated` themselves at persistence, so only the in-flight task carried the submitted value.