### PR TITLE
fix(web): stop a long author from widening the task table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A long author address no longer stretches the task table sideways. The Author cell
+  already refused to wrap, but nothing capped its width, so an address with no break
+  opportunity — a GitLab bot such as `project_1758_bot_<hash>@noreply.example.net` —
+  set the column's minimum content width and pushed the Images and Details columns out
+  of view. The address is now capped at a fixed width and ellipsised, with the full
+  address available in its tooltip and on the task detail page.
+
 ## [1.1.1] - 2026-09-02
 
 ### Fixed

--- a/web/e2e/no-auth/author-column.spec.ts
+++ b/web/e2e/no-auth/author-column.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { seedTask, waitForDeployed } from '../helpers';
-import { AUTHOR_MAX_WIDTH } from '../../src/features/tasks/components/TasksDatagrid';
 
 /**
  * @description An unbreakable CI bot address sets the Author cell's min-content
@@ -10,7 +9,12 @@ import { AUTHOR_MAX_WIDTH } from '../../src/features/tasks/components/TasksDatag
  */
 const BOT_AUTHOR = 'project_1758_bot_062d75c8b91e27fa4e5bb374cd9c1c39@noreply.example.net';
 
-/** Cell padding on top of the text cap; the column may exceed neither together. */
+/**
+ * @description Mirrors `AUTHOR_MAX_WIDTH` in TasksDatagrid.tsx, restated because
+ * this suite compiles without JSX support and cannot import a component module.
+ * `CELL_PADDING_ALLOWANCE` covers the surrounding table cell's own padding.
+ */
+const AUTHOR_MAX_WIDTH = 200;
 const CELL_PADDING_ALLOWANCE = 48;
 
 test('a long bot author is clipped instead of widening its column', async ({ page, request }) => {

--- a/web/e2e/no-auth/author-column.spec.ts
+++ b/web/e2e/no-auth/author-column.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+import { seedTask, waitForDeployed } from '../helpers';
+import { AUTHOR_MAX_WIDTH } from '../../src/features/tasks/components/TasksDatagrid';
+
+/**
+ * @description An unbreakable CI bot address sets the Author cell's min-content
+ * width under `table-layout: auto` unless the text box is capped. jsdom runs no
+ * layout, so the unit tests can only assert declared CSS — the rendered width is
+ * measurable here and nowhere else.
+ */
+const BOT_AUTHOR = 'project_1758_bot_062d75c8b91e27fa4e5bb374cd9c1c39@noreply.example.net';
+
+/** Cell padding on top of the text cap; the column may exceed neither together. */
+const CELL_PADDING_ALLOWANCE = 48;
+
+test('a long bot author is clipped instead of widening its column', async ({ page, request }) => {
+  const id = await seedTask(request, BOT_AUTHOR);
+  await waitForDeployed(request, id);
+
+  // Wider than the table's natural width, so only the cap constrains the column:
+  // a viewport narrow enough to scroll would mask an uncapped cell.
+  await page.setViewportSize({ width: 1920, height: 800 });
+  await page.goto('/');
+
+  const author = page.getByTitle(BOT_AUTHOR);
+  await expect(author).toBeVisible();
+
+  const box = (await author.boundingBox())!;
+  expect(box.width).toBeLessThanOrEqual(AUTHOR_MAX_WIDTH);
+
+  // Clipped, not merely narrow: the text overflows the box it is painted in.
+  const overflows = await author.evaluate(el => el.scrollWidth > el.clientWidth);
+  expect(overflows, 'the address must be ellipsised, not laid out in full').toBe(true);
+
+  const cellWidth = await author.evaluate(el => el.closest('td')!.getBoundingClientRect().width);
+  expect(cellWidth).toBeLessThanOrEqual(AUTHOR_MAX_WIDTH + CELL_PADDING_ALLOWANCE);
+});

--- a/web/src/features/tasks/components/TasksDatagrid.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import type { Task } from '../../../data/types';
-import { TasksDatagrid, __testing } from './TasksDatagrid';
+import { AUTHOR_MAX_WIDTH, TasksDatagrid, __testing } from './TasksDatagrid';
 import { TaskListProvider, useTaskListContext } from './TaskListContext';
 
 const sampleRecord: Task = {
@@ -55,7 +55,7 @@ describe('TasksDatagrid', () => {
     renderInRouter(<TasksDatagrid />);
     expect(screen.getByTestId('function-app')).toBeInTheDocument();
     expect(screen.getByTestId('function-project')).toBeInTheDocument();
-    expect(screen.getByTestId('function-author')).toBeInTheDocument();
+    expect(screen.getByTestId('function-author')).toHaveTextContent(sampleRecord.author);
     expect(screen.getByTestId('function-status')).toBeInTheDocument();
     expect(screen.getByTestId('function-created')).toBeInTheDocument();
     expect(screen.getByTestId('function-updated')).toBeInTheDocument();
@@ -127,6 +127,32 @@ describe('TasksDatagrid', () => {
       </TaskListProvider>,
     );
     expect(screen.getByTestId('reasons').textContent).toBe('');
+  });
+
+  describe('AuthorCell', () => {
+    const { AuthorCell } = __testing;
+
+    it('renders an em-dash placeholder when the author is empty', () => {
+      render(<AuthorCell author="" />);
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('caps a long author at a fixed width and keeps the full value in the tooltip', () => {
+      const author = 'project_1758_bot_062d75c8b91e27fa4e5bb374cd9c1c39@noreply.gitlab.dyninno.net';
+      render(<AuthorCell author={author} />);
+
+      const cell = screen.getByText(author);
+      expect(cell).toHaveStyle({
+        // Without an explicit block box the unbreakable address sets the cell's
+        // min-content width and stretches the whole table.
+        display: 'block',
+        maxWidth: `${AUTHOR_MAX_WIDTH}px`,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      });
+      expect(cell).toHaveAttribute('title', author);
+    });
   });
 
   describe('ProjectCell', () => {

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -16,6 +16,9 @@ import { RollbackIndicator } from './RollbackIndicator';
 import { TimeCell } from './TimeCell';
 import { usePauseRefresh, useTaskListContext } from './TaskListContext';
 
+/** Widest the author text may grow, in px, before the address is ellipsised. */
+export const AUTHOR_MAX_WIDTH = 200;
+
 /**
  * Shared by both the recent and history views. `rowClick="expand"` means any
  * click inside a row toggles the status-reason panel, so nested links and
@@ -64,16 +67,7 @@ export const TasksDatagrid = () => {
         label="Author"
         sortBy="author"
         cellClassName="cell-author"
-        render={(record: Task) => (
-          <Typography
-            variant="body2"
-            sx={{ fontFamily: tokens.fontMono, fontSize: 11.5 }}
-            noWrap
-            title={record.author}
-          >
-            {record.author || '—'}
-          </Typography>
-        )}
+        render={(record: Task) => <AuthorCell author={record.author} />}
       />
       <FunctionField
         source="status"
@@ -163,7 +157,7 @@ const datagridSx: SxProps<Theme> = theme => {
     },
     '& .cell-app': { minWidth: 200, maxWidth: 280 },
     '& .cell-project': { minWidth: 180, maxWidth: 280 },
-    '& .cell-author': { width: 200 },
+    '& .cell-author': { width: AUTHOR_MAX_WIDTH },
     '& .cell-status': { width: 156 },
     '& .cell-created': {
       width: 200,
@@ -182,6 +176,32 @@ const datagridSx: SxProps<Theme> = theme => {
       paddingRight: theme.spacing(1.5),
     },
   };
+};
+
+const AuthorCell = ({ author }: { author?: string | null }) => {
+  if (!author) {
+    return <EmptyCell />;
+  }
+  return (
+    <Typography
+      variant="body2"
+      sx={{
+        // A bot address such as project_1758_bot_<hash>@noreply.example.net has no
+        // break opportunity, so without an explicit capped block box it sets the
+        // cell's min-content width and stretches the whole table sideways.
+        display: 'block',
+        maxWidth: AUTHOR_MAX_WIDTH,
+        fontFamily: tokens.fontMono,
+        fontSize: 11.5,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+      title={author}
+    >
+      {author}
+    </Typography>
+  );
 };
 
 const ProjectCell = ({ project }: { project?: string | null }) => {
@@ -305,6 +325,7 @@ const StatusReasonContent = ({ record }: { record?: Task | null }) => {
 };
 
 export const __testing = {
+  AuthorCell,
   ProjectCell,
   StatusReasonContent,
   StatusReasonPanel,


### PR DESCRIPTION
A CI bot address with no break opportunity set the Author cell's min-content width under table-layout:auto, so the column grew to fit it and pushed Images and Details out of view. The address is now capped at 200px and ellipsised, with the full value in its tooltip and on the task detail page. The Playwright spec is the cover that matters: jsdom performs no layout, so only a real browser can measure that the column stopped growing. ProjectCell still has the same shape and is left alone.