### PR TITLE
refactor(server): share the auth rejection path and drop global registry

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -10,7 +10,7 @@ Setting up a local environment. What a change must satisfy before it can be merg
 - **[Task](https://taskfile.dev/)** — every automation lives in `Taskfile.yml`
 - **[pre-commit](https://pre-commit.com/)** — `pre-commit install`
 
-`nix develop` provides all of the above plus the scanners CI runs (`trufflehog`, `gosec`, `govulncheck`, `trivy`, `zizmor`). Without Nix, install `trufflehog` yourself — one pre-commit hook is a secret scan and fails without it. The frontend scanner, retire.js, is a `web/` dev dependency rather than a Nix package, so `task scan-web` provides it via `npm ci`.
+`nix develop` provides all of the above except Docker, plus the scanners CI runs (`trufflehog`, `gosec`, `govulncheck`, `trivy`, `zizmor`). Without Nix, install `trufflehog` yourself — one pre-commit hook is a secret scan and fails without it. The frontend scanner, retire.js, is a `web/` dev dependency rather than a Nix package, so `task scan-web` provides it via `npm ci`.
 
 Then install the Go tooling (`swag`, `migrate`):
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,9 @@
         # bats-assert/-support are needed by test/e2e/scripts/lib.bats; yq-go by
         # test/e2e/ports.bats, which reads the lab's kind/NodePort YAML.
         # NOTE: this covers `task -d test/e2e lint` only. Running the lab itself also
-        # needs kind, kubectl, helm, jq and task, which this shell does NOT provide.
+        # needs kind, kubectl, helm and jq, which this shell does NOT provide.
         shellToolchain = with pkgs; [
+          go-task
           shellcheck
           yq-go
           (bats.withLibraries (p: [ p.bats-support p.bats-assert ]))

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -24,9 +24,9 @@ type TokenAuthenticator interface {
 	Authenticate(token string) error
 }
 
-// AppScopedStrategy is implemented by a strategy whose tokens are confined to
+// AppValidator is implemented by a strategy whose tokens are confined to
 // named applications. One that authorizes the whole estate does not.
-type AppScopedStrategy interface {
+type AppValidator interface {
 	ValidateForApp(token, app string) (bool, error)
 }
 
@@ -162,7 +162,7 @@ func authenticate(strategy AuthStrategy, token string) (bool, error) {
 // are confined to named applications exposes ValidateForApp; one whose tokens
 // authorize the whole estate does not, and answers the unscoped question instead.
 func validateForApp(strategy AuthStrategy, token, app string) (bool, error) {
-	scoped, ok := strategy.(AppScopedStrategy)
+	scoped, ok := strategy.(AppValidator)
 	if !ok {
 		return strategy.Validate(token)
 	}
@@ -329,9 +329,9 @@ var (
 	_ TokenAuthenticator = (*OIDCAuthService)(nil)
 	_ TokenAuthenticator = (*AppTokenAuthService)(nil)
 	_ TokenAuthenticator = (*PrefixRouter)(nil)
-	_ AppScopedStrategy  = (*AppTokenAuthService)(nil)
-	_ AppScopedStrategy  = (*JWTAuthService)(nil)
-	_ AppScopedStrategy  = (*PrefixRouter)(nil)
+	_ AppValidator       = (*AppTokenAuthService)(nil)
+	_ AppValidator       = (*JWTAuthService)(nil)
+	_ AppValidator       = (*PrefixRouter)(nil)
 	_ UserIdentifier     = (*OIDCAuthService)(nil)
 	_ TokenMatcher       = (*PrefixRouter)(nil)
 )

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,6 +17,31 @@ type AuthStrategy interface {
 	Validate(token string) (bool, error)
 }
 
+// TokenAuthenticator is implemented by a strategy that separates authentication
+// from authorization. One without a group concept does not: for it a valid token
+// answers both questions.
+type TokenAuthenticator interface {
+	Authenticate(token string) error
+}
+
+// AppScopedStrategy is implemented by a strategy whose tokens are confined to
+// named applications. One that authorizes the whole estate does not.
+type AppScopedStrategy interface {
+	ValidateForApp(token, app string) (bool, error)
+}
+
+// UserIdentifier is implemented by a strategy that can name the user behind a
+// token, for attributing a privileged action.
+type UserIdentifier interface {
+	Identify(token string) (string, error)
+}
+
+// TokenMatcher is implemented by a strategy that can recognise its own tokens by
+// shape, so a credential no strategy reads is not mistaken for one in use.
+type TokenMatcher interface {
+	Handles(token string) bool
+}
+
 // ErrNoCredential reports that no configured strategy evaluates a token of the
 // presented shape, so the request carries nothing to judge. walk skips it instead
 // of recording a rejection, which keeps a header no strategy reads behaving as it
@@ -121,7 +146,7 @@ func (a *Authenticator) AuthenticateToken(header, token string) (bool, error) {
 // concept (the deploy token, a CI JWT) does not, because for it a valid token answers
 // both questions.
 func authenticate(strategy AuthStrategy, token string) (bool, error) {
-	authenticator, ok := strategy.(interface{ Authenticate(token string) error })
+	authenticator, ok := strategy.(TokenAuthenticator)
 	if !ok {
 		return strategy.Validate(token)
 	}
@@ -137,9 +162,7 @@ func authenticate(strategy AuthStrategy, token string) (bool, error) {
 // are confined to named applications exposes ValidateForApp; one whose tokens
 // authorize the whole estate does not, and answers the unscoped question instead.
 func validateForApp(strategy AuthStrategy, token, app string) (bool, error) {
-	scoped, ok := strategy.(interface {
-		ValidateForApp(token, app string) (bool, error)
-	})
+	scoped, ok := strategy.(AppScopedStrategy)
 	if !ok {
 		return strategy.Validate(token)
 	}
@@ -206,9 +229,7 @@ func (a *Authenticator) IdentifyRequest(request *http.Request, header string) (s
 		return "", nil
 	}
 
-	identifier, ok := strategy.(interface {
-		Identify(token string) (string, error)
-	})
+	identifier, ok := strategy.(UserIdentifier)
 	if !ok {
 		return "", nil
 	}
@@ -302,4 +323,15 @@ var (
 	_ AuthStrategy = (*OIDCAuthService)(nil)
 	_ AuthStrategy = (*DeployTokenAuthService)(nil)
 	_ AuthStrategy = (*JWTAuthService)(nil)
+
+	// Optional capabilities, asserted here so dropping one is a compile error
+	// rather than a silent fall back to the unscoped answer.
+	_ TokenAuthenticator = (*OIDCAuthService)(nil)
+	_ TokenAuthenticator = (*AppTokenAuthService)(nil)
+	_ TokenAuthenticator = (*PrefixRouter)(nil)
+	_ AppScopedStrategy  = (*AppTokenAuthService)(nil)
+	_ AppScopedStrategy  = (*JWTAuthService)(nil)
+	_ AppScopedStrategy  = (*PrefixRouter)(nil)
+	_ UserIdentifier     = (*OIDCAuthService)(nil)
+	_ TokenMatcher       = (*PrefixRouter)(nil)
 )

--- a/internal/server/auth_rejection.go
+++ b/internal/server/auth_rejection.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/shini4i/argo-watcher/internal/auth"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// Hints naming how to present a credential. A browser cannot set a header on a
+// WebSocket handshake, so the socket names its subprotocol instead.
+const (
+	headerCredentialHint = "set " + oidcHeader + " header"
+	wsCredentialHint     = "offer the " + wsTokenSubprotocolPrefix + "<token> subprotocol"
+)
+
+// writeAuthRejection writes the response for a credential that was not accepted:
+// 503 for ErrProviderUnavailable, since the Web UI discards its session on a 401,
+// and 401 otherwise. subject names the rejected thing in the log; credentialHint
+// tells a caller that sent nothing how to present one.
+func writeAuthRejection(w http.ResponseWriter, r *http.Request, err error, subject, credentialHint string) {
+	if errors.Is(err, auth.ErrProviderUnavailable) {
+		slog.Error("rejecting "+subject+": authentication provider unavailable",
+			"method", r.Method, "url", r.URL.Path, "error", err)
+		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
+			Status: providerUnavailableMessage,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	// The strategy's own reason, so the client can show something actionable.
+	if err != nil {
+		slog.Warn("rejecting "+subject+" with invalid credential",
+			"method", r.Method, "url", r.URL.Path, "error", err)
+		writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
+			Status: unauthorizedMessage,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	slog.Warn("rejecting unauthenticated "+subject, "method", r.Method, "url", r.URL.Path)
+	writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
+		Status: unauthorizedMessage,
+		Error:  "authentication required (" + credentialHint + ")",
+	})
+}

--- a/internal/server/auth_rejection_test.go
+++ b/internal/server/auth_rejection_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/auth"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// authGate is one of the three surfaces that turn a credential verdict into a
+// response: the privileged-action check, the read middleware and the WebSocket
+// handshake. They answer the same three states and must not drift apart.
+type authGate struct {
+	name string
+	// allow reports whether the gate let the request through, having written the
+	// rejection itself when it did not.
+	allow func(env *Env, w http.ResponseWriter, r *http.Request) bool
+}
+
+func authGates() []authGate {
+	return []authGate{
+		{
+			name:  "privileged action",
+			allow: func(env *Env, w http.ResponseWriter, r *http.Request) bool { return env.requireOIDCAuth(w, r) },
+		},
+		{
+			name: "read middleware",
+			allow: func(env *Env, w http.ResponseWriter, r *http.Request) bool {
+				passed := false
+				next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { passed = true })
+				env.requireAuthenticatedRead()(next).ServeHTTP(w, r)
+				return passed
+			},
+		},
+		{
+			name:  "websocket handshake",
+			allow: func(env *Env, w http.ResponseWriter, r *http.Request) bool { return env.authorizeWebSocket(w, r) },
+		},
+	}
+}
+
+// TestAuthRejectionContract pins the status and client-facing status text every
+// gate must produce for the same credential state. The three share one rejection
+// path; this is what that path owes the caller.
+func TestAuthRejectionContract(t *testing.T) {
+	cases := []struct {
+		name           string
+		strategy       *oidcLikeStrategy
+		sendCredential bool
+		expectedStatus int
+		expectedText   string
+		// expectedReason separates the helper's two 401 branches: a caller that sent
+		// nothing is told how to present a credential, one whose credential was
+		// refused is told why.
+		expectedReason string
+	}{
+		{
+			name:           "no credential",
+			strategy:       &oidcLikeStrategy{},
+			expectedStatus: http.StatusUnauthorized,
+			expectedText:   unauthorizedMessage,
+			expectedReason: "authentication required",
+		},
+		{
+			name:           "credential rejected",
+			strategy:       &oidcLikeStrategy{},
+			sendCredential: true,
+			expectedStatus: http.StatusUnauthorized,
+			expectedText:   unauthorizedMessage,
+			expectedReason: "token validation failed",
+		},
+		{
+			name:           "provider unavailable",
+			strategy:       &oidcLikeStrategy{unavailable: true},
+			sendCredential: true,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedText:   providerUnavailableMessage,
+			expectedReason: auth.ErrProviderUnavailable.Error(),
+		},
+	}
+
+	for _, tc := range cases {
+		for _, gate := range authGates() {
+			t.Run(tc.name+"/"+gate.name, func(t *testing.T) {
+				env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{oidcHeader: *tc.strategy})
+
+				request := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+				if tc.sendCredential {
+					request.Header.Set(oidcHeader, "token")
+				}
+				recorder := httptest.NewRecorder()
+
+				assert.False(t, gate.allow(env, recorder, request))
+				assert.Equal(t, tc.expectedStatus, recorder.Code)
+
+				var body models.TaskStatus
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+				assert.Equal(t, tc.expectedText, body.Status)
+				assert.Contains(t, body.Error, tc.expectedReason, "a rejection must say why")
+			})
+		}
+	}
+}
+
+// TestAuthRejectionNamesTheCredentialToSend pins the part the gates deliberately
+// do not share: an uncredentialed caller is told how to present one on the
+// transport it is using, which for a browser WebSocket is not a header.
+func TestAuthRejectionNamesTheCredentialToSend(t *testing.T) {
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{oidcHeader: oidcLikeStrategy{}})
+
+	headerRecorder := httptest.NewRecorder()
+	require.False(t, env.requireOIDCAuth(headerRecorder, httptest.NewRequest(http.MethodGet, "/", nil)))
+	assert.Contains(t, headerRecorder.Body.String(), oidcHeader)
+
+	wsRecorder := httptest.NewRecorder()
+	require.False(t, env.authorizeWebSocket(wsRecorder, httptest.NewRequest(http.MethodGet, "/ws", nil)))
+	assert.Contains(t, wsRecorder.Body.String(), wsTokenSubprotocolPrefix)
+}
+
+// TestWebSocketRejectionCarriesTheStrategyReason pins that a rejected handshake
+// reports why, as the HTTP gates already did. It previously answered every 401
+// with the subprotocol hint, which misleads a client that did offer a credential.
+func TestWebSocketRejectionCarriesTheStrategyReason(t *testing.T) {
+	env, _ := readAuthEnv(t, true, map[string]auth.AuthStrategy{oidcHeader: oidcLikeStrategy{}})
+
+	request := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	request.Header.Set(oidcHeader, "token")
+	recorder := httptest.NewRecorder()
+
+	require.False(t, env.authorizeWebSocket(recorder, request))
+
+	var body models.TaskStatus
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.Contains(t, body.Error, "token validation failed")
+	assert.NotContains(t, body.Error, wsTokenSubprotocolPrefix)
+}

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -38,6 +38,8 @@ type Env struct {
 	shutdownOnce sync.Once
 	// connWg tracks active WebSocket connection goroutines for graceful shutdown.
 	connWg sync.WaitGroup
+	// ws holds the clients this server broadcasts to.
+	ws wsRegistry
 }
 
 // lockdownPollInterval is how often the lockdown watcher re-evaluates the lock
@@ -69,7 +71,7 @@ func (env *Env) StartLockdownWatcher() {
 	env.connWg.Add(1)
 	go func() {
 		defer env.connWg.Done()
-		env.lockdown.WatchTransitions(env.shutdownCh, lockdownPollInterval, notifyWebSocketClients)
+		env.lockdown.WatchTransitions(env.shutdownCh, lockdownPollInterval, env.notifyWebSocketClients)
 	}()
 }
 
@@ -108,7 +110,7 @@ func (env *Env) StartArgoWatcher() {
 	env.connWg.Add(1)
 	go func() {
 		defer env.connWg.Done()
-		watchArgoTransitions(env.shutdownCh, argoWatchInterval, env.argo.UnavailableReason, notifyWebSocketClients)
+		watchArgoTransitions(env.shutdownCh, argoWatchInterval, env.argo.UnavailableReason, env.notifyWebSocketClients)
 	}()
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -406,14 +406,10 @@ func (env *Env) getConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, env.config)
 }
 
-// requireOIDCAuth validates the OIDC token from the Oidc-Authorization header when
-// OIDC auth is enabled. It returns true if validation passes (or OIDC is disabled).
-// On failure the response distinguishes:
-//   - 401 with "authentication required" when no auth header was sent.
-//   - 401 with the strategy's reason when the token was rejected.
-//   - 503 when the provider could not be consulted at all, so that a provider
-//     outage does not make the Web UI treat the session as dead (see
-//     requireAuthenticatedRead). Details land in the server log only.
+// requireOIDCAuth reports whether the request may perform a privileged action,
+// writing the rejection itself when it may not (see writeAuthRejection). It
+// demands the OIDC token from the Oidc-Authorization header, which alone carries
+// privileged-group membership. With OIDC disabled it always passes.
 func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 	if !env.config.OIDC.Enabled {
 		return true
@@ -423,42 +419,15 @@ func (env *Env) requireOIDCAuth(w http.ResponseWriter, r *http.Request) bool {
 	if valid {
 		return true
 	}
-	if errors.Is(err, auth.ErrProviderUnavailable) {
-		slog.Error("rejecting request: authentication provider unavailable",
-			"method", r.Method, "url", r.URL.Path, "error", err)
-		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-			Status: providerUnavailableMessage,
-			Error:  err.Error(),
-		})
-		return false
-	}
-	if err != nil {
-		slog.Warn("rejected request with invalid token",
-			"method", r.Method, "url", r.URL.Path, "error", err)
-		writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-			Status: unauthorizedMessage,
-			Error:  err.Error(),
-		})
-		return false
-	}
 
-	slog.Warn("rejected unauthenticated request", "method", r.Method, "url", r.URL.Path)
-	writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-		Status: unauthorizedMessage,
-		Error:  "authentication required (set " + oidcHeader + " header)",
-	})
+	writeAuthRejection(w, r, err, "request", headerCredentialHint)
 	return false
 }
 
 // requireAuthenticatedRead returns middleware that rejects reads carrying no valid
-// credential once OIDC auth is enabled; with OIDC disabled it is a no-op.
-//
-// Any configured credential is accepted — an OIDC session, the deploy token or a CI
-// JWT — and reads are deliberately not restricted to OIDC_PRIVILEGED_GROUPS, which
-// gates the deploy-lock writes alone.
-//
-// A rejected or missing credential is 401; a provider that could not be consulted is
-// 503, because the Web UI discards its session on a 401.
+// credential once OIDC auth is enabled; with OIDC disabled it is a no-op. Any
+// configured credential is accepted — an OIDC session, the deploy token or a CI JWT
+// — because reads are deliberately not restricted to OIDC_PRIVILEGED_GROUPS.
 func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -473,31 +442,7 @@ func (env *Env) requireAuthenticatedRead() func(http.Handler) http.Handler {
 				return
 			}
 
-			if errors.Is(err, auth.ErrProviderUnavailable) {
-				slog.Error("rejecting read: authentication provider unavailable",
-					"method", r.Method, "url", r.URL.Path, "error", err)
-				writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-					Status: providerUnavailableMessage,
-					Error:  err.Error(),
-				})
-				return
-			}
-
-			if err != nil {
-				slog.Warn("rejecting read with invalid credential",
-					"method", r.Method, "url", r.URL.Path, "error", err)
-				writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-					Status: unauthorizedMessage,
-					Error:  err.Error(),
-				})
-				return
-			}
-
-			slog.Warn("rejecting unauthenticated read", "method", r.Method, "url", r.URL.Path)
-			writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-				Status: unauthorizedMessage,
-				Error:  "authentication required (set " + oidcHeader + " header)",
-			})
+			writeAuthRejection(w, r, err, "read", headerCredentialHint)
 		})
 	}
 }
@@ -545,7 +490,7 @@ func (env *Env) hasCredential(request *http.Request) bool {
 			continue
 		}
 
-		if handler, ok := strategy.(interface{ Handles(token string) bool }); ok && !handler.Handles(token) {
+		if matcher, ok := strategy.(auth.TokenMatcher); ok && !matcher.Handles(token) {
 			continue
 		}
 

--- a/internal/server/keycloak_integration_test.go
+++ b/internal/server/keycloak_integration_test.go
@@ -334,9 +334,6 @@ func TestKeycloakWebSocketHandshake(t *testing.T) {
 		defer cancel()
 		env.Shutdown(ctx)
 		srv.Close()
-		connectionsMutex.Lock()
-		connections = nil
-		connectionsMutex.Unlock()
 	})
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"

--- a/internal/server/limits_test.go
+++ b/internal/server/limits_test.go
@@ -206,11 +206,6 @@ func TestApiAcceptsTheLargestLegitimateBody(t *testing.T) {
 // out of an ordinary request. It survives because the hijack clears the deadlines
 // net/http set — which is not visible at the call site that adds a timeout.
 func TestWebSocketOutlivesServerWriteTimeout(t *testing.T) {
-	connectionsMutex.Lock()
-	connections = nil
-	closedConns = make(map[*websocket.Conn]bool)
-	connectionsMutex.Unlock()
-
 	env, _ := readAuthEnv(t, false, nil)
 	env.config.DevEnvironment = true // accept the httptest origin
 
@@ -222,9 +217,6 @@ func TestWebSocketOutlivesServerWriteTimeout(t *testing.T) {
 	t.Cleanup(func() {
 		shutdownEnv(env)
 		server.Close()
-		connectionsMutex.Lock()
-		connections = nil
-		connectionsMutex.Unlock()
 	})
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
@@ -237,7 +229,7 @@ func TestWebSocketOutlivesServerWriteTimeout(t *testing.T) {
 	// Past both deadlines the handshake inherited.
 	time.Sleep(300 * time.Millisecond)
 
-	notifyWebSocketClients("still alive")
+	env.notifyWebSocketClients("still alive")
 
 	_, message, err := conn.Read(ctx)
 	require.NoError(t, err)

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -302,12 +302,12 @@ func timeWithinSchedule(now time.Time, startDay, endDay time.Weekday, startHour,
 	}
 }
 
-func timeAtOrAfter(hour, min, refHour, refMin int) bool {
-	return hour > refHour || (hour == refHour && min >= refMin)
+func timeAtOrAfter(hour, minute, refHour, refMin int) bool {
+	return hour > refHour || (hour == refHour && minute >= refMin)
 }
 
-func timeBefore(hour, min, refHour, refMin int) bool {
-	return hour < refHour || (hour == refHour && min < refMin)
+func timeBefore(hour, minute, refHour, refMin int) bool {
+	return hour < refHour || (hour == refHour && minute < refMin)
 }
 
 // dayInRange reports whether day falls within [start, end], wrapping to the next

--- a/internal/server/lockdown.go
+++ b/internal/server/lockdown.go
@@ -119,17 +119,23 @@ func parseTime(timeStr string) (int, int, error) {
 	return hour, minutes, nil
 }
 
-// Parse parses the lockdown schedules from a string and stores them in the Lockdown struct.
-func (l *Lockdown) Parse(schedules string) error {
+// parse replaces the lockdown schedules with the ones described by the given
+// comma-separated string. The whole string is parsed before anything is stored, so
+// a malformed entry leaves the previous schedules in place rather than half of the
+// new ones.
+func (l *Lockdown) parse(schedules string) error {
 	timeFramesSplit := strings.Split(schedules, ",")
 
+	parsed := make([]LockdownSchedule, 0, len(timeFramesSplit))
 	for _, tf := range timeFramesSplit {
 		schedule, err := parseSchedule(tf)
 		if err != nil {
 			return err
 		}
-		l.Schedules = append(l.Schedules, schedule)
+		parsed = append(parsed, schedule)
 	}
+
+	l.Schedules = parsed
 
 	slog.Debug("parsed lockdown schedules", "schedules", l.Schedules)
 
@@ -261,7 +267,7 @@ func NewLockdown(schedules string, store lock.DeployLockStore) (*Lockdown, error
 		overrideDuration: defaultOverrideDuration,
 	}
 	if schedules != "" {
-		if err := lockdown.Parse(schedules); err != nil {
+		if err := lockdown.parse(schedules); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/server/lockdown_test.go
+++ b/internal/server/lockdown_test.go
@@ -93,7 +93,7 @@ func TestLockdown_Parse(t *testing.T) {
 
 	for _, tt := range testCases {
 		l := Lockdown{}
-		err := l.Parse(tt.input)
+		err := l.parse(tt.input)
 
 		if tt.expectError {
 			assert.Error(t, err)
@@ -597,4 +597,30 @@ func TestLockdown_IsLockedWith(t *testing.T) {
 			assert.Equal(t, tt.expected, l.isLockedWith(tt.state, now))
 		})
 	}
+}
+
+// TestLockdown_ParseReplacesSchedules pins that parsing is idempotent: a second
+// parse describes the whole configuration, it does not add to the previous one.
+func TestLockdown_ParseReplacesSchedules(t *testing.T) {
+	l := Lockdown{}
+
+	require.NoError(t, l.parse("Fri 13:20 - Mon 06:30"))
+	require.NoError(t, l.parse("Tue 03:00 - Thu 08:00"))
+
+	assert.Equal(t, []LockdownSchedule{
+		{time.Tuesday, 3, 0, time.Thursday, 8, 0},
+	}, l.Schedules)
+}
+
+// TestLockdown_ParseRejectionKeepsSchedules pins that a rejected schedule string
+// leaves the previously parsed configuration untouched rather than half-applied.
+func TestLockdown_ParseRejectionKeepsSchedules(t *testing.T) {
+	l := Lockdown{}
+	require.NoError(t, l.parse("Fri 13:20 - Mon 06:30"))
+
+	require.Error(t, l.parse("Tue 03:00 - Thu 08:00, garbage"))
+
+	assert.Equal(t, []LockdownSchedule{
+		{time.Friday, 13, 20, time.Monday, 6, 30},
+	}, l.Schedules)
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -239,44 +239,6 @@ func TestDeployLockEndpointRegistration(t *testing.T) {
 	})
 }
 
-func TestRemoveWebSocketConnection(t *testing.T) {
-	conn := &websocket.Conn{}
-	connectionsMutex.Lock()
-	connections = append(connections, conn)
-	connectionsMutex.Unlock()
-	removeWebSocketConnection(conn)
-	connectionsMutex.Lock()
-	assert.NotContains(t, connections, conn)
-	connectionsMutex.Unlock()
-}
-
-func TestWebSocketConnectionsConcurrentAccess(t *testing.T) {
-	connectionsMutex.Lock()
-	connections = nil
-	connectionsMutex.Unlock()
-
-	var wg sync.WaitGroup
-	numGoroutines := 10
-
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			conn := &websocket.Conn{}
-			connectionsMutex.Lock()
-			connections = append(connections, conn)
-			connectionsMutex.Unlock()
-			removeWebSocketConnection(conn)
-		}()
-	}
-
-	wg.Wait()
-
-	connectionsMutex.Lock()
-	assert.Empty(t, connections)
-	connectionsMutex.Unlock()
-}
-
 // signJWT mints an HS256 token valid for an hour, so a claim assertion is never
 // decided by expiry.
 func signJWT(t *testing.T, secret string, claims jwt.MapClaims) string {
@@ -867,11 +829,6 @@ func TestWebSocketInterceptor(t *testing.T) {
 // (wired in .github/workflows/run-tests.yml), since a plain run cannot observe
 // it. Keep the -race CI step if you touch this test.
 func TestWebSocketConnectionIntegration(t *testing.T) {
-
-	connectionsMutex.Lock()
-	connections = nil
-	connectionsMutex.Unlock()
-
 	tmpDir := t.TempDir()
 	err := os.WriteFile(tmpDir+"/index.html", []byte("<html></html>"), 0644)
 	assert.NoError(t, err)
@@ -889,13 +846,10 @@ func TestWebSocketConnectionIntegration(t *testing.T) {
 	// Use httptest.Server for real HTTP connection (supports hijacking)
 	server := httptest.NewServer(router)
 
-	// Cleanup: shut down the env (stops checkConnection goroutines), then the HTTP server, then reset connections.
+	// Shut the env down first: that stops the checkConnection goroutines.
 	t.Cleanup(func() {
 		shutdownEnv(env)
 		server.Close()
-		connectionsMutex.Lock()
-		connections = nil
-		connectionsMutex.Unlock()
 	})
 
 	// Capture debug output around the handshake: a successful upgrade must not
@@ -964,11 +918,6 @@ func TestDeployLockNotifiedOnlyByWatcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			connectionsMutex.Lock()
-			connections = nil
-			closedConns = make(map[*websocket.Conn]bool)
-			connectionsMutex.Unlock()
-
 			tmpDir := t.TempDir()
 			require.NoError(t, os.WriteFile(tmpDir+"/index.html", []byte("<html></html>"), 0644))
 
@@ -998,10 +947,6 @@ func TestDeployLockNotifiedOnlyByWatcher(t *testing.T) {
 			t.Cleanup(func() {
 				shutdownEnv(env)
 				server.Close()
-				connectionsMutex.Lock()
-				connections = nil
-				closedConns = make(map[*websocket.Conn]bool)
-				connectionsMutex.Unlock()
 			})
 
 			dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -1015,7 +960,7 @@ func TestDeployLockNotifiedOnlyByWatcher(t *testing.T) {
 			// Run the watcher far faster than production so the test does not wait 5s.
 			stop := make(chan struct{})
 			defer close(stop)
-			go lockdown.WatchTransitions(stop, 5*time.Millisecond, notifyWebSocketClients)
+			go lockdown.WatchTransitions(stop, 5*time.Millisecond, env.notifyWebSocketClients)
 
 			// The watcher captures its baseline on entry, and only a change against
 			// that baseline is broadcast. Wait for the baseline read before mutating,
@@ -1384,141 +1329,6 @@ func TestStartRouter(t *testing.T) {
 	assert.Equal(t, 30*time.Second, srv.ReadTimeout)
 	assert.Equal(t, 120*time.Second, srv.WriteTimeout)
 	assert.Equal(t, 120*time.Second, srv.IdleTimeout)
-}
-
-func TestNotifyWebSocketClients(t *testing.T) {
-	t.Run("notifies with no connections", func(t *testing.T) {
-		connectionsMutex.Lock()
-		connections = nil
-		closedConns = make(map[*websocket.Conn]bool)
-		connectionsMutex.Unlock()
-
-		t.Cleanup(func() {
-			connectionsMutex.Lock()
-			connections = nil
-			closedConns = make(map[*websocket.Conn]bool)
-			connectionsMutex.Unlock()
-		})
-
-		notifyWebSocketClients("test message")
-	})
-}
-
-func TestRemoveWebSocketConnectionCleanup(t *testing.T) {
-	t.Run("removes connection and cleans up closedConns", func(t *testing.T) {
-		connectionsMutex.Lock()
-		connections = nil
-		closedConns = make(map[*websocket.Conn]bool)
-		connectionsMutex.Unlock()
-
-		t.Cleanup(func() {
-			connectionsMutex.Lock()
-			connections = nil
-			closedConns = make(map[*websocket.Conn]bool)
-			connectionsMutex.Unlock()
-		})
-
-		removeWebSocketConnection(nil)
-
-		connectionsMutex.RLock()
-		assert.Len(t, connections, 0)
-		assert.Len(t, closedConns, 0)
-		connectionsMutex.RUnlock()
-	})
-
-	t.Run("removes actual connection from slice", func(t *testing.T) {
-		connectionsMutex.Lock()
-		connections = nil
-		closedConns = make(map[*websocket.Conn]bool)
-		connectionsMutex.Unlock()
-
-		t.Cleanup(func() {
-			connectionsMutex.Lock()
-			connections = nil
-			closedConns = make(map[*websocket.Conn]bool)
-			connectionsMutex.Unlock()
-		})
-
-		conn := &websocket.Conn{}
-		connectionsMutex.Lock()
-		connections = append(connections, conn)
-		connectionsMutex.Unlock()
-
-		removeWebSocketConnection(conn)
-
-		connectionsMutex.RLock()
-		assert.NotContains(t, connections, conn)
-		assert.Len(t, closedConns, 0)
-		connectionsMutex.RUnlock()
-	})
-
-	t.Run("removes connection from middle of slice", func(t *testing.T) {
-		connectionsMutex.Lock()
-		connections = nil
-		closedConns = make(map[*websocket.Conn]bool)
-		connectionsMutex.Unlock()
-
-		t.Cleanup(func() {
-			connectionsMutex.Lock()
-			connections = nil
-			closedConns = make(map[*websocket.Conn]bool)
-			connectionsMutex.Unlock()
-		})
-
-		conn1 := &websocket.Conn{}
-		conn2 := &websocket.Conn{}
-		conn3 := &websocket.Conn{}
-		connectionsMutex.Lock()
-		connections = append(connections, conn1, conn2, conn3)
-		connectionsMutex.Unlock()
-
-		removeWebSocketConnection(conn2)
-
-		connectionsMutex.RLock()
-		assert.Len(t, connections, 2)
-		// Check by pointer address, not value (all zero-value Conns are equal by value)
-		foundConn1 := false
-		foundConn2 := false
-		foundConn3 := false
-		for _, c := range connections {
-			if c == conn1 {
-				foundConn1 = true
-			}
-			if c == conn2 {
-				foundConn2 = true
-			}
-			if c == conn3 {
-				foundConn3 = true
-			}
-		}
-		connectionsMutex.RUnlock()
-
-		assert.True(t, foundConn1, "conn1 should still be in the slice")
-		assert.False(t, foundConn2, "conn2 should have been removed")
-		assert.True(t, foundConn3, "conn3 should still be in the slice")
-	})
-}
-
-func TestNotifyWebSocketClientsFiltersClosedConnections(t *testing.T) {
-	connectionsMutex.Lock()
-	connections = nil
-	closedConns = make(map[*websocket.Conn]bool)
-	connectionsMutex.Unlock()
-
-	t.Cleanup(func() {
-		connectionsMutex.Lock()
-		connections = nil
-		closedConns = make(map[*websocket.Conn]bool)
-		connectionsMutex.Unlock()
-	})
-
-	conn := &websocket.Conn{}
-	connectionsMutex.Lock()
-	connections = append(connections, conn)
-	closedConns[conn] = true
-	connectionsMutex.Unlock()
-
-	notifyWebSocketClients("test message")
 }
 
 func TestConnWgTracking(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,9 +44,6 @@ const (
 
 type Server struct {
 	router      http.Handler
-	config      *config.ServerConfig
-	argo        *argocd.Argo
-	metrics     *prom.Metrics
 	updater     *argocd.ArgoStatusUpdater
 	env         *Env
 	probeCancel context.CancelFunc
@@ -144,9 +141,6 @@ func NewServer(serverConfig *config.ServerConfig, reg prometheus.Registerer) (*S
 
 	return &Server{
 		router:      router,
-		config:      serverConfig,
-		argo:        argo,
-		metrics:     metrics,
 		updater:     statusUpdater,
 		env:         env,
 		probeCancel: probeCancel,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,7 +30,7 @@ func TestNewServer_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	assert.Equal(t, cfg, s.config)
+	assert.Equal(t, cfg, s.env.config)
 	// A zero drainDelay silently skips the readiness-propagation phase of shutdown,
 	// and every other test constructs Server directly — so this is the only place a
 	// dropped wiring line would be caught before the lab.

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -2,24 +2,52 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/coder/websocket"
-
-	"github.com/shini4i/argo-watcher/internal/auth"
-	"github.com/shini4i/argo-watcher/internal/models"
 )
 
-var (
-	connectionsMutex sync.RWMutex
-	connections      []*websocket.Conn
-	closedConns      = make(map[*websocket.Conn]bool) // Track closed connections to prevent use-after-close
-)
+// wsRegistry holds the WebSocket connections one server broadcasts to. It is a
+// field of Env rather than a package variable so that two servers running in the
+// same process — which is every test that starts one — never see each other's
+// clients.
+type wsRegistry struct {
+	mu    sync.RWMutex
+	conns []*websocket.Conn
+}
+
+func (r *wsRegistry) add(conn *websocket.Conn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.conns = append(r.conns, conn)
+}
+
+// remove drops conn from the registry. Callers close the connection first.
+// slices.Delete clears the vacated tail slot, so a closed connection is not left
+// reachable through the backing array.
+func (r *wsRegistry) remove(conn *websocket.Conn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if i := slices.Index(r.conns, conn); i >= 0 {
+		r.conns = slices.Delete(r.conns, i, i+1)
+	}
+}
+
+// snapshot copies the registered connections, so a broadcast can write to them
+// without holding the lock for the length of every write.
+func (r *wsRegistry) snapshot() []*websocket.Conn {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return slices.Clone(r.conns)
+}
 
 const (
 	// wsSubprotocol is the protocol the server negotiates. A browser fails the
@@ -55,27 +83,7 @@ func (env *Env) authorizeWebSocket(w http.ResponseWriter, r *http.Request) bool 
 		return true
 	}
 
-	// Mirrors requireAuthenticatedRead: a provider outage is 503, so a reconnecting tab
-	// does not discard a session that may still be valid.
-	if errors.Is(err, auth.ErrProviderUnavailable) {
-		slog.Error("rejecting websocket: authentication provider unavailable", "error", err)
-		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
-			Status: providerUnavailableMessage,
-			Error:  err.Error(),
-		})
-		return false
-	}
-
-	if err != nil {
-		slog.Warn("rejecting websocket with invalid credential", "error", err)
-	} else {
-		slog.Warn("rejecting unauthenticated websocket")
-	}
-	writeJSON(w, http.StatusUnauthorized, models.TaskStatus{
-		Status: unauthorizedMessage,
-		Error:  "authentication required (offer the " + wsTokenSubprotocolPrefix + "<token> subprotocol)",
-	})
-
+	writeAuthRejection(w, r, err, "websocket", wsCredentialHint)
 	return false
 }
 
@@ -125,9 +133,7 @@ func (env *Env) handleWebSocketConnection(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	connectionsMutex.Lock()
-	connections = append(connections, conn)
-	connectionsMutex.Unlock()
+	env.ws.add(conn)
 
 	env.connWg.Add(1)
 	go env.checkConnection(conn)
@@ -143,7 +149,7 @@ func (env *Env) checkConnection(c *websocket.Conn) {
 		select {
 		case <-env.shutdownCh:
 			_ = c.Close(websocket.StatusGoingAway, "server shutdown")
-			removeWebSocketConnection(c)
+			env.ws.remove(c)
 			return
 		case <-ticker.C:
 			// we are not using c.Ping here, because it's not working as expected
@@ -153,7 +159,7 @@ func (env *Env) checkConnection(c *websocket.Conn) {
 			if c.Write(ctx, websocket.MessageText, []byte("heartbeat")) != nil {
 				cancel()
 				_ = c.Close(websocket.StatusNormalClosure, "heartbeat failed")
-				removeWebSocketConnection(c)
+				env.ws.remove(c)
 				return
 			}
 			cancel()
@@ -161,51 +167,25 @@ func (env *Env) checkConnection(c *websocket.Conn) {
 	}
 }
 
-func notifyWebSocketClients(message string) {
+// notifyWebSocketClients pushes message to every connected client, dropping any
+// connection the write fails on. It returns once every write has finished or
+// timed out.
+func (env *Env) notifyWebSocketClients(message string) {
 	var wg sync.WaitGroup
 
-	connectionsMutex.RLock()
-	connsCopy := make([]*websocket.Conn, 0, len(connections))
-	for _, c := range connections {
-		if !closedConns[c] {
-			connsCopy = append(connsCopy, c)
-		}
-	}
-	connectionsMutex.RUnlock()
-
-	for _, conn := range connsCopy {
+	for _, conn := range env.ws.snapshot() {
 		wg.Add(1)
 
-		go func(c *websocket.Conn, message string) {
+		go func(c *websocket.Conn) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if c.Write(ctx, websocket.MessageText, []byte(message)) != nil {
 				_ = c.Close(websocket.StatusNormalClosure, "write failed")
-				removeWebSocketConnection(c)
+				env.ws.remove(c)
 			}
-		}(conn, message)
+		}(conn)
 	}
 
 	wg.Wait()
-}
-
-// removeWebSocketConnection removes conn from the global connections slice under
-// the mutex. Callers are responsible for closing the connection first.
-func removeWebSocketConnection(conn *websocket.Conn) {
-	connectionsMutex.Lock()
-	defer connectionsMutex.Unlock()
-
-	// Mark as closed first to prevent use-after-close during concurrent access
-	closedConns[conn] = true
-
-	for i := range connections {
-		if connections[i] == conn {
-			connections = append(connections[:i], connections[i+1:]...)
-			break
-		}
-	}
-
-	// Clean up closedConns entry to prevent memory leak
-	delete(closedConns, conn)
 }

--- a/internal/server/websocket_registry_test.go
+++ b/internal/server/websocket_registry_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wsRegistryServer starts a server whose WebSocket clients are tracked by the
+// returned Env alone, and gives back the ws:// URL of its /ws endpoint.
+func wsRegistryServer(t *testing.T) (*Env, string) {
+	t.Helper()
+
+	env, _ := readAuthEnv(t, false, nil)
+	env.config.DevEnvironment = true // accept the httptest origin
+	server := httptest.NewServer(env.CreateRouter())
+
+	t.Cleanup(func() {
+		shutdownEnv(env)
+		server.Close()
+	})
+
+	return env, "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+}
+
+// dialAndHold opens a WebSocket, drains it, and keeps it open until the test ends.
+// The drain matters: the server closes with a WebSocket closing handshake, which
+// waits out its own timeout against a client that never reads.
+func dialAndHold(t *testing.T, url string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			if _, _, err := conn.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+
+	// CloseNow, not Close: a graceful close waits for a reply frame the server's
+	// write-only connection goroutine never sends.
+	t.Cleanup(func() { _ = conn.CloseNow() })
+}
+
+// registered waits for the server to record the handshake, which completes on the
+// client before the server adds the connection.
+func registered(t *testing.T, env *Env, want int) {
+	t.Helper()
+
+	assert.Eventually(t, func() bool {
+		return len(env.ws.snapshot()) == want
+	}, 5*time.Second, time.Millisecond)
+}
+
+// TestWebSocketRegistryIsPerEnv pins that one server's clients are invisible to
+// another running in the same process. A shared registry makes every broadcast
+// reach both, and forces tests to reset global state by hand.
+func TestWebSocketRegistryIsPerEnv(t *testing.T) {
+	dialed, url := wsRegistryServer(t)
+	idle, _ := wsRegistryServer(t)
+
+	dialAndHold(t, url)
+
+	registered(t, dialed, 1)
+	assert.Empty(t, idle.ws.snapshot())
+}
+
+// TestWebSocketRegistryDrainsOnShutdown pins checkConnection's shutdown branch:
+// once Shutdown returns, connWg has waited for every connection goroutine, so
+// none may still be registered.
+func TestWebSocketRegistryDrainsOnShutdown(t *testing.T) {
+	env, url := wsRegistryServer(t)
+	dialAndHold(t, url)
+	registered(t, env, 1)
+
+	shutdownEnv(env)
+
+	assert.Empty(t, env.ws.snapshot())
+}
+
+// TestNotifyWebSocketClientsDropsFailedConnection pins the registry's only
+// self-healing path: without it a dead socket is retained for the life of the
+// process and every later broadcast waits out its write timeout.
+func TestNotifyWebSocketClientsDropsFailedConnection(t *testing.T) {
+	env, url := wsRegistryServer(t)
+	dialAndHold(t, url)
+	registered(t, env, 1)
+
+	// Close the server side, so the next broadcast write to it fails at once.
+	env.ws.snapshot()[0].CloseNow() //nolint:errcheck // the close is the point
+
+	env.notifyWebSocketClients("unreachable")
+
+	assert.Empty(t, env.ws.snapshot())
+}
+
+func TestWsRegistryAddAndRemove(t *testing.T) {
+	var registry wsRegistry
+	conn := &websocket.Conn{}
+
+	registry.add(conn)
+	assert.Equal(t, []*websocket.Conn{conn}, registry.snapshot())
+
+	registry.remove(conn)
+	assert.Empty(t, registry.snapshot())
+}
+
+func TestWsRegistryRemoveFromTheMiddle(t *testing.T) {
+	var registry wsRegistry
+	first, middle, last := &websocket.Conn{}, &websocket.Conn{}, &websocket.Conn{}
+	registry.add(first)
+	registry.add(middle)
+	registry.add(last)
+
+	registry.remove(middle)
+
+	// Compared by pointer: zero-value connections are all equal by value.
+	assert.Equal(t, []*websocket.Conn{first, last}, registry.snapshot())
+}
+
+func TestWsRegistryRemoveUnknownConnection(t *testing.T) {
+	var registry wsRegistry
+	conn := &websocket.Conn{}
+	registry.add(conn)
+
+	registry.remove(&websocket.Conn{})
+
+	assert.Equal(t, []*websocket.Conn{conn}, registry.snapshot())
+}
+
+// TestWsRegistrySnapshotIsACopy pins that a broadcast iterating the snapshot is
+// unaffected by a removal racing it. Removing the FIRST of two is what makes this
+// fail on a snapshot that aliases the registry: the shift overwrites the index
+// the snapshot already handed out.
+func TestWsRegistrySnapshotIsACopy(t *testing.T) {
+	var registry wsRegistry
+	first, second := &websocket.Conn{}, &websocket.Conn{}
+	registry.add(first)
+	registry.add(second)
+
+	taken := registry.snapshot()
+	registry.remove(first)
+
+	assert.Equal(t, []*websocket.Conn{first, second}, taken)
+}
+
+func TestWsRegistryConcurrentAccess(t *testing.T) {
+	var registry wsRegistry
+	var wg sync.WaitGroup
+
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn := &websocket.Conn{}
+			registry.add(conn)
+			registry.snapshot()
+			registry.remove(conn)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Empty(t, registry.snapshot())
+}
+
+// TestNotifyWebSocketClientsWithNoConnections pins that a broadcast to an empty
+// registry is a no-op rather than a panic: both watchers fire on every transition,
+// including before any client has connected.
+func TestNotifyWebSocketClientsWithNoConnections(t *testing.T) {
+	env, _ := readAuthEnv(t, false, nil)
+
+	assert.NotPanics(t, func() { env.notifyWebSocketClients("test message") })
+}

--- a/internal/server/ws_auth_test.go
+++ b/internal/server/ws_auth_test.go
@@ -20,10 +20,6 @@ import (
 func wsAuthServer(t *testing.T, oidcEnabled bool, strategies map[string]auth.AuthStrategy) (*Env, string) {
 	t.Helper()
 
-	connectionsMutex.Lock()
-	connections = nil
-	connectionsMutex.Unlock()
-
 	env, _ := readAuthEnv(t, oidcEnabled, strategies)
 	env.config.DevEnvironment = true // accept the httptest origin
 	server := httptest.NewServer(env.CreateRouter())
@@ -31,9 +27,6 @@ func wsAuthServer(t *testing.T, oidcEnabled bool, strategies map[string]auth.Aut
 	t.Cleanup(func() {
 		shutdownEnv(env)
 		server.Close()
-		connectionsMutex.Lock()
-		connections = nil
-		connectionsMutex.Unlock()
 	})
 
 	return env, "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
@@ -63,10 +56,8 @@ func dialWS(t *testing.T, url string, opts *websocket.DialOptions) (int, string)
 	return status, subprotocol
 }
 
-func activeConnections() int {
-	connectionsMutex.RLock()
-	defer connectionsMutex.RUnlock()
-	return len(connections)
+func activeConnections(env *Env) int {
+	return len(env.ws.snapshot())
 }
 
 func TestWebSocketAuthDisabled(t *testing.T) {
@@ -88,7 +79,7 @@ func TestWebSocketAuthRejectsUncredentialed(t *testing.T) {
 	status, _ := dialWS(t, url, nil)
 
 	assert.Equal(t, http.StatusUnauthorized, status)
-	assert.Zero(t, activeConnections(), "a rejected handshake must not register a connection")
+	assert.Zero(t, activeConnections(env), "a rejected handshake must not register a connection")
 
 	// The rejection happens before the hijack, so shutdown has nothing to drain.
 	shutdownEnv(env)
@@ -176,7 +167,7 @@ func TestWebSocketAuthAcceptsSubprotocolCredential(t *testing.T) {
 }
 
 func TestWebSocketAuthRejectsBadSubprotocolCredential(t *testing.T) {
-	_, url := wsAuthServer(t, true, map[string]auth.AuthStrategy{
+	env, url := wsAuthServer(t, true, map[string]auth.AuthStrategy{
 		oidcHeader: oidcLikeStrategy{authenticated: false},
 	})
 
@@ -185,13 +176,13 @@ func TestWebSocketAuthRejectsBadSubprotocolCredential(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusUnauthorized, status)
-	assert.Zero(t, activeConnections())
+	assert.Zero(t, activeConnections(env))
 }
 
 // TestWebSocketAuthProviderUnavailable keeps the handshake consistent with the reads:
 // a provider outage is 503, so a reconnecting tab does not treat it as a dead session.
 func TestWebSocketAuthProviderUnavailable(t *testing.T) {
-	_, url := wsAuthServer(t, true, map[string]auth.AuthStrategy{
+	env, url := wsAuthServer(t, true, map[string]auth.AuthStrategy{
 		oidcHeader: oidcLikeStrategy{unavailable: true},
 	})
 
@@ -200,7 +191,7 @@ func TestWebSocketAuthProviderUnavailable(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusServiceUnavailable, status)
-	assert.Zero(t, activeConnections())
+	assert.Zero(t, activeConnections(env))
 }
 
 // TestWebSocketSubprotocolTokenParsing covers the wire format directly, including the


### PR DESCRIPTION
Collapses the duplicated auth-rejection path and removes the global WebSocket
registry, acting on the maintainability audit of `main`.

- `writeAuthRejection` replaces three copies of the 401/503 block, owning the
  503-for-`ErrProviderUnavailable` split and the per-transport hint that names
  how to present a credential.
- The optional capabilities a strategy may add to `AuthStrategy` are now named
  interfaces in `auth` with compile-time assertions, instead of anonymous
  assertions in four places.
- The connection registry becomes a `wsRegistry` field on `Env`, so two servers
  in one process no longer share clients.
- `closedConns` is deleted. It was written and removed inside a single exclusive
  critical section, so no reader under the read lock could observe it set; the
  three tests covering it only reached that state by poking the global directly.
- Drops the dead `argo`/`metrics`/`config` fields on `Server`, and makes the
  lockdown schedule parser replace rather than append.

One deliberate behaviour change: a rejected WebSocket credential now returns the
strategy's reason, where the handshake previously answered every 401 with the
subprotocol hint — misleading for a client that did offer a credential. Status
codes are unchanged on all three surfaces, and a browser cannot read a failed
handshake body.

`go-task` joins the devshell, and `development.md` no longer claims the shell
provides Docker.