### PR TITLE
fix: stop trusting what Argo CD calls and query params are given

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,8 @@ repos:
         name: TruffleHog secret scan
         entry: trufflehog filesystem --results=verified,unknown --fail
         language: system
-        # docker-compose.yml (local dev credentials), updater_test.go (SSH key
-        # fixtures for unit tests) and database.md (an example postgres DSN using
-        # the RFC 2606 db.example.com placeholder) hold intentional non-secrets
-        # that TruffleHog flags as "unknown". Filesystem mode ignores
-        # --exclude-paths for explicitly-passed files, so skip them at the
-        # pre-commit layer. Keep this list in sync with .trufflehog-exclude
-        # (used by CI).
-        exclude: ^(docker-compose\.yml|internal/updater/updater_test\.go|docs/operations/database\.md)$
+        # The excluded files hold deliberate non-secrets TruffleHog reports as
+        # "unknown": dev credentials, SSH key fixtures, an example DSN, and a URL
+        # whose fake password a test asserts never reaches an error. Filesystem mode
+        # ignores --exclude-paths, so keep this in sync with .trufflehog-exclude.
+        exclude: ^(docker-compose\.yml|internal/updater/updater_test\.go|docs/operations/database\.md|internal/config/argo_endpoint_test\.go)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         entry: trufflehog filesystem --results=verified,unknown --fail
         language: system
         # The excluded files hold deliberate non-secrets TruffleHog reports as
-        # "unknown": dev credentials, SSH key fixtures, an example DSN, and a URL
-        # whose fake password a test asserts never reaches an error. Filesystem mode
-        # ignores --exclude-paths, so keep this in sync with .trufflehog-exclude.
-        exclude: ^(docker-compose\.yml|internal/updater/updater_test\.go|docs/operations/database\.md|internal/config/argo_endpoint_test\.go)$
+        # "unknown": dev credentials, SSH key fixtures and an example DSN.
+        # Filesystem mode ignores --exclude-paths for explicitly-passed files, so
+        # keep this list in sync with .trufflehog-exclude, which CI uses.
+        exclude: ^(docker-compose\.yml|internal/updater/updater_test\.go|docs/operations/database\.md)$

--- a/.trufflehog-exclude
+++ b/.trufflehog-exclude
@@ -1,4 +1,3 @@
 docker-compose\.yml
 internal/updater/updater_test\.go
 docs/operations/database\.md
-internal/config/argo_endpoint_test\.go

--- a/.trufflehog-exclude
+++ b/.trufflehog-exclude
@@ -1,3 +1,4 @@
 docker-compose\.yml
 internal/updater/updater_test\.go
 docs/operations/database\.md
+internal/config/argo_endpoint_test\.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the concrete problem — waiting for an Argo CD deployment from a CI pipeline and learning whether
   the built image rolled out — instead of the "feedback loop for GitOps" tagline. The README gains a
   short **Why not `argocd app wait`?** section pointing at the new guide.
+- The server now refuses to start on two settings it previously accepted and then failed on at
+  runtime. `ARGO_URL` must be an absolute `http`/`https` URL with a host — a bare host was read as a
+  relative path, which made every Argo CD call fail with `unsupported protocol scheme` and silently
+  dropped the API token, since a cookie jar keys its cookies by scheme. `ARGO_API_TIMEOUT` must be
+  between 1 and 3600 seconds — anything outside that range left Argo CD calls with no timeout at
+  all. Both are reported by name at startup.
 
 ### Fixed
 
@@ -60,6 +66,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cancelled the other, both were monitored, and both wrote back — leaving the Git repository on
   whichever tag happened to be pushed last while both deployments reported success. Superseding and
   recording a deployment are now a single step, so the later submission always wins.
+
+- A retried Argo CD API call no longer resends the session token once per attempt. The retry reused
+  one request object, so the HTTP client appended the token again each time and the header grew with
+  every attempt. A proxy refusing the oversized header answers with a client error, which Argo
+  Watcher reads as the deployment failing rather than as Argo CD being unreachable — so a transient
+  blip could end a healthy deployment as `failed`.
+- `from_timestamp` and `to_timestamp` no longer accept a value that no window limit can bound.
+  `NaN`, `Inf` and numbers far outside the range of a real timestamp were parsed as valid, and
+  because every comparison against `NaN` is false they slipped past the look-back limit and reached
+  the database as written. Such a value is now ignored, as any other unparseable one already was.
+
+### Security
+
+- A `ARGO_URL` containing basic-auth credentials no longer has its password written into the startup
+  error, and from there into the container log, when the value is rejected. The configuration
+  endpoint already stripped userinfo for the same reason.
 
 ## [1.3.0] - 2026-09-09
 

--- a/docs/reference/server-env.md
+++ b/docs/reference/server-env.md
@@ -8,11 +8,11 @@ On startup all missing or invalid variables are reported together in one error, 
 
 | Variable | Description | Default | Required |
 |---|---|---|---|
-| `ARGO_URL` | Argo CD server URL | | Yes |
+| `ARGO_URL` | Argo CD server URL; must be absolute, with an `http`/`https` scheme and a host | | Yes |
 | `ARGO_TOKEN` | Argo CD API token | | Yes |
 | `STATE_TYPE` | Storage backend: `in-memory` (single replica) or `postgres` | | Yes |
 | `DEPLOYMENT_TIMEOUT` | Seconds to wait for a deployment to finish; capped at `86400` | `900` | No |
-| `ARGO_API_TIMEOUT` | Timeout for Argo CD API calls, in seconds | `60` | No |
+| `ARGO_API_TIMEOUT` | Timeout for Argo CD API calls, in seconds (1–3600) | `60` | No |
 | `ARGO_API_RETRIES` | Total attempts per Argo CD API call (1–10) | `3` | No |
 | `ARGO_REFRESH_APP` | Refresh the application during status checks | `true` | No |
 | `ACCEPT_SUSPENDED_APP` | Treat a `Suspended` health status as deployed | `false` | No |

--- a/internal/argocd/argo_api.go
+++ b/internal/argocd/argo_api.go
@@ -93,15 +93,17 @@ func (api *ArgoApi) doGet(ctx context.Context, reqURL string) ([]byte, int, erro
 		return nil, 0, err
 	}
 
-	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "application/json")
 
-	// Safe to reuse across retries: GET request has no body that would be consumed.
+	// Cloned per attempt rather than reused: the client's jar appends the session
+	// cookie to the request it is handed, so a reused one accumulates a copy of the
+	// token per attempt until a proxy rejects the header. Replaying a clone is safe
+	// only because this GET has no body — Clone shallow-copies Body.
 	var resp *http.Response
 	err = retry.Do(
 		func() error {
 			var doErr error
-			resp, doErr = api.client.Do(req)
+			resp, doErr = api.client.Do(req.Clone(ctx))
 			return doErr
 		},
 		retry.Context(ctx),

--- a/internal/argocd/argo_api_retry_test.go
+++ b/internal/argocd/argo_api_retry_test.go
@@ -1,0 +1,108 @@
+package argocd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The client's jar appends the ArgoCD session cookie to the request it is given,
+// so retrying with the same *http.Request accumulates one copy of the token per
+// attempt. A proxy that rejects the oversized header answers 4xx, which is not
+// treated as an outage, so the deployment is recorded as failed rather than aborted.
+func TestArgoApiDoGetSendsTheTokenOncePerAttempt(t *testing.T) {
+	baseURL, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	jar.SetCookies(baseURL, []*http.Cookie{{Name: "argocd.token", Value: "secret"}})
+
+	var cookieHeaders []string
+	api := NewArgoApi()
+	api.baseUrl = *baseURL
+	api.maxRetries = 2
+	api.client = &http.Client{
+		Jar: jar,
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			cookieHeaders = append(cookieHeaders, req.Header.Get("Cookie"))
+			return nil, errors.New("connection refused")
+		}),
+	}
+
+	_, _, err = api.doGet(context.Background(), "https://example.com/api/v1/session/userinfo")
+	require.Error(t, err)
+	require.Len(t, cookieHeaders, 2, "every attempt must reach the transport")
+
+	for attempt, header := range cookieHeaders {
+		assert.Equal(t, 1, strings.Count(header, "argocd.token="),
+			"attempt %d must carry the token exactly once, got %q", attempt+1, header)
+	}
+}
+
+// Every attempt is a fresh clone of one request, so a header the caller set must
+// survive to the last of them.
+func TestArgoApiDoGetKeepsItsHeadersAcrossRetries(t *testing.T) {
+	baseURL, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	var accepts []string
+	api := NewArgoApi()
+	api.baseUrl = *baseURL
+	api.maxRetries = 2
+	api.client = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			accepts = append(accepts, req.Header.Get("Accept"))
+			return nil, errors.New("connection refused")
+		}),
+	}
+
+	_, _, err = api.doGet(context.Background(), "https://example.com/api/v1/session/userinfo")
+	require.Error(t, err)
+	require.Len(t, accepts, 2)
+	for _, accept := range accepts {
+		assert.Equal(t, "application/json", accept)
+	}
+}
+
+// ctxKey types the sentinel the clone must carry through.
+type ctxKey struct{}
+
+// Clone(ctx) is the only thing attaching the caller's context to the in-flight
+// round-trip now that the request is rebuilt per attempt. Cloning from
+// context.Background() instead would leave a call bounded only by the client
+// timeout, well past the rollout deadline doGet promises to honour.
+func TestArgoApiDoGetClonesWithTheCallersContext(t *testing.T) {
+	baseURL, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKey{}, "sentinel"))
+	defer cancel()
+
+	var seen context.Context
+	api := NewArgoApi()
+	api.baseUrl = *baseURL
+	api.maxRetries = 1
+	api.client = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			seen = req.Context()
+			return nil, errors.New("connection refused")
+		}),
+	}
+
+	_, _, err = api.doGet(ctx, "https://example.com/api/v1/session/userinfo")
+	require.Error(t, err)
+
+	require.NotNil(t, seen)
+	assert.Equal(t, "sentinel", seen.Value(ctxKey{}), "the request must carry the caller's context, not a fresh one")
+
+	cancel()
+	assert.ErrorIs(t, seen.Err(), context.Canceled, "cancelling the caller must reach the in-flight request")
+}

--- a/internal/config/argo_endpoint_test.go
+++ b/internal/config/argo_endpoint_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// url.Parse accepts a bare host as a relative path, so a scheme-less ARGO_URL
+// starts the server cleanly and then fails every call with "unsupported protocol
+// scheme" — and the cookie jar drops the session token for it, since a jar keys
+// cookies by scheme. Nothing in that failure names ARGO_URL as the cause.
+func TestNewServerConfig_ArgoUrlNeedsAnAbsoluteHttpUrl(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		// want is the scheme and host the message echoes. The raw value is never
+		// echoed: url.String() renders basic-auth userinfo, password included.
+		want string
+	}{
+		{name: "no scheme", url: "argocd.example.com", want: `scheme "" and host ""`},
+		{name: "scheme-relative", url: "//argocd.example.com", want: `scheme "" and host "argocd.example.com"`},
+		{name: "a scheme the client cannot dial", url: "ftp://argocd.example.com", want: `scheme "ftp" and host "argocd.example.com"`},
+		{name: "no host", url: "https://", want: `scheme "https" and host ""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ARGO_URL", tt.url)
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+
+			_, err := NewServerConfig()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ArgoUrl")
+			assert.Contains(t, err.Error(), tt.want, "the rejected parts must be named")
+		})
+	}
+}
+
+func TestNewServerConfig_ArgoUrlAcceptsHttpAndHttps(t *testing.T) {
+	for _, argoUrl := range []string{"http://argocd.example.com", "https://argocd.example.com:8080/argo"} {
+		t.Run(argoUrl, func(t *testing.T) {
+			t.Setenv("ARGO_URL", argoUrl)
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+
+			_, err := NewServerConfig()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// A non-positive timeout means "no timeout" to http.Client, so the initial
+// application fetch — which runs on context.Background() — can hang forever while
+// the lease guard keeps renewing the claim, leaving a task no sweep can resume.
+func TestNewServerConfig_ArgoApiTimeoutMustBeInRange(t *testing.T) {
+	// 3601 pins where the ceiling is; 9223372037 is where the nanosecond conversion
+	// would overflow back into "no timeout".
+	for _, timeout := range []string{"0", "-1", "3601", "9223372037"} {
+		t.Run(timeout, func(t *testing.T) {
+			t.Setenv("ARGO_URL", "https://example.com")
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+			t.Setenv("ARGO_API_TIMEOUT", timeout)
+
+			_, err := NewServerConfig()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ArgoApiTimeout")
+			assert.Contains(t, err.Error(), timeout)
+		})
+	}
+}
+
+func TestNewServerConfig_ArgoApiTimeoutAcceptsTheWholeRange(t *testing.T) {
+	for _, timeout := range []string{"1", "60", "3600"} {
+		t.Run(timeout, func(t *testing.T) {
+			t.Setenv("ARGO_URL", "https://example.com")
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+			t.Setenv("ARGO_API_TIMEOUT", timeout)
+
+			_, err := NewServerConfig()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// url.URL.String() renders basic-auth credentials, password included, and the
+// startup error is logged. MarshalText already strips userinfo for the config
+// endpoint; neither the validation message nor the parse error may reintroduce it.
+func TestNewServerConfig_ArgoUrlRejectionKeepsCredentialsOut(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		// want is what the error must still say, so a rejection for some unrelated
+		// reason cannot satisfy the redaction assertions on its own.
+		want string
+	}{
+		{name: "unusable scheme", url: "ftp://admin:s3cret@argocd.example.com", want: "ArgoUrl"},
+		{name: "username read as the scheme", url: "admin:s3cret@argocd.example.com", want: "ArgoUrl"},
+		// Rejected by url.Parse itself, whose *url.Error quotes the whole value.
+		{name: "url.Parse refuses it", url: "https://admin:s3cret @argocd.example.com", want: "invalid userinfo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ARGO_URL", tt.url)
+			t.Setenv("ARGO_TOKEN", "secret-token")
+			t.Setenv("STATE_TYPE", "in-memory")
+
+			_, err := NewServerConfig()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want, "the error must name why the value was refused")
+			assert.NotContains(t, err.Error(), "s3cret", "the password must never reach the error")
+		})
+	}
+}

--- a/internal/config/argo_endpoint_test.go
+++ b/internal/config/argo_endpoint_test.go
@@ -100,7 +100,7 @@ func TestNewServerConfig_ArgoUrlRejectionKeepsCredentialsOut(t *testing.T) {
 		// reason cannot satisfy the redaction assertions on its own.
 		want string
 	}{
-		{name: "unusable scheme", url: "ftp://admin:s3cret@argocd.example.com", want: "ArgoUrl"},
+		{name: "unusable scheme", url: "gopher://admin:s3cret@argocd.example.com", want: "ArgoUrl"},
 		{name: "username read as the scheme", url: "admin:s3cret@argocd.example.com", want: "ArgoUrl"},
 		// Rejected by url.Parse itself, whose *url.Error quotes the whole value.
 		{name: "url.Parse refuses it", url: "https://admin:s3cret @argocd.example.com", want: "invalid userinfo"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,11 @@ import (
 // sweep instead, once an hour, without naming the setting at fault.
 const maxTaskRetentionDays = 36500
 
+// maxArgoApiTimeout is the ceiling on ARGO_API_TIMEOUT, in seconds. It is far
+// below where `time.Duration(seconds) * time.Second` overflows int64 back into a
+// non-positive value, which http.Client reads as no timeout at all.
+const maxArgoApiTimeout = 3600
+
 // URL is a url.URL that crosses every boundary as a URL string: the JSON of
 // GET /api/v1/config and the structured logs, which would otherwise carry the
 // eleven exported fields of a url.URL for every consumer to reassemble. It parses
@@ -38,10 +43,16 @@ func (u URL) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalText parses a URL string, rejecting one url.Parse cannot read. It backs
-// both env parsing and JSON decoding of the config payload.
+// both env parsing and JSON decoding of the config payload. Only the parse reason
+// is returned: *url.Error quotes the value it rejected, which for ARGO_URL renders
+// basic-auth credentials into the startup error, as MarshalText notes.
 func (u *URL) UnmarshalText(text []byte) error {
 	parsed, err := url.Parse(string(text))
 	if err != nil {
+		var parseErr *url.Error
+		if errors.As(err, &parseErr) {
+			return parseErr.Err
+		}
 		return err
 	}
 	u.URL = *parsed
@@ -290,6 +301,20 @@ func validateServerConfig(config *ServerConfig) error {
 	}
 	if config.ArgoApiRetries < 1 || config.ArgoApiRetries > 10 {
 		problems = append(problems, fmt.Sprintf("  - ArgoApiRetries: must be between 1 and 10, got %d", config.ArgoApiRetries))
+	}
+	// url.Parse reads a bare host as a relative path, so without this the server
+	// starts and every call fails on "unsupported protocol scheme" — with the token
+	// silently dropped too, since a cookie jar keys its cookies by scheme. Only the
+	// parsed parts are echoed: String() would render basic-auth userinfo, as above.
+	if scheme := config.ArgoUrl.Scheme; (scheme != "http" && scheme != "https") || config.ArgoUrl.Host == "" {
+		problems = append(problems, fmt.Sprintf("  - ArgoUrl: must be an absolute http(s) URL with a host, got scheme %q and host %q",
+			config.ArgoUrl.Scheme, config.ArgoUrl.Host))
+	}
+	// The lower bound is load-bearing: http.Client reads a non-positive timeout as
+	// "no timeout". The upper one is a policy ceiling that also keeps the value far
+	// from the nanosecond overflow, which lands in the same place (maxArgoApiTimeout).
+	if config.ArgoApiTimeout < 1 || config.ArgoApiTimeout > maxArgoApiTimeout {
+		problems = append(problems, fmt.Sprintf("  - ArgoApiTimeout: must be between 1 and %d seconds, got %d", maxArgoApiTimeout, config.ArgoApiTimeout))
 	}
 	// A non-positive connect timeout means "wait indefinitely" for both pgx and
 	// libpq, silently defeating the fail-fast guard; only relevant for postgres.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,6 +289,59 @@ func taskRetentionProblems(config *ServerConfig) []string {
 	return nil
 }
 
+// argoApiProblems reports the settings that decide whether the Argo CD client can
+// reach the API at all. Each is wrong in a way that surfaces far from its cause:
+// a call that never times out, or one that fails on the protocol scheme.
+func argoApiProblems(config *ServerConfig) []string {
+	var problems []string
+
+	if config.ArgoApiRetries < 1 || config.ArgoApiRetries > 10 {
+		problems = append(problems, fmt.Sprintf("  - ArgoApiRetries: must be between 1 and 10, got %d", config.ArgoApiRetries))
+	}
+
+	// url.Parse reads a bare host as a relative path, so without this the server
+	// starts and every call fails on "unsupported protocol scheme" — with the token
+	// silently dropped too, since a cookie jar keys its cookies by scheme. Only the
+	// parsed parts are echoed: String() would render basic-auth userinfo.
+	if scheme := config.ArgoUrl.Scheme; (scheme != "http" && scheme != "https") || config.ArgoUrl.Host == "" {
+		problems = append(problems, fmt.Sprintf("  - ArgoUrl: must be an absolute http(s) URL with a host, got scheme %q and host %q",
+			config.ArgoUrl.Scheme, config.ArgoUrl.Host))
+	}
+
+	// The lower bound is load-bearing: http.Client reads a non-positive timeout as
+	// "no timeout". The upper one is a policy ceiling that also keeps the value far
+	// from the nanosecond overflow, which lands in the same place (maxArgoApiTimeout).
+	if config.ArgoApiTimeout < 1 || config.ArgoApiTimeout > maxArgoApiTimeout {
+		problems = append(problems, fmt.Sprintf("  - ArgoApiTimeout: must be between 1 and %d seconds, got %d", maxArgoApiTimeout, config.ArgoApiTimeout))
+	}
+
+	return problems
+}
+
+// oidcProblems reports the OIDC settings that contradict each other. A switch
+// honoured on its own would leave a read endpoint open while the configuration
+// reads as though it were closed.
+func oidcProblems(config *ServerConfig) []string {
+	var problems []string
+
+	// With OIDC enabled the issuer and client id are mandatory; discovery and the
+	// login redirect cannot proceed without them.
+	if config.OIDC.Enabled {
+		if strings.TrimSpace(config.OIDC.IssuerURL) == "" {
+			problems = append(problems, "  - OIDC.IssuerURL: must be set when OIDC auth is enabled (OIDC_ISSUER_URL)")
+		}
+		if strings.TrimSpace(config.OIDC.ClientId) == "" {
+			problems = append(problems, "  - OIDC.ClientId: must be set when OIDC auth is enabled (OIDC_CLIENT_ID)")
+		}
+	}
+
+	if config.OIDC.RequireTaskReadAuth && !config.OIDC.Enabled {
+		problems = append(problems, "  - OIDC.RequireTaskReadAuth: OIDC_REQUIRE_TASK_READ_AUTH requires OIDC_ENABLED=true; with OIDC disabled no read endpoint is protected")
+	}
+
+	return problems
+}
+
 // validateServerConfig checks the semantic rules that env parsing cannot
 // express (allowed enum values, numeric ranges). It reports every violation in
 // one grouped message — mirroring helpers.PrettifyEnvError — so an operator can
@@ -299,44 +352,13 @@ func validateServerConfig(config *ServerConfig) error {
 	if config.StateType != "postgres" && config.StateType != "in-memory" {
 		problems = append(problems, fmt.Sprintf("  - StateType: must be one of [postgres in-memory], got %q", config.StateType))
 	}
-	if config.ArgoApiRetries < 1 || config.ArgoApiRetries > 10 {
-		problems = append(problems, fmt.Sprintf("  - ArgoApiRetries: must be between 1 and 10, got %d", config.ArgoApiRetries))
-	}
-	// url.Parse reads a bare host as a relative path, so without this the server
-	// starts and every call fails on "unsupported protocol scheme" — with the token
-	// silently dropped too, since a cookie jar keys its cookies by scheme. Only the
-	// parsed parts are echoed: String() would render basic-auth userinfo, as above.
-	if scheme := config.ArgoUrl.Scheme; (scheme != "http" && scheme != "https") || config.ArgoUrl.Host == "" {
-		problems = append(problems, fmt.Sprintf("  - ArgoUrl: must be an absolute http(s) URL with a host, got scheme %q and host %q",
-			config.ArgoUrl.Scheme, config.ArgoUrl.Host))
-	}
-	// The lower bound is load-bearing: http.Client reads a non-positive timeout as
-	// "no timeout". The upper one is a policy ceiling that also keeps the value far
-	// from the nanosecond overflow, which lands in the same place (maxArgoApiTimeout).
-	if config.ArgoApiTimeout < 1 || config.ArgoApiTimeout > maxArgoApiTimeout {
-		problems = append(problems, fmt.Sprintf("  - ArgoApiTimeout: must be between 1 and %d seconds, got %d", maxArgoApiTimeout, config.ArgoApiTimeout))
-	}
 	// A non-positive connect timeout means "wait indefinitely" for both pgx and
 	// libpq, silently defeating the fail-fast guard; only relevant for postgres.
 	if config.StateType == "postgres" && config.Db.ConnectTimeout < 1 {
 		problems = append(problems, fmt.Sprintf("  - ConnectTimeout: must be at least 1 second, got %d", config.Db.ConnectTimeout))
 	}
-	// When OIDC auth is enabled the issuer and client id are mandatory; discovery
-	// and the login redirect cannot proceed without them.
-	if config.OIDC.Enabled {
-		if strings.TrimSpace(config.OIDC.IssuerURL) == "" {
-			problems = append(problems, "  - OIDC.IssuerURL: must be set when OIDC auth is enabled (OIDC_ISSUER_URL)")
-		}
-		if strings.TrimSpace(config.OIDC.ClientId) == "" {
-			problems = append(problems, "  - OIDC.ClientId: must be set when OIDC auth is enabled (OIDC_CLIENT_ID)")
-		}
-	}
-	// Rejected rather than ignored: with OIDC disabled no read is protected, so
-	// honouring the switch alone would leave the endpoint open while the configuration
-	// reads as though it were closed.
-	if config.OIDC.RequireTaskReadAuth && !config.OIDC.Enabled {
-		problems = append(problems, "  - OIDC.RequireTaskReadAuth: OIDC_REQUIRE_TASK_READ_AUTH requires OIDC_ENABLED=true; with OIDC disabled no read endpoint is protected")
-	}
+	problems = append(problems, argoApiProblems(config)...)
+	problems = append(problems, oidcProblems(config)...)
 	problems = append(problems, taskRetentionProblems(config)...)
 
 	if len(problems) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ func (u *URL) UnmarshalText(text []byte) error {
 	if err != nil {
 		var parseErr *url.Error
 		if errors.As(err, &parseErr) {
-			return parseErr.Err
+			err = parseErr.Err
 		}
 		return err
 	}

--- a/internal/server/app_summary_handler_test.go
+++ b/internal/server/app_summary_handler_test.go
@@ -222,6 +222,12 @@ func TestGetAppSummariesClampsTheLookBack(t *testing.T) {
 		{name: "epoch from_timestamp", query: "?from_timestamp=0"},
 		{name: "unparseable from_timestamp", query: "?from_timestamp=not-a-number"},
 		{name: "negative from_timestamp", query: "?from_timestamp=-99999999999"},
+		// The clamp is a `<` comparison, which is false for NaN, and the to_timestamp
+		// branch would skip its now-fallback for one too — both reach the query unbounded
+		// unless the parse rejects them.
+		{name: "NaN from_timestamp", query: "?from_timestamp=NaN"},
+		{name: "NaN to_timestamp", query: "?from_timestamp=0&to_timestamp=NaN"},
+		{name: "out-of-range to_timestamp", query: "?from_timestamp=0&to_timestamp=1e308"},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -19,13 +20,18 @@ import (
 
 var version = "local"
 
-// parseFloatQuery reads a numeric query parameter, yielding 0 when it is absent
-// or unparseable. A present-but-invalid value is logged and then treated as
-// absent: the list endpoints clamp their window rather than reject a caller.
+// parseFloatQuery reads a numeric query parameter, yielding 0 when it is absent,
+// unparseable, or not finite. A present-but-invalid value is logged and then
+// treated as absent: the list endpoints clamp their window rather than reject a
+// caller.
 func parseFloatQuery(query url.Values, name string) float64 {
 	raw := query.Get(name)
 	value, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
+	// ParseFloat accepts "NaN" and "Inf", and every comparison against NaN is false,
+	// so such a value slips past the window clamps. A finite one beyond the epoch
+	// range does the same to the float-to-int64 conversion the state layer performs,
+	// where the Go spec leaves an out-of-range result undefined.
+	if err != nil || math.IsNaN(value) || math.Abs(value) > maxEpochSeconds {
 		if raw != "" {
 			slog.Debug("ignoring an invalid query parameter", "parameter", name, "value", raw)
 		}
@@ -46,6 +52,11 @@ func parseIntQuery(query url.Values, name string) int {
 	}
 	return value
 }
+
+// maxEpochSeconds bounds the Unix timestamps the list endpoints accept. It is far
+// past any real task (the year 33658) and far short of where a float64 stops
+// converting to int64, which is what the state layer does with these values.
+const maxEpochSeconds = 1e12
 
 // maxTaskListLimit caps the page size accepted by GET /api/v1/tasks. The
 // underlying backends treat limit <= 0 as "no LIMIT clause", which would let

--- a/internal/server/numeric_query_test.go
+++ b/internal/server/numeric_query_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// strconv.ParseFloat accepts "NaN" and "Inf" with a nil error, and every
+// comparison against NaN is false — so a window clamp written as `if start <
+// earliest` never fires and the value reaches the query untouched. A finite value
+// past the epoch range escapes the same way, into an undefined int64 conversion.
+func TestParseFloatQueryRejectsValuesNoClampCanBound(t *testing.T) {
+	for _, raw := range []string{
+		"NaN", "nan", "Inf", "+Inf", "-Inf", "infinity", "-infinity",
+		"1e308", "-1e308", "1e13",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			query := url.Values{"from_timestamp": []string{raw}}
+			assert.Equal(t, float64(0), parseFloatQuery(query, "from_timestamp"),
+				"a value no clamp can bound must be treated as absent")
+		})
+	}
+}
+
+func TestParseFloatQueryKeepsOrdinaryNumbers(t *testing.T) {
+	tests := map[string]float64{
+		"0":          0,
+		"1700000000": 1700000000,
+		"1e12":       1e12,
+		"-5":         -5,
+		"1.5":        1.5,
+		"":           0,
+		"not-a-time": 0,
+	}
+
+	for raw, want := range tests {
+		t.Run(raw, func(t *testing.T) {
+			query := url.Values{"from_timestamp": []string{raw}}
+			assert.Equal(t, want, parseFloatQuery(query, "from_timestamp"))
+		})
+	}
+}


### PR DESCRIPTION
Four long-standing defects, each one an input the server took on trust. They are unrelated in code but identical in shape, so they travel together.

- **Retries resent the Argo CD token once per attempt.** `doGet` reused one request object, so the cookie jar appended the session token again each time. A proxy refusing the oversized header answers with a client error, which `isArgoUnavailable` does not treat as an outage — so a transient blip could end a healthy deployment as `failed`. The request is now cloned per attempt.
- **`ARGO_URL` was only rejected if unparseable.** A bare host parsed as a relative path: the server started clean, every call failed with `unsupported protocol scheme`, and the token was silently dropped because a cookie jar keys its cookies by scheme.
- **`ARGO_API_TIMEOUT` was unvalidated** where the analogous database timeout was checked. Now bounded at both ends — `time.Duration(n) * time.Second` overflows a large value back to a non-positive one, which `http.Client` reads as no timeout, so the hole is reachable from either direction.
- **`from_timestamp`/`to_timestamp` accepted `NaN`, `Inf` and absurd epochs.** Every comparison against `NaN` is false, so the look-back limit never fired.

Worth knowing while reviewing:

- Rejecting a URL must not echo it. `url.URL.String()` renders basic-auth credentials and the startup error is logged, which the config endpoint already guards against via `MarshalText`. The validation message names scheme and host only, and `UnmarshalText` returns the parse reason rather than the `*url.Error` that quotes the whole value.
- The epoch bound is not only about `NaN`. A finite `1e308` also escapes the clamp, into a float-to-int64 conversion the Go spec leaves undefined, so the guard rejects implausible magnitudes too.
- The clone must carry the caller's context — it is now the only thing bounding an in-flight call — and there is a test that fails if it becomes `context.Background()`.

**Upgrade note:** a deployment that set `ARGO_API_TIMEOUT` outside 1–3600, or a scheme-less `ARGO_URL`, now fails at startup with the setting named instead of misbehaving at runtime. Nothing in this repo sets either.

Each of the eight guards is mutation-checked: reverting it individually fails a test written for it and nothing else. I swept the tree for the same request-reuse pattern elsewhere — every other HTTP caller builds a fresh request per attempt or sends once, and `argocd` is the only client with a cookie jar.