### PR TITLE
fix(web): restore the task list layout and flag rollbacks on task detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,17 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keyboard shortcuts on Recent Tasks, listed beside the pagination controls: `/` focuses search,
   `a` shows all tasks, `i` in-progress, `f` toggles failed, and `m` toggles the Mine scope.
 - A failed task now carries its reason inline in the list — the extracted headline plus **Copy** and
-  **Full reason** — so finding out why a deployment failed no longer needs a click.
+  **Full reason** — so finding out why a deployment failed no longer needs a click. Cancelled tasks
+  are left out: their reason only restates the status.
 
 ### Changed
 
-- Recent Tasks went from ten columns to six: Application, Status, Image · tag, Author, When and
-  Duration. The project moved under the application name, Created and Updated collapsed into a
-  single relative-plus-exact **When** column, and the rollback flag moved from the Status cell to a
-  labelled chip beside the application it describes. Column widths are now fixed, so a long
-  application or author name no longer stretches the table.
-- Clicking anywhere in a task row opens that task. The row expander and the **View** button are
-  gone, and the extra images in a row collapse to a `+n` counter instead of an inline expander.
+- The rollback flag moved out of the Status cell: it is now a labelled chip beneath the
+  application name, which is what it qualifies. Column widths are fixed, so a long application
+  or author name no longer stretches the table.
+- A task row no longer expands: its status reason is always visible, so the expander is gone.
+  **View** remains the way to open a task, and clicking elsewhere in the row does nothing.
 - The task detail screen leads with the failure: the application name is the title, the task id is a
   copy chip beside it, the reason is the first block on the page with the raw Argo CD text one click
   away, and the lifecycle reads left to right. It also links to the previous deployment of the same
@@ -61,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The History date range picker no longer loses a selection while you are making it. Any
   re-render of the surrounding filters reset the open calendar, so a range with the start
   clicked but not the end was discarded and the view jumped back to the committed month.
+- `GET /api/v1/tasks/{id}` now reports `is_rollback` and `rollback_target_id`. The task list
+  served both, but the single-task response omitted them, so a client reading one task could not
+  tell a rollback from an ordinary deployment. The task detail page now flags one.
 
 ## [1.2.0] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clicked but not the end was discarded and the view jumped back to the committed month.
 - `GET /api/v1/tasks/{id}` now reports `is_rollback` and `rollback_target_id`. The task list
   served both, but the single-task response omitted them, so a client reading one task could not
-  tell a rollback from an ordinary deployment. The task detail page now flags one.
+  tell a rollback from an ordinary deployment. The task detail page now flags one as such.
 
 ## [1.2.0] - 2026-09-07
 

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -113,7 +113,11 @@ type TaskStatus struct {
 	Images       []Image `json:"images,omitempty" binding:"required"`
 	Status       string  `json:"status,omitempty"`
 	StatusReason string  `json:"status_reason,omitempty"`
-	Error        string  `json:"error,omitempty"`
+	// Served alongside the task list's own copies, so the detail view can tell a
+	// rollback apart from an ordinary deployment and link to what it returned to.
+	IsRollback       bool   `json:"is_rollback,omitempty"`
+	RollbackTargetId string `json:"rollback_target_id,omitempty"`
+	Error            string `json:"error,omitempty"`
 }
 
 type ArgoApiErrorResponse struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -337,15 +337,17 @@ func (env *Env) getTaskStatus(w http.ResponseWriter, r *http.Request) {
 	} else {
 		setTaskApp(r, task.MetricApp())
 		writeJSON(w, http.StatusOK, models.TaskStatus{
-			Id:           task.Id,
-			Created:      task.Created,
-			Updated:      task.Updated,
-			App:          task.App,
-			Author:       task.Author,
-			Project:      task.Project,
-			Images:       task.Images,
-			Status:       task.Status,
-			StatusReason: task.StatusReason,
+			Id:               task.Id,
+			Created:          task.Created,
+			Updated:          task.Updated,
+			App:              task.App,
+			Author:           task.Author,
+			Project:          task.Project,
+			Images:           task.Images,
+			Status:           task.Status,
+			StatusReason:     task.StatusReason,
+			IsRollback:       task.IsRollback,
+			RollbackTargetId: task.RollbackTargetId,
 		})
 	}
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1694,6 +1694,39 @@ func TestGetTaskStatusEndpoint(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "test-app")
 	})
 
+	t.Run("carries the rollback flag and its target", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		repo, _ := newRepo(ctrl)
+		repo.EXPECT().GetTask(gomock.Any()).DoAndReturn(func(id string) (*models.Task, error) {
+			return &models.Task{
+				Id:               id,
+				App:              "test-app",
+				Author:           "test-author",
+				Project:          "test-project",
+				Status:           "deployed",
+				IsRollback:       true,
+				RollbackTargetId: "previous-task-id",
+			}, nil
+		}).AnyTimes()
+		argo := &argocd.Argo{}
+		argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+		env := &Env{argo: argo}
+
+		router := chi.NewRouter()
+		router.Get("/api/v1/tasks/{id}", env.getTaskStatus)
+
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/tasks/test-task-id", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		// The task list serves both fields, so the detail view must too or the
+		// UI cannot tell a rollback apart from an ordinary deployment.
+		assert.Contains(t, w.Body.String(), `"is_rollback":true`)
+		assert.Contains(t, w.Body.String(), `"rollback_target_id":"previous-task-id"`)
+	})
+
 	t.Run("returns 404 when task not found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		repo, _ := newRepo(ctrl)

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1692,6 +1692,10 @@ func TestGetTaskStatusEndpoint(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "test-task-id")
 		assert.Contains(t, w.Body.String(), "test-app")
+		// Both carry omitempty, so an ordinary deployment omits the keys entirely.
+		// Without this a handler hardcoding the flag would still look correct.
+		assert.NotContains(t, w.Body.String(), "is_rollback")
+		assert.NotContains(t, w.Body.String(), "rollback_target_id")
 	})
 
 	t.Run("carries the rollback flag and its target", func(t *testing.T) {

--- a/web/README.md
+++ b/web/README.md
@@ -70,7 +70,7 @@ Playwright covers only what jsdom structurally cannot: real cross-document navig
 
 | Project | Covers |
 |---|---|
-| `no-auth` | The server's SPA fallback for a deep-linked task URL; Back from a directly-opened task page; and the auth-less mode, which must render with no sign-in and no privileged controls. |
+| `no-auth` | The server's SPA fallback for a deep-linked task URL; Back from a directly-opened task page; the auth-less mode, which must render with no sign-in and no privileged controls; and the task table's header rule surviving `position: sticky`, plus the header row not being styled as a clickable task row. |
 | `auth` | The top-level OIDC redirect and the stripping of its callback query; returning to the linked task via `url_state`; session recovery through the SSO cookie after a reload; the deploy-lock banner arriving over the live socket and being toggled from the drawer; rollback as a privileged user; and privilege gating for a privileged versus a regular user. |
 
 Two constraints when adding specs:

--- a/web/e2e/no-auth/author-column.spec.ts
+++ b/web/e2e/no-auth/author-column.spec.ts
@@ -14,7 +14,7 @@ const BOT_AUTHOR = 'project_1758_bot_062d75c8b91e27fa4e5bb374cd9c1c39@noreply.ex
  * this suite compiles without JSX support and cannot import a component module.
  * `CELL_PADDING_ALLOWANCE` covers the surrounding table cell's own padding.
  */
-const AUTHOR_MAX_WIDTH = 180;
+const AUTHOR_MAX_WIDTH = 200;
 const CELL_PADDING_ALLOWANCE = 48;
 
 test('a long bot author is clipped instead of widening its column', async ({ page, request }) => {

--- a/web/e2e/no-auth/task-table-layout.spec.ts
+++ b/web/e2e/no-auth/task-table-layout.spec.ts
@@ -48,16 +48,27 @@ test('no row navigates on click — only the View button does', async ({ page, r
 
   await page.goto('/');
   await expect(page.getByRole('columnheader', { name: 'Application' })).toBeVisible();
-  const listPath = new URL(page.url()).pathname;
+
+  // Counting history entries beats polling the URL: polling an unchanged value
+  // passes on its first sample, racing any navigation the click may still start.
+  await page.evaluate(() => {
+    const w = window as unknown as { __navCount: number };
+    w.__navCount = 0;
+    const original = history.pushState.bind(history);
+    history.pushState = (...args: Parameters<typeof history.pushState>) => {
+      w.__navCount += 1;
+      return original(...args);
+    };
+  });
+  const navCount = () =>
+    page.evaluate(() => (window as unknown as { __navCount: number }).__navCount);
 
   // react-admin puts RaDatagrid-row on the header row too, so a rule meant for
   // task rows would style the header as one; neither may act as a link.
   await page.locator('.RaDatagrid-headerRow').click();
   await page.locator('tbody .RaDatagrid-row td.cell-author').first().click();
-  // react-admin keeps its list state in the query string, so compare the path.
-  await expect
-    .poll(() => new URL(page.url()).pathname, { message: 'a row click must not navigate' })
-    .toBe(listPath);
+  await page.waitForTimeout(500);
+  expect(await navCount(), 'a row click must not navigate').toBe(0);
 
   // Scoped and exact: an unscoped substring match also hits the top bar's Overview link.
   await page
@@ -68,4 +79,5 @@ test('no row navigates on click — only the View button does', async ({ page, r
   await expect
     .poll(() => new URL(page.url()).pathname)
     .toMatch(/^\/task\/[0-9a-f-]{36}$/);
+  expect(await navCount(), 'the View link must navigate exactly once').toBe(1);
 });

--- a/web/e2e/no-auth/task-table-layout.spec.ts
+++ b/web/e2e/no-auth/task-table-layout.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+import { seedTask, waitForDeployed } from '../helpers';
+
+/**
+ * @description The task table's header rule. jsdom paints nothing and runs no
+ * layout, so the unit tests can only assert declared CSS — that the rule
+ * actually renders, and renders once, is measurable here and nowhere else.
+ */
+
+/** Wide enough that the header sticks and the rule spans several columns. */
+const WIDE_VIEWPORT = { width: 2065, height: 900 };
+
+test('the header rule survives the header sticking to the top', async ({ page, request }) => {
+  const id = await seedTask(request, 'layout-header-rule');
+  await waitForDeployed(request, id);
+
+  await page.setViewportSize(WIDE_VIEWPORT);
+  await page.goto('/');
+  await expect(page.getByRole('columnheader', { name: 'Application' })).toBeVisible();
+
+  const header = await page.evaluate(() =>
+    [...document.querySelectorAll('.RaDatagrid-headerCell')].map(el => {
+      const style = getComputedStyle(el);
+      return { shadow: style.boxShadow, border: style.borderBottomWidth, position: style.position };
+    }),
+  );
+
+  expect(header.length).toBeGreaterThan(1);
+  for (const cell of header) {
+    // A collapsed border is painted by the table, which a sticky cell cannot
+    // carry with it, leaving the rule drawn across one column only.
+    expect(cell.position).toBe('sticky');
+    expect(cell.border).toBe('0px');
+    expect(cell.shadow).not.toBe('none');
+  }
+
+  // A shadow does not collapse with the first row's top border the way the old
+  // border did, so leaving both in place stacks them into a 2px rule.
+  const firstRowBorder = await page.evaluate(
+    () => getComputedStyle(document.querySelector('tbody .RaDatagrid-row')!).borderTopWidth,
+  );
+  expect(firstRowBorder).toBe('0px');
+});
+
+test('the header row is not presented as a clickable task row', async ({ page, request }) => {
+  const id = await seedTask(request, 'layout-header-cursor');
+  await waitForDeployed(request, id);
+
+  await page.goto('/');
+  const headerRow = page.locator('.RaDatagrid-headerRow');
+  await expect(headerRow).toBeVisible();
+
+  // react-admin puts RaDatagrid-row on the header row too, so a rule meant for
+  // task rows gives the header a pointer cursor and the row hover highlight.
+  await expect(headerRow).not.toHaveCSS('cursor', 'pointer');
+});

--- a/web/e2e/no-auth/task-table-layout.spec.ts
+++ b/web/e2e/no-auth/task-table-layout.spec.ts
@@ -42,15 +42,30 @@ test('the header rule survives the header sticking to the top', async ({ page, r
   expect(firstRowBorder).toBe('0px');
 });
 
-test('the header row is not presented as a clickable task row', async ({ page, request }) => {
-  const id = await seedTask(request, 'layout-header-cursor');
+test('no row navigates on click — only the View button does', async ({ page, request }) => {
+  const id = await seedTask(request, 'layout-row-inert');
   await waitForDeployed(request, id);
 
   await page.goto('/');
-  const headerRow = page.locator('.RaDatagrid-headerRow');
-  await expect(headerRow).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Application' })).toBeVisible();
+  const listPath = new URL(page.url()).pathname;
 
   // react-admin puts RaDatagrid-row on the header row too, so a rule meant for
-  // task rows gives the header a pointer cursor and the row hover highlight.
-  await expect(headerRow).not.toHaveCSS('cursor', 'pointer');
+  // task rows would style the header as one; neither may act as a link.
+  await page.locator('.RaDatagrid-headerRow').click();
+  await page.locator('tbody .RaDatagrid-row td.cell-author').first().click();
+  // react-admin keeps its list state in the query string, so compare the path.
+  await expect
+    .poll(() => new URL(page.url()).pathname, { message: 'a row click must not navigate' })
+    .toBe(listPath);
+
+  // Scoped and exact: an unscoped substring match also hits the top bar's Overview link.
+  await page
+    .locator('tbody .RaDatagrid-row td.cell-view')
+    .first()
+    .getByRole('link', { name: 'View', exact: true })
+    .click();
+  await expect
+    .poll(() => new URL(page.url()).pathname)
+    .toMatch(/^\/task\/[0-9a-f-]{36}$/);
 });

--- a/web/src/features/tasks/components/AppCell.test.tsx
+++ b/web/src/features/tasks/components/AppCell.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { AppCell, APP_TEXT_MAX_WIDTH, deriveMonogram, describeProject } from './AppCell';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AppCell, deriveMonogram, describeProject } from './AppCell';
 
 describe('deriveMonogram', () => {
   it('returns first letter of each segment for hyphenated names', () => {
@@ -47,71 +47,12 @@ describe('AppCell', () => {
     expect(screen.getByText('checkout-api')).toBeInTheDocument();
   });
 
-  it('renders the project as a subtitle beneath the app name', () => {
-    render(<AppCell app="checkout-api" project="infra/prod" />);
-    expect(screen.getByText('infra/prod')).toBeInTheDocument();
-    expect(screen.queryByRole('link')).toBeNull();
-  });
-
-  // Both lines are nowrap, so an uncapped box would set the cell's min-content
-  // width under `table-layout: auto` and stretch the whole table sideways.
-  it('caps the subtitle so a long project cannot widen the column', () => {
-    render(<AppCell app="checkout-api" project="infra/prod" />);
-    expect(screen.getByText('infra/prod')).toHaveStyle({
-      display: 'block',
-      maxWidth: `${APP_TEXT_MAX_WIDTH}px`,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    });
-  });
-
-  it('caps the app name for the same reason', () => {
-    const app = 'a-very-long-application-name-that-would-otherwise-set-the-column-width';
-    render(<AppCell app={app} />);
-    expect(screen.getByText(app)).toHaveStyle({
-      display: 'block',
-      maxWidth: `${APP_TEXT_MAX_WIDTH}px`,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    });
-  });
-
-  it('caps the linked project label too', () => {
-    render(<AppCell app="checkout-api" project="https://gitlab.example.net/acme/checkout" />);
-    expect(screen.getByRole('link')).toHaveStyle({ maxWidth: `${APP_TEXT_MAX_WIDTH}px` });
-  });
-
-  it('links a URL project out to the repository without triggering the row', () => {
-    const onRowClick = vi.fn();
-    render(
-      <button type="button" aria-label="parent row" onClick={onRowClick} onKeyDown={onRowClick}>
-        <AppCell app="checkout-api" project="https://github.com/org/repo/" />
-      </button>,
-    );
-
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/');
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveTextContent('github.com/repo');
-
-    fireEvent.click(link);
-    expect(onRowClick).not.toHaveBeenCalled();
-  });
-
-  it('renders no subtitle when the task carries no project', () => {
-    render(<AppCell app="checkout-api" project="" />);
-    expect(screen.queryByText('—')).toBeNull();
-    expect(screen.getByText('checkout-api')).toBeInTheDocument();
-  });
-
-  it('flags a rollback beside the app name', () => {
+  it('flags a rollback beneath the app name, where it qualifies the deployment', () => {
     render(<AppCell app="checkout-api" isRollback />);
     expect(screen.getByText('Rollback')).toBeInTheDocument();
   });
 
-  it('omits the rollback chip for a regular deployment', () => {
+  it('shows no badge for an ordinary deployment', () => {
     render(<AppCell app="checkout-api" />);
     expect(screen.queryByText('Rollback')).toBeNull();
   });

--- a/web/src/features/tasks/components/AppCell.tsx
+++ b/web/src/features/tasks/components/AppCell.tsx
@@ -1,12 +1,10 @@
-import { Box, Link, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { tokens } from '../../../theme/tokens';
 import { RollbackIndicator } from './RollbackIndicator';
 
 interface AppCellProps {
   readonly app: string;
-  readonly project?: string | null;
   readonly isRollback?: boolean;
 }
 
@@ -60,71 +58,25 @@ export const describeProject = (project: string): ProjectLinkInfo => {
   return { isUrl: true, label, href: project };
 };
 
-// Both text lines are nowrap, so without an explicit cap they set the cell's
-// min-content width under `table-layout: auto` and stretch the table sideways.
-export const APP_TEXT_MAX_WIDTH = 230;
-
-const SUBTITLE_SX = {
-  display: 'block',
-  maxWidth: APP_TEXT_MAX_WIDTH,
-  fontFamily: tokens.fontMono,
-  fontSize: 11,
-  color: 'text.secondary',
-  lineHeight: 1.2,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-} as const;
-
-/** Absent rather than an em-dash: the row already names the app on the line above. */
-const ProjectSubtitle = ({ project }: { project?: string | null }) => {
-  if (!project) {
-    return null;
-  }
-
-  const info = describeProject(project);
-  if (info.isUrl && info.href) {
-    return (
-      <Link
-        href={info.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        underline="hover"
-        onClick={event => event.stopPropagation()}
-        title={info.href}
-        sx={{ ...SUBTITLE_SX, display: 'inline-flex', alignItems: 'center', gap: 0.25 }}
-      >
-        <Box
-          component="span"
-          sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-        >
-          {info.label}
-        </Box>
-        <OpenInNewIcon aria-hidden sx={{ fontSize: 11, flexShrink: 0 }} />
-      </Link>
-    );
-  }
-
-  return (
-    <Typography component="span" title={info.label} sx={SUBTITLE_SX}>
-      {info.label}
-    </Typography>
-  );
-};
-
 /**
- * @description Application identity for a task row: monogram, app name, the
- * rollback flag, and the project as a subtitle. Carries the project so the list
- * needs no separate column for it.
+ * @description Application identity for a task row: the monogram, the app name,
+ * and the rollback badge beneath it. The badge describes the deployment, so it
+ * sits with the application rather than in the Status cell.
  */
-export const AppCell = ({ app, project, isRollback }: AppCellProps) => {
+export const AppCell = ({ app, isRollback }: AppCellProps) => {
   const theme = useTheme();
   const swatches = theme.palette.mode === 'dark' ? tokens.monogramSwatchesDark : tokens.monogramSwatches;
   const monogram = deriveMonogram(app);
   const swatch = swatches[hashIndex(app, swatches.length)];
 
   return (
-    <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{
+        alignItems: 'center',
+        minWidth: 0
+      }}>
       <Box
         aria-hidden
         sx={{
@@ -144,27 +96,16 @@ export const AppCell = ({ app, project, isRollback }: AppCellProps) => {
       >
         {monogram}
       </Box>
-      <Stack spacing={0.25} sx={{ minWidth: 0, maxWidth: APP_TEXT_MAX_WIDTH }}>
-        <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
-          <Typography
-            variant="body2"
-            sx={{
-              display: 'block',
-              maxWidth: APP_TEXT_MAX_WIDTH,
-              fontWeight: 500,
-              fontSize: 13.5,
-              lineHeight: 1.2,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-            title={app}
-          >
-            {app}
-          </Typography>
-          <RollbackIndicator isRollback={isRollback} />
-        </Stack>
-        <ProjectSubtitle project={project} />
+      <Stack spacing={0.25} sx={{ minWidth: 0, alignItems: 'flex-start' }}>
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 500, fontSize: 13.5, lineHeight: 1.2, minWidth: 0, maxWidth: '100%' }}
+          noWrap
+          title={app}
+        >
+          {app}
+        </Typography>
+        <RollbackIndicator isRollback={isRollback} />
       </Stack>
     </Stack>
   );

--- a/web/src/features/tasks/components/ImagesCell.test.tsx
+++ b/web/src/features/tasks/components/ImagesCell.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { ImagesCell, stripRegistryPrefix, TAG_MAX_WIDTH } from './ImagesCell';
 
 describe('stripRegistryPrefix', () => {
@@ -26,14 +26,14 @@ describe('ImagesCell', () => {
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
-  it('renders a single image with no counter', () => {
+  it('renders a single image inline without a toggle', () => {
     render(<ImagesCell images={[{ image: 'api', tag: 'v1' }]} />);
     expect(screen.getByText('api')).toBeInTheDocument();
     expect(screen.getByText('v1')).toBeInTheDocument();
-    expect(screen.queryByText(/^\+/)).toBeNull();
+    expect(screen.queryByText(/more/)).toBeNull();
   });
 
-  it('shows only the first image and counts the rest', () => {
+  it('collapses extra images behind a +N more toggle', () => {
     render(
       <ImagesCell
         images={[
@@ -45,32 +45,31 @@ describe('ImagesCell', () => {
     );
     expect(screen.getByText('api')).toBeInTheDocument();
     expect(screen.queryByText('worker')).toBeNull();
-    expect(screen.getByText('+2')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '+2 more' }));
+    expect(screen.getByText('worker')).toBeInTheDocument();
+    expect(screen.getByText('cron')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
 
-  it('offers no control to expand, so a click always reaches the row', () => {
+  it('stops propagation so row navigation does not fire when toggling', () => {
+    const onRowClick = vi.fn();
     render(
-      <ImagesCell
-        images={[
-          { image: 'api', tag: 'v1' },
-          { image: 'worker', tag: 'v2' },
-        ]}
-      />,
+      <button
+        type="button"
+        aria-label="parent row"
+        onClick={onRowClick}
+        onKeyDown={onRowClick}
+      >
+        <ImagesCell
+          images={[
+            { image: 'api', tag: 'v1' },
+            { image: 'worker', tag: 'v2' },
+          ]}
+        />
+      </button>,
     );
-    expect(screen.queryByRole('button')).toBeNull();
-  });
-
-  it('names the hidden images in the counter tooltip', () => {
-    render(
-      <ImagesCell
-        images={[
-          { image: 'api', tag: 'v1' },
-          { image: 'ghcr.io/org/worker', tag: 'v2' },
-          { image: 'cron', tag: 'v3' },
-        ]}
-      />,
-    );
-    expect(screen.getByText('+2')).toHaveAttribute('title', 'worker:v2, cron:v3');
+    fireEvent.click(screen.getByRole('button', { name: '+1 more' }));
+    expect(onRowClick).not.toHaveBeenCalled();
   });
 
   it('keeps a hyphenated tag on one line instead of shrinking its badge', () => {
@@ -91,6 +90,7 @@ describe('ImagesCell', () => {
       maxWidth: `${TAG_MAX_WIDTH}px`,
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+      // With inline-block the line-height, not flex alignment, centers the text.
       height: '18px',
       lineHeight: '18px',
     });

--- a/web/src/features/tasks/components/ImagesCell.test.tsx
+++ b/web/src/features/tasks/components/ImagesCell.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ImagesCell, stripRegistryPrefix, TAG_MAX_WIDTH } from './ImagesCell';
 
 describe('stripRegistryPrefix', () => {
@@ -51,25 +51,21 @@ describe('ImagesCell', () => {
     expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
 
-  it('stops propagation so row navigation does not fire when toggling', () => {
-    const onRowClick = vi.fn();
+  it('collapses again on a second click, so the row can be folded back', () => {
     render(
-      <button
-        type="button"
-        aria-label="parent row"
-        onClick={onRowClick}
-        onKeyDown={onRowClick}
-      >
-        <ImagesCell
-          images={[
-            { image: 'api', tag: 'v1' },
-            { image: 'worker', tag: 'v2' },
-          ]}
-        />
-      </button>,
+      <ImagesCell
+        images={[
+          { image: 'api', tag: 'v1' },
+          { image: 'worker', tag: 'v2' },
+        ]}
+      />,
     );
+
     fireEvent.click(screen.getByRole('button', { name: '+1 more' }));
-    expect(onRowClick).not.toHaveBeenCalled();
+    expect(screen.getByText('worker')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /show less/i }));
+    expect(screen.getByRole('button', { name: '+1 more' })).toBeInTheDocument();
   });
 
   it('keeps a hyphenated tag on one line instead of shrinking its badge', () => {

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -65,7 +65,8 @@ const ImageRow = ({ image }: ImageRowProps) => (
         lineHeight: '18px',
         padding: '0 6px',
         borderRadius: tokens.radiusPill,
-        backgroundColor: tokens.accentSoft,
+        backgroundColor: theme =>
+          theme.palette.mode === 'dark' ? tokens.accentSoftDark : tokens.accentSoft,
         color: tokens.accent,
         fontFamily: tokens.fontMono,
         fontSize: 11,
@@ -77,16 +78,10 @@ const ImageRow = ({ image }: ImageRowProps) => (
   </Stack>
 );
 
-/** The "+N more" toggle stops propagation so it does not also expand the row. */
+/** The "+N more" toggle reveals the remaining images in place. */
 export const ImagesCell = ({ images }: ImagesCellProps) => {
   const [expanded, setExpanded] = useState(false);
-  const handleToggle = useCallback(
-    (event: React.MouseEvent) => {
-      event.stopPropagation();
-      setExpanded(prev => !prev);
-    },
-    [],
-  );
+  const handleToggle = useCallback(() => setExpanded(prev => !prev), []);
 
   if (!images?.length) {
     return <EmptyCell />;

--- a/web/src/features/tasks/components/ImagesCell.tsx
+++ b/web/src/features/tasks/components/ImagesCell.tsx
@@ -1,4 +1,5 @@
-import { Box, Stack, Typography } from '@mui/material';
+import { useState, useCallback } from 'react';
+import { Box, ButtonBase, Stack, Typography } from '@mui/material';
 import type { Image } from '../../../data/types';
 import { tokens } from '../../../theme/tokens';
 import { EmptyCell } from './EmptyCell';
@@ -64,7 +65,7 @@ const ImageRow = ({ image }: ImageRowProps) => (
         lineHeight: '18px',
         padding: '0 6px',
         borderRadius: tokens.radiusPill,
-        backgroundColor: theme => (theme.palette.mode === 'dark' ? tokens.accentSoftDark : tokens.accentSoft),
+        backgroundColor: tokens.accentSoft,
         color: tokens.accent,
         fontFamily: tokens.fontMono,
         fontSize: 11,
@@ -76,36 +77,59 @@ const ImageRow = ({ image }: ImageRowProps) => (
   </Stack>
 );
 
-/**
- * @description One line per task: the first image and a count of the rest. The
- * extras are named in the counter's tooltip and listed in full on the task
- * detail page, so nothing here competes with the row's own click target.
- */
+/** The "+N more" toggle stops propagation so it does not also expand the row. */
 export const ImagesCell = ({ images }: ImagesCellProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const handleToggle = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      setExpanded(prev => !prev);
+    },
+    [],
+  );
+
   if (!images?.length) {
     return <EmptyCell />;
   }
 
   const [primary, ...rest] = images;
+  const moreCount = rest.length;
 
   return (
-    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
-      <Box sx={{ minWidth: 0 }}>
-        <ImageRow image={primary} />
-      </Box>
-      {rest.length > 0 && (
-        <Typography
-          component="span"
-          title={rest.map(image => `${stripRegistryPrefix(image.image)}:${image.tag}`).join(', ')}
+    <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+      <ImageRow image={primary} />
+      {moreCount > 0 && !expanded && (
+        <ButtonBase
+          onClick={handleToggle}
           sx={{
-            flexShrink: 0,
+            justifyContent: 'flex-start',
             fontFamily: tokens.fontMono,
             fontSize: 11,
             color: 'text.secondary',
+            '&:hover': { color: 'text.primary' },
           }}
         >
-          +{rest.length}
-        </Typography>
+          +{moreCount} more
+        </ButtonBase>
+      )}
+      {expanded && (
+        <>
+          {rest.map((image, index) => (
+            <ImageRow key={`${image.image}:${image.tag}:${index}`} image={image} />
+          ))}
+          <ButtonBase
+            onClick={handleToggle}
+            sx={{
+              justifyContent: 'flex-start',
+              fontFamily: tokens.fontMono,
+              fontSize: 11,
+              color: 'text.secondary',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            Show less
+          </ButtonBase>
+        </>
       )}
     </Stack>
   );

--- a/web/src/features/tasks/components/RollbackIndicator.test.tsx
+++ b/web/src/features/tasks/components/RollbackIndicator.test.tsx
@@ -36,4 +36,16 @@ describe('RollbackIndicator', () => {
     const { container } = render(<RollbackIndicator />);
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('defaults to the compact badge a table row needs', () => {
+    render(<RollbackIndicator isRollback />);
+    expect(screen.getByText('Rollback')).toHaveStyle({ height: '18px', fontSize: '10.5px' });
+  });
+
+  it('matches StatusPill at medium, so the detail header reads as one row', () => {
+    render(<RollbackIndicator isRollback size="medium" />);
+    // StatusPill is a 24px pill with 12px text; a shorter badge beside it reads
+    // as a rendering fault rather than a second label.
+    expect(screen.getByText('Rollback')).toHaveStyle({ height: '24px', fontSize: '12px' });
+  });
 });

--- a/web/src/features/tasks/components/RollbackIndicator.tsx
+++ b/web/src/features/tasks/components/RollbackIndicator.tsx
@@ -5,20 +5,31 @@ import { tokens } from '../../../theme/tokens';
 
 export interface RollbackIndicatorProps {
   readonly isRollback?: boolean;
+  /** `medium` matches StatusPill, for placing the badge beside one. */
+  readonly size?: 'small' | 'medium';
 }
+
+/** `medium` mirrors StatusPill's metrics so the two read as one row of labels. */
+const SIZES = {
+  small: { height: 18, padding: '0 6px', fontSize: 10.5, iconSize: 12, gap: '3px' },
+  medium: { height: 24, padding: '0 10px', fontSize: 12, iconSize: 14, gap: '4px' },
+} as const;
 
 /**
  * @description Chip flagging a deployment that returns to a previously deployed
- * version; renders nothing otherwise. It belongs beside the app name rather than
- * in the status cell, because a rollback qualifies the deployment, not its outcome.
+ * version; renders nothing otherwise. It qualifies the deployment rather than its
+ * outcome, so it accompanies the application name rather than the status.
+ * @param size `medium` where it sits beside a StatusPill, `small` in a table row
  */
-export const RollbackIndicator = ({ isRollback }: RollbackIndicatorProps) => {
+export const RollbackIndicator = ({ isRollback, size = 'small' }: RollbackIndicatorProps) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
 
   if (!isRollback) {
     return null;
   }
+
+  const metrics = SIZES[size];
 
   return (
     <Tooltip title="Rollback to a previously deployed version">
@@ -27,19 +38,19 @@ export const RollbackIndicator = ({ isRollback }: RollbackIndicatorProps) => {
         sx={{
           display: 'inline-flex',
           alignItems: 'center',
-          gap: '3px',
-          height: 18,
-          padding: '0 6px',
+          gap: metrics.gap,
+          height: metrics.height,
+          padding: metrics.padding,
           borderRadius: tokens.radiusPill,
           backgroundColor: isDark ? tokens.statusRunningBgDark : tokens.statusRunningBg,
           color: isDark ? tokens.statusRunningFgDark : tokens.statusRunningFg,
-          fontSize: 10.5,
+          fontSize: metrics.fontSize,
           fontWeight: 600,
           whiteSpace: 'nowrap',
           flexShrink: 0,
         }}
       >
-        <RestoreIcon aria-hidden sx={{ fontSize: 12 }} />
+        <RestoreIcon aria-hidden sx={{ fontSize: metrics.iconSize }} />
         Rollback
       </Box>
     </Tooltip>

--- a/web/src/features/tasks/components/TasksDatagrid.integration.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.integration.test.tsx
@@ -62,14 +62,15 @@ const panelRows = () =>
     .filter(row => row.querySelectorAll('td').length === 1 && row.querySelector('td[colspan]'));
 
 describe('TasksDatagrid on real react-admin', () => {
-  it('renders one reason panel per task carrying a status_reason', async () => {
+  it('renders a reason panel per task whose reason adds something', async () => {
     renderDatagrid([FAILED, CANCELLED, CLEAN]);
 
     await waitFor(() => expect(screen.getByText('payments-worker')).toBeInTheDocument());
 
-    expect(panelRows()).toHaveLength(2);
+    // Cancelled has one cause, so its reason only restates the status label.
+    expect(panelRows()).toHaveLength(1);
     expect(screen.getByText('Application deployment failed. Rollout status is not available')).toBeInTheDocument();
-    expect(screen.getByText('Cancelled by lee@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('Cancelled by lee@example.com')).toBeNull();
   });
 
   it('renders no panel for a task without a status_reason', async () => {
@@ -113,13 +114,23 @@ describe('TasksDatagrid on real react-admin', () => {
     );
   });
 
-  it('drops the separate project column, carrying the project in the app cell', async () => {
+  it('renders the full column set, with Project on its own', async () => {
     renderDatagrid([CLEAN]);
 
     await waitFor(() => expect(screen.getByText('billing')).toBeInTheDocument());
 
     const headers = screen.getAllByRole('columnheader').map(cell => cell.textContent?.trim());
-    expect(headers).toEqual(['Application', 'Status', 'Image · tag', 'Author', 'When', 'Duration']);
+    expect(headers).toEqual([
+      'Application',
+      'Project',
+      'Author',
+      'Status',
+      'Created',
+      'Updated',
+      'Duration',
+      'Images',
+      'Details',
+    ]);
     expect(screen.getByText('acme/checkout')).toBeInTheDocument();
   });
 });

--- a/web/src/features/tasks/components/TasksDatagrid.integration.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.integration.test.tsx
@@ -114,6 +114,18 @@ describe('TasksDatagrid on real react-admin', () => {
     );
   });
 
+  it('shows Created as an absolute date and Updated as a relative one', async () => {
+    renderDatagrid([CLEAN]);
+
+    await waitFor(() => expect(screen.getByText('billing')).toBeInTheDocument());
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('billing'))!;
+    // The two columns divide the labour; swapping their modes reads as a bug.
+    expect(row.querySelector('td.cell-created')!.textContent).toMatch(/\d{4}/);
+    expect(row.querySelector('td.cell-updated')!.textContent).toMatch(/ago|just now/i);
+    expect(row.querySelector('td.cell-updated')!.textContent).not.toMatch(/\d{4}/);
+  });
+
   it('renders the full column set, with Project on its own', async () => {
     renderDatagrid([CLEAN]);
 

--- a/web/src/features/tasks/components/TasksDatagrid.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.test.tsx
@@ -2,11 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
 import type { Task } from '../../../data/types';
 import { AUTHOR_MAX_WIDTH, TasksDatagrid, __testing } from './TasksDatagrid';
 import { TaskListProvider, useTaskListContext } from './TaskListContext';
-import { tokens } from '../../../theme/tokens';
 
 const sampleRecord: Task = {
   id: 'task-1',
@@ -21,7 +19,6 @@ const sampleRecord: Task = {
   ],
   status: 'deployed',
   status_reason: 'all green',
-  is_rollback: true,
 };
 
 const datagridPropsLog: Array<Record<string, unknown>> = [];
@@ -38,6 +35,7 @@ vi.mock('react-admin', () => ({
   ),
   useRecordContext: () => sampleRecord,
   useListContext: () => ({ filterValues: {} }),
+  // The failure panel's Copy button reaches for it through useCopyToClipboard.
   useNotify: () => vi.fn(),
 }));
 
@@ -45,50 +43,43 @@ const renderInRouter = (ui: ReactNode) =>
   render(<MemoryRouter>{ui}</MemoryRouter>);
 
 describe('TasksDatagrid', () => {
-  it('opens the task when a row is clicked instead of expanding it', () => {
+  it('leaves the row inert — the View button is the only way into a task', () => {
     datagridPropsLog.length = 0;
     renderInRouter(<TasksDatagrid />);
 
     const props = datagridPropsLog.at(-1);
-    expect(props).toMatchObject({ bulkActionButtons: false });
+    expect(props).toMatchObject({ bulkActionButtons: false, rowClick: false });
+    // The reason panel goes through DatagridBody, not the expand mechanism.
     expect(props?.expand).toBeUndefined();
     expect(props?.isRowExpandable).toBeUndefined();
-
-    const rowClick = props?.rowClick as (id: string) => string;
-    expect(rowClick('task-1')).toBe('/task/task-1');
+    expect(props?.body).toBeDefined();
   });
 
-  it('escapes an id that would otherwise break out of the path', () => {
-    const { rowClickToTask } = __testing;
-    expect(rowClickToTask('a/b?c')).toBe('/task/a%2Fb%3Fc');
-  });
-
-  it('renders the six task columns and no details action', () => {
+  it('renders all expected task columns in the new layout', () => {
     renderInRouter(<TasksDatagrid />);
     expect(screen.getByTestId('function-app')).toBeInTheDocument();
-    expect(screen.getByTestId('function-status')).toBeInTheDocument();
-    expect(screen.getByTestId('function-images')).toBeInTheDocument();
+    expect(screen.getByTestId('function-project')).toBeInTheDocument();
     expect(screen.getByTestId('function-author')).toHaveTextContent(sampleRecord.author);
+    expect(screen.getByTestId('function-status')).toBeInTheDocument();
     expect(screen.getByTestId('function-created')).toBeInTheDocument();
+    expect(screen.getByTestId('function-updated')).toBeInTheDocument();
     expect(screen.getByTestId('function-duration')).toBeInTheDocument();
-    expect(screen.queryByTestId('function-Details')).toBeNull();
+    expect(screen.getByTestId('function-images')).toBeInTheDocument();
+    expect(screen.getByTestId('function-Details')).toBeInTheDocument();
   });
 
-  it('drops the separate project column — the app cell carries the project', () => {
-    renderInRouter(<TasksDatagrid />);
-    expect(screen.queryByTestId('function-project')).toBeNull();
-    expect(screen.getByTestId('function-app')).toHaveTextContent('github.com/repo');
-  });
+  it('renders the failure panel beneath a row carrying a status reason', () => {
+    const { TaskRow } = __testing;
+    renderInRouter(
+      <table>
+        <tbody>
+          <TaskRow></TaskRow>
+        </tbody>
+      </table>,
+    );
 
-  it('collapses created and updated into one column', () => {
-    renderInRouter(<TasksDatagrid />);
-    expect(screen.queryByTestId('function-updated')).toBeNull();
-  });
-
-  it('moves the rollback flag out of the status cell and onto the app', () => {
-    renderInRouter(<TasksDatagrid />);
-    expect(screen.getByTestId('function-status')).not.toHaveTextContent('Rollback');
-    expect(screen.getByTestId('function-app')).toHaveTextContent('Rollback');
+    expect(screen.getByTestId('datagrid-row')).toBeInTheDocument();
+    expect(screen.getByText(sampleRecord.status_reason!)).toBeInTheDocument();
   });
 
   it('pauses auto-refresh while the cursor is over the table body', () => {
@@ -113,70 +104,25 @@ describe('TasksDatagrid', () => {
     expect(screen.getByTestId('reasons').textContent).toBe('');
   });
 
-  it('adds no pause reason for the failure panel — it is static', () => {
+  it('adds no pause reason for the failure panel — it is always open, not expanded', () => {
+    const { TaskRow } = __testing;
     const Probe = () => {
       const ctx = useTaskListContext();
       return <span data-testid="reasons">{Array.from(ctx.state.pausedReasons).join(',')}</span>;
     };
-    const { TaskRow } = __testing;
 
     renderInRouter(
       <TaskListProvider>
         <Probe />
         <table>
-          <TaskRow></TaskRow>
+          <tbody>
+            <TaskRow></TaskRow>
+          </tbody>
         </table>
       </TaskListProvider>,
     );
 
     expect(screen.getByTestId('reasons').textContent).toBe('');
-  });
-
-  describe('TaskRow', () => {
-    const { TaskRow } = __testing;
-
-    it('renders the failure panel beneath a row carrying a status reason', () => {
-      renderInRouter(
-        <table>
-          <TaskRow></TaskRow>
-        </table>,
-      );
-
-      expect(screen.getByTestId('datagrid-row')).toBeInTheDocument();
-      expect(screen.getByText('all green')).toBeInTheDocument();
-    });
-  });
-
-  describe('taskRowSx', () => {
-    const { taskRowSx } = __testing;
-    const resolve = (record: Task) => {
-      const factory = taskRowSx(record) as (theme: unknown) => Record<string, string>;
-      return factory(createTheme({ palette: { mode: 'light' } }));
-    };
-
-    it('marks a failed row with the failed edge and tint', () => {
-      const style = resolve({ ...sampleRecord, status: 'failed' });
-      expect(style.borderLeft).toBe(`4px solid ${tokens.statusFailedFg}`);
-      expect(style.backgroundColor).toBe(tokens.rowFailedBg);
-    });
-
-    it('treats an aborted task as failed — the deployment did not land', () => {
-      expect(resolve({ ...sampleRecord, status: 'aborted' }).borderLeft).toBe(
-        `4px solid ${tokens.statusFailedFg}`,
-      );
-    });
-
-    it('marks a running row with the running edge and tint', () => {
-      const style = resolve({ ...sampleRecord, status: 'in progress' });
-      expect(style.borderLeft).toBe(`4px solid ${tokens.statusRunningFg}`);
-      expect(style.backgroundColor).toBe(tokens.rowRunningBg);
-    });
-
-    it('keeps a transparent edge on a settled row so widths never shift', () => {
-      expect(resolve({ ...sampleRecord, status: 'deployed' }).borderLeft).toBe(
-        '4px solid transparent',
-      );
-    });
   });
 
   describe('AuthorCell', () => {
@@ -204,17 +150,41 @@ describe('TasksDatagrid', () => {
       expect(cell).toHaveAttribute('title', author);
     });
   });
-});
 
-describe('ThemeProvider smoke', () => {
-  it('renders the datagrid under a dark theme without throwing', () => {
-    render(
-      <MemoryRouter>
-        <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
-          <TasksDatagrid />
-        </ThemeProvider>
-      </MemoryRouter>,
-    );
-    expect(screen.getByTestId('datagrid')).toBeInTheDocument();
+  describe('ProjectCell', () => {
+    const { ProjectCell } = __testing;
+
+    it('renders an em-dash placeholder when project is empty', () => {
+      render(<ProjectCell project={null} />);
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('renders plain projects as monospace text', () => {
+      render(<ProjectCell project="infra/prod" />);
+      expect(screen.getByText('infra/prod')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).toBeNull();
+    });
+
+    it('renders URL projects as external links', () => {
+      render(<ProjectCell project="https://github.com/org/repo/" />);
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', 'https://github.com/org/repo/');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+  });
+
+  describe('ViewButton', () => {
+    const { ViewButton } = __testing;
+
+    it('navigates to the task detail page', () => {
+      renderInRouter(<ViewButton id="task-42" />);
+      expect(screen.getByRole('link', { name: /view/i })).toHaveAttribute('href', '/task/task-42');
+    });
+
+    it('escapes an id that would otherwise break out of the path', () => {
+      renderInRouter(<ViewButton id="a/b?c" />);
+      expect(screen.getByRole('link', { name: /view/i })).toHaveAttribute('href', '/task/a%2Fb%3Fc');
+    });
   });
 });

--- a/web/src/features/tasks/components/TasksDatagrid.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
+import { createTheme } from '@mui/material/styles';
 import type { Task } from '../../../data/types';
+import { tokens } from '../../../theme/tokens';
 import { AUTHOR_MAX_WIDTH, TasksDatagrid, __testing } from './TasksDatagrid';
 import { TaskListProvider, useTaskListContext } from './TaskListContext';
 
@@ -23,6 +25,9 @@ const sampleRecord: Task = {
 
 const datagridPropsLog: Array<Record<string, unknown>> = [];
 
+/** Mutable so a test can drive FilteredEmptyState down either branch. */
+const listContext: { filterValues: Record<string, unknown> } = { filterValues: {} };
+
 vi.mock('react-admin', () => ({
   Datagrid: (props: Record<string, unknown>) => {
     datagridPropsLog.push(props);
@@ -34,7 +39,7 @@ vi.mock('react-admin', () => ({
     <div data-testid={`function-${source ?? label}`}>{render(sampleRecord)}</div>
   ),
   useRecordContext: () => sampleRecord,
-  useListContext: () => ({ filterValues: {} }),
+  useListContext: () => listContext,
   // The failure panel's Copy button reaches for it through useCopyToClipboard.
   useNotify: () => vi.fn(),
 }));
@@ -123,6 +128,67 @@ describe('TasksDatagrid', () => {
     );
 
     expect(screen.getByTestId('reasons').textContent).toBe('');
+  });
+
+  describe('taskRowSx', () => {
+    const { taskRowSx } = __testing;
+    const resolve = (record: Task) => {
+      const factory = taskRowSx(record) as (theme: unknown) => Record<string, string>;
+      return factory(createTheme({ palette: { mode: 'light' } }));
+    };
+
+    it('marks a failed row with the failed edge and tint', () => {
+      const style = resolve({ ...sampleRecord, status: 'failed' });
+      expect(style.borderLeft).toBe(`4px solid ${tokens.statusFailedFg}`);
+      expect(style.backgroundColor).toBe(tokens.rowFailedBg);
+    });
+
+    it('treats an aborted task as failed — the deployment did not land', () => {
+      expect(resolve({ ...sampleRecord, status: 'aborted' }).borderLeft).toBe(
+        `4px solid ${tokens.statusFailedFg}`,
+      );
+    });
+
+    it('marks a running row with the running edge and tint', () => {
+      const style = resolve({ ...sampleRecord, status: 'in progress' });
+      expect(style.borderLeft).toBe(`4px solid ${tokens.statusRunningFg}`);
+      expect(style.backgroundColor).toBe(tokens.rowRunningBg);
+    });
+
+    it('keeps a transparent edge on a settled row so widths never shift', () => {
+      expect(resolve({ ...sampleRecord, status: 'deployed' }).borderLeft).toBe(
+        '4px solid transparent',
+      );
+    });
+  });
+
+  describe('FilteredEmptyState', () => {
+    const { FilteredEmptyState } = __testing;
+
+    it('says nothing matches the view when no filter is active', () => {
+      listContext.filterValues = {};
+      renderInRouter(
+        <TaskListProvider>
+          <FilteredEmptyState />
+        </TaskListProvider>,
+      );
+
+      expect(screen.getByText('No tasks to show')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
+    });
+
+    it('offers the clear-filters CTA once a filter is narrowing the list', () => {
+      listContext.filterValues = { status: 'failed' };
+      renderInRouter(
+        <TaskListProvider>
+          <FilteredEmptyState />
+        </TaskListProvider>,
+      );
+
+      expect(screen.getByText('No tasks match the active filters')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
+      listContext.filterValues = {};
+    });
   });
 
   describe('AuthorCell', () => {

--- a/web/src/features/tasks/components/TasksDatagrid.test.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.test.tsx
@@ -21,6 +21,7 @@ const sampleRecord: Task = {
   ],
   status: 'deployed',
   status_reason: 'all green',
+  is_rollback: true,
 };
 
 const datagridPropsLog: Array<Record<string, unknown>> = [];
@@ -128,6 +129,53 @@ describe('TasksDatagrid', () => {
     );
 
     expect(screen.getByTestId('reasons').textContent).toBe('');
+  });
+
+  it('flags a rollback in the application cell, not the status cell', () => {
+    renderInRouter(<TasksDatagrid />);
+    // The chip qualifies the deployment, so it travels with the app name.
+    expect(screen.getByTestId('function-app')).toHaveTextContent('Rollback');
+    expect(screen.getByTestId('function-status')).not.toHaveTextContent('Rollback');
+  });
+
+  describe('datagridSx', () => {
+    const { datagridSx } = __testing;
+    const resolve = (mode: 'light' | 'dark') => {
+      const theme = createTheme({ palette: { mode } });
+      const factory = datagridSx as (theme: unknown) => Record<string, Record<string, unknown>>;
+      return { sx: factory(theme), divider: theme.palette.divider };
+    };
+
+    it('paints the header rule as an inset shadow, never as a collapsed border', () => {
+      const { sx, divider } = resolve('dark');
+      const header = sx['& .RaDatagrid-headerCell'];
+      // A collapsed border belongs to the table, not the cell, so a sticky
+      // header cannot carry it and the rule renders in fragments once stuck.
+      expect(header.position).toBe('sticky');
+      expect(header.borderBottom).toBe('none');
+      expect(header.boxShadow).toBe(`inset 0 -1px 0 ${divider}`);
+    });
+
+    it('scopes the row rule to the body, which the header row is not part of', () => {
+      const { sx } = resolve('light');
+      // react-admin puts RaDatagrid-row on the header row too, so an unscoped
+      // rule hands the header the task rows' hover tint.
+      expect(sx['& .RaDatagrid-row']).toBeUndefined();
+      expect(sx['& tbody .RaDatagrid-row']).toBeDefined();
+    });
+
+    it('drops the first row top border so it does not stack with the shadow', () => {
+      const row = resolve('light').sx['& tbody .RaDatagrid-row'];
+      expect(row['&:first-of-type']).toEqual({ borderTop: 'none' });
+    });
+
+    it('tints the row hover per theme', () => {
+      const hover = (mode: 'light' | 'dark') =>
+        (resolve(mode).sx['& tbody .RaDatagrid-row']['&:hover'] as Record<string, string>)
+          .backgroundColor;
+      expect(hover('light')).toBe(tokens.rowHoverLight);
+      expect(hover('dark')).toBe(tokens.rowHoverDark);
+    });
   });
 
   describe('taskRowSx', () => {

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement, useCallback, useEffect, type ReactElement } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Link, Typography } from '@mui/material';
 import { type SxProps, type Theme } from '@mui/material/styles';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {
   Datagrid,
   DatagridBody,
@@ -9,9 +10,10 @@ import {
   useListContext,
   useRecordContext,
 } from 'react-admin';
+import { Link as RouterLink } from 'react-router-dom';
 import type { Task } from '../../../data/types';
 import { tokens } from '../../../theme/tokens';
-import { AppCell } from './AppCell';
+import { AppCell, describeProject } from './AppCell';
 import { DurationField } from './DurationField';
 import { EmptyCell } from './EmptyCell';
 import { EmptyState, EmptyStateCta } from './EmptyState';
@@ -21,19 +23,17 @@ import { TaskFailureRow } from './TaskFailureRow';
 import { TimeCell } from './TimeCell';
 import { useTaskListContext } from './TaskListContext';
 import { summariseFailure } from '../utils/failureReason';
-import { isFailedStatus, isRunningStatus } from '../utils/statusPresentation';
+import { hasInformativeReason, isFailedStatus, isRunningStatus } from '../utils/statusPresentation';
 
 /** Widest the author text may grow, in px, before the address is ellipsised. */
-export const AUTHOR_MAX_WIDTH = 180;
-
-/** Navigating a whole row means nested links and buttons must stopPropagation. */
-const rowClickToTask = (id: string | number) => `/task/${encodeURIComponent(String(id))}`;
+export const AUTHOR_MAX_WIDTH = 200;
 
 /**
- * @description The task table, shared by the recent and history views. A click
- * anywhere in a row opens that task; a row carrying a status reason is followed
- * by an always-open panel showing it. The wrapping div emits `pause('hover')`
- * so the toolbar's countdown freezes while the cursor is over the table body.
+ * @description The task table, shared by the recent and history views. The View
+ * button is the only way into a task, and a row carrying a status reason is
+ * followed by an always-open panel showing it. The wrapping div emits
+ * `pause('hover')` so the toolbar's countdown freezes while the cursor is over
+ * the table body.
  */
 export const TasksDatagrid = () => {
   const { pause, resume } = useTaskListContext();
@@ -47,7 +47,7 @@ export const TasksDatagrid = () => {
   return (
     <Box onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
     <Datagrid
-      rowClick={rowClickToTask}
+      rowClick={false}
       bulkActionButtons={false}
       body={<DatagridBody row={<TaskRow />} />}
       rowSx={taskRowSx}
@@ -60,25 +60,15 @@ export const TasksDatagrid = () => {
         sortBy="app"
         cellClassName="cell-app"
         headerClassName="cell-app"
-        render={(record: Task) => (
-          <AppCell app={record.app} project={record.project} isRollback={record.is_rollback} />
-        )}
+        render={(record: Task) => <AppCell app={record.app} isRollback={record.is_rollback} />}
       />
       <FunctionField
-        source="status"
-        label="Status"
-        sortBy="status"
-        cellClassName="cell-status"
-        headerClassName="cell-status"
-        render={(record: Task) => <StatusPill status={record.status} />}
-      />
-      <FunctionField
-        source="images"
-        label="Image · tag"
-        sortable={false}
-        cellClassName="cell-images"
-        headerClassName="cell-images"
-        render={(record: Task) => <ImagesCell images={record.images} />}
+        source="project"
+        label="Project"
+        sortBy="project"
+        cellClassName="cell-project"
+        headerClassName="cell-project"
+        render={(record: Task) => <ProjectCell project={record.project} />}
       />
       <FunctionField
         source="author"
@@ -89,12 +79,28 @@ export const TasksDatagrid = () => {
         render={(record: Task) => <AuthorCell author={record.author} />}
       />
       <FunctionField
+        source="status"
+        label="Status"
+        sortBy="status"
+        cellClassName="cell-status"
+        headerClassName="cell-status"
+        render={(record: Task) => <StatusPill status={record.status} />}
+      />
+      <FunctionField
         source="created"
-        label="When"
+        label="Created"
         sortBy="created"
-        cellClassName="cell-when"
-        headerClassName="cell-when"
-        render={(record: Task) => <TimeCell ts={record.created} />}
+        cellClassName="cell-created"
+        headerClassName="cell-created"
+        render={(record: Task) => <TimeCell ts={record.created} mode="date" />}
+      />
+      <FunctionField
+        source="updated"
+        label="Updated"
+        sortBy="updated"
+        cellClassName="cell-updated"
+        headerClassName="cell-updated"
+        render={(record: Task) => <TimeCell ts={record.updated ?? record.created} mode="relative" />}
       />
       <FunctionField
         source="duration"
@@ -103,6 +109,21 @@ export const TasksDatagrid = () => {
         cellClassName="cell-duration"
         headerClassName="cell-duration"
         render={(record: Task) => <DurationField record={record} />}
+      />
+      <FunctionField
+        source="images"
+        label="Images"
+        sortable={false}
+        cellClassName="cell-images"
+        headerClassName="cell-images"
+        render={(record: Task) => <ImagesCell images={record.images} />}
+      />
+      <FunctionField
+        label="Details"
+        sortable={false}
+        cellClassName="cell-view"
+        headerClassName="cell-view"
+        render={(record: Task) => <ViewButton id={record.id} />}
       />
     </Datagrid>
     </Box>
@@ -116,7 +137,10 @@ export const TasksDatagrid = () => {
  */
 const TaskRow = (props: Record<string, unknown>) => {
   const record = useRecordContext<Task>();
-  const summary = summariseFailure(record?.status_reason);
+  // A cancelled task's reason restates its status, so it earns no panel here.
+  const summary = hasInformativeReason(record?.status)
+    ? summariseFailure(record?.status_reason)
+    : null;
   // The panel spans every data column; the grid renders no checkbox or expander.
   const colSpan = Children.toArray(props.children as ReactElement[]).filter(isValidElement).length;
 
@@ -164,10 +188,8 @@ const datagridSx: SxProps<Theme> = theme => {
   const rowHover = theme.palette.mode === 'dark' ? tokens.rowHoverDark : tokens.rowHoverLight;
 
   return {
-    // Fixed layout, so the declared column widths hold instead of the browser
-    // redistributing slack into every column and bloating them (issue seen
-    // after the column set shrank from ten to six). Image · tag declares no
-    // width and absorbs whatever is left over.
+    // Fixed, because the always-open reason panel spans every column and its
+    // nowrap headline would otherwise set the table's width under auto layout.
     '& .RaDatagrid-table': {
       tableLayout: 'fixed',
       width: '100%',
@@ -181,43 +203,54 @@ const datagridSx: SxProps<Theme> = theme => {
       fontSize: 11,
       letterSpacing: 0.8,
       color: theme.palette.text.secondary,
-      borderBottom: `1px solid ${theme.palette.divider}`,
+      // An inset shadow, not a border — including MUI's own TableCell default:
+      // border-collapse hands the border to the table, which a sticky cell
+      // cannot carry, so it renders in fragments once the header sticks.
+      borderBottom: 'none',
+      boxShadow: `inset 0 -1px 0 ${theme.palette.divider}`,
     },
-    // Each row draws the divider ABOVE itself, not below. A reason panel is not
-    // a .RaDatagrid-row, so no line is drawn between a row and its own panel,
-    // while the next task's own top border still closes the block off.
-    '& .RaDatagrid-row': {
+    // Scoped to the body — react-admin puts RaDatagrid-row on the header row too.
+    // Each row draws the divider ABOVE itself, not below: a reason panel is not
+    // a .RaDatagrid-row, so no line falls between a row and its own panel, while
+    // the next task's own top border still closes the block off.
+    '& tbody .RaDatagrid-row': {
       borderTop: `1px solid ${theme.palette.divider}`,
-      cursor: 'pointer',
       transition: theme.transitions.create('background-color', {
         duration: theme.transitions.duration.shortest,
       }),
       '&:hover': {
         backgroundColor: rowHover,
       },
+      // The header rule is a shadow, which does not collapse with this border;
+      // both together would stack into a 2px line.
+      '&:first-of-type': {
+        borderTop: 'none',
+      },
     },
     '& .RaDatagrid-cell': {
       paddingTop: theme.spacing(1.25),
       paddingBottom: theme.spacing(1.25),
     },
-    '& .cell-app': { width: 290 },
-    '& .cell-status': { width: 150 },
-    // No width: this is the column that takes up the remaining space.
-    '& .cell-images': { minWidth: 200 },
+    // Definite widths, not min/max: a fixed layout ignores both.
+    '& .cell-app': { width: 240 },
+    '& .cell-project': { width: 220 },
     '& .cell-author': { width: AUTHOR_MAX_WIDTH },
-    '& .cell-when': {
-      width: 150,
-      textAlign: 'right',
+    '& .cell-status': { width: 156 },
+    '& .cell-created': {
+      width: 200,
       fontVariantNumeric: 'tabular-nums',
     },
-    '& .cell-duration': {
-      width: 100,
-      textAlign: 'right',
+    '& .cell-updated': {
+      width: 130,
       fontVariantNumeric: 'tabular-nums',
     },
-    // MUI left-aligns a header cell regardless of its column's own alignment.
-    '& .RaDatagrid-headerCell.cell-when, & .RaDatagrid-headerCell.cell-duration': {
+    '& .cell-duration': { width: 110, fontVariantNumeric: 'tabular-nums' },
+    '& .cell-images': { width: 280 },
+    '& .cell-view': {
+      width: 96,
       textAlign: 'right',
+      paddingLeft: 0,
+      paddingRight: theme.spacing(1.5),
     },
   };
 };
@@ -248,11 +281,66 @@ const AuthorCell = ({ author }: { author?: string | null }) => {
   );
 };
 
+const ProjectCell = ({ project }: { project?: string | null }) => {
+  if (!project) {
+    return <EmptyCell />;
+  }
+  const info = describeProject(project);
+  if (info.isUrl && info.href) {
+    return (
+      <Link
+        href={info.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        underline="hover"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.25,
+          fontFamily: tokens.fontMono,
+          fontSize: 12,
+          color: 'text.secondary',
+          maxWidth: '100%',
+        }}
+      >
+        <Box
+          component="span"
+          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {info.label}
+        </Box>
+        <OpenInNewIcon sx={{ fontSize: 12 }} />
+      </Link>
+    );
+  }
+  return (
+    <Typography
+      variant="body2"
+      sx={{ fontFamily: tokens.fontMono, fontSize: 12, color: 'text.secondary' }}
+      noWrap
+      title={info.label}
+    >
+      {info.label}
+    </Typography>
+  );
+};
+
+/** The only way into a task from the list: the row itself does not navigate. */
+const ViewButton = ({ id }: { id: string }) => (
+  <Button
+    component={RouterLink}
+    to={`/task/${encodeURIComponent(id)}`}
+    size="small"
+    variant="outlined"
+  >
+    View
+  </Button>
+);
+
 /**
- * The "Clear filters" CTA drains all three sinks (URL, storage, react-admin
- * filterValues) via the page's registered clearAll handler — react-admin's
- * default ListNoResults only resets filterValues, leaving the toolbar chips
- * stuck.
+ * @description The "Clear filters" CTA drains all three sinks (URL, storage,
+ * filterValues) through the page's clearAll handler — react-admin's default
+ * ListNoResults resets only filterValues, leaving the toolbar chips stuck.
  */
 const FilteredEmptyState = () => {
   const { filterValues } = useListContext();
@@ -281,8 +369,9 @@ const FilteredEmptyState = () => {
 
 export const __testing = {
   AuthorCell,
+  ProjectCell,
   TaskRow,
+  ViewButton,
   datagridSx,
-  rowClickToTask,
   taskRowSx,
 };

--- a/web/src/features/tasks/components/TasksDatagrid.tsx
+++ b/web/src/features/tasks/components/TasksDatagrid.tsx
@@ -23,7 +23,7 @@ import { TaskFailureRow } from './TaskFailureRow';
 import { TimeCell } from './TimeCell';
 import { useTaskListContext } from './TaskListContext';
 import { summariseFailure } from '../utils/failureReason';
-import { hasInformativeReason, isFailedStatus, isRunningStatus } from '../utils/statusPresentation';
+import { isFailedStatus, isRunningStatus, statusExplainsItself } from '../utils/statusPresentation';
 
 /** Widest the author text may grow, in px, before the address is ellipsised. */
 export const AUTHOR_MAX_WIDTH = 200;
@@ -137,10 +137,10 @@ export const TasksDatagrid = () => {
  */
 const TaskRow = (props: Record<string, unknown>) => {
   const record = useRecordContext<Task>();
-  // A cancelled task's reason restates its status, so it earns no panel here.
-  const summary = hasInformativeReason(record?.status)
-    ? summariseFailure(record?.status_reason)
-    : null;
+  // A cancelled task's pill already names its only cause, so it earns no panel.
+  const summary = statusExplainsItself(record?.status)
+    ? null
+    : summariseFailure(record?.status_reason);
   // The panel spans every data column; the grid renders no checkbox or expander.
   const colSpan = Children.toArray(props.children as ReactElement[]).filter(isValidElement).length;
 
@@ -369,6 +369,7 @@ const FilteredEmptyState = () => {
 
 export const __testing = {
   AuthorCell,
+  FilteredEmptyState,
   ProjectCell,
   TaskRow,
   ViewButton,

--- a/web/src/features/tasks/components/TimeCell.test.tsx
+++ b/web/src/features/tasks/components/TimeCell.test.tsx
@@ -25,34 +25,26 @@ describe('TimeCell', () => {
   });
 
   it('renders an em-dash when ts is missing', () => {
-    render(<TimeCell ts={null} />);
+    render(<TimeCell ts={null} mode="date" />);
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
-  it('stacks the relative time over the exact clock time', () => {
+  it('renders the full date with year and seconds in "date" mode', () => {
     const ts = Math.floor(new Date('2026-04-27T14:12:08Z').getTime() / 1000);
-    render(<TimeCell ts={ts} />);
+    render(<TimeCell ts={ts} mode="date" />);
 
-    expect(screen.getByText(`relative-${ts}`)).toBeInTheDocument();
+    const passed = formatDateMock.mock.calls[0][1] as Intl.DateTimeFormatOptions;
+    expect(passed.year).toBe('numeric');
+    expect(passed.second).toBe('2-digit');
     expect(screen.getByText('formatted')).toBeInTheDocument();
+    expect(screen.queryByText(`relative-${ts}`)).toBeNull();
   });
 
-  it('shows only hours, minutes and seconds on the exact line', () => {
+  it('renders the relative-to-now string in "relative" mode', () => {
     const ts = Math.floor(new Date('2026-04-27T14:12:08Z').getTime() / 1000);
-    render(<TimeCell ts={ts} />);
+    render(<TimeCell ts={ts} mode="relative" />);
 
-    const optionSets = formatDateMock.mock.calls.map(call => call[1] as Intl.DateTimeFormatOptions);
-    const clockOnly = optionSets.find(options => options.year === undefined);
-    expect(clockOnly).toMatchObject({ hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
-  });
-
-  it('carries the full timestamp as a tooltip for the ambiguous relative line', () => {
-    const ts = Math.floor(new Date('2026-04-27T14:12:08Z').getTime() / 1000);
-    formatDateMock.mockImplementation((_value: number, options: Intl.DateTimeFormatOptions) =>
-      options.year ? 'full-timestamp' : 'clock-only',
-    );
-    render(<TimeCell ts={ts} />);
-
-    expect(screen.getByTitle('full-timestamp')).toBeInTheDocument();
+    expect(formatDateMock).not.toHaveBeenCalled();
+    expect(screen.getByText(`relative-${ts}`)).toBeInTheDocument();
   });
 });

--- a/web/src/features/tasks/components/TimeCell.tsx
+++ b/web/src/features/tasks/components/TimeCell.tsx
@@ -1,55 +1,53 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useTimezone } from '../../../shared/providers/TimezoneProvider';
 import { formatRelativeTime } from '../../../shared/utils/time';
 import { tokens } from '../../../theme/tokens';
 import { EmptyCell } from './EmptyCell';
 
+export type TimeCellMode = 'date' | 'relative';
+
 interface TimeCellProps {
   readonly ts?: number | null;
+  readonly mode: TimeCellMode;
 }
 
-const CLOCK_FORMAT: Intl.DateTimeFormatOptions = {
+const FULL_FORMAT: Intl.DateTimeFormatOptions = {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
   hour12: false,
 };
 
-const FULL_FORMAT: Intl.DateTimeFormatOptions = {
-  day: '2-digit',
-  month: 'short',
-  year: 'numeric',
-  ...CLOCK_FORMAT,
-};
-
 /**
- * @description The list's "When" column: relative time over the exact clock
- * time, so a row reads at a glance and still pins down the moment. The full
- * date lives in the tooltip, since "3 days ago" alone loses the day.
+ * The Created column passes `mode="date"`; the Updated column passes
+ * `mode="relative"`.
  */
-export const TimeCell = ({ ts }: TimeCellProps) => {
+export const TimeCell = ({ ts, mode }: TimeCellProps) => {
   const { formatDate } = useTimezone();
   if (ts == null) {
     return <EmptyCell />;
   }
 
-  return (
-    <Box title={formatDate(ts, FULL_FORMAT)}>
-      <Typography variant="body2" sx={{ fontSize: 13, lineHeight: 1.2 }}>
-        {formatRelativeTime(ts)}
-      </Typography>
+  if (mode === 'relative') {
+    return (
       <Typography
         variant="body2"
-        sx={{
-          fontFamily: tokens.fontMono,
-          fontSize: 11,
-          color: 'text.secondary',
-          lineHeight: 1.3,
-          fontVariantNumeric: 'tabular-nums',
-        }}
+        sx={{ fontSize: 12.5, color: 'text.secondary', fontFamily: tokens.fontMono, fontVariantNumeric: 'tabular-nums' }}
       >
-        {formatDate(ts, CLOCK_FORMAT)}
+        {formatRelativeTime(ts)}
       </Typography>
-    </Box>
+    );
+  }
+
+  return (
+    <Typography
+      variant="body2"
+      sx={{ fontSize: 13, lineHeight: 1.2, fontVariantNumeric: 'tabular-nums' }}
+    >
+      {formatDate(ts, FULL_FORMAT)}
+    </Typography>
   );
 };

--- a/web/src/features/tasks/show/components/TaskHeader.tsx
+++ b/web/src/features/tasks/show/components/TaskHeader.tsx
@@ -80,7 +80,7 @@ export const TaskHeader = ({
             {app}
           </Typography>
           <StatusPill status={task.status} />
-          <RollbackIndicator isRollback={task.is_rollback} />
+          <RollbackIndicator isRollback={task.is_rollback} size="medium" />
         </Stack>
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap', mt: 0.5 }}>
           {task.id && <CopyChip value={task.id} label="Task id" />}

--- a/web/src/features/tasks/utils/statusPresentation.test.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.test.tsx
@@ -158,21 +158,21 @@ describe('isFailedStatus / isRunningStatus', () => {
       expect(isRunningStatus(status)).toBe(false);
     }
   });
+});
 
-  describe('statusExplainsItself', () => {
-    it('claims cancelled, whose pill names its only cause', () => {
-      expect(statusExplainsItself('cancelled')).toBe(true);
-    });
+describe('statusExplainsItself', () => {
+  it('claims cancelled, whose pill names its only cause', () => {
+    expect(statusExplainsItself('cancelled')).toBe(true);
+  });
 
-    it('claims no status whose reason carries a diagnosis', () => {
-      for (const status of ['failed', 'aborted', 'app not found', 'deployed', 'in progress']) {
-        expect(statusExplainsItself(status), status).toBe(false);
-      }
-    });
+  it('claims no status whose reason carries a diagnosis', () => {
+    for (const status of ['failed', 'aborted', 'app not found', 'deployed', 'in progress']) {
+      expect(statusExplainsItself(status), status).toBe(false);
+    }
+  });
 
-    it('claims nothing when the status is missing', () => {
-      expect(statusExplainsItself(undefined)).toBe(false);
-      expect(statusExplainsItself(null)).toBe(false);
-    });
+  it('claims nothing when the status is missing', () => {
+    expect(statusExplainsItself(undefined)).toBe(false);
+    expect(statusExplainsItself(null)).toBe(false);
   });
 });

--- a/web/src/features/tasks/utils/statusPresentation.test.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   describeTaskStatus,
-  hasInformativeReason,
+  statusExplainsItself,
   isFailedStatus,
   isRunningStatus,
   type TaskStatusPresentation,
@@ -159,20 +159,20 @@ describe('isFailedStatus / isRunningStatus', () => {
     }
   });
 
-  describe('hasInformativeReason', () => {
-    it('withholds a panel from cancelled, whose reason restates the status', () => {
-      expect(hasInformativeReason('cancelled')).toBe(false);
+  describe('statusExplainsItself', () => {
+    it('claims cancelled, whose pill names its only cause', () => {
+      expect(statusExplainsItself('cancelled')).toBe(true);
     });
 
-    it('keeps the panel for every status whose reason carries a diagnosis', () => {
+    it('claims no status whose reason carries a diagnosis', () => {
       for (const status of ['failed', 'aborted', 'app not found', 'deployed', 'in progress']) {
-        expect(hasInformativeReason(status), status).toBe(true);
+        expect(statusExplainsItself(status), status).toBe(false);
       }
     });
 
-    it('keeps the panel when the status is missing — nothing says it is redundant', () => {
-      expect(hasInformativeReason(undefined)).toBe(true);
-      expect(hasInformativeReason(null)).toBe(true);
+    it('claims nothing when the status is missing', () => {
+      expect(statusExplainsItself(undefined)).toBe(false);
+      expect(statusExplainsItself(null)).toBe(false);
     });
   });
 });

--- a/web/src/features/tasks/utils/statusPresentation.test.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.test.tsx
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { describeTaskStatus, isFailedStatus, isRunningStatus, type TaskStatusPresentation } from './statusPresentation';
+import {
+  describeTaskStatus,
+  hasInformativeReason,
+  isFailedStatus,
+  isRunningStatus,
+  type TaskStatusPresentation,
+} from './statusPresentation';
 
 type StatusExpectation = Pick<
   TaskStatusPresentation,
@@ -151,5 +157,22 @@ describe('isFailedStatus / isRunningStatus', () => {
     for (const status of ['deployed', 'failed', 'accepted', 'In Progress']) {
       expect(isRunningStatus(status)).toBe(false);
     }
+  });
+
+  describe('hasInformativeReason', () => {
+    it('withholds a panel from cancelled, whose reason restates the status', () => {
+      expect(hasInformativeReason('cancelled')).toBe(false);
+    });
+
+    it('keeps the panel for every status whose reason carries a diagnosis', () => {
+      for (const status of ['failed', 'aborted', 'app not found', 'deployed', 'in progress']) {
+        expect(hasInformativeReason(status), status).toBe(true);
+      }
+    });
+
+    it('keeps the panel when the status is missing — nothing says it is redundant', () => {
+      expect(hasInformativeReason(undefined)).toBe(true);
+      expect(hasInformativeReason(null)).toBe(true);
+    });
   });
 });

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -145,4 +145,4 @@ const SELF_EXPLANATORY_STATUSES: ReadonlySet<string> = new Set(['cancelled']);
  * @returns true for a status the pill fully explains on its own
  */
 export const statusExplainsItself = (status?: string | null): boolean =>
-  Boolean(status) && SELF_EXPLANATORY_STATUSES.has(status!);
+  SELF_EXPLANATORY_STATUSES.has(status ?? '');

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -135,14 +135,14 @@ export const isFailedStatus = (status?: string | null): boolean =>
 
 export const isRunningStatus = (status?: string | null): boolean => status === 'in progress';
 
-/** Statuses with exactly one cause, whose reason only restates the status label. */
+/** Statuses with exactly one cause, which the pill already names in full. */
 const SELF_EXPLANATORY_STATUSES: ReadonlySet<string> = new Set(['cancelled']);
 
 /**
- * @description Whether a task's stored reason tells a reader anything its status
- * label does not, and so earns a panel in the list.
+ * @description Whether the status pill already conveys the task's single cause,
+ * so the list can withhold a reason panel that would only repeat it.
  * @param status the task's status
- * @returns false for a status that already explains itself
+ * @returns true for a status the pill fully explains on its own
  */
-export const hasInformativeReason = (status?: string | null): boolean =>
-  !status || !SELF_EXPLANATORY_STATUSES.has(status);
+export const statusExplainsItself = (status?: string | null): boolean =>
+  Boolean(status) && SELF_EXPLANATORY_STATUSES.has(status!);

--- a/web/src/features/tasks/utils/statusPresentation.tsx
+++ b/web/src/features/tasks/utils/statusPresentation.tsx
@@ -134,3 +134,15 @@ export const isFailedStatus = (status?: string | null): boolean =>
   Boolean(status) && FAILED_STATUSES.has(status!);
 
 export const isRunningStatus = (status?: string | null): boolean => status === 'in progress';
+
+/** Statuses with exactly one cause, whose reason only restates the status label. */
+const SELF_EXPLANATORY_STATUSES: ReadonlySet<string> = new Set(['cancelled']);
+
+/**
+ * @description Whether a task's stored reason tells a reader anything its status
+ * label does not, and so earns a panel in the list.
+ * @param status the task's status
+ * @returns false for a status that already explains itself
+ */
+export const hasInformativeReason = (status?: string | null): boolean =>
+  !status || !SELF_EXPLANATORY_STATUSES.has(status);


### PR DESCRIPTION
Puts the task list's columns, widths and cells back to the 1.2.0 shape — Project on its own, Created absolute, Updated relative, single-line rows — and adds the two rollback fields the single-task endpoint never returned.

The table stays `table-layout: fixed` rather than reverting to 1.2.0's auto layout: the reason panel is now always open and spans every column, so its nowrap headline would set the table width. Consequence is a horizontal scrollbar below ~1610px, which 1.2.0 also had below ~1552px.

`is_rollback` and `rollback_target_id` are additions to the `TaskStatus` response, so the generated Swagger spec is stale until `task docs` can run — it currently fails on swag 1.16.6 being unable to parse Go 1.27's `math/rand/v2`.