### PR TITLE
refactor(web): simplify the date range picker and drop a fixed e2e wait

### DIFF
--- a/web/e2e/no-auth/task-table-layout.spec.ts
+++ b/web/e2e/no-auth/task-table-layout.spec.ts
@@ -67,8 +67,6 @@ test('no row navigates on click — only the View button does', async ({ page, r
   // task rows would style the header as one; neither may act as a link.
   await page.locator('.RaDatagrid-headerRow').click();
   await page.locator('tbody .RaDatagrid-row td.cell-author').first().click();
-  await page.waitForTimeout(500);
-  expect(await navCount(), 'a row click must not navigate').toBe(0);
 
   // Scoped and exact: an unscoped substring match also hits the top bar's Overview link.
   await page
@@ -79,5 +77,12 @@ test('no row navigates on click — only the View button does', async ({ page, r
   await expect
     .poll(() => new URL(page.url()).pathname)
     .toMatch(/^\/task\/[0-9a-f-]{36}$/);
-  expect(await navCount(), 'the View link must navigate exactly once').toBe(1);
+
+  // The View click is the only navigation the test performs, so a total of one
+  // is also what proves the two clicks above navigated nowhere. Waiting on this
+  // count beats sleeping after those clicks to see whether anything happened.
+  expect(
+    await navCount(),
+    'the View link must navigate exactly once, and the header and row clicks not at all',
+  ).toBe(1);
 });

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.test.tsx
@@ -193,4 +193,50 @@ describe('DateRangePicker', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onApply).not.toHaveBeenCalled();
   });
+
+  it('shows no day-count while only one endpoint is picked', () => {
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    fireEvent.click(dayCell('20 April 2026'));
+
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+  });
+
+  it('counts a single-day range as one day', () => {
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    fireEvent.click(dayCell('20 April 2026'));
+    fireEvent.click(dayCell('20 April 2026'));
+
+    expect(screen.getByText(/1 day selected/)).toBeInTheDocument();
+  });
+
+  it('pluralises a multi-day range', () => {
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+    fireEvent.click(dayCell('20 April 2026'));
+    fireEvent.click(dayCell('27 April 2026'));
+
+    expect(screen.getByText(/8 days selected/)).toBeInTheDocument();
+  });
+
+  it('browses back from January into the previous December', () => {
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+
+    const previous = screen.getByRole('button', { name: 'Previous month' });
+    for (let i = 0; i < 4; i++) fireEvent.click(previous);
+
+    expect(screen.getByText('December 2025')).toBeInTheDocument();
+  });
+
+  it('browses forward from December into the next January', () => {
+    render(<DateRangePicker value={{ start: null, end: null }} onApply={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select date range/ }));
+
+    const next = screen.getByRole('button', { name: 'Next month' });
+    for (let i = 0; i < 9; i++) fireEvent.click(next);
+
+    expect(screen.getByText('January 2027')).toBeInTheDocument();
+  });
 });

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -13,7 +13,7 @@ import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { useTimezone } from '../../../../shared/providers/TimezoneProvider';
+import { useTimezone, type TimezoneMode } from '../../../../shared/providers/TimezoneProvider';
 import { tokens } from '../../../../theme/tokens';
 import {
   PRESETS,
@@ -52,6 +52,55 @@ const MONTH_FORMAT: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric
 
 const CELL_FORMAT: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'long', year: 'numeric' };
 
+/** Steps the browsed month by delta, carrying into the year. */
+const shiftMonth = (year: number, month: number, delta: number) => {
+  const absolute = year * 12 + month + delta;
+  return { year: Math.floor(absolute / 12), month: ((absolute % 12) + 12) % 12 };
+};
+
+/** The " · N days selected" suffix, empty while the range is incomplete. */
+const spanSuffix = (range: DateRangeValue) => {
+  if (range.start === null || range.end === null) {
+    return '';
+  }
+  const span = dayCount(range.start, range.end);
+  return span > 0 ? ` · ${span} ${span === 1 ? 'day' : 'days'} selected` : '';
+};
+
+/**
+ * @description Reseeds the draft and browsed month when the popover opens or the
+ * committed range changes beneath it, during render so the first painted frame is
+ * already correct. The guard compares endpoints rather than the `value` object:
+ * callers pass a fresh literal each render, and identity would drop a half-picked
+ * range.
+ */
+const usePopoverSeed = (
+  anchor: HTMLElement | null,
+  value: DateRangeValue,
+  timezone: TimezoneMode,
+  reseed: (value: DateRangeValue) => void,
+) => {
+  const [lastSeed, setLastSeed] = useState({
+    anchor,
+    start: value.start,
+    end: value.end,
+    timezone,
+  });
+
+  const changed =
+    lastSeed.anchor !== anchor ||
+    lastSeed.start !== value.start ||
+    lastSeed.end !== value.end ||
+    lastSeed.timezone !== timezone;
+
+  if (changed) {
+    setLastSeed({ anchor, start: value.start, end: value.end, timezone });
+    if (anchor) {
+      reseed(value);
+    }
+  }
+};
+
 /**
  * `value` is in Unix seconds; `onApply` fires only when the user clicks Apply
  * with a complete and dirty range. Computation honours the active timezone.
@@ -65,32 +114,14 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
   const [viewYear, setViewYear] = useState(() => ymd(new Date(), timezone).year);
   const [viewMonth, setViewMonth] = useState(() => ymd(new Date(), timezone).month);
 
-  // Opening the popover reseeds the draft and the visible month; adjusting
-  // during render means the first painted frame is already the right month.
-  // The guard compares endpoints, not the `value` object — callers pass a fresh
-  // literal each render, and identity would drop a half-picked range.
-  const [lastSeed, setLastSeed] = useState({
-    anchor,
-    start: value.start,
-    end: value.end,
-    timezone,
+  usePopoverSeed(anchor, value, timezone, seed => {
+    setDraft(seed);
+    setPickingStart(true);
+    const anchorDate = seed.start == null ? new Date() : new Date(seed.start * 1000);
+    const focused = ymd(anchorDate, timezone);
+    setViewYear(focused.year);
+    setViewMonth(focused.month);
   });
-  if (
-    lastSeed.anchor !== anchor ||
-    lastSeed.start !== value.start ||
-    lastSeed.end !== value.end ||
-    lastSeed.timezone !== timezone
-  ) {
-    setLastSeed({ anchor, start: value.start, end: value.end, timezone });
-    if (anchor) {
-      setDraft(value);
-      setPickingStart(true);
-      const anchorDate = value.start == null ? new Date() : new Date(value.start * 1000);
-      const focused = ymd(anchorDate, timezone);
-      setViewYear(focused.year);
-      setViewMonth(focused.month);
-    }
-  }
 
   const open = Boolean(anchor);
   const handleOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
@@ -154,33 +185,19 @@ export const DateRangePicker = ({ value, onApply }: DateRangePickerProps) => {
   const draftStartDate = draft.start === null ? null : new Date(draft.start * 1000);
   const draftEndDate = draft.end === null ? null : new Date(draft.end * 1000);
 
-  const goPrevMonth = () => {
-    if (viewMonth === 0) {
-      setViewMonth(11);
-      setViewYear(viewYear - 1);
-    } else {
-      setViewMonth(viewMonth - 1);
-    }
+  const browseMonth = (delta: number) => {
+    const next = shiftMonth(viewYear, viewMonth, delta);
+    setViewYear(next.year);
+    setViewMonth(next.month);
   };
-  const goNextMonth = () => {
-    if (viewMonth === 11) {
-      setViewMonth(0);
-      setViewYear(viewYear + 1);
-    } else {
-      setViewMonth(viewMonth + 1);
-    }
-  };
+  const goPrevMonth = () => browseMonth(-1);
+  const goNextMonth = () => browseMonth(1);
 
-  const isDirty =
-    draft.start !== value.start || draft.end !== value.end;
+  const isDirty = draft.start !== value.start || draft.end !== value.end;
   const isComplete = draft.start !== null && draft.end !== null;
   const canApply = isDirty && isComplete;
 
-  const span = isComplete && draft.start !== null && draft.end !== null
-    ? dayCount(draft.start, draft.end)
-    : 0;
-  const dayWord = span === 1 ? 'day' : 'days';
-  const spanLabel = span > 0 ? ` · ${span} ${dayWord} selected` : '';
+  const spanLabel = spanSuffix(draft);
 
   // formatDate merges over DEFAULT_DATE_FORMAT, which leaks day/hour/minute
   // into the header. Use Intl directly so we get just "April 2026".

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -23,6 +23,7 @@ import {
   endOfDay,
   isSameDay,
   matchPreset,
+  shiftMonth,
   startOfDay,
   ymd,
   type DateRangeValue,
@@ -51,12 +52,6 @@ const formatTriggerLabel = (range: DateRangeValue, formatDate: (ts: number, opts
 const MONTH_FORMAT: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' };
 
 const CELL_FORMAT: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'long', year: 'numeric' };
-
-/** Steps the browsed month by delta, carrying into the year. */
-const shiftMonth = (year: number, month: number, delta: number) => {
-  const absolute = year * 12 + month + delta;
-  return { year: Math.floor(absolute / 12), month: ((absolute % 12) + 12) % 12 };
-};
 
 /** The " · N days selected" suffix, empty while the range is incomplete. */
 const spanSuffix = (range: DateRangeValue) => {

--- a/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
+++ b/web/src/features/tasks/components/dateRange/DateRangePicker.tsx
@@ -59,7 +59,11 @@ const spanSuffix = (range: DateRangeValue) => {
     return '';
   }
   const span = dayCount(range.start, range.end);
-  return span > 0 ? ` · ${span} ${span === 1 ? 'day' : 'days'} selected` : '';
+  if (span === 0) {
+    return '';
+  }
+  const dayWord = span === 1 ? 'day' : 'days';
+  return ` · ${span} ${dayWord} selected`;
 };
 
 /**

--- a/web/src/features/tasks/components/dateRange/calendar.test.ts
+++ b/web/src/features/tasks/components/dateRange/calendar.test.ts
@@ -7,6 +7,7 @@ import {
   endOfDay,
   isSameDay,
   matchPreset,
+  shiftMonth,
   startOfDay,
 } from './calendar';
 
@@ -91,5 +92,18 @@ describe('calendar helpers', () => {
   it('dateAt builds midnight in UTC', () => {
     const date = dateAt(2026, 0, 1, 'utc');
     expect(date.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('shiftMonth steps within a year without touching it', () => {
+    expect(shiftMonth(2026, 5, 1)).toEqual({ year: 2026, month: 6 });
+    expect(shiftMonth(2026, 5, -1)).toEqual({ year: 2026, month: 4 });
+  });
+
+  it('shiftMonth carries December forward into the next January', () => {
+    expect(shiftMonth(2026, 11, 1)).toEqual({ year: 2027, month: 0 });
+  });
+
+  it('shiftMonth carries January back into the previous December', () => {
+    expect(shiftMonth(2026, 0, -1)).toEqual({ year: 2025, month: 11 });
   });
 });

--- a/web/src/features/tasks/components/dateRange/calendar.ts
+++ b/web/src/features/tasks/components/dateRange/calendar.ts
@@ -177,3 +177,9 @@ export const dayCount = (start: number, end: number): number => {
   if (end < start) return 0;
   return Math.max(1, Math.round((end - start) / (60 * 60 * 24)));
 };
+
+/** Steps the browsed month by delta, carrying into the year. */
+export const shiftMonth = (year: number, month: number, delta: number): { year: number; month: number } => {
+  const absolute = year * 12 + month + delta;
+  return { year: Math.floor(absolute / 12), month: ((absolute % 12) + 12) % 12 };
+};


### PR DESCRIPTION
Clears the two remaining SonarCloud findings on `main`, both in `web/`.

- `DateRangePicker` was over the cognitive complexity limit. Three pieces move
  out of its body: `shiftMonth` for the month-carry arithmetic, `spanSuffix`
  for the "N days selected" label, and `usePopoverSeed` for the render-phase
  reseed of the draft and browsed month. The reseed is the delicate one — the
  five tests covering the behaviour fixed in #594 still pass unchanged.
- The row-inertness e2e test dropped its `waitForTimeout(500)`. The closing
  assertion already requires exactly one history entry, which the View link
  accounts for, so a stray navigation from the header or row click surfaces
  there as two. What this costs is attribution, not a failure mode: a failure
  now reports the total rather than naming which click navigated.

`shiftMonth` was checked exhaustively against the original carry logic for
every month from 1970 to 2100 in both directions.

The Playwright suite was not run locally — `task build-ui` fails at the swagger
step because the local swag cannot parse Go 1.27's stdlib. CI runs it here.