### PR TITLE
fix(argocd): trim both halves of a managed-images entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped the API token, since a cookie jar keys its cookies by scheme. `ARGO_API_TIMEOUT` must be
   between 1 and 3600 seconds — anything outside that range left Argo CD calls with no timeout at
   all. Both are reported by name at startup.
+- A malformed `argo-watcher/managed-images` entry now fails the deployment immediately, naming the
+  entry at fault, instead of quietly skipping the write-back. Rejected shapes are an entry with no
+  `=`, an empty alias or image, whitespace inside either, a second `=`, and the same alias listed
+  twice. Whitespace around the `=` is accepted and trimmed. Pointing two aliases at one image is
+  unaffected.
 
 ### Fixed
 
@@ -76,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NaN`, `Inf` and numbers far outside the range of a real timestamp were parsed as valid, and
   because every comparison against `NaN` is false they slipped past the look-back limit and reached
   the database as written. Such a value is now ignored, as any other unparseable one already was.
+- Spaces around the `=` in an `argo-watcher/managed-images` entry no longer break the image
+  write-back. `app = myimage` left the alias and the image each carrying a space, so neither matched
+  and the tag was never committed — the deployment then timed out reporting that the image was not
+  part of the application, naming everything except the annotation that caused it.
 
 ### Security
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -119,6 +119,18 @@ curl -sSI "$ARGO_WATCHER_URL/api/v1/config"
 !!! warning
     Do not work around this by letting the credential follow the redirect. The deploy token does not expire, is not scoped to an application, and authorizes commits to your GitOps repository — whoever answers for the redirect target would receive it on every request.
 
+## Managed-images annotation is rejected
+
+**Symptom:** the deployment fails immediately, reporting `ArgoCD API Error: invalid format for argo-watcher/managed-images annotation: "<entry>" is not alias=image`.
+
+Despite the label, nothing was asked of Argo CD — the annotation is parsed locally, before the write-back, and every failure on that path is reported through the same template.
+
+Each entry must read `alias=image`. Whitespace around the `=` is ignored, so `app = myimage` is accepted, but neither half may be empty or contain whitespace of its own, and the image may not contain a second `=`.
+
+An alias may not be repeated either — `app=one,app=two` is rejected, since only one of the two could ever be written back. Pointing two aliases at the same image is fine.
+
+**Fix:** correct the entry named in the error on the `Application`. The alias must also match the one in the matching `argo-watcher/<alias>.helm.image-tag` annotation.
+
 ## Client refuses a redirect away from https
 
 **Symptom:** the deployment fails immediately with `refused to follow a redirect away from https`, naming the endpoint that answered and the plain-`http` target it pointed at.

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -5,7 +5,7 @@ Argo Watcher reads these annotations from the Argo CD `Application` resource. Al
 | Annotation | Example | Description |
 |---|---|---|
 | `argo-watcher/managed` | `"true"` | Enables Argo Watcher management, and with it the GitOps write-back. |
-| `argo-watcher/managed-images` | `app=registry.example.com/group/project` | Maps an alias to a full image name; comma-separated for several. |
+| `argo-watcher/managed-images` | `app=registry.example.com/group/project` | Maps an alias to a full image name; comma-separated for several. Whitespace around `=` is ignored. An entry with an empty alias or image, whitespace inside either, or a second `=` is rejected, as is a repeated alias. |
 | `argo-watcher/<alias>.helm.image-tag` | `app.image.tag` | Helm value path the new tag is written to, keyed by an alias from `managed-images`. |
 | `argo-watcher/write-back-filename` | `values-override.yaml` | Overrides the override-file name (derived from the app name by default). |
 | `argo-watcher/write-back-repo` | `git@github.com:example/gitops.git` | Write-back repository. **Multi-source applications only.** |

--- a/internal/argocd/git_writeback.go
+++ b/internal/argocd/git_writeback.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/updater"
@@ -222,21 +223,54 @@ func runGitUpdateAttempt(parentCtx context.Context, repo *updater.GitRepo, opTim
 	return nil
 }
 
-// extractManagedImages maps each application alias from the annotations to its image name.
+// extractManagedImages maps each application alias from the annotations to its
+// image name. Both halves of an "alias=image" entry are trimmed: a space left on
+// either one makes the alias miss its tag annotation and the image miss the
+// task's, which skips the write-back and leaves the rollout blaming the image.
 func extractManagedImages(annotations map[string]string) (map[string]string, error) {
 	managedImages := map[string]string{}
 
-	for annotation, value := range annotations {
-		if annotation == managedImagesAnnotation {
-			for _, image := range strings.Split(value, ",") {
-				if !strings.Contains(image, "=") {
-					return nil, fmt.Errorf("invalid format for %s annotation", managedImagesAnnotation)
-				}
-				managedImage := strings.Split(strings.TrimSpace(image), "=")
-				managedImages[managedImage[0]] = managedImage[1]
-			}
+	value, declared := annotations[managedImagesAnnotation]
+	if !declared {
+		return managedImages, nil
+	}
+
+	for _, entry := range strings.Split(value, ",") {
+		alias, image, err := parseManagedImage(entry)
+		if err != nil {
+			return nil, err
 		}
+		// Two images cannot share an alias: the loser would be declared managed,
+		// match nothing, and let the write-back report success having written
+		// neither. Two aliases sharing one image is a different, supported thing.
+		if _, repeated := managedImages[alias]; repeated {
+			return nil, fmt.Errorf("duplicate alias %q in %s annotation", alias, managedImagesAnnotation)
+		}
+		managedImages[alias] = image
 	}
 
 	return managedImages, nil
+}
+
+// parseManagedImage splits one "alias=image" entry, rejecting anything that could
+// only fail later: a missing separator, an empty half, or a half still carrying a
+// character it cannot hold. Salvaging a prefix instead would write back an image
+// nobody asked for, or skip the write-back and leave the rollout blaming the image.
+func parseManagedImage(entry string) (string, string, error) {
+	alias, image, found := strings.Cut(entry, "=")
+	alias, image = strings.TrimSpace(alias), strings.TrimSpace(image)
+
+	if !found || unusableManagedImageHalf(alias) || unusableManagedImageHalf(image) {
+		return "", "", fmt.Errorf("invalid format for %s annotation: %q is not alias=image", managedImagesAnnotation, strings.TrimSpace(entry))
+	}
+
+	return alias, image, nil
+}
+
+// unusableManagedImageHalf reports whether a trimmed half can never be matched.
+// The alias becomes part of an annotation key and the image is a registry
+// reference, so interior whitespace is impossible in either, and only the first
+// "=" of an entry separates them.
+func unusableManagedImageHalf(half string) bool {
+	return half == "" || strings.ContainsFunc(half, unicode.IsSpace) || strings.Contains(half, "=")
 }

--- a/internal/argocd/git_writeback_test.go
+++ b/internal/argocd/git_writeback_test.go
@@ -29,6 +29,9 @@ func TestExtractManagedImages(t *testing.T) {
 		annotation map[string]string
 		expected   map[string]string
 		expectErr  bool
+		// errContains is the fragment the troubleshooting page tells operators to
+		// look for: the offending entry, named and quoted.
+		errContains string
 	}{
 		{
 			name: "Extracts multiple managed images",
@@ -106,8 +109,99 @@ func TestExtractManagedImages(t *testing.T) {
 			annotation: map[string]string{
 				managedImagesAnnotation: "alias1image1",
 			},
-			expected:  nil,
-			expectErr: true,
+			expectErr:   true,
+			errContains: `"alias1image1"`,
+		},
+		{
+			// The separator is what an operator is most likely to pad. A surviving
+			// space makes the alias miss its tag annotation and the image miss the
+			// task's, so the write-back is skipped and the rollout blames the image.
+			name: "Trims whitespace around the separator, not just the entry",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1 = image1 ,\talias2\t=\timage2",
+			},
+			expected: map[string]string{
+				"alias1": "image1",
+				"alias2": "image2",
+			},
+		},
+		{
+			// An image reference cannot contain "=", so a second one is a malformed
+			// entry. Keeping the prefix silently would write back the wrong image.
+			name: "Rejects an entry with more than one separator",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=image1=extra",
+			},
+			expectErr:   true,
+			errContains: `"alias1=image1=extra"`,
+		},
+		{
+			// A YAML block scalar without commas splits into one entry carrying a
+			// newline. It holds no second "=", so it used to pass and then match no
+			// task image — the silent skip this whole guard exists to remove.
+			name: "Rejects an entry split across lines",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=image1\nalias2",
+			},
+			expectErr:   true,
+			errContains: `"alias1=image1\nalias2"`,
+		},
+		{
+			// The alias half has its own reason to reject whitespace: it is formatted
+			// into an annotation key, which cannot hold a space, so it would miss its
+			// tag annotation exactly as a padded image misses the task's.
+			name: "Rejects whitespace inside the alias",
+			annotation: map[string]string{
+				managedImagesAnnotation: "my alias=image1",
+			},
+			expectErr:   true,
+			errContains: `"my alias=image1"`,
+		},
+		{
+			// The last shape that could still fail silently: the losing image is
+			// declared managed, matches no alias, and the write-back reports success
+			// without touching git.
+			name: "Rejects a repeated alias",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=image1,alias1=image2",
+			},
+			expectErr:   true,
+			errContains: `"alias1"`,
+		},
+		{
+			// A Helm template can render this. It is a misconfiguration rather than
+			// "nothing managed", and fails loudly like every other malformed value.
+			name: "Rejects a declared but empty annotation",
+			annotation: map[string]string{
+				managedImagesAnnotation: "",
+			},
+			expectErr:   true,
+			errContains: `""`,
+		},
+		{
+			// Names the entry that is wrong, not the whole annotation value.
+			name: "Names only the offending entry",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=image1,alias2",
+			},
+			expectErr:   true,
+			errContains: `"alias2"`,
+		},
+		{
+			name: "Rejects an empty alias",
+			annotation: map[string]string{
+				managedImagesAnnotation: "=image1",
+			},
+			expectErr:   true,
+			errContains: `"=image1"`,
+		},
+		{
+			name: "Rejects an empty image",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=",
+			},
+			expectErr:   true,
+			errContains: `"alias1="`,
 		},
 	}
 
@@ -115,8 +209,11 @@ func TestExtractManagedImages(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			extractedImages, err := extractManagedImages(test.annotation)
 			if test.expectErr {
-				assert.Error(t, err)
-			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains, "the error must name the entry an operator has to correct")
+				return
+			}
+			{
 				assert.NoError(t, err)
 				assert.Equal(t, test.expected, extractedImages)
 			}
@@ -162,6 +259,22 @@ func TestGenerateOverrideFileContent(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, override)
+		require.Len(t, override.Helm.Parameters, 1)
+		assert.Equal(t, "image.tag", override.Helm.Parameters[0].Name)
+		assert.Equal(t, "v1.0.0", override.Helm.Parameters[0].Value)
+	})
+
+	// The defect this guards was silent: a padded separator left the alias and image
+	// carrying a space, so neither matched, no parameter was produced, and the
+	// write-back reported success while never touching git.
+	t.Run("Builds the same override when the annotation is padded", func(t *testing.T) {
+		app := newAppWithImages("app")
+		app.Metadata.Annotations["argo-watcher/managed-images"] = "  app = myimage  "
+
+		override, err := generateOverrideFileContent(app.Metadata.Annotations, newImageTask())
+
+		require.NoError(t, err)
+		require.NotNil(t, override, "a padded annotation must not read as no managed images")
 		require.Len(t, override.Helm.Parameters, 1)
 		assert.Equal(t, "image.tag", override.Helm.Parameters[0].Name)
 		assert.Equal(t, "v1.0.0", override.Helm.Parameters[0].Value)

--- a/internal/argocd/git_writeback_test.go
+++ b/internal/argocd/git_writeback_test.go
@@ -158,6 +158,18 @@ func TestExtractManagedImages(t *testing.T) {
 			errContains: `"my alias=image1"`,
 		},
 		{
+			// The mirror of the repeated-alias rejection below: two aliases may share
+			// one image, since each still names a distinct Helm value to write.
+			name: "Accepts two aliases pointing at one image",
+			annotation: map[string]string{
+				managedImagesAnnotation: "alias1=image1,alias2=image1",
+			},
+			expected: map[string]string{
+				"alias1": "image1",
+				"alias2": "image1",
+			},
+		},
+		{
 			// The last shape that could still fail silently: the losing image is
 			// declared managed, matches no alias, and the write-back reports success
 			// without touching git.


### PR DESCRIPTION
A space around the `=` in an `argo-watcher/managed-images` entry silently disabled the image write-back: `app = myimage` produced the alias `app ` and the image ` myimage`, so neither matched and the rollout timed out reporting that the image was not part of the application.

Entries are now cut at the first `=` with both halves trimmed, and a shape that could only fail later is refused outright — missing separator, empty half, whitespace inside one, a second `=`, or a repeated alias.

- Two aliases pointing at one image stays supported; only a repeated *alias* is refused.
- Whitespace is rejected inside a half, not just around it: a YAML block scalar without commas yields `a=img1\nb`, which carried no second `=` and so used to pass, then match nothing.
- A malformed annotation now fails the deployment instead of being tolerated. Every e2e fixture and doc example uses clean unpadded entries, so nothing in the repo is affected.
- The error surfaces as `ArgoCD API Error:` like everything on that path, which sends operators looking in the wrong place — the troubleshooting page gains an entry saying so.