### PR TITLE
docs: lead with waiting for an Argo CD deployment from CI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,7 +60,7 @@ dockers_v2:
     annotations:
       org.opencontainers.image.created: "{{.Date}}"
       org.opencontainers.image.title: argo-watcher
-      org.opencontainers.image.description: "A feedback loop for your GitOps workflow, bridging CI pipelines and Argo CD."
+      org.opencontainers.image.description: "Wait for an Argo CD deployment from your CI pipeline, and learn whether the image you built rolled out."
       org.opencontainers.image.revision: "{{.FullCommit}}"
       org.opencontainers.image.version: "{{.Version}}"
       org.opencontainers.image.source: "{{.GitURL}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A new guide, **Wait for an Argo CD Deployment from CI**, compares Argo Watcher with
+  `argocd app wait`, polling the Argo CD API, and `kubectl rollout status`, and spells out what the
+  client waits for and how the common task outcomes reach the pipeline.
+
+### Changed
+
+- The README, documentation home page, OpenAPI description, and container image label now lead with
+  the concrete problem — waiting for an Argo CD deployment from a CI pipeline and learning whether
+  the built image rolled out — instead of the "feedback loop for GitOps" tagline. The README gains a
+  short **Why not `argocd app wait`?** section pointing at the new guide.
+
+### Fixed
+
+- The Web UI browser tab is titled "Argo Watcher" on first load instead of "Argo Watcher
+  React-admin".
+- The troubleshooting page no longer lists an uncommitted tag as a cause of "Image is not part of
+  application" — that check compares image names only — and the task lifecycle table notes that a
+  `cancelled` task still exits non-zero.
+
 ## [1.3.0] - 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Argo Watcher watches the Argo CD application for the images the pipeline just bu
 
 `argocd app wait` waits for an application to be `Synced` and `Healthy`. It has no argument for a revision or an image tag, so if Argo CD has not picked up your commit yet, the previous revision already satisfies it and the command returns success for a deployment that has not started. It also needs the `argocd` CLI and an Argo CD token in every pipeline.
 
-Argo Watcher waits for the application to be `Synced` and `Healthy` **with the image tag you built running**, fails fast when the application finishes rolling out without declaring that image name at all, and keeps every deployment as history in the Web UI. Pipelines need only the server URL and an optional deploy token. The full comparison, including polling the API and `kubectl rollout status`, is in [Wait for an Argo CD Deployment from CI](https://argo-watcher.readthedocs.io/en/latest/guides/ci-pipeline-wait/).
+Argo Watcher waits until the image tag you built is running in a `Synced` and `Healthy` application, and keeps every deployment as history in the Web UI. Pipelines need only the server URL and an optional deploy token. The full comparison, including polling the API and `kubectl rollout status`, is in [Wait for an Argo CD Deployment from CI](https://argo-watcher.readthedocs.io/en/latest/guides/ci-pipeline-wait/).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Argo Watcher
 
-**A feedback loop for your GitOps workflow.**
+**Wait for an Argo CD deployment from your CI pipeline, and learn whether the image you just built rolled out.**
 
-Argo Watcher bridges the gap between your CI pipeline and Argo CD, providing real-time status and visibility into your deployments. No more "fire-and-forget" deployments.
+Argo Watcher tracks Argo CD deployments for CI/CD pipelines. After a pipeline builds and pushes an image, the Argo Watcher client waits for that exact image to be deployed and exits with success or failure, so the pipeline can act on it. A feedback loop for your GitOps workflow, with an optional built-in GitOps updater.
 
 ![GitHub Actions](https://img.shields.io/github/actions/workflow/status/shini4i/argo-watcher/run-tests.yml?branch=main)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/shini4i/argo-watcher)
@@ -34,6 +34,12 @@ Argo Watcher watches the Argo CD application for the images the pipeline just bu
 - **Deployment lock** — freeze deployments on a schedule or on demand.
 - **Notifications** — webhook or Mattermost, on deployment start and result.
 - **Authentication** — a deploy token or JWT for pipelines, any OIDC provider (Keycloak, Authentik, …) for the Web UI.
+
+## Why not `argocd app wait`?
+
+`argocd app wait` waits for an application to be `Synced` and `Healthy`. It has no argument for a revision or an image tag, so if Argo CD has not picked up your commit yet, the previous revision already satisfies it and the command returns success for a deployment that has not started. It also needs the `argocd` CLI and an Argo CD token in every pipeline.
+
+Argo Watcher waits for the application to be `Synced` and `Healthy` **with the image tag you built running**, fails fast when the application finishes rolling out without declaring that image name at all, and keeps every deployment as history in the Web UI. Pipelines need only the server URL and an optional deploy token. The full comparison, including polling the API and `kubectl rollout status`, is in [Wait for an Argo CD Deployment from CI](https://argo-watcher.readthedocs.io/en/latest/guides/ci-pipeline-wait/).
 
 ## Architecture
 

--- a/cmd/argo-watcher/main.go
+++ b/cmd/argo-watcher/main.go
@@ -15,7 +15,7 @@ import (
 
 // @title Argo-Watcher API
 // @version 1.0
-// @description A small tool that will help to improve deployment visibility
+// @description Track Argo CD deployments from CI pipelines and wait for an image tag to roll out.
 // @BasePath /
 func main() {
 	// Configure structured logging up front so both the --migrate and server

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -8,6 +8,8 @@ A CI pipeline builds an image, pushes it, and updates a Git repository. Argo CD 
 
 Argo Watcher watches the Argo CD application for the images the pipeline just built and reports the deployment's final state back to it — turning an asynchronous process into a result the pipeline can branch on.
 
+Coming from `argocd app wait`, API polling, or `kubectl rollout status`? [Wait for an Argo CD Deployment from CI](../guides/ci-pipeline-wait.md) compares them with Argo Watcher.
+
 ## Server, client, and updater
 
 - **Server** — the long-running service. It talks to Argo CD, persists task state, exposes the HTTP API, and serves the Web UI, which shows every task in real time.
@@ -25,7 +27,7 @@ Argo Watcher watches the Argo CD application for the images the pipeline just bu
 | `failed` | Argo CD reported a health or sync failure, `DEPLOYMENT_TIMEOUT` elapsed, or the application finished rolling out without ever declaring the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)). |
 | `app not found` | Argo CD has no application with that name, or the token cannot see it. Counted under `unconfirmed_deployment_failures`, or under `failed_deployment` in the rarer case where an application that was already confirmed disappeared mid-rollout. |
 | `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure — under `failed_deployment` when Argo CD had already confirmed the application, under `unconfirmed_deployment_failures` when it never did; `argocd_unavailable` tells you whether Argo CD was the reason. |
-| `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure. |
+| `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure in the metrics, but the client still exits non-zero. |
 
 Every terminal status also increments `deployments_total{app,result}` once the deployment ends, provided Argo CD confirmed the application — see [Observability](../operations/observability.md#metrics).
 

--- a/docs/guides/ci-pipeline-wait.md
+++ b/docs/guides/ci-pipeline-wait.md
@@ -19,7 +19,7 @@ This guide compares the ways to close that gap and explains when Argo Watcher is
 
 **It does not know about your image.** The command takes an application name and waits for `Synced` and `Healthy`. Its flags select *which* conditions to wait for (`--sync`, `--health`, `--operation`, `--suspended`, `--degraded`, `--delete`, `--hydrated`) and *which* resources to watch (`--resource`, `--selector`). None of them names a revision or an image tag. If Argo CD has not noticed your commit yet, the application is still `Synced` and `Healthy` on the previous revision, that condition is already met, and the command returns success for a deployment that has not started.
 
-**It reports a state, not an outcome.** When it does time out, you know the application is unhealthy — not whether your image was ever part of it, whether a newer deployment replaced yours, or what the failing resource was. Argo Watcher fails a task as soon as the application finishes rolling out without declaring the requested image, and records the reason ([Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)).
+**It reports a state, not an outcome.** When it does time out, all you have is an exit code in one pipeline log. Argo Watcher records every deployment as a task with its final status and reason, so the outcome outlives the pipeline run and sits in the Web UI next to the deployments before and after it.
 
 **It lives in the pipeline.** Every project's CI needs the `argocd` binary and an Argo CD token with read access to its applications. Argo Watcher holds the single Argo CD token; pipelines talk to Argo Watcher with a URL and an optional [deploy token](../reference/api.md#authentication).
 

--- a/docs/guides/ci-pipeline-wait.md
+++ b/docs/guides/ci-pipeline-wait.md
@@ -35,6 +35,8 @@ A task names the application, the images, and the tag the pipeline expects. The 
 
 The full list of states is in [Concepts](../getting-started/concepts.md#task-lifecycle).
 
+Two opt-ins relax the check. The [`argo-watcher/fire-and-forget`](../reference/annotations.md) annotation marks a task `deployed` without monitoring the rollout, and [`ACCEPT_SUSPENDED_APP`](../reference/server-env.md#core) treats a `Synced` application whose health is `Suspended` as deployed.
+
 Beyond the exit code, every task is kept as history and shown in the Web UI, can trigger [notifications](notifications.md), is blocked by the [deployment lock](deployment-lock.md), and can carry the image-tag commit itself through the [GitOps Updater](gitops-updater.md).
 
 ## Minimal pipeline step

--- a/docs/guides/ci-pipeline-wait.md
+++ b/docs/guides/ci-pipeline-wait.md
@@ -1,0 +1,58 @@
+# Wait for an Argo CD Deployment from CI
+
+Your pipeline builds an image, pushes it, and commits the new tag to the GitOps repository. Argo CD deploys it. The pipeline finishes long before the rollout does, so it cannot tell you whether the image you built is running.
+
+This guide compares the ways to close that gap and explains when Argo Watcher is the right one.
+
+## The options
+
+| Approach | What it waits for | Knows which image you built | Needs in every pipeline |
+|---|---|---|---|
+| `argocd app wait` | The Application to be `Synced` and `Healthy` | No | The `argocd` CLI and an Argo CD account token |
+| Polling the Argo CD API | Whatever you script — usually the same two states | Only if you write the check yourself | An Argo CD account token and the polling script |
+| `kubectl rollout status` | One workload's current rollout to finish | No | Cluster credentials, which the GitOps pull model exists to avoid |
+| Argo Watcher client | The Application to be `Synced` and `Healthy` **with your image tag among its running images** | Yes | The server URL and, optionally, a deploy token |
+
+## Why not `argocd app wait`?
+
+`argocd app wait` is the right tool when the pipeline itself runs `argocd app sync` and owns the deployment end to end. In a GitOps setup the pipeline only commits, and the command falls short in three ways.
+
+**It does not know about your image.** The command takes an application name and waits for `Synced` and `Healthy`. Its flags select *which* conditions to wait for (`--sync`, `--health`, `--operation`, `--suspended`, `--degraded`, `--delete`, `--hydrated`) and *which* resources to watch (`--resource`, `--selector`). None of them names a revision or an image tag. If Argo CD has not noticed your commit yet, the application is still `Synced` and `Healthy` on the previous revision, that condition is already met, and the command returns success for a deployment that has not started.
+
+**It reports a state, not an outcome.** When it does time out, you know the application is unhealthy — not whether your image was ever part of it, whether a newer deployment replaced yours, or what the failing resource was. Argo Watcher fails a task as soon as the application finishes rolling out without declaring the requested image, and records the reason ([Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)).
+
+**It lives in the pipeline.** Every project's CI needs the `argocd` binary and an Argo CD token with read access to its applications. Argo Watcher holds the single Argo CD token; pipelines talk to Argo Watcher with a URL and an optional [deploy token](../reference/api.md#authentication).
+
+The same three points apply to a hand-written polling loop against the Argo CD API, plus the cost of maintaining it.
+
+## What Argo Watcher checks
+
+A task names the application, the images, and the tag the pipeline expects. The server polls Argo CD until it can report an outcome to the client, which exits with a matching status code. The three you will meet most often:
+
+- `deployed` — the application is `Synced` and `Healthy` and the requested images carry the requested tag.
+- `failed` — Argo CD reported a health or sync failure, the deployment timed out, or the application rolled out without the requested image.
+- `cancelled` — a newer deployment of one of the same images superseded this one. The metrics do not count it as a deployment failure, but the client still exits non-zero.
+
+The full list of states is in [Concepts](../getting-started/concepts.md#task-lifecycle).
+
+Beyond the exit code, every task is kept as history and shown in the Web UI, can trigger [notifications](notifications.md), is blocked by the [deployment lock](deployment-lock.md), and can carry the image-tag commit itself through the [GitOps Updater](gitops-updater.md).
+
+## Minimal pipeline step
+
+The client is a container image that reads everything from the environment ([full list](../reference/client-env.md)). A GitLab CI job:
+
+```yaml
+watch:
+  image: ghcr.io/shini4i/argo-watcher-client:<VERSION>
+  variables:
+    ARGO_WATCHER_URL: https://argo-watcher.example.com
+    ARGO_APP: example
+    IMAGES: $CI_REGISTRY_IMAGE
+    IMAGE_TAG: $CI_COMMIT_SHORT_SHA
+    COMMIT_AUTHOR: $GITLAB_USER_EMAIL
+    PROJECT_NAME: $CI_PROJECT_PATH
+  script:
+    - /client
+```
+
+Complete GitLab CI and GitHub Actions examples, including the build step, are in [Installation](install.md#run-the-client-in-ci).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,6 +2,7 @@
 
 Step-by-step instructions for common tasks and integrations.
 
+- **[Wait for an Argo CD Deployment from CI](ci-pipeline-wait.md)** — Make a pipeline wait for the image it built, and see how that differs from `argocd app wait`.
 - **[Installation](install.md)** — Deploy the server with Helm and wire the client into your pipeline.
 - **[GitOps Updater](gitops-updater.md)** — Use Argo Watcher to update image tags in your Git repository.
 - **[Notifications](notifications.md)** — Report deployments to a webhook or Mattermost.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ hide:
 
 # Argo Watcher
 
-**A feedback loop for your GitOps workflow.**
+**Wait for an Argo CD deployment from your CI pipeline, and learn whether the image you just built rolled out.**
 
-Argo Watcher bridges the gap between your CI pipeline and Argo CD, providing real-time status and visibility into your deployments. Stop guessing whether your deployment succeeded — Argo Watcher tells your pipeline exactly what happened.
+Argo Watcher tracks Argo CD deployments for CI/CD pipelines. After a pipeline builds and pushes an image, the Argo Watcher client waits for that exact image to be deployed and exits with success or failure, so the pipeline can act on it. A feedback loop for your GitOps workflow, with an optional built-in GitOps updater. Coming from `argocd app wait`? Start with [Wait for an Argo CD Deployment from CI](guides/ci-pipeline-wait.md).
 
 If a page looks wrong, [open an issue](https://github.com/shini4i/argo-watcher/issues) or use the pencil icon at the top right to suggest a fix.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -131,13 +131,14 @@ curl -sSI "$ARGO_WATCHER_URL/api/v1/config"
 
 **Symptom:** the deployment fails immediately with `Image "<name>" is not part of application "<app>"`, followed by the images the application does declare.
 
-**Meaning:** the application finished rolling out — synced and healthy — but its desired state never declares the requested image, so waiting would only burn the timeout. The desired state comes from Argo CD's managed resources, not from running pods, so a workload with no pod yet (an untriggered `CronJob`, a `Deployment` scaled to zero) still counts as declaring its image.
+**Meaning:** the application finished rolling out — synced and healthy — but its desired state never declares the requested image, so waiting would only burn the timeout. The check compares image names and ignores the tag. The desired state comes from Argo CD's managed resources, not from running pods, so a workload with no pod yet (an untriggered `CronJob`, a `Deployment` scaled to zero) still counts as declaring its image.
 
 **Likely causes**
 
 - The image name is misspelled, or its registry prefix does not match the manifests.
 - The deployment targets a real but different application — it exists, so it is not `app not found`, but it does not contain this image.
-- The tag was never committed: see [Image tag is never committed](#image-tag-is-never-committed-write-back-skipped).
+
+An uncommitted tag does not trigger this error: the image name is still declared, so the task polls until `DEPLOYMENT_TIMEOUT` and fails with a timeout instead. See [Image tag is never committed](#image-tag-is-never-committed-write-back-skipped).
 
 **How to verify:** compare the requested image against the list in the failure reason, or run `argocd app manifests <app> | grep image:`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,10 +151,9 @@ plugins:
       markdown_description: >-
         Argo Watcher lets a CI/CD pipeline wait for an Argo CD deployment and
         learn whether the image it just built rolled out. Unlike `argocd app
-        wait`, it tracks the specific image tag, fails when the application
-        rolls out without it, and keeps every deployment as history. It can
-        also commit image tags to the GitOps repository, replacing Argo CD
-        Image Updater.
+        wait`, it waits for the specific image tag to be running and keeps
+        every deployment as history. It can also commit image tags to the
+        GitOps repository, replacing Argo CD Image Updater.
       sections:
         Getting Started:
           - getting-started/index.md: Starting point for new users.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Argo Watcher
 site_url: https://argo-watcher.readthedocs.io
-site_description: Documentation for Argo Watcher - a feedback loop for your GitOps workflow
+site_description: Documentation for Argo Watcher - wait for an Argo CD deployment from your CI pipeline and learn whether the image you built rolled out
 site_author: Vadim Gedz
 copyright: Copyright &copy; 2023 - 2026 Vadim Gedz
 
@@ -56,6 +56,7 @@ nav:
     - Concepts: 'getting-started/concepts.md'
   - Guides:
     - Overview: 'guides/index.md'
+    - Wait for a Deployment from CI: 'guides/ci-pipeline-wait.md'
     - Installation: 'guides/install.md'
     - GitOps Updater: 'guides/gitops-updater.md'
     - Notifications: 'guides/notifications.md'
@@ -148,10 +149,12 @@ plugins:
       base_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://argo-watcher.readthedocs.io/en/latest/']
       full_output: llms-full.txt
       markdown_description: >-
-        Argo Watcher is a feedback loop for your GitOps workflow. It bridges the
-        gap between your CI pipeline and Argo CD, reporting real-time deployment
-        status back to the pipeline and optionally updating image tags in your
-        GitOps repository.
+        Argo Watcher lets a CI/CD pipeline wait for an Argo CD deployment and
+        learn whether the image it just built rolled out. Unlike `argocd app
+        wait`, it tracks the specific image tag, fails when the application
+        rolls out without it, and keeps every deployment as history. It can
+        also commit image tags to the GitOps repository, replacing Argo CD
+        Image Updater.
       sections:
         Getting Started:
           - getting-started/index.md: Starting point for new users.
@@ -159,6 +162,7 @@ plugins:
           - getting-started/concepts.md: The problem Argo Watcher solves, its parts, and the task lifecycle.
         Guides:
           - guides/index.md: Index of task-oriented guides.
+          - guides/ci-pipeline-wait.md: Waiting for an Argo CD deployment from a CI pipeline, compared with argocd app wait, API polling, and kubectl.
           - guides/install.md: Installing the server and client.
           - guides/gitops-updater.md: Configuring the GitOps Updater to commit image tag changes.
           - guides/notifications.md: Sending deployment notifications via webhook or Mattermost.

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Argo Watcher React-admin</title>
+    <title>Argo Watcher</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Rewords every self-description (README, docs home, mkdocs metadata, OpenAPI description, OCI image label) around the concrete problem instead of the GitOps feedback-loop tagline, and adds a guide comparing Argo Watcher with `argocd app wait`, API polling and `kubectl rollout status`.

Also corrects two doc statements that contradicted the code: the desired-state check compares image names only, and a `cancelled` task still exits non-zero.