### PR TITLE
fix(notifications): escape webhook values rendered into a JSON body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Webhook notifications no longer break when a value contains a quote or a newline. The body
+  is assembled by a Go template, which escapes nothing, so a `StatusReason` — which carries
+  newlines and quotes Argo CD's own messages — produced invalid JSON and the receiver rejected
+  it. Failure notifications were the ones affected, since a successful deployment has no
+  reason to report, so the integration looked healthy while exactly the alerts worth having
+  went missing. Values are now escaped before the template renders them, which also stops an
+  `author` submitted through the open task endpoint from adding keys of its own to the body.
+  A `WEBHOOK_CONTENT_TYPE` that is not JSON is left alone and keeps receiving literal text.
+
+### Fixed
+
 - A git write-back that succeeded is no longer reported as a failure when the database
   hiccups. The advisory lock that serializes write-backs is held in a Postgres transaction
   for the whole clone-commit-push, and the driver returns that transaction's `COMMIT` error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `author` submitted through the open task endpoint from adding keys of its own to the body.
   A `WEBHOOK_CONTENT_TYPE` that is not JSON is left alone and keeps receiving literal text.
 
+### Changed
+
+- A `WEBHOOK_FORMAT` that quotes a value itself must stop doing so. Values reaching a JSON
+  body are now escaped before the template renders them, so a format such as
+  `{"text": {{printf "%q" .StatusReason}}}` escapes an already-escaped value and the receiver
+  shows a literal `\n` where a line break belongs. Drop the `printf` and put the value inside
+  quotes instead: `{"text": "{{.StatusReason}}"}`. A format written the way the guide
+  documents needs no change.
+
 ### Fixed
 
 - A git write-back that succeeded is no longer reported as a failure when the database

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -24,6 +24,16 @@ Argo Watcher does not sign the payload; the receiver authenticates the request t
 
 When `WEBHOOK_CONTENT_TYPE` is a JSON type, values are escaped for you before the template renders them, so a quote or a newline in `StatusReason` cannot break the body. Put each value inside a JSON string (`"{{.Author}}"`) and quote nothing yourself. For any other content type the values are rendered as they are.
 
+!!! warning "If your format quotes values itself"
+    A format that produces its own quotes — `{{printf "%q" .StatusReason}}` — now escapes an
+    already-escaped value, and the receiver shows a literal `\n` instead of a line break.
+    Drop the `printf` and wrap the value in quotes instead:
+
+    ```diff
+    - WEBHOOK_FORMAT='{"text": {{printf "%q" .StatusReason}}}'
+    + WEBHOOK_FORMAT='{"text": "{{.StatusReason}}"}'
+    ```
+
 | Variable | Type | Description |
 |---|---|---|
 | `Id` | `string` | Task id (UUID) |

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -22,6 +22,8 @@ Argo Watcher does not sign the payload; the receiver authenticates the request t
 
 `WEBHOOK_FORMAT` (and `MATTERMOST_FORMAT`) is a [Go template](https://pkg.go.dev/text/template) rendered over the task:
 
+When `WEBHOOK_CONTENT_TYPE` is a JSON type, values are escaped for you before the template renders them, so a quote or a newline in `StatusReason` cannot break the body. Put each value inside a JSON string (`"{{.Author}}"`) and quote nothing yourself. For any other content type the values are rendered as they are.
+
 | Variable | Type | Description |
 |---|---|---|
 | `Id` | `string` | Task id (UUID) |

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"slices"
 	"strings"
@@ -68,8 +69,17 @@ func (n *Notifier) Send(task models.Task) error {
 
 // isJSONBody reports whether the configured content type describes JSON, and so
 // whether the values rendered into the body have to be escaped as JSON strings.
+// The media type is parsed rather than searched: a parameter may contain "json"
+// while the body is something else entirely ("text/plain; profile=json").
 func isJSONBody(contentType string) bool {
-	return strings.Contains(strings.ToLower(contentType), "json")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+
+	_, subtype, found := strings.Cut(mediaType, "/")
+
+	return found && (subtype == "json" || strings.HasSuffix(subtype, "+json"))
 }
 
 // escapeForJSON returns a copy of task whose every string field is escaped for

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -101,23 +101,18 @@ func escapeForJSON(task models.Task) models.Task {
 // quotes. HTML escaping is off so a value keeps the bytes it arrived with
 // wherever JSON does not require otherwise.
 func jsonStringBody(s string) string {
-	if s == "" {
-		return s
-	}
-
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(s); err != nil {
-		// Unreachable: encoding a string cannot fail. Returning it unescaped
-		// keeps a notification going out rather than dropping it.
-		slog.Error("failed to escape a webhook value", "error", err)
-		return s
-	}
 
-	encoded := strings.TrimRight(buf.String(), "\n")
+	// Encoding a string cannot fail: bytes.Buffer never errors, string is always
+	// a supported type, and invalid UTF-8 is replaced rather than rejected.
+	_ = encoder.Encode(s)
 
-	return encoded[1 : len(encoded)-1]
+	// Encode appends a newline after the quoted string.
+	quoted := strings.TrimRight(buf.String(), "\n")
+
+	return strings.TrimSuffix(strings.TrimPrefix(quoted, `"`), `"`)
 }
 
 // WebhookStrategy holds the configuration and a pre-compiled template for sending webhooks.

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -65,6 +66,60 @@ func (n *Notifier) Send(task models.Task) error {
 	return nil
 }
 
+// isJSONBody reports whether the configured content type describes JSON, and so
+// whether the values rendered into the body have to be escaped as JSON strings.
+func isJSONBody(contentType string) bool {
+	return strings.Contains(strings.ToLower(contentType), "json")
+}
+
+// escapeForJSON returns a copy of task whose every string field is escaped for
+// use inside a JSON string literal. A value carrying a quote or a newline —
+// an author from an unauthenticated submission, a StatusReason quoting Argo CD —
+// would otherwise end the string it sits in and break the body.
+func escapeForJSON(task models.Task) models.Task {
+	task.Id = jsonStringBody(task.Id)
+	task.App = jsonStringBody(task.App)
+	task.Author = jsonStringBody(task.Author)
+	task.Project = jsonStringBody(task.Project)
+	task.Status = jsonStringBody(task.Status)
+	task.StatusReason = jsonStringBody(task.StatusReason)
+	task.RollbackTargetId = jsonStringBody(task.RollbackTargetId)
+
+	images := make([]models.Image, len(task.Images))
+	for i, image := range task.Images {
+		images[i] = models.Image{
+			Image: jsonStringBody(image.Image),
+			Tag:   jsonStringBody(image.Tag),
+		}
+	}
+	task.Images = images
+
+	return task
+}
+
+// jsonStringBody renders s as a JSON string and returns what belongs between the
+// quotes. HTML escaping is off so a value keeps the bytes it arrived with
+// wherever JSON does not require otherwise.
+func jsonStringBody(s string) string {
+	if s == "" {
+		return s
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(s); err != nil {
+		// Unreachable: encoding a string cannot fail. Returning it unescaped
+		// keeps a notification going out rather than dropping it.
+		slog.Error("failed to escape a webhook value", "error", err)
+		return s
+	}
+
+	encoded := strings.TrimRight(buf.String(), "\n")
+
+	return encoded[1 : len(encoded)-1]
+}
+
 // WebhookStrategy holds the configuration and a pre-compiled template for sending webhooks.
 type WebhookStrategy struct {
 	url                  string
@@ -112,8 +167,16 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// The template assembles the body by hand and text/template escapes nothing,
+	// so the values are escaped instead. Left alone for a receiver that is not
+	// expecting JSON, which wants the literal text it has always been sent.
+	data := task
+	if isJSONBody(s.contentType) {
+		data = escapeForJSON(task)
+	}
+
 	var payload bytes.Buffer
-	if err := s.template.Execute(&payload, task); err != nil {
+	if err := s.template.Execute(&payload, data); err != nil {
 		return fmt.Errorf("failed to execute webhook template: %w", err)
 	}
 

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -1,9 +1,11 @@
 package notifications
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 	"text/template"
@@ -262,4 +264,109 @@ type errorReader struct {
 
 func (r *errorReader) Read(p []byte) (n int, err error) {
 	return 0, r.err
+}
+
+// A JSON body is assembled by a text/template, which does no escaping of its
+// own, so the values are escaped before rendering. Author, App and Project come
+// from an unauthenticated submission, and StatusReason carries newlines and
+// quoted operator messages built by internal/models.
+func TestSendEscapesValuesForAJSONBody(t *testing.T) {
+	renderBody := func(t *testing.T, format, contentType string, task models.Task) string {
+		t.Helper()
+
+		tmpl, err := template.New("webhook").Parse(format)
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		mockClient := mocks.NewMockHTTPClient(ctrl)
+
+		var sent string
+		mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			sent = string(body)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})
+
+		service := &WebhookStrategy{
+			url:                  "http://testhost/hook",
+			contentType:          contentType,
+			allowedResponseCodes: []int{200},
+			client:               mockClient,
+			template:             tmpl,
+		}
+		require.NoError(t, service.Send(task))
+
+		return sent
+	}
+
+	t.Run("an author that closes the string cannot add keys", func(t *testing.T) {
+		body := renderBody(t,
+			`{"app": "{{.App}}", "author": "{{.Author}}"}`,
+			"application/json",
+			models.Task{App: "demo", Author: `x", "channel": "#alerts", "z": "`},
+		)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		assert.Equal(t, []string{"app", "author"}, sortedKeys(parsed))
+		assert.Equal(t, `x", "channel": "#alerts", "z": "`, parsed["author"])
+	})
+
+	t.Run("a multi-line status reason stays valid JSON", func(t *testing.T) {
+		reason := "Out-of-sync resources:\n\tDeployment/demo\n\nLast sync operation: Failed, message: \"one or more objects failed to apply\""
+		body := renderBody(t,
+			`{"text": "{{.App}}: {{.Status}}{{with .StatusReason}} — {{.}}{{end}}"}`,
+			"application/json",
+			models.Task{App: "demo", Status: "app not available", StatusReason: reason},
+		)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		assert.Contains(t, parsed["text"], reason)
+	})
+
+	t.Run("images are escaped too", func(t *testing.T) {
+		body := renderBody(t,
+			`{"images": [{{range $i, $img := .Images}}{{if $i}},{{end}}{"image": "{{$img.Image}}", "tag": "{{$img.Tag}}"}{{end}}]}`,
+			"application/json",
+			models.Task{Images: []models.Image{{Image: `evil", "x": "`, Tag: "v1"}}},
+		)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		images := parsed["images"].([]any)
+		require.Len(t, images, 1)
+		assert.Equal(t, `evil", "x": "`, images[0].(map[string]any)["image"])
+	})
+
+	t.Run("ordinary values render exactly as before", func(t *testing.T) {
+		body := renderBody(t,
+			`{"app": "{{.App}}", "author": "{{.Author}}"}`,
+			"application/json",
+			models.Task{App: "demo", Author: "ci-bot"},
+		)
+
+		assert.Equal(t, `{"app": "demo", "author": "ci-bot"}`, body)
+	})
+
+	// A receiver expecting something other than JSON must keep receiving the
+	// literal text it always did.
+	t.Run("a non-JSON body is left alone", func(t *testing.T) {
+		body := renderBody(t,
+			`{{.App}} deployed by {{.Author}}`,
+			"text/plain",
+			models.Task{App: "demo", Author: `someone "quoted"`},
+		)
+
+		assert.Equal(t, `demo deployed by someone "quoted"`, body)
+	})
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -349,6 +349,23 @@ func TestSendEscapesValuesForAJSONBody(t *testing.T) {
 		assert.Equal(t, `{"app": "demo", "author": "ci-bot"}`, body)
 	})
 
+	// Pins the one incompatibility: a template that quotes the value itself now
+	// double-escapes, because the value reaches it already escaped. Such a format
+	// has to drop its own quoting — see the migration note in the notifications
+	// guide.
+	t.Run("a template that quotes the value itself double-escapes", func(t *testing.T) {
+		body := renderBody(t,
+			`{"text": {{printf "%q" .StatusReason}}}`,
+			"application/json",
+			models.Task{StatusReason: "line one\nline two"},
+		)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		assert.Equal(t, `line one\nline two`, parsed["text"],
+			"the value arrives escaped, so the template's own quoting escapes it again")
+	})
+
 	// A receiver expecting something other than JSON must keep receiving the
 	// literal text it always did.
 	t.Run("a non-JSON body is left alone", func(t *testing.T) {

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -379,6 +379,25 @@ func TestSendEscapesValuesForAJSONBody(t *testing.T) {
 	})
 }
 
+func TestIsJSONBody(t *testing.T) {
+	tests := map[string]bool{
+		"application/json":                  true,
+		"application/json; charset=utf-8":   true,
+		"APPLICATION/JSON":                  true,
+		"application/vnd.api+json":          true,
+		"application/problem+json":          true,
+		"text/plain":                        false,
+		"text/plain; profile=json":          false,
+		"application/x-www-form-urlencoded": false,
+		"":                                  false,
+		"not a media type":                  false,
+	}
+
+	for contentType, want := range tests {
+		assert.Equal(t, want, isJSONBody(contentType), "content type %q", contentType)
+	}
+}
+
 func sortedKeys(m map[string]any) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
The webhook body is assembled by a Go `text/template`, which escapes nothing, so any value carrying a quote or a newline ended the JSON string it sat in.

`StatusReason` does both — it is multi-line and quotes Argo CD's own messages — so a **failure** notification rendered as invalid JSON and the receiver rejected it. A success carries no reason and kept working, so the integration looked healthy while exactly the alerts worth having went missing. The example in `docs/guides/notifications.md` is one of the affected formats.

The same gap let an `author` submitted through the open task endpoint close the string and add top-level keys of its own to the body.

Values are escaped before the template renders them, rather than adding a function operators would have to adopt, so a format written the way the guide documents keeps working and simply becomes correct. Escaping applies only when `WEBHOOK_CONTENT_TYPE` is a JSON type; any other receiver keeps being sent the literal text it always was. Ordinary values render byte-for-byte as before. Both are pinned by tests. Mattermost already marshals its payload and is unaffected.

**Requires a config change if your format quotes values itself.** `{"text": {{printf "%q" .StatusReason}}}` now escapes an already-escaped value, so the receiver shows a literal `\n` where a line break belongs. Drop the `printf` and put the value in quotes — `{"text": "{{.StatusReason}}"}`. This is the one incompatibility; it has a test pinning the behaviour, a migration note in the notifications guide, and an entry under `### Changed`.