### PR TITLE
fix(web): keep the date picker draft across parent re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `backend` and `mock` services pinned `golang:1.26.4`, below the Go version `go.mod` requires,
   and the official Go image refuses to fetch a newer toolchain — so both exited immediately with
   `go.mod requires go >= 1.26.7`.
+- The History date range picker no longer loses a selection while you are making it. Any
+  re-render of the surrounding filters — the periodic task-list refresh among them — reset the
+  open calendar, so a range with the start clicked but not the end was discarded and the view
+  jumped back to the committed month.
 
 ## [1.2.0] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the official Go image refuses to fetch a newer toolchain — so both exited immediately with
   `go.mod requires go >= 1.26.7`.
 - The History date range picker no longer loses a selection while you are making it. Any
-  re-render of the surrounding filters — the periodic task-list refresh among them — reset the
-  open calendar, so a range with the start clicked but not the end was discarded and the view
-  jumped back to the committed month.
+  re-render of the surrounding filters reset the open calendar, so a range with the start
+  clicked but not the end was discarded and the view jumped back to the committed month.
 
 ## [1.2.0] - 2026-09-07
 

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -14,16 +14,8 @@ vi.mock('../../../../shared/providers/TimezoneProvider', () => ({
 
 const FIXED_NOW = new Date('2026-04-27T12:00:00Z'); // a Monday
 
-const dayCell = (day: string) => {
-  const grid = screen.getByRole('grid', { name: 'Calendar' });
-  const matches = within(grid)
-    .getAllByRole('gridcell')
-    .filter(cell => cell.textContent === day);
-  if (matches.length !== 1) {
-    throw new Error(`expected one calendar cell labelled ${day}, found ${matches.length}`);
-  }
-  return matches[0];
-};
+const dayCell = (date: string) =>
+  within(screen.getByRole('grid', { name: 'Calendar' })).getByRole('gridcell', { name: date });
 
 describe('DateRangePicker', () => {
   beforeEach(() => {
@@ -102,8 +94,8 @@ describe('DateRangePicker', () => {
     const onApply = vi.fn();
     render(<DateRangePicker value={{ start: null, end: null }} onApply={onApply} />);
     fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
-    fireEvent.click(dayCell('27'));
-    fireEvent.click(dayCell('20'));
+    fireEvent.click(dayCell('27 April 2026'));
+    fireEvent.click(dayCell('20 April 2026'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
     expect(onApply).toHaveBeenCalledWith({
@@ -119,13 +111,13 @@ describe('DateRangePicker', () => {
     const { rerender } = render(empty());
 
     fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
-    fireEvent.click(dayCell('20'));
+    fireEvent.click(dayCell('20 April 2026'));
 
     rerender(empty());
 
-    expect(dayCell('20')).toHaveAttribute('aria-selected', 'true');
+    expect(dayCell('20 April 2026')).toHaveAttribute('aria-selected', 'true');
     // Closing the range on the next click is what proves pickingStart survived too.
-    fireEvent.click(dayCell('27'));
+    fireEvent.click(dayCell('27 April 2026'));
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
     expect(onApply).toHaveBeenCalledWith({
       start: Math.floor(Date.parse('2026-04-20T00:00:00Z') / 1000),

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -14,6 +14,17 @@ vi.mock('../../../../shared/providers/TimezoneProvider', () => ({
 
 const FIXED_NOW = new Date('2026-04-27T12:00:00Z'); // a Monday
 
+const dayCell = (day: string) => {
+  const grid = screen.getByRole('grid', { name: 'Calendar' });
+  const matches = within(grid)
+    .getAllByRole('gridcell')
+    .filter(cell => cell.textContent === day);
+  if (matches.length !== 1) {
+    throw new Error(`expected one calendar cell labelled ${day}, found ${matches.length}`);
+  }
+  return matches[0];
+};
+
 describe('DateRangePicker', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -91,20 +102,77 @@ describe('DateRangePicker', () => {
     const onApply = vi.fn();
     render(<DateRangePicker value={{ start: null, end: null }} onApply={onApply} />);
     fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
-    const grid = screen.getByRole('grid', { name: 'Calendar' });
-
-    const cells = within(grid).getAllByRole('gridcell');
-    const cell27 = cells.find(c => c.textContent === '27' && !c.hasAttribute('disabled'));
-    const cell20 = cells.find(c => c.textContent === '20' && !c.hasAttribute('disabled'));
-    if (!cell27 || !cell20) throw new Error('expected calendar cells not found');
-    fireEvent.click(cell27);
-    fireEvent.click(cell20);
+    fireEvent.click(dayCell('27'));
+    fireEvent.click(dayCell('20'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
     expect(onApply).toHaveBeenCalledWith({
       start: Math.floor(Date.parse('2026-04-20T00:00:00Z') / 1000),
       end: Math.floor(Date.parse('2026-04-27T23:59:59Z') / 1000),
     });
+  });
+
+  it('keeps an in-progress selection when the parent re-renders with an equal range', () => {
+    // HistoryFilters hands the picker a fresh object literal on every render.
+    const onApply = vi.fn();
+    const empty = () => <DateRangePicker value={{ start: null, end: null }} onApply={onApply} />;
+    const { rerender } = render(empty());
+
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    fireEvent.click(dayCell('20'));
+
+    rerender(empty());
+
+    expect(dayCell('20')).toHaveAttribute('aria-selected', 'true');
+    // Closing the range on the next click is what proves pickingStart survived too.
+    fireEvent.click(dayCell('27'));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onApply).toHaveBeenCalledWith({
+      start: Math.floor(Date.parse('2026-04-20T00:00:00Z') / 1000),
+      end: Math.floor(Date.parse('2026-04-27T23:59:59Z') / 1000),
+    });
+  });
+
+  it('keeps the browsed month when the parent re-renders with an equal range', () => {
+    const empty = () => <DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />;
+    const { rerender } = render(empty());
+
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+    expect(screen.getByText('March 2026')).toBeInTheDocument();
+
+    rerender(empty());
+
+    expect(screen.getByText('March 2026')).toBeInTheDocument();
+  });
+
+  it('reseeds the draft when the committed range changes while the popover is open', () => {
+    const start = Math.floor(Date.parse('2026-02-10T00:00:00Z') / 1000);
+    const end = Math.floor(Date.parse('2026-02-14T23:59:59Z') / 1000);
+    const { rerender } = render(
+      <DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    rerender(<DateRangePicker value={{ start, end }} onApply={() => {}} />);
+
+    expect(screen.getByText('February 2026')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  it('reseeds the draft when only the committed end moves while the popover is open', () => {
+    const start = Math.floor(Date.parse('2026-02-10T00:00:00Z') / 1000);
+    const end = Math.floor(Date.parse('2026-02-14T23:59:59Z') / 1000);
+    const laterEnd = Math.floor(Date.parse('2026-02-18T23:59:59Z') / 1000);
+    const { rerender } = render(
+      <DateRangePicker value={{ start, end }} onApply={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /10.*Feb.*2026/ }));
+    rerender(<DateRangePicker value={{ start, end: laterEnd }} onApply={() => {}} />);
+
+    // A stale draft would still read as dirty and re-enable Apply.
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
   });
 
   it('Cancel closes the popover without firing onApply', () => {

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -2,9 +2,11 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DateRangePicker } from './DateRangePicker';
 
+let mockTimezone: 'utc' | 'local' = 'utc';
+
 vi.mock('../../../../shared/providers/TimezoneProvider', () => ({
   useTimezone: () => ({
-    timezone: 'utc',
+    timezone: mockTimezone,
     formatDate: (ts: number, opts?: Intl.DateTimeFormatOptions) => {
       const date = new Date(ts * 1000);
       return new Intl.DateTimeFormat('en-GB', { ...opts, timeZone: 'UTC' }).format(date);
@@ -25,6 +27,7 @@ describe('DateRangePicker', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    mockTimezone = 'utc';
   });
 
   it('renders "Select date range" placeholder when value is empty', () => {
@@ -165,6 +168,16 @@ describe('DateRangePicker', () => {
 
     // A stale draft would still read as dirty and re-enable Apply.
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  it('names the month and its cells in local time when the timezone is local', () => {
+    mockTimezone = 'local';
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+
+    expect(screen.getByText('April 2026')).toBeInTheDocument();
+    expect(dayCell('20 April 2026')).toBeInTheDocument();
   });
 
   it('Cancel closes the popover without firing onApply', () => {

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -28,6 +28,7 @@ describe('DateRangePicker', () => {
   afterEach(() => {
     vi.useRealTimers();
     mockTimezone = 'utc';
+    process.env.TZ = 'UTC';
   });
 
   it('renders "Select date range" placeholder when value is empty', () => {
@@ -171,13 +172,17 @@ describe('DateRangePicker', () => {
   });
 
   it('names the month and its cells in local time when the timezone is local', () => {
+    // 12:00 UTC on 30 April is already 1 May at UTC+14, so a calendar that
+    // slipped back to UTC would say April here.
+    process.env.TZ = 'Pacific/Kiritimati';
+    vi.setSystemTime(new Date('2026-04-30T12:00:00Z'));
     mockTimezone = 'local';
     render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
 
-    expect(screen.getByText('April 2026')).toBeInTheDocument();
-    expect(dayCell('20 April 2026')).toBeInTheDocument();
+    expect(screen.getByText('May 2026')).toBeInTheDocument();
+    expect(dayCell('1 May 2026')).toBeInTheDocument();
   });
 
   it('Cancel closes the popover without firing onApply', () => {

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -63,12 +63,23 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
   const [viewYear, setViewYear] = useState(() => ymd(new Date(), timezone).year);
   const [viewMonth, setViewMonth] = useState(() => ymd(new Date(), timezone).month);
 
-  // Opening the popover reseeds the draft and the visible month. Adjusting
-  // during render rather than in an effect means the calendar's first painted
-  // frame is already the right month.
-  const [lastSeed, setLastSeed] = useState({ anchor, value, timezone });
-  if (lastSeed.anchor !== anchor || lastSeed.value !== value || lastSeed.timezone !== timezone) {
-    setLastSeed({ anchor, value, timezone });
+  // Opening the popover reseeds the draft and the visible month; adjusting
+  // during render means the first painted frame is already the right month.
+  // The guard compares endpoints, not the `value` object — callers pass a fresh
+  // literal each render, and identity would drop a half-picked range.
+  const [lastSeed, setLastSeed] = useState({
+    anchor,
+    start: value.start,
+    end: value.end,
+    timezone,
+  });
+  if (
+    lastSeed.anchor !== anchor ||
+    lastSeed.start !== value.start ||
+    lastSeed.end !== value.end ||
+    lastSeed.timezone !== timezone
+  ) {
+    setLastSeed({ anchor, start: value.start, end: value.end, timezone });
     if (anchor) {
       setDraft(value);
       setPickingStart(true);

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -50,6 +50,8 @@ const formatTriggerLabel = (range: DateRangeValue, formatDate: (ts: number, opts
 
 const MONTH_FORMAT: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' };
 
+const CELL_FORMAT: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'long', year: 'numeric' };
+
 /**
  * `value` is in Unix seconds; `onApply` fires only when the user clicks Apply
  * with a complete and dirty range. Computation honours the active timezone.
@@ -136,6 +138,17 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
   const grid = useMemo(
     () => buildMonthGrid(viewYear, viewMonth, timezone),
     [viewYear, viewMonth, timezone],
+  );
+
+  // The grid spills into the neighbouring months, so a bare day number names
+  // two cells. One formatter, reused across all 42.
+  const cellFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-GB', {
+        ...CELL_FORMAT,
+        timeZone: timezone === 'utc' ? 'UTC' : undefined,
+      }),
+    [timezone],
   );
 
   const draftStartDate = draft.start === null ? null : new Date(draft.start * 1000);
@@ -325,6 +338,7 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
                   <CalendarCell
                     key={cell.date.toISOString()}
                     label={String(ymd(cell.date, timezone).day)}
+                    accessibleLabel={cellFormatter.format(cell.date)}
                     isInMonth={cell.inMonth}
                     isToday={cell.isToday}
                     isStart={isStart}
@@ -375,6 +389,7 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
 
 interface CalendarCellProps {
   readonly label: string;
+  readonly accessibleLabel: string;
   readonly isInMonth: boolean;
   readonly isToday: boolean;
   readonly isStart: boolean;
@@ -383,7 +398,16 @@ interface CalendarCellProps {
   readonly onClick: () => void;
 }
 
-const CalendarCell = ({ label, isInMonth, isToday, isStart, isEnd, isInRange, onClick }: CalendarCellProps) => {
+const CalendarCell = ({
+  label,
+  accessibleLabel,
+  isInMonth,
+  isToday,
+  isStart,
+  isEnd,
+  isInRange,
+  onClick,
+}: CalendarCellProps) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const isEndpoint = isStart || isEnd;
@@ -413,6 +437,7 @@ const CalendarCell = ({ label, isInMonth, isToday, isStart, isEnd, isInRange, on
   return (
     <ButtonBase
       role="gridcell"
+      aria-label={accessibleLabel}
       aria-selected={isEndpoint}
       onClick={onClick}
       sx={{


### PR DESCRIPTION
The History date range picker's seed guard compared the `value` prop by object identity, but `HistoryFilters` builds a fresh literal every render — so any re-render, the auto-refresh tick included, reset the open calendar and discarded a half-picked range. The guard now compares the start and end endpoints.

Closes #593