### PR TITLE
fix(argocd): hand a rollout over at shutdown instead of failing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   milliseconds and an empty `updated`; both are now Unix seconds, matching the API responses and the
   in-memory backend, so a webhook template that renders `{{ .Created }}` or `{{ .Updated }}` gets
   the documented value.
+- A deployment still running when Argo Watcher is restarted is no longer recorded as `failed`. On
+  the PostgreSQL backend it is handed to another replica, which watches it to its real outcome —
+  previously the shutdown cut off the deployment's git write-back and that was reported as the
+  deployment failing, and a failed task is never picked up again. Only a deployment the replica had
+  accepted itself was affected; one already taken over from another replica was handed on correctly.
+  With the in-memory backend there is no other replica to hand it to, so an interrupted deployment
+  is still reported as failed rather than disappearing without a result.
 
 ## [1.3.0] - 2026-09-09
 

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -112,28 +112,11 @@ func (updater *ArgoStatusUpdater) Close(ctx context.Context) {
 	}
 }
 
-// WaitForRollout monitors the application until it reaches a final state (deployed
-// or failed), or stops early if a newer deployment for the same app supersedes it
-// (issue #353), or if another replica takes the task over.
-//
-// resumed marks a task picked up from another replica: its start notification was
-// already sent by the replica that accepted it, so sending a second one would
-// announce the same deployment twice.
-func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool) {
-	updater.waitForRollout(task, resumed, neverDraining)
-}
-
-// neverDraining is the abandon predicate for a rollout monitored by the replica
-// that accepted the deployment. Such a task has nowhere to be handed back to:
-// nothing else holds its claim, so it is watched until it finishes or until the
-// process ends with it.
-func neverDraining() bool { return false }
-
-// waitForRollout is WaitForRollout with the condition under which this replica
-// gives the rollout up: draining reports that shutdown has begun, which ends the
-// monitoring as a takeover would — without a status, so the replica that resumes
-// the task records the outcome instead.
-func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool, draining func() bool) {
+// WaitForRollout monitors the application until it reaches a final state, giving it
+// up without a status when a newer deployment supersedes it (issue #353), when
+// another replica takes the task over, or when draining reports shutdown has begun.
+// resumed marks a task already announced as started by the replica that accepted it.
+func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool, draining func() bool) {
 	updater.monitor.BeginTracking()
 	defer updater.monitor.EndTracking()
 
@@ -175,6 +158,10 @@ func (updater *ArgoStatusUpdater) waitForRollout(task models.Task, resumed bool,
 		// whatever wrote it, and neither a cancelled nor an aborted task is re-claimed by
 		// a sweep — so this replica is the last one able to announce it.
 	case draining():
+		// Covers the write-back errors shutdown raises (errBatcherClosed,
+		// errWritebackDraining) as well as a poll given up: the predicate is true from
+		// the first shutdown phase, before the batcher is torn down. Classifying those
+		// errors on their own instead would abandon a rollout nothing can resume.
 		err = errReplicaDraining
 	}
 

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -75,6 +75,10 @@ func zeroDelay(_ uint, _ error, _ *retry.Config) time.Duration {
 	return 0
 }
 
+// neverDraining is the abandon predicate for a test whose subject is not the
+// shutdown handover: the replica stays up for the whole rollout.
+func neverDraining() bool { return false }
+
 // newArgoApiMock builds an ArgoApi mock pre-loaded with the best-effort defaults every test
 // tolerates. The failure-path resource-tree fetch is best-effort, so it defaults to "no tree"
 // (rolloutMessage then falls back to the app's top-level resources). Only tests that assert
@@ -168,7 +172,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application deployed with Retry", func(t *testing.T) {
@@ -216,7 +220,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application deployed with Registry proxy", func(t *testing.T) {
@@ -256,7 +260,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application deployed without Registry proxy", func(t *testing.T) {
@@ -302,7 +306,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application not found", func(t *testing.T) {
@@ -331,7 +335,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAppNotFoundMessage, "ArgoCD API Error: applications.argoproj.io \"test-app\" not found")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - ArgoCD unavailable", func(t *testing.T) {
@@ -358,7 +362,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, "ArgoCD API Error: dial tcp: connect: connection refused")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application API error", func(t *testing.T) {
@@ -384,7 +388,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 		metricsMock.EXPECT().RemoveInProgressTask()
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, "ArgoCD API Error: unexpected failure")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application not available", func(t *testing.T) {
@@ -426,7 +430,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"List of expected images:\n"+
 				"\tghcr.io/shini4i/argo-watcher:dev")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("Status Updater - Application out of Sync", func(t *testing.T) {
@@ -479,7 +483,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				return nil
 			})
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 
 		assert.True(t, strings.HasPrefix(capturedReason, "Deployment failed: ArgoCD reports sync status Syncing"),
 			"unexpected headline: %s", capturedReason)
@@ -527,7 +531,7 @@ func TestArgoStatusUpdaterCheck(t *testing.T) {
 				"App sync status \"Synced\"\n"+
 				"App health status \"NotHealthy\"")
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 }
 
@@ -796,7 +800,7 @@ func TestArgoStatusUpdaterDegradedReportsRolloutDiagnostics(t *testing.T) {
 			return nil
 		})
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	assert.NotContains(t, capturedReason, "ArgoCD API Error")
 	assert.Contains(t, capturedReason, "Application deployment failed. Rollout status is degraded")
@@ -857,7 +861,7 @@ func TestArgoStatusUpdaterSupersededAfterSuccessfulPollWritesNoStatus(t *testing
 	// No SetTaskStatus and no failed-deployment metric are expected, so gomock fails the test
 	// if the superseded task is mistaken for a reportable rollout state.
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	require.NotEmpty(t, capture.sent)
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
@@ -913,7 +917,7 @@ func TestArgoStatusUpdaterAbortsWhenArgoBecomesUnreachableMidPoll(t *testing.T) 
 			return nil
 		})
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	assert.Contains(t, capturedReason, "connection refused")
 }
@@ -1415,7 +1419,7 @@ func TestArgoStatusUpdaterFailureDurationExcludesSetup(t *testing.T) {
 			return nil
 		})
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	assert.Equal(t,
 		"Deployment failed: ArgoCD reports sync status OutOfSync.\n\n"+
@@ -1641,7 +1645,7 @@ func TestArgoStatusUpdaterStopsWhenSuperseded(t *testing.T) {
 	// "cancelled" status the newer deployment already wrote untouched. Any
 	// GetApplication or SetTaskStatus call would be unexpected and fail the test.
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	require.NotEmpty(t, capture.sent)
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[len(capture.sent)-1].Status)
@@ -1692,7 +1696,7 @@ func TestArgoStatusUpdaterStopsMidPollWhenSuperseded(t *testing.T) {
 	// No SetTaskStatus and no failed-deployment metric: a superseded rollout is not
 	// a failure and its status must not be overwritten.
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 }
 
 // TestArgoStatusUpdaterAppDisappearsMidRollout is the regression guard for issue #387:
@@ -1747,7 +1751,7 @@ func TestArgoStatusUpdaterAppDisappearsMidRollout(t *testing.T) {
 		fmt.Sprintf(ArgoAPIErrorTemplate, notFound.Error()),
 	)
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 }
 
 // TestArgoStatusUpdaterProceedsWhenStatusReadFails verifies that a transient
@@ -1791,7 +1795,7 @@ func TestArgoStatusUpdaterProceedsWhenStatusReadFails(t *testing.T) {
 	metricsMock.EXPECT().RemoveInProgressTask()
 	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "")
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 }
 
 func TestHandleApplicationFetchError(t *testing.T) {
@@ -2449,7 +2453,7 @@ func TestArgoStatusUpdaterLostLeaseWritesNoStatus(t *testing.T) {
 				Images:  []models.Image{{Image: "ghcr.io/shini4i/argo-watcher", Tag: "dev"}},
 			}
 
-			updater.WaitForRollout(task, false)
+			updater.WaitForRollout(task, false, neverDraining)
 
 			for _, sent := range capture.sent {
 				assert.Equal(t, models.StatusInProgressMessage, sent.Status,
@@ -2586,7 +2590,7 @@ func TestWaitForRollout_LeavesASupersessionItLostToTheNewOwner(t *testing.T) {
 		Images:  []models.Image{{Image: "demo", Tag: "v1"}},
 	}
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	for _, sent := range capture.sent {
 		assert.Equal(t, models.StatusInProgressMessage, sent.Status,
@@ -2680,7 +2684,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("an application ArgoCD never confirmed is counted without a label", func(t *testing.T) {
@@ -2692,7 +2696,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 		// controller fails the test if the unconfirmed name reaches either.
 		metricsMock.EXPECT().AddUnconfirmedFailure()
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("a failure after confirmation names the app", func(t *testing.T) {
@@ -2707,7 +2711,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 		metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusAppNotFoundMessage)
 		metricsMock.EXPECT().AddFailedDeployment(task.App)
 
-		updater.WaitForRollout(task, false)
+		updater.WaitForRollout(task, false, neverDraining)
 	})
 
 	t.Run("a resumed deployment is counted by the replica that finishes it", func(t *testing.T) {
@@ -2719,7 +2723,7 @@ func TestWaitForRollout_PerAppSeriesWaitForArgoConfirmation(t *testing.T) {
 		metricsMock.EXPECT().ResetFailedDeployment(task.App)
 		metricsMock.EXPECT().ObserveDeploymentDuration(task.App, gomock.Any())
 
-		updater.WaitForRollout(task, true)
+		updater.WaitForRollout(task, true, neverDraining)
 	})
 }
 
@@ -2806,7 +2810,7 @@ func TestArgoStatusUpdaterStopsWhenTheStaleSweepAborted(t *testing.T) {
 	metricsMock.EXPECT().RemoveInProgressTask()
 	// No SetTaskStatus: the sweep already wrote the terminal status, with its own reason.
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	// Exactly the start and the result: announcing one deployment twice is the
 	// failure the no-status-written branches exist to avoid.
@@ -2843,7 +2847,7 @@ func TestArgoStatusUpdaterStopsBeforeStartingAnAbortedTask(t *testing.T) {
 	metricsMock.EXPECT().AddInProgressTask()
 	metricsMock.EXPECT().RemoveInProgressTask()
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	require.Len(t, capture.sent, 2)
 	assert.Empty(t, capture.sent[0].Status, "the first is the start notification")
@@ -2913,7 +2917,7 @@ func TestWaitForRollout_EveryTerminalOutcomeIsPreCreated(t *testing.T) {
 			task := models.Task{Id: "test-id", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v1"}}}
 			tt.arrange(apiMock, task)
 
-			initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo).WaitForRollout(task, false)
+			initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo).WaitForRollout(task, false, neverDraining)
 
 			var expected strings.Builder
 			expected.WriteString("# HELP deployments_total Deployments that reached a terminal state for an application ArgoCD confirmed, by outcome.\n")

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -49,10 +49,10 @@ var errTaskAborted = errors.New("task aborted by the staleness sweep")
 // rollout without writing a status: the new owner records the outcome.
 var errLeaseLost = errors.New("task taken over by another replica")
 
-// errReplicaDraining is an internal sentinel returned when this replica began
-// shutting down while it was monitoring a resumed rollout. It stops the rollout
-// without writing a status, like errLeaseLost: the claim is released at the end of
-// shutdown and the replica that resumes the task records the outcome.
+// errReplicaDraining is an internal sentinel returned when this replica gives a
+// rollout up to shutdown — whether it accepted or resumed the task, or its
+// write-back never ran. It stops the rollout without writing a status, like
+// errLeaseLost: the replica that resumes the task records the outcome.
 var errReplicaDraining = errors.New("replica is shutting down")
 
 // ImageNotPartOfAppError reports that a task expects an image the application's desired

--- a/internal/argocd/image_validation_test.go
+++ b/internal/argocd/image_validation_test.go
@@ -351,7 +351,7 @@ func TestWaitForRolloutCountsImageNotPartOfAppAsFailed(t *testing.T) {
 			return nil
 		})
 
-	updater.WaitForRollout(task, false)
+	updater.WaitForRollout(task, false, neverDraining)
 
 	assert.Contains(t, capturedReason, "is not part of application")
 }

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -44,7 +44,7 @@ func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task, draining func(
 		"id", task.Id, "app", task.App, "remaining", remaining)
 
 	task.Timeout = int(remaining.Seconds())
-	updater.waitForRollout(task, true, draining)
+	updater.WaitForRollout(task, true, draining)
 }
 
 // remainingWindow returns how much of the task's rollout window is left at now,

--- a/internal/argocd/shutdown_rollout_test.go
+++ b/internal/argocd/shutdown_rollout_test.go
@@ -1,0 +1,338 @@
+package argocd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/lock"
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/notifications"
+)
+
+// managedApp is a settled application the watcher writes back for, so a rollout
+// reaches the git write-back and then ends on its first poll.
+func managedApp() *models.Application {
+	app := &models.Application{}
+	app.Metadata.Annotations = map[string]string{"argo-watcher/managed": "true"}
+	app.Spec.Source.RepoURL = "git@example.com/repo.git"
+	app.Spec.Source.TargetRevision = "main"
+	app.Spec.Source.Path = "path"
+	app.Status.Summary.Images = []string{"app:v1"}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Healthy"
+	return app
+}
+
+func shutdownTestTask(id string) models.Task {
+	return models.Task{
+		Id:        id,
+		App:       "test-app",
+		Status:    models.StatusInProgressMessage,
+		Timeout:   15,
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+}
+
+// A write-back that failed and one that never ran because the batcher was torn
+// down surface on the same return path. Which of the two a task is depends on
+// whether anything can resume it: a "failed" task is never re-claimed by a sweep,
+// so misreading a handover as a failure buries a healthy rollout permanently.
+func TestWaitForRollout_ShutdownWriteBackIsNotADeploymentFailure(t *testing.T) {
+	gitFailure := errors.New("remote refused the update")
+	batchDrained := fmt.Errorf("batch git update stopped early: %w", errors.Join(errWritebackDraining, gitFailure))
+
+	tests := []struct {
+		name string
+		// closeBatcher reproduces errBatcherClosed the way production raises it:
+		// from Submit itself, once shutdown has torn the batcher down.
+		closeBatcher bool
+		writeBack    error
+		draining     bool
+		wantStatus   string
+	}{
+		{
+			name:         "the batcher was closed before the write-back was queued",
+			closeBatcher: true,
+			draining:     true,
+		},
+		{
+			// A different error, deliberately reaching the same outcome: once the replica
+			// is draining the cause no longer decides anything, which is the arm's point.
+			name:      "the batch retry loop stopped for the drain",
+			writeBack: batchDrained,
+			draining:  true,
+		},
+		{
+			// In-memory state, where nothing resumes the task: silence would lose the
+			// deployment outright, so the lost commit is reported as the failure it is.
+			name:         "a write-back lost to shutdown with nobody to hand over to",
+			closeBatcher: true,
+			wantStatus:   models.StatusFailedMessage,
+		},
+		{
+			// The control: an ordinary write-back failure is still this deployment's
+			// outcome and must keep failing the task.
+			name:       "an ordinary write-back failure still fails the deployment",
+			writeBack:  gitFailure,
+			wantStatus: models.StatusFailedMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := notSupersededState(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+			apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(managedApp(), nil).AnyTimes()
+
+			metricsMock.EXPECT().AddInProgressTask()
+			metricsMock.EXPECT().RemoveInProgressTask()
+			metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+
+			locker := lock.NewInMemoryLocker()
+			updater := initTestUpdater(t, newUpdaterTestConfig(locker), argo)
+			capture := &capturingStrategy{}
+			updater.notifier = notifications.NewNotifier(capture)
+
+			batcher := NewBatcher(locker, "/tmp/cache", 20, nil)
+			batcher.flushFn = func(batch []*batchWriteRequest) {
+				for _, req := range batch {
+					req.resultCh <- tt.writeBack
+				}
+			}
+			updater.gitUpdater = NewGitUpdater(locker, "/tmp/cache", nil, batcher)
+			if tt.closeBatcher {
+				batcher.Close(context.Background())
+			}
+
+			task := shutdownTestTask("shutdown-id")
+
+			if tt.wantStatus != "" {
+				metricsMock.EXPECT().AddFailedDeployment(task.App)
+				metricsMock.EXPECT().AddDeploymentOutcome(task.App, tt.wantStatus)
+				stateMock.EXPECT().SetTaskStatus(task.Id, tt.wantStatus, gomock.Any())
+			}
+
+			updater.WaitForRollout(task, false, func() bool { return tt.draining })
+
+			if tt.wantStatus == "" {
+				require.Len(t, capture.sent, 1, "the replica that resumes the task announces the result")
+				assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
+				return
+			}
+			require.Len(t, capture.sent, 2, "a deployment this replica failed must be announced")
+			assert.Equal(t, tt.wantStatus, capture.sent[1].Status)
+		})
+	}
+}
+
+// The drain now stops an in-flight write-back for a rollout this replica accepted,
+// not only for a resumed one. The commit is deliberately not pushed, so the task
+// must be handed on — unless a newer deployment cancelled it, which no sweep will
+// re-claim and therefore nobody else could announce.
+func TestWaitForRollout_WriteBackStoppedByTheDrain(t *testing.T) {
+	tests := []struct {
+		name      string
+		cancelled bool
+		wantFinal string
+	}{
+		{name: "handed on, so this replica announces nothing"},
+		{
+			name:      "cancelled mid-write-back, so the drain must not swallow it",
+			cancelled: true,
+			wantFinal: models.StatusCancelledMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := newTaskRepositoryMock(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+			apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(managedApp(), nil).AnyTimes()
+
+			// In progress when the rollout starts, so the write-back is reached. The
+			// flush below is what flips this, which is what makes the cancellation
+			// discovered inside the write-back however many reads precede it.
+			var cancelledMidFlush atomic.Bool
+			stateMock.EXPECT().GetTask(gomock.Any()).
+				DoAndReturn(func(string) (*models.Task, error) {
+					if cancelledMidFlush.Load() {
+						return &models.Task{Status: models.StatusCancelledMessage}, nil
+					}
+					return &models.Task{Status: models.StatusInProgressMessage}, nil
+				}).AnyTimes()
+
+			metricsMock.EXPECT().AddInProgressTask()
+			metricsMock.EXPECT().RemoveInProgressTask()
+			metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+			if tt.wantFinal != "" {
+				// The cancellation is an outcome this replica reports; it still writes no
+				// status, because whichever replica cancelled the task already did.
+				metricsMock.EXPECT().AddDeploymentOutcome("test-app", tt.wantFinal)
+			}
+			// Nothing else is declared: gomock fails the test if a status, a failure or a
+			// deployment outcome is recorded for a write-back this replica gave up.
+
+			locker := lock.NewInMemoryLocker()
+			updater := initTestUpdater(t, newUpdaterTestConfig(locker), argo)
+			capture := &capturingStrategy{}
+			updater.notifier = notifications.NewNotifier(capture)
+
+			// The real batch loop consults each request's stop predicate and resolves it
+			// as superseded; this stands in for that without reaching a repository.
+			var pushed atomic.Bool
+			batcher := NewBatcher(locker, "/tmp/cache", 20, nil)
+			batcher.flushFn = func(batch []*batchWriteRequest) {
+				for _, req := range batch {
+					// A newer deployment cancels the task while this batch is in flight.
+					cancelledMidFlush.Store(tt.cancelled)
+					if req.isSuperseded != nil && req.isSuperseded() {
+						req.resultCh <- ErrDeploymentSuperseded
+						continue
+					}
+					pushed.Store(true)
+					req.resultCh <- nil
+				}
+			}
+			updater.gitUpdater = NewGitUpdater(locker, "/tmp/cache", nil, batcher)
+
+			updater.WaitForRollout(shutdownTestTask("write-back-id"), false, func() bool { return true })
+
+			assert.False(t, pushed.Load(), "a write-back given up to the shutdown must not commit")
+			if tt.wantFinal == "" {
+				require.Len(t, capture.sent, 1, "the replica that resumes the task announces the result")
+				assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
+				return
+			}
+			require.Len(t, capture.sent, 2, "a cancellation is never re-claimed, so it must be announced here")
+			assert.Equal(t, tt.wantFinal, capture.sent[1].Status)
+		})
+	}
+}
+
+// Shutdown can begin after the rollout is already being polled. The accepting side
+// must give it up there too, exactly as a resumed rollout does: its claim is
+// released in the last shutdown phase and another replica records the outcome.
+func TestWaitForRollout_GivesUpWhenTheDrainBeginsMidPoll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := notSupersededState(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	// Unmanaged, so no write-back stands between the confirmation and the poll loop,
+	// and still Progressing, so the loop reaches a second iteration to be stopped at.
+	app := &models.Application{}
+	app.Status.Summary.Images = []string{"app:v1"}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Progressing"
+
+	// Shutdown begins during the poll's own fetch: after the abandon check that opens
+	// the iteration, so only the next one can act on it.
+	var fetches atomic.Int32
+	var draining atomic.Bool
+	apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string, bool) (*models.Application, error) {
+			if fetches.Add(1) > 1 {
+				draining.Store(true)
+			}
+			return app, nil
+		}).Times(2)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+	// No SetTaskStatus and no outcome counter: this replica decides nothing now.
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := shutdownTestTask("mid-poll-id")
+	task.Validated = false
+
+	updater.WaitForRollout(task, false, draining.Load)
+
+	assert.Equal(t, int32(2), fetches.Load(), "the rollout must be polled before it is given up")
+	require.Len(t, capture.sent, 1, "the replica that resumes the task announces the result")
+	assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
+}
+
+// The drain can flip during the poll that settles the rollout, so the iteration
+// finishes and reports a terminal outcome. Writing it is what a monitor about to
+// disappear must not do: the claim is released moments later and the replica that
+// resumes the task decides the result.
+func TestWaitForRollout_GivesUpARolloutThatSettledAsTheDrainBegan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := notSupersededState(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	// Unmanaged, so nothing but the poll loop stands between confirmation and the
+	// outcome, and already carrying the task's image, so the first poll settles it.
+	app := &models.Application{}
+	app.Status.Summary.Images = []string{"app:v1"}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Healthy"
+
+	var fetches atomic.Int32
+	var draining atomic.Bool
+	apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string, bool) (*models.Application, error) {
+			if fetches.Add(1) > 1 {
+				draining.Store(true)
+			}
+			return app, nil
+		}).Times(2)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+	// Nothing else: gomock fails the test if this replica records the outcome it
+	// observed — the status, the outcome counter or the duration.
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	task := shutdownTestTask("settled-id")
+	task.Validated = false
+
+	updater.WaitForRollout(task, false, draining.Load)
+
+	assert.Equal(t, int32(2), fetches.Load(), "the rollout must reach its outcome before it is given up")
+	require.Len(t, capture.sent, 1, "the replica that resumes the task announces the result")
+}

--- a/internal/server/env.go
+++ b/internal/server/env.go
@@ -158,6 +158,14 @@ func (env *Env) isDraining() bool {
 	return env.draining.Load()
 }
 
+// handsOverOnShutdown reports that a rollout given up now will be picked up again.
+// Only the shared state can hand one over: with in-memory state the task dies with
+// the process, so abandoning it would drop the deployment — its git write-back
+// included — instead of handing it on.
+func (env *Env) handsOverOnShutdown() bool {
+	return env.config.StateType == "postgres" && env.isDraining()
+}
+
 // Shutdown gracefully shuts down the server and all WebSocket connections.
 // This method is safe to call multiple times. It blocks until all WebSocket
 // goroutines have finished or ctx expires. If it gives up, some goroutines may

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -200,7 +200,7 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go env.updater.WaitForRollout(*newTask, false)
+	go env.updater.WaitForRollout(*newTask, false, env.handsOverOnShutdown)
 
 	writeJSON(w, http.StatusAccepted, models.TaskStatus{
 		Id:     newTask.Id,

--- a/internal/server/shutdown_handover_test.go
+++ b/internal/server/shutdown_handover_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shini4i/argo-watcher/internal/config"
+)
+
+// Giving a rollout up at shutdown only helps when something can pick it up. With
+// in-memory state nothing can, so the deployment — its git write-back included —
+// would be dropped rather than handed on.
+func TestHandsOverOnShutdown(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateType string
+		draining  bool
+		want      bool
+	}{
+		{name: "shared state, shutting down", stateType: "postgres", draining: true, want: true},
+		{name: "shared state, still serving", stateType: "postgres"},
+		{name: "in-memory state, shutting down", stateType: "in-memory", draining: true},
+		{name: "in-memory state, still serving", stateType: "in-memory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &Env{config: &config.ServerConfig{StateType: tt.stateType}}
+			if tt.draining {
+				env.beginDraining()
+			}
+
+			assert.Equal(t, tt.want, env.handsOverOnShutdown())
+		})
+	}
+}

--- a/internal/server/task_reaper.go
+++ b/internal/server/task_reaper.go
@@ -42,10 +42,8 @@ func reapAbandonedTasks(stop <-chan struct{}, draining func() bool, interval tim
 			return
 		case <-ticker.C:
 			// Draining begins several seconds before the shutdown channel closes.
-			// Claiming in that window takes deployments this replica cannot finish: it
-			// releases them again moments later, and a resume that outlives the
-			// write-back drain fails on the closed batcher and writes a terminal status
-			// no other replica will revisit.
+			// Claiming in that window takes deployments this replica cannot finish and
+			// releases them again moments later, delaying the handover it was meant to be.
 			if draining() {
 				continue
 			}
@@ -88,21 +86,10 @@ func (env *Env) releaseTaskLeases() {
 	}
 }
 
-// resumeSafely runs resume and contains a panic to the one task that caused it.
-// A task is only ever abandoned back to the other replicas, so a panic that took
-// the process down would be re-claimed elsewhere and take that replica down too,
-// walking one bad deployment through the whole fleet.
-//
-// Draining is re-checked here because it can begin between the sweep's own check
-// and this goroutine starting. Monitoring a rollout this replica cannot finish is
-// worse than not starting it: once shutdown closes the write-back batcher, the
-// resumed task's write-back fails and records a terminal status for a deployment
-// that is otherwise healthy. Giving up before starting leaves the claim to be
-// released with the rest, so another replica takes it instead.
-//
-// The same predicate is handed to resume, which keeps watching it: shutdown can
-// also begin after a rollout is under way, and that rollout must be given up
-// rather than raced against the teardown.
+// resumeSafely contains a panic to the one task that caused it: a task is only ever
+// abandoned back to the other replicas, so a panic that took the process down would
+// walk one bad deployment through the whole fleet. Draining is re-checked because it
+// can begin after the sweep's own check, and handed on for a mid-rollout shutdown.
 func resumeSafely(task models.Task, draining func() bool, resume func(models.Task, func() bool)) {
 	defer func() {
 		if recovered := recover(); recovered != nil {


### PR DESCRIPTION
A deployment still being monitored when a replica shuts down is no longer recorded as `failed`.

`WaitForRollout` hard-wired a "never draining" predicate, so only a task resumed from another replica noticed shutdown. A task the replica had accepted itself kept polling into the teardown, and once `updater.Close` tore the write-back batcher down its error was classified as a deployment failure. `ClaimExpiredTasks` only offers tasks that are still in progress, so that status was terminal and the rollout was never watched again.

`WaitForRollout` now takes the predicate from its caller, and `addTask` passes the new `Env.handsOverOnShutdown`. That reports draining only on the PostgreSQL backend: with in-memory state nothing can take the task over, so giving it up would drop the deployment and its commit rather than hand them on — there the lost write-back is still reported as the failure it is.

Two behaviours deliberately left as they are:

- A rollout that settles in the same poll iteration the drain begins still writes no status, matching what `TestResumeRollout_WritesNothingWhenShutdownBeginsMidPoll` already pins for resumed tasks.
- Nothing asserts that `addTask` passes `handsOverOnShutdown`; `env.updater` is concrete on purpose and an interface seam for one wiring line is not worth it.