### PR TITLE
fix(web): show all recent tasks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The **Mine / Everyone** switch on Recent Tasks now defaults to **Everyone** for a signed-in user
+  as well. The list is read mostly by DevOps and SRE, whose first question is what the whole estate
+  is doing. Picking Mine is still remembered for your next visit. A scope remembered from 1.3.0 is
+  discarded on upgrade, because that release also recorded the default as though you had chosen it.
 - The README, documentation home page, OpenAPI description, and container image label now lead with
   the concrete problem — waiting for an Argo CD deployment from a CI pipeline and learning whether
   the built image rolled out — instead of the "feedback loop for GitOps" tagline. The README gains a
@@ -22,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Recent Tasks no longer remembers an application filter. Opening the list from an Overview card
+  filtered it to that application and kept the filter for every later visit, so returning to the
+  main page after viewing a task showed only that application's deployments. The History page still
+  remembers its application, which is picked there rather than arriving from a link.
 - The Web UI browser tab is titled "Argo Watcher" on first load instead of "Argo Watcher
   React-admin".
 - The troubleshooting page no longer lists an uncommitted tag as a cause of "Image is not part of

--- a/web/e2e/auth/task-scope.spec.ts
+++ b/web/e2e/auth/task-scope.spec.ts
@@ -11,7 +11,7 @@ const OWN_AUTHOR = 'priv-user@example.com';
  * sign-in proves the chain — token, identity, `author` query parameter, and the
  * rows the server actually returns.
  */
-test('the scope switch narrows the list to the signed-in user, and back', async ({ page, request }) => {
+test('the scope switch narrows the list to the signed-in user', async ({ page, request }) => {
   const mine = await seedTask(request, OWN_AUTHOR);
   const theirs = await seedTask(request, OTHER_AUTHOR);
   await waitForDeployed(request, mine);
@@ -21,19 +21,30 @@ test('the scope switch narrows the list to the signed-in user, and back', async 
   await page.waitForURL(url => url.href.startsWith(KEYCLOAK_ORIGIN));
   await signIn(page, PRIVILEGED_USER.username, PRIVILEGED_USER.password);
 
-  // Mine is the default for a signed-in reader who has never chosen a scope.
-  await expect(page.getByRole('tab', { name: 'Mine' })).toHaveAttribute('aria-selected', 'true');
+  // Everyone is the default for a signed-in reader who has never chosen a scope.
+  await expect(page.getByRole('tab', { name: 'Everyone' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(page.getByText(OTHER_AUTHOR).first()).toBeVisible();
+  await expect(page.getByText(OWN_AUTHOR).first()).toBeVisible();
+
+  // The shortcut is advertised only when there is an identity to scope by.
+  await expect(page.getByText('m mine')).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Mine' }).click();
+
   // The projection is server-side, so the applied filter has to name the address.
   await expect(page).toHaveURL(new RegExp(encodeURIComponent(OWN_AUTHOR)));
 
   await expect(page.getByText(OWN_AUTHOR).first()).toBeVisible();
   await expect(page.getByText(OTHER_AUTHOR)).toHaveCount(0);
 
-  // The shortcut is advertised only when there is an identity to scope by.
-  await expect(page.getByText('m mine')).toBeVisible();
+  // The choice is remembered under its own storage key, so a real page load is
+  // the only place that proves the bundle reads back the key it wrote.
+  await page.reload();
 
-  await page.getByRole('tab', { name: 'Everyone' }).click();
-
-  await expect(page.getByText(OTHER_AUTHOR).first()).toBeVisible();
-  await expect(page.getByText(OWN_AUTHOR).first()).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Mine' })).toHaveAttribute('aria-selected', 'true');
+  await expect(page).toHaveURL(new RegExp(encodeURIComponent(OWN_AUTHOR)));
+  await expect(page.getByText(OTHER_AUTHOR)).toHaveCount(0);
 });

--- a/web/src/features/tasks/components/RecentTasksToolbar.integration.test.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.integration.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { AdminContext, testDataProvider } from 'react-admin';
+import { AdminContext, memoryStore, testDataProvider } from 'react-admin';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RecentTasksToolbar } from './RecentTasksToolbar';
@@ -22,9 +22,9 @@ type ListCall = { filter?: Record<string, unknown> };
 const renderToolbar = (initialEntry: string) => {
   const getList = vi.fn(() => Promise.resolve({ data: [], total: 0 }));
 
-  render(
+  const utils = render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <AdminContext dataProvider={testDataProvider({ getList })}>
+      <AdminContext dataProvider={testDataProvider({ getList })} store={memoryStore()}>
         <TaskListLayout
           perPageStorageKey="integration.perPage"
           header={<RecentTasksToolbar storageKey="integrationRecent" />}
@@ -37,7 +37,7 @@ const renderToolbar = (initialEntry: string) => {
   );
 
   const filters = () => getList.mock.calls.map(call => (call[1] as ListCall).filter ?? {});
-  return { getList, filters, lastFilter: () => filters().at(-1) ?? {} };
+  return { ...utils, getList, filters, lastFilter: () => filters().at(-1) ?? {} };
 };
 
 describe('RecentTasksToolbar on real react-admin list params', () => {
@@ -50,7 +50,7 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
   // The regression this suite exists for: the scope must not replace the filter
   // object that the app/search filters were just written into.
   it('keeps the app filter when the scope adds an author', async () => {
-    const { lastFilter } = renderToolbar('/?app=checkout');
+    const { lastFilter } = renderToolbar('/?app=checkout&scope=mine');
 
     await waitFor(() => {
       expect(lastFilter()).toMatchObject({ app: 'checkout', author: 'jane@example.com' });
@@ -58,7 +58,7 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
   });
 
   it('keeps the search term alongside the author', async () => {
-    const { lastFilter } = renderToolbar('/?search=v1.2.3');
+    const { lastFilter } = renderToolbar('/?search=v1.2.3&scope=mine');
 
     await waitFor(() => {
       expect(lastFilter()).toMatchObject({ search: 'v1.2.3', author: 'jane@example.com' });
@@ -66,7 +66,7 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
   });
 
   it('keeps app, status and search together with the author', async () => {
-    const { lastFilter } = renderToolbar('/?app=checkout&status=failed&search=nginx');
+    const { lastFilter } = renderToolbar('/?app=checkout&status=failed&search=nginx&scope=mine');
 
     await waitFor(() => {
       expect(lastFilter()).toMatchObject({
@@ -79,7 +79,7 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
   });
 
   it('drops only the author when the reader switches to Everyone', async () => {
-    const { lastFilter } = renderToolbar('/?app=checkout');
+    const { lastFilter } = renderToolbar('/?app=checkout&scope=mine');
     await waitFor(() => expect(lastFilter()).toHaveProperty('author'));
 
     fireEvent.click(screen.getByRole('tab', { name: /Everyone/ }));
@@ -101,10 +101,11 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
     expect(screen.queryByRole('tablist', { name: 'Deployment scope' })).toBeNull();
   });
 
-  // A cold load resolves the identity after mount; the default must still land.
-  it('applies Mine once a late-arriving identity resolves', async () => {
+  // A cold load resolves the identity after mount, so a Mine chosen earlier has
+  // nothing to project onto until then; the author must land once it arrives.
+  it('projects the author once a late-arriving identity resolves', async () => {
     identity.mockReturnValue({ data: undefined, isLoading: true });
-    const { lastFilter } = renderToolbar('/?app=checkout');
+    const { lastFilter } = renderToolbar('/?app=checkout&scope=mine');
     await waitFor(() => expect(lastFilter()).toMatchObject({ app: 'checkout' }));
 
     identity.mockReturnValue({ data: { id: 'u1', email: 'jane@example.com' }, isLoading: false });
@@ -115,12 +116,90 @@ describe('RecentTasksToolbar on real react-admin list params', () => {
     });
   });
 
-  it('honours an explicit ?scope=everyone over the signed-in default', async () => {
-    const { filters, lastFilter } = renderToolbar('/?app=checkout&scope=everyone');
+  it('sends no author for a signed-in reader who has not chosen a scope', async () => {
+    const { filters, lastFilter } = renderToolbar('/?app=checkout');
 
     await waitFor(() => expect(lastFilter()).toMatchObject({ app: 'checkout' }));
+    // Let any later apply land before asserting the author never appears — the
+    // mount filter alone would settle too early to prove it.
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    expect(screen.getByRole('tab', { name: /Everyone/ })).toHaveAttribute('aria-selected', 'true');
     for (const filter of filters()) {
       expect(filter).not.toHaveProperty('author');
+    }
+  });
+
+  // The cold-load path every signed-in reader hits: the identity landing must
+  // not be mistaken for a reason to scope the list.
+  it('stays on Everyone when a late-arriving identity resolves', async () => {
+    identity.mockReturnValue({ data: undefined, isLoading: true });
+    const { filters, lastFilter } = renderToolbar('/?app=checkout');
+    await waitFor(() => expect(lastFilter()).toMatchObject({ app: 'checkout' }));
+
+    identity.mockReturnValue({ data: { id: 'u1', email: 'jane@example.com' }, isLoading: false });
+    fireEvent.click(screen.getByRole('button', { name: /refresh now/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: /Everyone/ })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      ),
+    );
+    expect(lastFilter()).toMatchObject({ app: 'checkout' });
+    for (const filter of filters()) {
+      expect(filter).not.toHaveProperty('author');
+    }
+    expect(localStorage.getItem('integrationRecent.scopeChoice')).toBeNull();
+  });
+
+  it('drops the author when the identity goes away', async () => {
+    const { lastFilter } = renderToolbar('/?app=checkout&scope=mine');
+    await waitFor(() => expect(lastFilter()).toHaveProperty('author'));
+
+    identity.mockReturnValue({ data: undefined, isLoading: false });
+    fireEvent.click(screen.getByRole('button', { name: /refresh now/i }));
+
+    await waitFor(() => expect(lastFilter()).not.toHaveProperty('author'));
+    expect(lastFilter()).toMatchObject({ app: 'checkout' });
+    expect(screen.queryByRole('tablist', { name: 'Deployment scope' })).toBeNull();
+  });
+
+  // The choice is stored, never the address, so Mine must follow whoever is
+  // signed in now rather than pinning the list to a previous reader.
+  it('re-points Mine at the new identity when the user changes', async () => {
+    const { lastFilter } = renderToolbar('/?scope=mine');
+    await waitFor(() => expect(lastFilter()).toMatchObject({ author: 'jane@example.com' }));
+
+    identity.mockReturnValue({ data: { id: 'u2', email: 'sam@example.com' }, isLoading: false });
+    fireEvent.click(screen.getByRole('button', { name: /refresh now/i }));
+
+    await waitFor(() => expect(lastFilter()).toMatchObject({ author: 'sam@example.com' }));
+    expect(JSON.stringify(localStorage)).not.toContain('@example.com');
+  });
+
+  // Recent has no application picker: an app filter only ever arrives from a
+  // link (an Overview card, a chip), so remembering it hides the rest of the
+  // estate on the next visit for a filter the reader never chose.
+  it('does not carry an app filter into a later unfiltered visit', async () => {
+    const first = renderToolbar('/?app=checkout');
+    await waitFor(() => expect(first.lastFilter()).toMatchObject({ app: 'checkout' }));
+
+    // Any apply mirrors every persisted field, so touch an unrelated filter —
+    // this is what used to write the link's app filter to storage for good.
+    fireEvent.click(screen.getByRole('tab', { name: /Failed/ }));
+    await waitFor(() => expect(first.lastFilter()).toMatchObject({ status: 'failed' }));
+    first.unmount();
+
+    const second = renderToolbar('/');
+    await waitFor(() => expect(second.getList).toHaveBeenCalled());
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    // The chip is what the reader sees; the filter is what the server is asked.
+    expect(screen.queryByText(/Remove filter app/i)).toBeNull();
+    expect(second.container.textContent).not.toContain('checkout');
+    for (const filter of second.filters()) {
+      expect(filter).not.toHaveProperty('app');
     }
   });
 

--- a/web/src/features/tasks/components/RecentTasksToolbar.test.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.test.tsx
@@ -247,9 +247,21 @@ describe('RecentTasksToolbar scope', () => {
     identityMock.mockReturnValue({ data: { id: 'u1', email: 'jane.doe@example.com' } });
   });
 
-  it('defaults a signed-in user to their own deployments', async () => {
+  it('defaults a signed-in user to every deployment', async () => {
     const { setFilters } = renderToolbar('/tasks');
 
+    expect(screen.getByRole('tab', { name: /Everyone/ })).toHaveAttribute('aria-selected', 'true');
+    await waitFor(() => expect(setFilters).toHaveBeenCalled());
+    for (const call of setFilters.mock.calls) {
+      expect(call[0]).not.toHaveProperty('author');
+    }
+  });
+
+  it('restores a stored "mine" choice on the next visit', async () => {
+    localStorage.setItem('recentTasks.scopeChoice', 'mine');
+    const { setFilters } = renderToolbar('/tasks');
+
+    expect(screen.getByRole('tab', { name: /Mine/ })).toHaveAttribute('aria-selected', 'true');
     await waitFor(() => {
       expect(setFilters).toHaveBeenCalledWith(
         expect.objectContaining({ author: 'jane.doe@example.com' }),
@@ -257,6 +269,56 @@ describe('RecentTasksToolbar scope', () => {
         false,
       );
     });
+  });
+
+  // Releases up to 1.3.0 wrote `recentTasks.scope` for readers who never chose
+  // it, so that key is not evidence of a choice and must not win the default.
+  it('ignores a scope left behind by an earlier release', async () => {
+    localStorage.setItem('recentTasks.scope', 'mine');
+    const { setFilters } = renderToolbar('/tasks');
+
+    expect(screen.getByRole('tab', { name: /Everyone/ })).toHaveAttribute('aria-selected', 'true');
+    await waitFor(() => expect(setFilters).toHaveBeenCalled());
+    for (const call of setFilters.mock.calls) {
+      expect(call[0]).not.toHaveProperty('author');
+    }
+  });
+
+  // Persisting the default would make it a "choice", which is what stopped the
+  // previous default flip from reaching anyone.
+  it('stores nothing when the scope is Everyone', async () => {
+    renderToolbar('/tasks');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Mine/ }));
+    await waitFor(() => expect(localStorage.getItem('recentTasks.scopeChoice')).toBe('mine'));
+
+    fireEvent.click(screen.getByRole('tab', { name: /Everyone/ }));
+    await waitFor(() => expect(localStorage.getItem('recentTasks.scopeChoice')).toBeNull());
+  });
+
+  // The removeItem path above would still pass if some other apply wrote the
+  // default; this covers an apply the reader made for an unrelated reason.
+  it('leaves the scope unwritten when another filter is applied', async () => {
+    renderToolbar('/tasks');
+
+    fireEvent.click(screen.getByRole('button', { name: 'failed' }));
+
+    await waitFor(() => expect(localStorage.getItem('recentTasks.app')).toBeNull());
+    expect(localStorage.getItem('recentTasks.scopeChoice')).toBeNull();
+    expect(capturedLocation?.search).not.toContain('scope=');
+  });
+
+  it('erases the remembered choice when everything is cleared', async () => {
+    localStorage.setItem('recentTasks.scopeChoice', 'mine');
+    const { setFilters } = renderToolbar('/tasks?app=alpha');
+    await screen.findByText(/jane\.doe@example\.com/);
+
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+
+    await waitFor(() => expect(localStorage.getItem('recentTasks.scopeChoice')).toBeNull());
+    expect(setFilters.mock.calls.at(-1)![0]).toEqual({});
+    expect(screen.getByRole('tab', { name: /Everyone/ })).toHaveAttribute('aria-selected', 'true');
+    expect(capturedLocation?.search).not.toContain('scope=');
   });
 
   it('hides the scope control and stays global in anonymous mode', async () => {
@@ -270,8 +332,23 @@ describe('RecentTasksToolbar scope', () => {
     }
   });
 
-  it('drops the author filter when the user switches to Everyone', async () => {
-    const { setFilters } = renderToolbar('/tasks', { author: 'jane.doe@example.com' });
+  // An OIDC deployment switched to anonymous, or the gap between sign-out and
+  // sign-in, leaves a remembered Mine with no address behind it.
+  it('ignores a remembered "mine" when there is no identity', async () => {
+    identityMock.mockReturnValue({ data: undefined });
+    localStorage.setItem('recentTasks.scopeChoice', 'mine');
+    const { setFilters } = renderToolbar('/tasks');
+
+    expect(screen.queryByRole('tablist', { name: 'Deployment scope' })).toBeNull();
+    expect(screen.queryByText(/Remove filter author/i)).toBeNull();
+    await waitFor(() => expect(setFilters).toHaveBeenCalled());
+    for (const call of setFilters.mock.calls) {
+      expect(call[0]).not.toHaveProperty('author');
+    }
+  });
+
+  it('drops the author filter when the user switches back to Everyone', async () => {
+    const { setFilters } = renderToolbar('/tasks?scope=mine', { author: 'jane.doe@example.com' });
 
     fireEvent.click(screen.getByRole('tab', { name: /Everyone/ }));
 
@@ -284,10 +361,10 @@ describe('RecentTasksToolbar scope', () => {
   it('mirrors the scope into the URL so a view can be shared', async () => {
     renderToolbar('/tasks');
 
-    fireEvent.click(screen.getByRole('tab', { name: /Everyone/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /Mine/ }));
 
     await waitFor(() => {
-      expect(capturedLocation?.search).toContain('scope=everyone');
+      expect(capturedLocation?.search).toContain('scope=mine');
     });
   });
 
@@ -296,14 +373,14 @@ describe('RecentTasksToolbar scope', () => {
   it('stores the choice, never the address', async () => {
     renderToolbar('/tasks');
 
-    fireEvent.click(screen.getByRole('tab', { name: /Everyone/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /Mine/ }));
 
-    await waitFor(() => expect(localStorage.getItem('recentTasks.scope')).toBe('everyone'));
+    await waitFor(() => expect(localStorage.getItem('recentTasks.scopeChoice')).toBe('mine'));
     expect(JSON.stringify(localStorage)).not.toContain('jane.doe@example.com');
   });
 
   it('shows the active scope as a removable chip', async () => {
-    const { setFilters } = renderToolbar('/tasks');
+    const { setFilters } = renderToolbar('/tasks?scope=mine');
 
     const chip = await screen.findByText(/jane\.doe@example\.com/);
     expect(chip).toBeInTheDocument();
@@ -316,7 +393,7 @@ describe('RecentTasksToolbar scope', () => {
   });
 
   it('scopes to the author without touching the search term', async () => {
-    const { setFilters } = renderToolbar('/tasks?search=checkout');
+    const { setFilters } = renderToolbar('/tasks?scope=mine&search=checkout');
 
     await waitFor(() => {
       const merged = setFilters.mock.calls.map(call => call[0] as Record<string, unknown>);
@@ -390,10 +467,11 @@ describe('RecentTasksToolbar keyboard shortcuts', () => {
     renderToolbar('/tasks');
 
     fireEvent.keyDown(document, { key: 'm' });
-    await waitFor(() => expect(capturedLocation?.search).toContain('scope=everyone'));
-
-    fireEvent.keyDown(document, { key: 'm' });
     await waitFor(() => expect(capturedLocation?.search).toContain('scope=mine'));
+
+    // Everyone is the default, so it leaves the URL rather than naming itself.
+    fireEvent.keyDown(document, { key: 'm' });
+    await waitFor(() => expect(capturedLocation?.search).not.toContain('scope='));
   });
 
   it('leaves a key alone while an input is focused', async () => {

--- a/web/src/features/tasks/components/RecentTasksToolbar.tsx
+++ b/web/src/features/tasks/components/RecentTasksToolbar.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Stack } from '@mui/material';
 import { useGetIdentity, useRefresh } from 'react-admin';
 import { normalizeApplicationFilterValue } from './ApplicationFilter';
-import { getBrowserWindow } from '../../../shared/utils';
 import { useFilterState, type FilterStateSchema } from '../../../shared/hooks/useFilterState';
 import { useKeyboardShortcuts } from '../../../shared/hooks/useKeyboardShortcuts';
 import { ActiveFilterBar, type FilterChipDescriptor } from './ActiveFilterBar';
@@ -30,10 +29,13 @@ const DEFAULTS: RecentFiltersValues = { app: '', status: null, search: '', scope
  * @param identityEmail signed-in address, or '' when anonymous
  */
 const buildSchema = (identityEmail: string): FilterStateSchema<RecentFiltersValues> => ({
+  // Not persisted: Recent has no application picker, so an app filter only ever
+  // arrives from a link and remembering it would hide the rest of the estate on
+  // the next visit. History persists its own, because there it is a picked value.
   app: {
     fromUrl: raw => normalizeApplicationFilterValue(raw),
     toUrl: value => value || null,
-    storage: true,
+    storage: false,
   },
   status: {
     fromUrl: raw => raw ?? null,
@@ -46,34 +48,26 @@ const buildSchema = (identityEmail: string): FilterStateSchema<RecentFiltersValu
     toUrl: value => value.trim() || null,
     storage: false,
   },
-  // Stored as the choice; the address is derived here on every apply, so a
-  // scope restored from a previous session follows whoever is signed in now.
+  // Only Mine is written, to URL and storage alike: absence means the Everyone
+  // default, so nothing pins a scope the reader never picked — and no shared
+  // link pins Everyone over their own Mine. The field is fresh because releases
+  // up to 1.3.0 auto-wrote `scope=mine` for readers who never chose it.
   scope: {
     fromUrl: raw => (raw === 'mine' ? 'mine' : 'everyone'),
-    toUrl: value => value,
+    toUrl: value => (value === 'mine' ? 'mine' : null),
     filterKey: 'author',
     toFilter: value => (value === 'mine' && identityEmail ? identityEmail : undefined),
     storage: true,
+    storageField: 'scopeChoice',
   },
 });
 
-const SCOPE_URL_KEY = 'scope';
-
-/** Whether the reader has an explicit scope choice, as opposed to the default. */
-const readExplicitScope = (storageKey: string): TaskScope | null => {
-  const fromUrl = new URLSearchParams(globalThis.location?.search ?? '').get(SCOPE_URL_KEY);
-  if (fromUrl === 'mine' || fromUrl === 'everyone') {
-    return fromUrl;
-  }
-  const stored = getBrowserWindow()?.localStorage?.getItem(`${storageKey}.${SCOPE_URL_KEY}`);
-  return stored === 'mine' || stored === 'everyone' ? stored : null;
-};
-
 /**
  * @description Filter bar for the recent list. The scope pills default to
- * "Mine" for a signed-in user, since a developer's usual question is whether
- * their own deployment landed; anonymous mode has no identity, so the control
- * is hidden and the scope stays "Everyone".
+ * "Everyone" — the readers of this list are on-call, and their usual question
+ * is what the whole estate is doing, not what they personally deployed. A
+ * chosen scope is remembered; anonymous mode has no identity to scope by, so
+ * the control is hidden.
  */
 export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?: string }) => {
   // Refresh every active query, not just the list: the status pills are backed
@@ -85,22 +79,12 @@ export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?
   const scopeAvailable = Boolean(identityEmail);
   const searchFocusRef = useRef<(() => void) | null>(null);
 
-  // Read once: whether the reader ever chose a scope, as opposed to inheriting
-  // the default. The identity may not have resolved yet on a cold load, so the
-  // default cannot be baked into the frozen `initial` below.
-  const explicitScopeRef = useRef<TaskScope | null>(readExplicitScope(storageKey));
-
-  const defaults = useMemo<RecentFiltersValues>(
-    () => ({ ...DEFAULTS, scope: explicitScopeRef.current ?? (scopeAvailable ? 'mine' : 'everyone') }),
-    [scopeAvailable],
-  );
-
   const schema = useMemo(() => buildSchema(identityEmail), [identityEmail]);
 
   const { values, applied, apply } = useFilterState<RecentFiltersValues>({
     storageKey,
     schema,
-    defaults,
+    defaults: DEFAULTS,
   });
 
   const { registerClearAll } = useTaskListContext();
@@ -108,15 +92,14 @@ export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?
   const effectiveScope: TaskScope = scopeAvailable ? applied.scope : 'everyone';
 
   // The identity arrives after mount on a cold load, so re-apply once it lands:
-  // the author projection needs it, and an unchosen scope defaults to Mine.
+  // a scope of Mine has no address to project onto until then.
   const syncedIdentityRef = useRef(identityEmail);
   useEffect(() => {
     if (syncedIdentityRef.current === identityEmail) {
       return;
     }
     syncedIdentityRef.current = identityEmail;
-    const scope = explicitScopeRef.current ?? (identityEmail ? 'mine' : 'everyone');
-    apply({ ...values, scope });
+    apply(values);
     // `apply` and `values` re-identify every render; keying on the identity is
     // what makes this fire exactly once per identity change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -138,8 +121,6 @@ export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?
 
   const handleScopeChange = useCallback(
     (next: TaskScope) => {
-      // Recording the choice stops a later identity change reverting it.
-      explicitScopeRef.current = next;
       apply({ ...values, scope: next });
     },
     [apply, values],
@@ -189,10 +170,7 @@ export const RecentTasksToolbar = ({ storageKey = 'recentTasks' }: { storageKey?
   }
 
   const handleClearAll = useCallback(() => {
-    // Clearing every filter is itself a choice of Everyone, so record it —
-    // otherwise the identity effect would restore Mine on the next mount.
-    explicitScopeRef.current = 'everyone';
-    apply({ app: '', status: null, search: '', scope: 'everyone' });
+    apply({ ...DEFAULTS });
   }, [apply]);
 
   // `apply` re-identifies on every searchParams/filterValues change, so


### PR DESCRIPTION
The Mine/Everyone switch on Recent Tasks now defaults to Everyone for a signed-in reader, and an application filter arriving from a link is no longer remembered.

The remembered scope moves to a new storage field. Releases up to 1.3.0 wrote `recentTasks.scope=mine` for readers who never chose it, so the old key cannot be read as a choice — without the rename the new default would reach nobody. That also discards a genuine pre-upgrade Mine, since the two are indistinguishable. Only Mine is written now, to URL and storage alike, so a link can no longer pin Everyone over a reader's own choice.

History keeps persisting its application filter: it has a picker, so there the value is chosen rather than link-supplied.