### PR TITLE
fix(state): fence status writes and stop reads failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   write-back. `app = myimage` left the alias and the image each carrying a space, so neither matched
   and the tag was never committed — the deployment then timed out reporting that the image was not
   part of the application, naming everything except the annotation that caused it.
+- A replica that lost a deployment to another one can no longer overwrite the outcome that
+  replica recorded. Ownership is now checked by the database on every status write, because a
+  replica can spend seconds reaching its verdict after its claim has already moved on. The same
+  deployment is also no longer counted or announced twice when that happens.
+- The task list no longer shows an empty estate when the database cannot be read. A failed read was
+  indistinguishable from "no deployments ran": `GET /api/v1/tasks` now answers with an `error`
+  field and no tasks, and a deployment is refused rather than recorded with the wrong rollback flag
+  when its history could not be read.
+- With the in-memory backend, deployments created in the same second are ordered consistently
+  instead of arbitrarily. The order decided which version counted as current, so a redeployment
+  could be recorded as a rollback, or a rollback missed.
 
 ### Security
+
+- A failure to read the database no longer puts the driver's own text — the schema, the SQL error
+  code, the database host — into the body of `GET /api/v1/tasks` or `POST /api/v1/tasks`. Both are
+  served without a credential when OIDC is off. The cause stays in the server log.
 
 - A `ARGO_URL` containing basic-auth credentials no longer has its password written into the startup
   error, and from there into the container log, when the value is rejected. The configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,9 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indistinguishable from "no deployments ran": `GET /api/v1/tasks` now answers with an `error`
   field and no tasks, and a deployment is refused rather than recorded with the wrong rollback flag
   when its history could not be read.
-- With the in-memory backend, deployments created in the same second are ordered consistently
-  instead of arbitrarily. The order decided which version counted as current, so a redeployment
-  could be recorded as a rollback, or a rollback missed.
+- With the in-memory backend, deployments created in the same second are now ordered by when they
+  were submitted. They used to be ordered by task id, which is a random uuid, so the older of the
+  two could count as the current version — recording a redeployment as a rollback, or missing a
+  rollback. The PostgreSQL backend stores microseconds and was never affected.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,10 +85,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   write-back. `app = myimage` left the alias and the image each carrying a space, so neither matched
   and the tag was never committed — the deployment then timed out reporting that the image was not
   part of the application, naming everything except the annotation that caused it.
-- A replica that lost a deployment to another one can no longer overwrite the outcome that
-  replica recorded. Ownership is now checked by the database on every status write, because a
-  replica can spend seconds reaching its verdict after its claim has already moved on. The same
-  deployment is also no longer counted or announced twice when that happens.
+- A replica that no longer holds a deployment can no longer record its outcome. Ownership is now
+  checked by the database on every status write, because a replica can spend seconds reaching its
+  verdict after its claim has moved on — whether another replica took it over, or this one handed
+  it back while shutting down. The second case mattered most: only an in-progress deployment is
+  picked up again, so a `failed` written on the way out ended a deployment another replica would
+  have finished watching. The same deployment is also no longer counted or announced twice.
 - The task list no longer shows an empty estate when the database cannot be read. A failed read was
   indistinguishable from "no deployments ran": `GET /api/v1/tasks` now answers with an `error`
   field and no tasks, and a deployment is refused rather than recorded with the wrong rollback flag

--- a/docs/operations/database.md
+++ b/docs/operations/database.md
@@ -20,7 +20,7 @@ There are two tables. `tasks` stores every deployment task and its status; index
 | `timeout` | `int NOT NULL DEFAULT 0` | Per-task rollout deadline in seconds; `0` when the client did not override `DEPLOYMENT_TIMEOUT`. |
 | `refresh` | `boolean` | Per-task override of `ARGO_REFRESH_APP`; `NULL` when the client omitted it, which is distinct from an explicit `false`. |
 | `owner_id` | `text` | The replica currently monitoring the rollout; `NULL` when unclaimed. See [High Availability](high-availability.md#task-ownership). |
-| `lease_expires_at` | `timestamptz` | When that claim lapses. A lapsed claim on an in-progress task is taken over by another replica; indexed for that sweep via the partial index `idx_tasks_claimable`. |
+| `lease_expires_at` | `timestamptz` | When that claim lapses. A lapsed claim on an in-progress task is taken over by another replica; indexed for that sweep via the partial index `idx_tasks_claimable`. Read together with `owner_id`, it also says which kind of unclaimed a task is: both `NULL` means never claimed, while a `NULL` owner with a deadline set means a replica released it on shutdown for another to resume — only the former may still have its outcome written by the replica that accepted it. |
 | `app` | `varchar(255) NOT NULL` | Argo CD application name. |
 | `author` | `varchar(255) NOT NULL` | Deployment author identifier. |
 | `project` | `varchar(255) NOT NULL` | Business project identifier. |

--- a/docs/operations/high-availability.md
+++ b/docs/operations/high-availability.md
@@ -40,6 +40,11 @@ claim, which it discovers on its next renewal, or because it has begun shutting
 down and is about to release the claim itself. Either way it stops without
 writing a status, so it cannot clobber the outcome the new owner records.
 
+Stopping is not the only guard. A replica checks its claim and then spends
+seconds reaching the outcome, so the claim can move on while a write is already
+under way. The database refuses that write: a status only lands for the task's
+current owner, or for a task nobody has claimed.
+
 ### How long a deployment is unattended
 
 | Event | Time before another replica resumes it |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -180,6 +180,8 @@ A task that still ends up `aborted` means its rollout window elapsed while no re
 
 The other possibility is that no replica was left to take it over: with a single replica, nothing claims the task until that pod is back.
 
+A `Left the outcome to the replica that took the deployment over.` line in the log of the *previous* owner is expected during a handover, not a fault. It means that replica reached an outcome after its claim had already moved on, and the database refused the write so the new owner's result stands.
+
 **Cause with `STATE_TYPE=in-memory`:** the task lives only in the process that accepted it, so it cannot be handed over at all. The row is later reaped by the obsolete-task sweep, which marks a row `aborted` once it has gone quiet for the task's own rollout window plus an hour (its `TASK_TIMEOUT`, or the server's `DEPLOYMENT_TIMEOUT`) — bookkeeping only, so the recorded status can disagree with what really happened. This is expected, and is **not** fixed by tuning the shutdown budget: a graceful shutdown protects the git commit, not the task status. Treat the GitOps repository and Argo CD as the record of what happened, or move to Postgres.
 
 **How to verify**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,6 +11,7 @@ The server exposes a REST API on its own port (default `8080`), with every endpo
 - `GET /api/v1/tasks` returns at most 1000 tasks per request, which is also its default page size.
 - Authentication failures return `401 Unauthorized`, and `503 Service Unavailable` when the credential could not be checked because the OIDC provider was unreachable.
 - Server-side problems return `500 Internal Server Error`.
+- `GET /api/v1/tasks` and `GET /api/v1/apps/summary` answer `200` with an `error` field and no results when the state backend could not be read. Check `error` before reading an empty list as "nothing deployed".
 
 ## Security headers
 

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -23,6 +23,11 @@ var (
 	ArgoLivenessProbeInterval = 30 * time.Second
 )
 
+// ErrTaskHistoryUnavailable marks a submission refused because the app's deployment
+// history could not be read. The cause carries driver text and submission takes no
+// credential, so the handler answers with a fixed message and leaves detail to the log.
+var ErrTaskHistoryUnavailable = errors.New("could not read the deployment history")
+
 // rollbackHistoryWindow bounds how many of an app's most recent successfully
 // deployed tasks are inspected when deciding whether a new deployment is a
 // rollback. Rollbacks to a version older than this window are not flagged; this
@@ -186,7 +191,11 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 	// Always overwrite the rollback fields from server-side history so a
 	// client-supplied value (e.g. echoed back by the "rollback to this version"
 	// action) can never influence the stored result.
-	task.RollbackTargetId = argo.detectRollback(task)
+	rollbackTargetId, err := argo.detectRollback(task)
+	if err != nil {
+		return nil, err
+	}
+	task.RollbackTargetId = rollbackTargetId
 	task.IsRollback = task.RollbackTargetId != ""
 
 	// StatusReason and Updated are server-owned but JSON-bindable, and submission takes
@@ -227,15 +236,20 @@ func (argo *Argo) AddTask(task models.Task) (*models.Task, error) {
 // rolls back to, or an empty string when it is not one. A rollback's image set was
 // deployed successfully at some earlier point for the app AND differs from the
 // current version — redeploying the current version is not a rollback.
-func (argo *Argo) detectRollback(task models.Task) string {
-	deployed, _ := argo.State.GetTasks(models.TaskFilter{
+func (argo *Argo) detectRollback(task models.Task) (string, error) {
+	deployed, _, err := argo.State.GetTasks(models.TaskFilter{
 		EndTime: float64(time.Now().Unix()),
 		App:     task.App,
 		Status:  models.StatusDeployedMessage,
 		Limit:   rollbackHistoryWindow,
 	})
+	if err != nil {
+		// Treated as an empty history, this would record IsRollback=false for a task
+		// the backend never actually answered for.
+		return "", fmt.Errorf("%w of %q: %w", ErrTaskHistoryUnavailable, task.App, err)
+	}
 	if len(deployed) == 0 {
-		return ""
+		return "", nil
 	}
 
 	target := imageSignature(task)
@@ -243,16 +257,16 @@ func (argo *Argo) detectRollback(task models.Task) string {
 	// GetTasks orders by created DESC, so deployed[0] is the current version.
 	// Matching it means we are redeploying the current version, not rolling back.
 	if imageSignature(deployed[0]) == target {
-		return ""
+		return "", nil
 	}
 
 	for _, previous := range deployed[1:] {
 		if imageSignature(previous) == target {
-			return previous.Id
+			return previous.Id, nil
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
 // imageSignature returns a key for a task's image set that is independent of the
@@ -266,13 +280,23 @@ func imageSignature(task models.Task) string {
 // hang the whole list on the API retry budget during an outage and then hide
 // existing tasks behind an error. /readyz probes only the state backend.
 func (argo *Argo) GetTasks(filter models.TaskFilter) models.TasksResponse {
-	tasks, total := argo.State.GetTasks(filter)
+	tasks, total, err := argo.State.GetTasks(filter)
+	if err != nil {
+		// Reported in the body rather than as an empty page, as GetAppSummaries
+		// does: a reader cannot otherwise tell an outage from a quiet estate.
+		slog.Error("Failed to read tasks", "error", err)
+		return models.TasksResponse{Error: tasksFailedMessage}
+	}
 
 	return models.TasksResponse{
 		Tasks: tasks,
 		Total: total,
 	}
 }
+
+// tasksFailedMessage is the client-facing text for a failed task read. The real
+// cause stays in the server log, as appSummariesFailedMessage does.
+const tasksFailedMessage = "failed to read tasks"
 
 // appSummariesFailedMessage is the client-facing text for a failed aggregate.
 // The real cause stays in the server log, as internalErrorMessage does for the

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -166,6 +166,9 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 	}
 
 	var imageErr *ImageNotPartOfAppError
+	// The arms that stop without writing leave this true: there is no refused write
+	// to suppress, and they return before it is read.
+	recorded := true
 
 	switch {
 	case errors.Is(err, errReplicaDraining):
@@ -183,7 +186,7 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		slog.Info("Stopped monitoring a deployment taken over by another replica.", "id", task.Id)
 		return
 	case errors.As(err, &imageErr):
-		updater.monitor.HandleImageNotPartOfApp(&task, imageErr)
+		recorded = updater.monitor.HandleImageNotPartOfApp(&task, imageErr)
 	case errors.Is(err, errTaskSuperseded):
 		// A newer deployment for the same app already marked this task "cancelled"
 		// in the shared state (possibly on another replica). Stop without writing a
@@ -197,9 +200,16 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		slog.Info("Deployment already given up on by the staleness sweep; stopping.", "id", task.Id)
 		task.Status = models.StatusAborted
 	case err != nil:
-		updater.monitor.HandleArgoAPIFailure(&task, err, confirmed)
+		recorded = updater.monitor.HandleArgoAPIFailure(&task, err, confirmed)
 	default:
-		updater.monitor.ProcessDeploymentResult(&task, application, waited)
+		recorded = updater.monitor.ProcessDeploymentResult(&task, application, waited)
+	}
+
+	// The claim moved on while this replica was writing, so the outcome stored is
+	// the new owner's. Counting or announcing one here would report the deployment
+	// twice, and the two reports can disagree.
+	if !recorded {
+		return
 	}
 
 	// Counted once: the branches that return early leave the outcome to the replica that

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/notifications"
 	"github.com/shini4i/argo-watcher/internal/prometheus"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 var (
@@ -2933,4 +2934,57 @@ func TestWaitForRollout_EveryTerminalOutcomeIsPreCreated(t *testing.T) {
 			assert.NoError(t, testutil.CollectAndCompare(reg, strings.NewReader(expected.String()), "deployments_total"))
 		})
 	}
+}
+
+// The gauge operators alert on must not move for an outcome this replica did not
+// decide: the owner counts the same deployment, so a second increment trips a
+// threshold of N consecutive failures after N-1 real ones. The mirror case is a
+// loser's success clearing a gauge that holds the owner's failures.
+func TestDeploymentMonitorRefusedWriteLeavesTheGaugesAlone(t *testing.T) {
+	newMonitor := func(t *testing.T) (*DeploymentMonitor, *mocks.MockTaskRepository, models.Task) {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		metrics := mocks.NewMockMetricsInterface(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
+		// No metrics expectation is declared anywhere below: gomock fails the test if
+		// any gauge is touched for a write the backend refused.
+		monitor := NewDeploymentMonitor(Argo{metrics: metrics, State: stateMock}, "",
+			[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+		return monitor, stateMock, models.Task{Id: "refused-id", App: "demo", Validated: true}
+	}
+
+	t.Run("a confirmed API failure does not count one", func(t *testing.T) {
+		monitor, stateMock, task := newMonitor(t)
+		stateMock.EXPECT().SetTaskStatus(task.Id, gomock.Any(), gomock.Any()).Return(state.ErrTaskNotOwned)
+
+		assert.False(t, monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"), true))
+	})
+
+	t.Run("an unconfirmed API failure does not count one", func(t *testing.T) {
+		monitor, stateMock, task := newMonitor(t)
+		stateMock.EXPECT().SetTaskStatus(task.Id, gomock.Any(), gomock.Any()).Return(state.ErrTaskNotOwned)
+
+		assert.False(t, monitor.HandleArgoAPIFailure(&task, fmt.Errorf("boom"), false))
+	})
+
+	t.Run("a missing image does not count one", func(t *testing.T) {
+		monitor, stateMock, task := newMonitor(t)
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).Return(state.ErrTaskNotOwned)
+
+		imageErr := &ImageNotPartOfAppError{App: task.App, Image: "app", DesiredImages: []string{"other"}}
+		assert.False(t, monitor.HandleImageNotPartOfApp(&task, imageErr))
+	})
+
+	t.Run("a success does not clear the app's failures", func(t *testing.T) {
+		monitor, stateMock, task := newMonitor(t)
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "").Return(state.ErrTaskNotOwned)
+
+		app := &models.Application{}
+		app.Status.Summary.Images = []string{"app:v1"}
+		app.Status.Sync.Status = "Synced"
+		app.Status.Health.Status = "Healthy"
+		task.Images = []models.Image{{Image: "app", Tag: "v1"}}
+
+		assert.False(t, monitor.ProcessDeploymentResult(&task, app, time.Second))
+	})
 }

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -2987,4 +2987,27 @@ func TestDeploymentMonitorRefusedWriteLeavesTheGaugesAlone(t *testing.T) {
 
 		assert.False(t, monitor.ProcessDeploymentResult(&task, app, time.Second))
 	})
+
+	// The path that opened the window the store's fence closes: it fetches the
+	// resource tree before writing, so it is the likeliest of the five to be refused.
+	t.Run("a failure does not count one", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		metrics := mocks.NewMockMetricsInterface(ctrl)
+		stateMock := newTaskRepositoryMock(ctrl)
+		// The helper stubs the resource-tree fetch this path makes before writing.
+		api := newArgoApiMock(ctrl)
+
+		monitor := NewDeploymentMonitor(Argo{metrics: metrics, State: stateMock, api: api}, "",
+			[]retry.Option{retry.DelayType(zeroDelay), retry.LastErrorOnly(true)}, false, time.Millisecond)
+		task := models.Task{Id: "refused-id", App: "demo", Validated: true,
+			Images: []models.Image{{Image: "app", Tag: "v1"}}}
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).Return(state.ErrTaskNotOwned)
+
+		app := &models.Application{}
+		app.Status.Summary.Images = []string{"app:v1"}
+		app.Status.Sync.Status = "Synced"
+		app.Status.Health.Status = "Degraded"
+
+		assert.False(t, monitor.ProcessDeploymentResult(&task, app, time.Second))
+	})
 }

--- a/internal/argocd/argo_test.go
+++ b/internal/argocd/argo_test.go
@@ -277,7 +277,7 @@ func TestArgoAddTask(t *testing.T) {
 		state := newTaskRepositoryMock(ctrl)
 
 		stateError := fmt.Errorf("database error")
-		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0))
+		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0), nil)
 		state.EXPECT().SupersedeAndAdd(gomock.Any(), supersededTaskReason).Return(nil, int64(0), stateError)
 
 		argo := &Argo{}
@@ -327,7 +327,7 @@ func TestArgoAddTask(t *testing.T) {
 			// mock calls to add task. In-progress deployments for the app MUST be
 			// cancelled before the new task is persisted; otherwise the new task would
 			// match the cancel filter and cancel itself. gomock.InOrder locks that.
-			state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0))
+			state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0), nil)
 			// The task carries what scopes the supersede: its images keep it from
 			// cancelling the whole app, and its Validated flag is what stops an
 			// uncredentialed deployment cancelling a credentialed one.
@@ -363,7 +363,7 @@ func TestArgoAddTask(t *testing.T) {
 			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
 			{Id: "earlier", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v1"}}, Status: models.StatusDeployedMessage},
 		}
-		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return(deployed, int64(len(deployed)))
+		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return(deployed, int64(len(deployed)), nil)
 
 		var captured models.Task
 		state.EXPECT().SupersedeAndAdd(gomock.Any(), supersededTaskReason).DoAndReturn(func(task models.Task, _ string) (*models.Task, int64, error) {
@@ -391,7 +391,7 @@ func TestArgoAddTask(t *testing.T) {
 		deployed := []models.Task{
 			{Id: "current", App: "test-app", Images: []models.Image{{Image: "app", Tag: "v2"}}, Status: models.StatusDeployedMessage},
 		}
-		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return(deployed, int64(len(deployed)))
+		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return(deployed, int64(len(deployed)), nil)
 
 		var captured models.Task
 		state.EXPECT().SupersedeAndAdd(gomock.Any(), supersededTaskReason).DoAndReturn(func(task models.Task, _ string) (*models.Task, int64, error) {
@@ -421,7 +421,7 @@ func TestArgoAddTask(t *testing.T) {
 
 		metrics.EXPECT().AddAcceptedDeployment()
 
-		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0))
+		state.EXPECT().GetTasks(deployedHistoryFilter("test-app", anyLimit)).Return([]models.Task{}, int64(0), nil)
 
 		var captured models.Task
 		state.EXPECT().SupersedeAndAdd(gomock.Any(), supersededTaskReason).DoAndReturn(func(task models.Task, _ string) (*models.Task, int64, error) {
@@ -540,11 +540,12 @@ func TestArgoDetectRollback(t *testing.T) {
 			state := newTaskRepositoryMock(ctrl)
 			state.EXPECT().
 				GetTasks(deployedHistoryFilter("test-app", rollbackHistoryWindow)).
-				Return(deployed, int64(len(deployed)))
+				Return(deployed, int64(len(deployed)), nil)
 
 			argo := &Argo{State: state}
-			result := argo.detectRollback(models.Task{App: "test-app", Images: tt.target})
+			result, err := argo.detectRollback(models.Task{App: "test-app", Images: tt.target})
 
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantTargetID, result)
 		})
 	}
@@ -568,7 +569,7 @@ func TestArgoGetTasks(t *testing.T) {
 		expectedTasks := []models.Task{
 			{Id: "task-1", App: "demo", Images: []models.Image{{Image: "example.com/app", Tag: "v1.0.0"}}},
 		}
-		state.EXPECT().GetTasks(models.TaskFilter{StartTime: start, EndTime: end, App: "demo"}).Return(expectedTasks, int64(len(expectedTasks)))
+		state.EXPECT().GetTasks(models.TaskFilter{StartTime: start, EndTime: end, App: "demo"}).Return(expectedTasks, int64(len(expectedTasks)), nil)
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
@@ -594,7 +595,7 @@ func TestArgoGetTasks(t *testing.T) {
 		expectedTasks := []models.Task{
 			{Id: "task-1", App: "demo"},
 		}
-		state.EXPECT().GetTasks(models.TaskFilter{StartTime: 0, EndTime: 100, App: "demo"}).Return(expectedTasks, int64(len(expectedTasks)))
+		state.EXPECT().GetTasks(models.TaskFilter{StartTime: 0, EndTime: 100, App: "demo"}).Return(expectedTasks, int64(len(expectedTasks)), nil)
 
 		argo := &Argo{}
 		argo.Init(state, api, metrics)
@@ -675,7 +676,7 @@ func TestArgoAddTaskClaimsTheTask(t *testing.T) {
 			Images: []models.Image{{Image: "app", Tag: "v1"}}}
 
 		stateMock.EXPECT().GetTasks(gomock.Any()).
-			Return([]models.Task{}, int64(0)).AnyTimes()
+			Return([]models.Task{}, int64(0), nil).AnyTimes()
 		stateMock.EXPECT().SupersedeAndAdd(gomock.Any(), gomock.Any()).
 			Return(&models.Task{Id: "new-id", App: task.App}, int64(0), nil)
 		stateMock.EXPECT().ClaimTask("new-id").Return(nil).Times(1)
@@ -697,7 +698,7 @@ func TestArgoAddTaskClaimsTheTask(t *testing.T) {
 			Images: []models.Image{{Image: "app", Tag: "v1"}}}
 
 		stateMock.EXPECT().GetTasks(gomock.Any()).
-			Return([]models.Task{}, int64(0)).AnyTimes()
+			Return([]models.Task{}, int64(0), nil).AnyTimes()
 		stateMock.EXPECT().SupersedeAndAdd(gomock.Any(), gomock.Any()).
 			Return(&models.Task{Id: "new-id", App: task.App}, int64(0), nil)
 		stateMock.EXPECT().ClaimTask("new-id").Return(errors.New("database unreachable"))

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/shini4i/argo-watcher/internal/helpers"
 	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 const (
@@ -362,17 +363,17 @@ func (monitor *DeploymentMonitor) rolloutWindow(task models.Task) time.Duration 
 // ProcessDeploymentResult determines if the deployment was successful and updates the appropriate
 // status and metrics. waited is how long the rollout was polled, reported in the failure message so
 // the user can tell a rollout that ran out its window from one that failed immediately.
-func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, application *models.Application, waited time.Duration) {
+func (monitor *DeploymentMonitor) ProcessDeploymentResult(task *models.Task, application *models.Application, waited time.Duration) bool {
 	status := rolloutStatus(application, task.ListImages(), monitor.registryProxyUrl, monitor.acceptSuspended)
 	if application.IsFireAndForgetModeActive() {
 		status = ArgoRolloutAppSuccess
 	}
 
 	if status == ArgoRolloutAppSuccess {
-		monitor.handleDeploymentSuccess(task)
-	} else {
-		monitor.handleDeploymentFailure(task, status, application, waited)
+		return monitor.handleDeploymentSuccess(task)
 	}
+
+	return monitor.handleDeploymentFailure(task, status, application, waited)
 }
 
 // storedTaskStatus returns the task's status as the shared state holds it, or an empty
@@ -408,6 +409,23 @@ func (monitor *DeploymentMonitor) taskEndedElsewhere(id string) error {
 	}
 }
 
+// recordStatus writes the task's terminal status and reports whether this replica
+// decided it. A refusal means the claim moved on mid-write, which is an ordinary
+// handover: the holder reaches the same outcome, so the caller must not count or
+// announce one of its own. Any other failure is logged and the outcome still stands.
+func (monitor *DeploymentMonitor) recordStatus(task *models.Task, status, reason string) bool {
+	err := monitor.argo.State.SetTaskStatus(task.Id, status, reason)
+	if errors.Is(err, state.ErrTaskNotOwned) {
+		slog.Info("Left the outcome to the replica that took the deployment over.", "id", task.Id)
+		return false
+	}
+	if err != nil {
+		slog.Error("Failed to change task status", "error", err, "id", task.Id)
+	}
+
+	return true
+}
+
 // HandleArgoAPIFailure processes API errors and updates task status accordingly.
 // task is taken by pointer so the resolved terminal status is reflected back to
 // the caller, keeping the outgoing failure notification in sync with the stored
@@ -417,57 +435,72 @@ func (monitor *DeploymentMonitor) taskEndedElsewhere(id string) error {
 // Only then may the app name label a metric: without a confirmation the name is only as
 // trustworthy as the submission that supplied it, so the failure is counted under no app
 // at all (issue #552).
-func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error, confirmed bool) {
-	if confirmed {
-		monitor.argo.metrics.AddFailedDeployment(task.App)
-	} else {
-		monitor.argo.metrics.AddUnconfirmedFailure()
-	}
+func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err error, confirmed bool) bool {
 	finalStatus := determineFailureStatus(*task, err)
 	reason := fmt.Sprintf(ArgoAPIErrorTemplate, err.Error())
 	slog.Warn("Deployment not completed", "status", finalStatus, "reason", reason, "id", task.Id)
 
-	if err := monitor.argo.State.SetTaskStatus(task.Id, finalStatus, reason); err != nil {
-		slog.Error("Failed to change task status", "error", err, "id", task.Id)
-	}
+	recorded := monitor.recordStatus(task, finalStatus, reason)
 	task.Status = finalStatus
+
+	// Counted only for an outcome this replica decided: on a handover the owner
+	// counts the same deployment, and two increments would trip a threshold early.
+	if recorded {
+		if confirmed {
+			monitor.argo.metrics.AddFailedDeployment(task.App)
+		} else {
+			monitor.argo.metrics.AddUnconfirmedFailure()
+		}
+	}
+
+	return recorded
 }
 
 // HandleImageNotPartOfApp fails the task immediately instead of letting it run out its
 // timeout waiting for an image the application will never have.
-func (monitor *DeploymentMonitor) HandleImageNotPartOfApp(task *models.Task, imageErr *ImageNotPartOfAppError) {
+func (monitor *DeploymentMonitor) HandleImageNotPartOfApp(task *models.Task, imageErr *ImageNotPartOfAppError) bool {
 	slog.Warn("App deployment failed: expected image is not part of the application.",
 		"image", imageErr.Image, "app", imageErr.App, "id", task.Id)
-	monitor.argo.metrics.AddFailedDeployment(task.App)
 
-	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, imageErr.Reason()); err != nil {
-		slog.Error("Failed to change task status", "error", err, "id", task.Id)
-	}
+	recorded := monitor.recordStatus(task, models.StatusFailedMessage, imageErr.Reason())
 	task.Status = models.StatusFailedMessage
-}
-
-func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) {
-	slog.Info("App is running on the expected version.", "id", task.Id)
-	monitor.argo.metrics.ResetFailedDeployment(task.App)
-	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""); err != nil {
-		slog.Error("Failed to change task status", "error", err, "id", task.Id)
+	if recorded {
+		monitor.argo.metrics.AddFailedDeployment(task.App)
 	}
-	task.Status = models.StatusDeployedMessage
+
+	return recorded
 }
 
-func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application, waited time.Duration) {
+func (monitor *DeploymentMonitor) handleDeploymentSuccess(task *models.Task) bool {
+	slog.Info("App is running on the expected version.", "id", task.Id)
+
+	recorded := monitor.recordStatus(task, models.StatusDeployedMessage, "")
+	task.Status = models.StatusDeployedMessage
+	// Clearing the gauge for a rollout the owner decided would erase its failures.
+	if recorded {
+		monitor.argo.metrics.ResetFailedDeployment(task.App)
+	}
+
+	return recorded
+}
+
+func (monitor *DeploymentMonitor) handleDeploymentFailure(task *models.Task, status string, application *models.Application, waited time.Duration) bool {
 	slog.Warn("App deployment failed.", "id", task.Id)
-	monitor.argo.metrics.AddFailedDeployment(task.App)
 	tree := monitor.fetchResourceTree(task)
 	reason := fmt.Sprintf(
 		"%s\n\n%s",
 		rolloutFailureHeadline(application, status, waited),
 		rolloutMessage(application, status, task.ListImages(), tree),
 	)
-	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusFailedMessage, reason); err != nil {
-		slog.Error("Failed to change task status", "error", err, "id", task.Id)
-	}
+	recorded := monitor.recordStatus(task, models.StatusFailedMessage, reason)
 	task.Status = models.StatusFailedMessage
+	// The resource-tree fetch above widens the window between the lease check and
+	// the write, so this is the most likely place for the claim to have moved on.
+	if recorded {
+		monitor.argo.metrics.AddFailedDeployment(task.App)
+	}
+
+	return recorded
 }
 
 // resourceTreeTimeout bounds the best-effort resource-tree fetch on the failure path so

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -410,13 +410,13 @@ func (monitor *DeploymentMonitor) taskEndedElsewhere(id string) error {
 }
 
 // recordStatus writes the task's terminal status and reports whether this replica
-// decided it. A refusal means the claim moved on mid-write, which is an ordinary
-// handover: the holder reaches the same outcome, so the caller must not count or
-// announce one of its own. Any other failure is logged and the outcome still stands.
+// decided it. A refusal means the claim moved on mid-write — taken over, or released
+// at shutdown — so whoever resumes the task reaches the outcome and the caller must
+// not count or announce one. Any other failure is logged and the outcome stands.
 func (monitor *DeploymentMonitor) recordStatus(task *models.Task, status, reason string) bool {
 	err := monitor.argo.State.SetTaskStatus(task.Id, status, reason)
 	if errors.Is(err, state.ErrTaskNotOwned) {
-		slog.Info("Left the outcome to the replica that took the deployment over.", "id", task.Id)
+		slog.Info("Left the outcome to whichever replica resumes this deployment.", "id", task.Id)
 		return false
 	}
 	if err != nil {

--- a/internal/argocd/resume.go
+++ b/internal/argocd/resume.go
@@ -32,11 +32,12 @@ func (updater *ArgoStatusUpdater) ResumeRollout(task models.Task, draining func(
 	remaining, resumable := updater.monitor.remainingWindow(task, time.Now())
 	if !resumable {
 		slog.Info("Not resuming a deployment whose window already elapsed", "id", task.Id, "app", task.App)
-		updater.monitor.abortStaleTask(&task)
 		// The replica that accepted this deployment announced it as started, and this
 		// is where it ends, so the terminal notification is owed here as much as on
-		// any other final status.
-		sendNotification(task, updater.notifier)
+		// any other final status — unless the claim moved on and the abort was refused.
+		if updater.monitor.abortStaleTask(&task) {
+			sendNotification(task, updater.notifier)
+		}
 		return
 	}
 
@@ -74,11 +75,12 @@ func (monitor *DeploymentMonitor) remainingWindow(task models.Task, now time.Tim
 // this replica never asked ArgoCD about the application, and whether the replica
 // that accepted the deployment got that far cannot be known here, so the name is
 // only as trustworthy as the submission that supplied it (issue #552).
-func (monitor *DeploymentMonitor) abortStaleTask(task *models.Task) {
-	monitor.argo.metrics.AddUnconfirmedFailure()
-
-	if err := monitor.argo.State.SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason); err != nil {
-		slog.Error("Failed to change task status", "error", err, "id", task.Id)
-	}
+func (monitor *DeploymentMonitor) abortStaleTask(task *models.Task) bool {
+	recorded := monitor.recordStatus(task, models.StatusAborted, StaleResumedTaskReason)
 	task.Status = models.StatusAborted
+	if recorded {
+		monitor.argo.metrics.AddUnconfirmedFailure()
+	}
+
+	return recorded
 }

--- a/internal/argocd/resume_test.go
+++ b/internal/argocd/resume_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/notifications"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 func monitorWithDefaultWindow(window time.Duration) *DeploymentMonitor {
@@ -501,4 +502,40 @@ func TestResumeRollout_AnnouncesAnAbortedTaskEvenWhileDraining(t *testing.T) {
 
 	require.Len(t, capture.sent, 1, "the abort must still be announced")
 	assert.Equal(t, models.StatusAborted, capture.sent[0].Status)
+}
+
+// The claim can move on between the sweep taking it and the stale abort landing.
+// The write is then refused, so the outcome stored is the new owner's — counting
+// or announcing one here would report the same task twice.
+func TestResumeRollout_ARefusedStaleAbortIsNotCountedOrAnnounced(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := newTaskRepositoryMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, newArgoApiMock(ctrl), metricsMock)
+
+	task := models.Task{
+		Id:        "refused-abort",
+		App:       "test-app",
+		Timeout:   30,
+		Created:   float64(time.Now().Add(-10 * time.Minute).Unix()),
+		Validated: true,
+		Images:    []models.Image{{Image: "app", Tag: "v1"}},
+	}
+
+	stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusAborted, StaleResumedTaskReason).
+		Return(state.ErrTaskNotOwned)
+	// No metrics expectation at all: gomock fails if this replica counts a failure
+	// for a task whose abort the backend refused.
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	updater.ResumeRollout(task, neverDraining)
+
+	require.Empty(t, capture.sent, "a refused abort must not announce an outcome this replica did not decide")
 }

--- a/internal/argocd/shutdown_rollout_test.go
+++ b/internal/argocd/shutdown_rollout_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/notifications"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 // managedApp is a settled application the watcher writes back for, so a rollout
@@ -335,4 +336,46 @@ func TestWaitForRollout_GivesUpARolloutThatSettledAsTheDrainBegan(t *testing.T) 
 
 	assert.Equal(t, int32(2), fetches.Load(), "the rollout must reach its outcome before it is given up")
 	require.Len(t, capture.sent, 1, "the replica that resumes the task announces the result")
+}
+
+// The claim can move on between the last lease check and the status write, which
+// the backend refuses. The outcome stored is then the new owner's, so counting or
+// announcing one here would report the deployment twice — and the two reports can
+// disagree, this replica saying failed where the owner recorded deployed.
+func TestWaitForRollout_ARefusedWriteIsNotCountedOrAnnounced(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := notSupersededState(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	app := &models.Application{}
+	app.Status.Summary.Images = []string{"app:v1"}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Healthy"
+	apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(app, nil).AnyTimes()
+
+	// The rollout succeeded, so this replica tries to record "deployed" — and the
+	// backend refuses it because the claim is no longer here.
+	stateMock.EXPECT().SetTaskStatus("refused-id", models.StatusDeployedMessage, "").
+		Return(state.ErrTaskNotOwned)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+	// Nothing else: gomock fails the test if this replica touches the app's gauge,
+	// counts an outcome or times a deployment the owner already recorded.
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	updater.WaitForRollout(shutdownTestTask("refused-id"), false, neverDraining)
+
+	require.Len(t, capture.sent, 1, "only the start notification may be sent")
+	assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
 }

--- a/internal/argocd/shutdown_rollout_test.go
+++ b/internal/argocd/shutdown_rollout_test.go
@@ -379,3 +379,50 @@ func TestWaitForRollout_ARefusedWriteIsNotCountedOrAnnounced(t *testing.T) {
 	require.Len(t, capture.sent, 1, "only the start notification may be sent")
 	assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
 }
+
+// WaitForRollout re-checks draining before dispatching the outcome, and the failure
+// path then fetches the resource tree for up to ten seconds before writing. A drain
+// starting inside that fetch reaches SetTaskStatus unchecked, which is why the store
+// refuses the write rather than another in-process guard.
+func TestWaitForRollout_ADrainStartingInsideTheDiagnosticsFetchStillReachesTheWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := mocks.NewMockArgoApiInterface(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := notSupersededState(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	app := &models.Application{}
+	app.Status.Summary.Images = []string{"app:v1"}
+	app.Status.Sync.Status = "Synced"
+	app.Status.Health.Status = "Degraded"
+	apiMock.EXPECT().GetApplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(app, nil).AnyTimes()
+	apiMock.EXPECT().GetManagedResources(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	var draining atomic.Bool
+	apiMock.EXPECT().GetResourceTree(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string) (*models.ApplicationTree, error) {
+			draining.Store(true)
+			return nil, nil
+		})
+
+	// Reached despite the drain: the check that would have stopped it is already past.
+	stateMock.EXPECT().SetTaskStatus("drained-id", models.StatusFailedMessage, gomock.Any()).
+		Return(state.ErrTaskNotOwned).Times(1)
+
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().RemoveInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes("test-app")
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(lock.NewInMemoryLocker()), argo)
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	updater.WaitForRollout(shutdownTestTask("drained-id"), false, draining.Load)
+
+	require.Len(t, capture.sent, 1, "only the start notification may be sent")
+	assert.Equal(t, models.StatusInProgressMessage, capture.sent[0].Status)
+}

--- a/internal/argocd/task_read_failure_test.go
+++ b/internal/argocd/task_read_failure_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
+	"github.com/shini4i/argo-watcher/internal/state"
 )
 
 // detectRollback reads the app's deployed history to decide whether this
@@ -83,4 +84,42 @@ func TestArgoGetTasks_SuccessCarriesNoError(t *testing.T) {
 	assert.Empty(t, response.Error)
 	assert.Equal(t, stored, response.Tasks)
 	assert.Equal(t, int64(1), response.Total)
+}
+
+// The whole point of the in-memory backend's insertion-order tie-break, exercised
+// at the seam that consumes it: detectRollback reads the first deployed task as the
+// current version, and two deployments of one app land in the same whole second.
+func TestArgoDetectRollback_SameSecondHistoryNamesTheLastDeployment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	argo := &Argo{}
+	argo.Init(&state.InMemoryState{}, newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+
+	deploy := func(tag string) string {
+		task, err := argo.State.AddTask(models.Task{
+			App:    "app-a",
+			Images: []models.Image{{Image: "app", Tag: tag}},
+		})
+		require.NoError(t, err)
+		require.NoError(t, argo.State.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""))
+		return task.Id
+	}
+
+	firstId := deploy("v1")
+	deploy("v2")
+
+	current, err := argo.detectRollback(models.Task{
+		App:    "app-a",
+		Images: []models.Image{{Image: "app", Tag: "v2"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, current, "redeploying the version deployed last is not a rollback")
+
+	back, err := argo.detectRollback(models.Task{
+		App:    "app-a",
+		Images: []models.Image{{Image: "app", Tag: "v1"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, firstId, back, "returning to the earlier version is a rollback to it")
 }

--- a/internal/argocd/task_read_failure_test.go
+++ b/internal/argocd/task_read_failure_test.go
@@ -1,0 +1,86 @@
+package argocd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/mocks"
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// detectRollback reads the app's deployed history to decide whether this
+// deployment returns to an earlier image set. A backend that answered "no rows"
+// for what was really an outage made every deployment look like a first one, and
+// the wrong answer was then persisted on the task as IsRollback=false.
+func TestArgoAddTask_ReadFailureDoesNotRecordAWrongRollbackFlag(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stateMock := newTaskRepositoryMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+
+	readErr := errors.New("database unreachable")
+	stateMock.EXPECT().GetTasks(gomock.Any()).Return(nil, int64(0), readErr)
+	// Nothing else is declared: gomock fails the test if the submission is stored
+	// or counted on history the backend never actually returned.
+
+	argo := &Argo{}
+	argo.Init(stateMock, newArgoApiMock(ctrl), metricsMock)
+
+	newTask, err := argo.AddTask(models.Task{
+		App:    "test-app",
+		Images: []models.Image{{Image: "app", Tag: "v1"}},
+	})
+
+	require.Error(t, err, "a history read that failed must not be read as an empty history")
+	assert.ErrorIs(t, err, readErr, "the cause must reach the caller, not be flattened")
+	assert.Nil(t, newTask)
+}
+
+// The listing endpoint is the one read that must survive a backend failure
+// without pretending: an empty list reads as "no deployments ran", which is the
+// opposite of what an operator needs during an outage.
+func TestArgoGetTasks_ReadFailureIsReportedNotSwallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// The body is served unauthenticated when OIDC is off, so the driver's text —
+	// DSN, schema, SQLSTATE — must stay in the server log.
+	readErr := errors.New(`relation "tasks" does not exist (SQLSTATE 42P01) host=db.internal`)
+
+	stateMock := newTaskRepositoryMock(ctrl)
+	stateMock.EXPECT().GetTasks(gomock.Any()).Return(nil, int64(0), readErr)
+
+	argo := &Argo{}
+	argo.Init(stateMock, newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+
+	response := argo.GetTasks(models.TaskFilter{EndTime: 1})
+
+	assert.Equal(t, tasksFailedMessage, response.Error, "the client sees the fixed message, not the cause")
+	assert.NotContains(t, response.Error, "SQLSTATE")
+	assert.NotContains(t, response.Error, "db.internal")
+	assert.Empty(t, response.Tasks)
+	assert.Zero(t, response.Total, "a total alongside an error would read as a real count")
+}
+
+func TestArgoGetTasks_SuccessCarriesNoError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stored := []models.Task{{Id: "a", App: "test-app"}}
+	stateMock := newTaskRepositoryMock(ctrl)
+	stateMock.EXPECT().GetTasks(gomock.Any()).Return(stored, int64(1), nil)
+
+	argo := &Argo{}
+	argo.Init(stateMock, newArgoApiMock(ctrl), mocks.NewMockMetricsInterface(ctrl))
+
+	response := argo.GetTasks(models.TaskFilter{EndTime: 1})
+
+	assert.Empty(t, response.Error)
+	assert.Equal(t, stored, response.Tasks)
+	assert.Equal(t, int64(1), response.Total)
+}

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -88,6 +88,9 @@ func (task *Task) IsAppNotFoundError(err error) bool {
 	return strings.Contains(err.Error(), appNotFoundError) || strings.Contains(err.Error(), "permission denied")
 }
 
+// TasksResponse is the body of GET /api/v1/tasks. Error is set, with no tasks and
+// a zero total, when the state backend could not be read — a reader that ignores
+// it cannot tell an outage from an estate with nothing deployed.
 type TasksResponse struct {
 	Tasks []Task `json:"tasks"`
 	Error string `json:"error,omitempty"`

--- a/internal/server/app_summary_handler_test.go
+++ b/internal/server/app_summary_handler_test.go
@@ -17,7 +17,9 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/shini4i/argo-watcher/internal/argocd"
+	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/config"
+	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/mocks"
 	"github.com/shini4i/argo-watcher/internal/models"
 )
@@ -253,4 +255,75 @@ func TestGetAppSummariesKeepsAWindowInsideTheCap(t *testing.T) {
 
 	assert.Equal(t, float64(start), seen.StartTime)
 	assert.Equal(t, float64(end), seen.EndTime)
+}
+
+// The overview's sibling assertion, for the task list. This body is what the web
+// client reads, and with OIDC off it is served unauthenticated, so the driver's
+// text must stay in the log while the reader still learns the read failed.
+func TestGetStateReportsABackendFailureWithoutLeakingIt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mocks.NewMockTaskRepository(ctrl)
+	repo.EXPECT().GetTasks(gomock.Any()).
+		Return(nil, int64(0), fmt.Errorf(`relation "tasks" does not exist (SQLSTATE 42P01) host=db.internal`))
+
+	argo := &argocd.Argo{}
+	argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+	env := &Env{argo: argo, config: &config.ServerConfig{}}
+	router := chi.NewRouter()
+	router.Get("/api/v1/tasks", env.getState)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/tasks?from_timestamp=0", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var body models.TasksResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	assert.Equal(t, http.StatusOK, w.Code, "the soft-error shape the web client expects")
+	assert.Equal(t, "failed to read tasks", body.Error)
+	assert.Empty(t, body.Tasks, "an empty list alongside the error, never a silent one")
+	assert.NotContains(t, w.Body.String(), "SQLSTATE")
+	assert.NotContains(t, w.Body.String(), "db.internal")
+}
+
+// Submission takes no credential, so the same masking GET /api/v1/tasks got must
+// hold here: the history read now wraps the driver error, and without the mask it
+// would travel to any caller that can reach the endpoint.
+func TestAddTaskDoesNotLeakTheDatabaseErrorFromTheHistoryRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mocks.NewMockTaskRepository(ctrl)
+	repo.EXPECT().Check().Return(true).AnyTimes()
+	repo.EXPECT().GetTasks(gomock.Any()).
+		Return(nil, int64(0), fmt.Errorf(`relation "tasks" does not exist (SQLSTATE 42P01) host=db.internal`))
+
+	lockdown, err := NewLockdown("", lock.NewInMemoryDeployLockStore())
+	require.NoError(t, err)
+	argo := &argocd.Argo{}
+	argo.Init(repo, newArgoAPI(ctrl), newMetrics(ctrl))
+
+	strategies := map[string]auth.AuthStrategy{}
+	env := &Env{
+		lockdown:      lockdown,
+		strategies:    strategies,
+		authenticator: auth.NewAuthenticator(strategies),
+		argo:          argo,
+		config:        &config.ServerConfig{DeploymentTimeout: 900},
+	}
+	router := chi.NewRouter()
+	router.Post("/api/v1/tasks", env.addTask)
+
+	body := `{"app":"demo","author":"ci","project":"demo","images":[{"image":"nginx","tag":"1.0"}]}`
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), internalErrorMessage)
+	assert.NotContains(t, w.Body.String(), "SQLSTATE")
+	assert.NotContains(t, w.Body.String(), "db.internal")
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/shini4i/argo-watcher/internal/argocd"
 	"github.com/shini4i/argo-watcher/internal/auth"
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/state"
@@ -204,9 +205,15 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 	newTask, err := env.argo.AddTask(task)
 	if err != nil {
 		slog.Error("failed to add task", "error", err)
+		// Submission takes no credential, so a backend failure's driver text must not
+		// travel with the response. Every other cause here names a client mistake.
+		message := err.Error()
+		if errors.Is(err, argocd.ErrTaskHistoryUnavailable) {
+			message = internalErrorMessage
+		}
 		writeJSON(w, http.StatusServiceUnavailable, models.TaskStatus{
 			Status: "down",
-			Error:  err.Error(),
+			Error:  message,
 		})
 		return
 	}
@@ -231,7 +238,7 @@ func (env *Env) addTask(w http.ResponseWriter, r *http.Request) {
 // @Param to_timestamp query int false "To timestamp"
 // @Param limit query int false "Maximum number of tasks to return (1-1000, defaults to 1000)"
 // @Param offset query int false "Number of tasks to skip before returning results"
-// @Success 200 {object} models.TasksResponse
+// @Success 200 {object} models.TasksResponse "tasks, or an error field when unreadable"
 // @Failure 401 {object} models.TaskStatus "no credential, or the credential was rejected (only when OIDC auth is enabled)"
 // @Failure 503 {object} models.TaskStatus "the OIDC provider could not be consulted; retry"
 // @Router /api/v1/tasks [get]

--- a/internal/server/handlers_app_tokens_test.go
+++ b/internal/server/handlers_app_tokens_test.go
@@ -424,7 +424,7 @@ func TestAppTokenAuthorizesAnInScopeSubmission(t *testing.T) {
 			repo.EXPECT().Check().Return(true).AnyTimes()
 			// AddTask consults the history for rollback detection before inserting.
 			repo.EXPECT().GetTasks(gomock.Any()).
-				Return([]models.Task{}, int64(0)).AnyTimes()
+				Return([]models.Task{}, int64(0), nil).AnyTimes()
 
 			// Capture the task, then fail the insert: the success path would spawn the
 			// real rollout goroutine. Validated is already decided by this point.

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -56,9 +56,9 @@ func newRepo(ctrl *gomock.Controller) (*mocks.MockTaskRepository, *repoCapture) 
 	capture := &repoCapture{}
 	repo.EXPECT().Connect(gomock.Any()).Return(nil).AnyTimes()
 	repo.EXPECT().GetTasks(gomock.Any()).
-		DoAndReturn(func(filter models.TaskFilter) ([]models.Task, int64) {
+		DoAndReturn(func(filter models.TaskFilter) ([]models.Task, int64, error) {
 			capture.lastFilter = filter
-			return []models.Task{}, 0
+			return []models.Task{}, 0, nil
 		}).AnyTimes()
 	repo.EXPECT().GetAppSummaries(gomock.Any()).
 		DoAndReturn(func(filter models.TaskFilter) ([]models.AppSummary, error) {
@@ -1845,7 +1845,7 @@ func TestAddTaskEndpoint(t *testing.T) {
 		// case declares for itself.
 		ctrl := gomock.NewController(t)
 		repo := mocks.NewMockTaskRepository(ctrl)
-		repo.EXPECT().GetTasks(deployedHistoryOf("test-app")).Return([]models.Task{}, int64(0))
+		repo.EXPECT().GetTasks(deployedHistoryOf("test-app")).Return([]models.Task{}, int64(0), nil)
 
 		// The captured task is what ties the handler's authority to the state-layer
 		// rule: its Validated flag is what SupersedeAndAdd weighs.
@@ -2589,7 +2589,7 @@ func TestAddTaskResolvesTheDeploymentWindow(t *testing.T) {
 			argo.Init(stateMock, mocks.NewMockArgoApiInterface(ctrl), metricsMock)
 
 			stateMock.EXPECT().GetTasks(gomock.Any()).
-				Return([]models.Task{}, int64(0)).AnyTimes()
+				Return([]models.Task{}, int64(0), nil).AnyTimes()
 			stateMock.EXPECT().ClaimTask(gomock.Any()).Return(nil).AnyTimes()
 			metricsMock.EXPECT().AddAcceptedDeployment().AnyTimes()
 

--- a/internal/state/app_summary_test.go
+++ b/internal/state/app_summary_test.go
@@ -207,7 +207,7 @@ func TestInMemoryState_GetTasks_AuthorFilter(t *testing.T) {
 	t.Run("matches exactly, ignoring case", func(t *testing.T) {
 		filter := window
 		filter.Author = "jane.doe@example.com"
-		tasks, total := state.GetTasks(filter)
+		tasks, total, _ := state.GetTasks(filter)
 		require.Equal(t, int64(1), total)
 		assert.Equal(t, "Jane.Doe@example.com", tasks[0].Author)
 	})
@@ -215,7 +215,7 @@ func TestInMemoryState_GetTasks_AuthorFilter(t *testing.T) {
 	t.Run("is not a substring match", func(t *testing.T) {
 		filter := window
 		filter.Author = "jane"
-		_, total := state.GetTasks(filter)
+		_, total, _ := state.GetTasks(filter)
 		assert.Equal(t, int64(0), total)
 	})
 
@@ -224,16 +224,16 @@ func TestInMemoryState_GetTasks_AuthorFilter(t *testing.T) {
 		filter := window
 		filter.Author = "jane.doe@example.com"
 		filter.Search = "nothing-here"
-		_, total := state.GetTasks(filter)
+		_, total, _ := state.GetTasks(filter)
 		assert.Equal(t, int64(0), total)
 
 		filter.Search = "checkout"
-		_, total = state.GetTasks(filter)
+		_, total, _ = state.GetTasks(filter)
 		assert.Equal(t, int64(1), total)
 	})
 
 	t.Run("an empty author is a wildcard", func(t *testing.T) {
-		_, total := state.GetTasks(window)
+		_, total, _ := state.GetTasks(window)
 		assert.Equal(t, int64(2), total)
 	})
 }

--- a/internal/state/app_summary_test.go
+++ b/internal/state/app_summary_test.go
@@ -238,15 +238,15 @@ func TestInMemoryState_GetTasks_AuthorFilter(t *testing.T) {
 	})
 }
 
-// Second-granularity timestamps make two deployments of one app in the same
-// second ordinary; without a tie-breaker each backend picks a different winner.
-func TestInMemoryState_GetAppSummaries_BreaksASameSecondTieById(t *testing.T) {
+// Second-granularity timestamps make two deployments of one app in the same second
+// ordinary, and the summary names the newest of them as the app's last outcome.
+func TestInMemoryState_GetAppSummaries_BreaksASameSecondTieByInsertionOrder(t *testing.T) {
 	older := summaryTask("checkout", models.StatusDeployedMessage, 500, 510)
-	older.Id = "aaaaaaaa-0000-4000-8000-000000000001"
+	older.Id = "bbbbbbbb-0000-4000-8000-000000000002"
 	newer := summaryTask("checkout", models.StatusFailedMessage, 500, 520)
-	newer.Id = "bbbbbbbb-0000-4000-8000-000000000002"
+	newer.Id = "aaaaaaaa-0000-4000-8000-000000000001"
 
-	// Seeded oldest-id first, so insertion order alone would report the wrong one.
+	// The newer task carries the lower id, so ordering by id reports the wrong one.
 	summaries, err := seedSummaryState(older, newer).GetAppSummaries(
 		models.TaskFilter{StartTime: 0, EndTime: 1000},
 	)

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -76,16 +77,14 @@ func taskMatchesFilters(task models.Task, filter models.TaskFilter) bool {
 	return task.MatchesSearch(filter.Search)
 }
 
-// sortByRecency orders tasks newest first, breaking a same-second tie by Id as the
-// SQL does, so both backends name the same task as newest. Created holds whole
-// seconds here, so ties are ordinary rather than rare, and detectRollback reads the
-// first deployed task as the current version.
+// sortByRecency orders tasks newest first. The slice must arrive in insertion order:
+// Created holds whole seconds here, so ties are ordinary, and reversing before a
+// stable sort puts the task stored last within a second first. Ids are random uuids
+// and carry no order of their own.
 func sortByRecency(tasks []models.Task) {
+	slices.Reverse(tasks)
 	sort.SliceStable(tasks, func(i, j int) bool {
-		if tasks[i].Created != tasks[j].Created {
-			return tasks[i].Created > tasks[j].Created
-		}
-		return tasks[i].Id > tasks[j].Id
+		return tasks[i].Created > tasks[j].Created
 	})
 }
 

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -76,6 +76,19 @@ func taskMatchesFilters(task models.Task, filter models.TaskFilter) bool {
 	return task.MatchesSearch(filter.Search)
 }
 
+// sortByRecency orders tasks newest first, breaking a same-second tie by Id as the
+// SQL does, so both backends name the same task as newest. Created holds whole
+// seconds here, so ties are ordinary rather than rare, and detectRollback reads the
+// first deployed task as the current version.
+func sortByRecency(tasks []models.Task) {
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if tasks[i].Created != tasks[j].Created {
+			return tasks[i].Created > tasks[j].Created
+		}
+		return tasks[i].Id > tasks[j].Id
+	})
+}
+
 // paginate returns the [offset:offset+limit] slice of tasks, clamping to bounds.
 // A non-positive limit means "no upper bound" — return everything from offset onward.
 func paginate(tasks []models.Task, limit, offset int) []models.Task {
@@ -89,12 +102,12 @@ func paginate(tasks []models.Task, limit, offset int) []models.Task {
 	return tasks[offset:end]
 }
 
-func (state *InMemoryState) GetTasks(filter models.TaskFilter) ([]models.Task, int64) {
+func (state *InMemoryState) GetTasks(filter models.TaskFilter) ([]models.Task, int64, error) {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
 
 	if state.tasks == nil {
-		return []models.Task{}, 0
+		return []models.Task{}, 0, nil
 	}
 
 	limit := filter.Limit
@@ -114,14 +127,12 @@ func (state *InMemoryState) GetTasks(filter models.TaskFilter) ([]models.Task, i
 	}
 
 	if len(tasks) == 0 {
-		return []models.Task{}, 0
+		return []models.Task{}, 0, nil
 	}
 
-	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].Created > tasks[j].Created
-	})
+	sortByRecency(tasks)
 
-	return paginate(tasks, limit, offset), int64(len(tasks))
+	return paginate(tasks, limit, offset), int64(len(tasks)), nil
 }
 
 // GetTask returns ErrTaskNotFound when no task matches.
@@ -277,14 +288,7 @@ func (state *InMemoryState) GetAppSummaries(filter models.TaskFilter) ([]models.
 // the status counters, the median settled duration, the newest outcomes, and the
 // newest task's own details. It requires at least one task.
 func summariseApp(app string, tasks []models.Task) models.AppSummary {
-	// Id breaks a same-second tie the same way the SQL does, so both backends
-	// report the same task as newest.
-	sort.SliceStable(tasks, func(i, j int) bool {
-		if tasks[i].Created != tasks[j].Created {
-			return tasks[i].Created > tasks[j].Created
-		}
-		return tasks[i].Id > tasks[j].Id
-	})
+	sortByRecency(tasks)
 
 	summary := models.AppSummary{
 		App:            app,

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -64,7 +64,7 @@ func TestInMemoryState_GetTasks(t *testing.T) {
 		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10})
 		assert.Len(t, tasks, 2)
 		assert.Equal(t, int64(2), total)
-		// Both tasks are present, newest first, id descending on a tie.
+		// Both tasks are present, newest first.
 		taskIDs := []string{tasks[0].Id, tasks[1].Id}
 		assert.Contains(t, taskIDs, firstTask.Id)
 		assert.Contains(t, taskIDs, secondTask.Id)
@@ -350,10 +350,10 @@ func TestInMemoryState_Contract(t *testing.T) {
 }
 
 // detectRollback takes the first deployed task as the current version, so a
-// same-second tie has to resolve the same way every call and the same way the
-// Postgres backend resolves it. Seconds-granularity Created makes ties ordinary
-// in-memory, where Postgres stores microseconds and rarely sees one.
-func TestInMemoryState_GetTasksBreaksASameSecondTieById(t *testing.T) {
+// same-second tie has to name the task that really came last. Created holds whole
+// seconds in-memory, which makes ties ordinary, and the ids are random uuids that
+// say nothing about order — only the insertion position does.
+func TestInMemoryState_GetTasksBreaksASameSecondTieByInsertionOrder(t *testing.T) {
 	state := &InMemoryState{}
 
 	now := float64(time.Now().Unix())
@@ -369,7 +369,57 @@ func TestInMemoryState_GetTasksBreaksASameSecondTieById(t *testing.T) {
 			App:     "app-a",
 		})
 		require.Len(t, tasks, 3)
-		assert.Equal(t, []string{"cccc", "bbbb", "aaaa"}, []string{tasks[0].Id, tasks[1].Id, tasks[2].Id},
-			"a same-second tie must resolve by id, as summariseApp already does")
+		assert.Equal(t, []string{"bbbb", "cccc", "aaaa"}, []string{tasks[0].Id, tasks[1].Id, tasks[2].Id},
+			"the task added last in a second must be the one reported as current")
 	}
+}
+
+// The production shape: ties inside more than one second. Created decides first and
+// insertion order only within a second, which a sort applied before the reverse — or
+// an unstable one — gets wrong. Reading must also leave the store as it found it.
+func TestInMemoryState_GetTasksOrdersByCreatedThenInsertion(t *testing.T) {
+	state := &InMemoryState{}
+
+	now := float64(time.Now().Unix())
+	state.tasks = append(state.tasks,
+		models.Task{Id: "a-early", App: "app-a", Created: now - 1},
+		models.Task{Id: "b-late", App: "app-a", Created: now},
+		models.Task{Id: "c-early", App: "app-a", Created: now - 1},
+		models.Task{Id: "d-late", App: "app-a", Created: now},
+	)
+
+	for range 2 {
+		tasks, _, _ := state.GetTasks(models.TaskFilter{EndTime: now + 1, App: "app-a"})
+		require.Len(t, tasks, 4)
+		assert.Equal(t, []string{"d-late", "b-late", "c-early", "a-early"},
+			[]string{tasks[0].Id, tasks[1].Id, tasks[2].Id, tasks[3].Id})
+	}
+
+	assert.Equal(t, []string{"a-early", "b-late", "c-early", "d-late"},
+		[]string{state.tasks[0].Id, state.tasks[1].Id, state.tasks[2].Id, state.tasks[3].Id},
+		"reading must not reorder the stored insertion sequence")
+}
+
+// Insertion position is the only recency a same-second tie has, so the sweep that
+// rewrites the store must not reorder what it keeps.
+func TestInMemoryState_ProcessObsoleteTasksKeepsInsertionOrder(t *testing.T) {
+	state := &InMemoryState{}
+
+	now := float64(time.Now().Unix())
+	stale := now - TaskStaleThresholdSeconds - 60
+	state.tasks = append(state.tasks,
+		models.Task{Id: "kept-first", App: "app-a", Status: models.StatusDeployedMessage, Created: now, Updated: now},
+		models.Task{Id: "dropped", App: "app-a", Status: models.StatusAppNotFoundMessage, Created: now, Updated: now},
+		models.Task{Id: "aborted", App: "app-a", Status: models.StatusInProgressMessage, Created: stale, Updated: stale},
+		models.Task{Id: "kept-last", App: "app-a", Status: models.StatusDeployedMessage, Created: now, Updated: now},
+	)
+
+	state.ProcessObsoleteTasks(1)
+
+	assert.Equal(t, []string{"kept-first", "aborted", "kept-last"},
+		[]string{state.tasks[0].Id, state.tasks[1].Id, state.tasks[2].Id})
+
+	tasks, _, _ := state.GetTasks(models.TaskFilter{EndTime: now + 1, App: "app-a"})
+	require.NotEmpty(t, tasks)
+	assert.Equal(t, "kept-last", tasks[0].Id, "the last task stored in a second stays the current one")
 }

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -61,64 +61,64 @@ func TestInMemoryState_GetTasks(t *testing.T) {
 	now := float64(time.Now().Unix())
 
 	t.Run("returns all tasks within time range", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10})
 		assert.Len(t, tasks, 2)
 		assert.Equal(t, int64(2), total)
-		// Verify both tasks are present (order may vary when timestamps are equal)
+		// Both tasks are present, newest first, id descending on a tie.
 		taskIDs := []string{tasks[0].Id, tasks[1].Id}
 		assert.Contains(t, taskIDs, firstTask.Id)
 		assert.Contains(t, taskIDs, secondTask.Id)
 	})
 
 	t.Run("filters by app name", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, App: "Test"})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, App: "Test"})
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(1), total)
 		assert.Equal(t, firstTask.Id, tasks[0].Id)
 	})
 
 	t.Run("returns empty for non-matching app", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, App: "NonExistent"})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, App: "NonExistent"})
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(0), total)
 	})
 
 	t.Run("filters by status", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Status: models.StatusInProgressMessage})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Status: models.StatusInProgressMessage})
 		assert.Len(t, tasks, 2)
 		assert.Equal(t, int64(2), total)
 	})
 
 	t.Run("returns empty for non-matching status", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Status: "deployed"})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Status: "deployed"})
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(0), total)
 	})
 
 	t.Run("search matches an app name substring, case-insensitively", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "test2"})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "test2"})
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(1), total)
 		assert.Equal(t, secondTask.Id, tasks[0].Id)
 	})
 
 	t.Run("search matches the author and the image tag", func(t *testing.T) {
-		_, byAuthor := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "author"})
+		_, byAuthor, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "author"})
 		assert.Equal(t, int64(2), byAuthor)
 
-		_, byTag := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "test:v0.0.1"})
+		_, byTag, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "test:v0.0.1"})
 		assert.Equal(t, int64(2), byTag)
 	})
 
 	t.Run("search combines with the app filter", func(t *testing.T) {
 		filter := models.TaskFilter{StartTime: now - 10, EndTime: now + 10, App: "Test", Search: "Test2"}
-		tasks, total := state.GetTasks(filter)
+		tasks, total, _ := state.GetTasks(filter)
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(0), total)
 	})
 
 	t.Run("returns empty for a non-matching search", func(t *testing.T) {
-		tasks, total := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "payments"})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "payments"})
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(0), total)
 	})
@@ -127,12 +127,12 @@ func TestInMemoryState_GetTasks(t *testing.T) {
 	// the rows searched, and the total counts every match beyond the page.
 	t.Run("pagination applies after the search", func(t *testing.T) {
 		filter := models.TaskFilter{StartTime: now - 10, EndTime: now + 10, Search: "test", Limit: 1}
-		tasks, total := state.GetTasks(filter)
+		tasks, total, _ := state.GetTasks(filter)
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(2), total)
 
 		filter.Offset = 1
-		second, total := state.GetTasks(filter)
+		second, total, _ := state.GetTasks(filter)
 		assert.Len(t, second, 1)
 		assert.Equal(t, int64(2), total)
 		assert.NotEqual(t, tasks[0].Id, second[0].Id)
@@ -142,7 +142,7 @@ func TestInMemoryState_GetTasks(t *testing.T) {
 func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 	t.Run("empty state returns empty slice", func(t *testing.T) {
 		state := InMemoryState{}
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(0), total)
 	})
@@ -152,7 +152,7 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 		_, err := state.AddTask(createTestTask("test"))
 		require.NoError(t, err)
 
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Offset: 100})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Offset: 100})
 		assert.Empty(t, tasks)
 		assert.Equal(t, int64(1), total)
 	})
@@ -164,7 +164,7 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: 2})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: 2})
 		assert.Len(t, tasks, 2)
 		assert.Equal(t, int64(5), total)
 	})
@@ -176,7 +176,7 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: 2, Offset: 2})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: 2, Offset: 2})
 		assert.Len(t, tasks, 2)
 		assert.Equal(t, int64(5), total)
 	})
@@ -186,7 +186,7 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 		_, err := state.AddTask(createTestTask("test"))
 		require.NoError(t, err)
 
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: -5})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Limit: -5})
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(1), total)
 	})
@@ -196,7 +196,7 @@ func TestInMemoryState_GetTasks_EdgeCases(t *testing.T) {
 		_, err := state.AddTask(createTestTask("test"))
 		require.NoError(t, err)
 
-		tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Offset: -5})
+		tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10, Offset: -5})
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(1), total)
 	})
@@ -284,7 +284,7 @@ func TestInMemoryState_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
+			_, _, _ = state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
 		}()
 	}
 
@@ -295,7 +295,7 @@ func TestInMemoryState_ConcurrentAccess(t *testing.T) {
 		t.Errorf("AddTask failed: %v", err)
 	}
 
-	tasks, total := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
+	tasks, total, _ := state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Unix()) + 10})
 	assert.Equal(t, int64(taskCount), total)
 	assert.Len(t, tasks, taskCount)
 }
@@ -347,4 +347,29 @@ func TestInMemoryState_Contract(t *testing.T) {
 	runTaskRepositoryContract(t, func(t *testing.T) TaskRepository {
 		return &InMemoryState{}
 	})
+}
+
+// detectRollback takes the first deployed task as the current version, so a
+// same-second tie has to resolve the same way every call and the same way the
+// Postgres backend resolves it. Seconds-granularity Created makes ties ordinary
+// in-memory, where Postgres stores microseconds and rarely sees one.
+func TestInMemoryState_GetTasksBreaksASameSecondTieById(t *testing.T) {
+	state := &InMemoryState{}
+
+	now := float64(time.Now().Unix())
+	for _, id := range []string{"aaaa", "cccc", "bbbb"} {
+		state.tasks = append(state.tasks, models.Task{
+			Id: id, App: "app-a", Status: models.StatusDeployedMessage, Created: now,
+		})
+	}
+
+	for range 5 {
+		tasks, _, _ := state.GetTasks(models.TaskFilter{
+			EndTime: now + 1,
+			App:     "app-a",
+		})
+		require.Len(t, tasks, 3)
+		assert.Equal(t, []string{"cccc", "bbbb", "aaaa"}, []string{tasks[0].Id, tasks[1].Id, tasks[2].Id},
+			"a same-second tie must resolve by id, as summariseApp already does")
+	}
 }

--- a/internal/state/lease.go
+++ b/internal/state/lease.go
@@ -113,17 +113,10 @@ func (state *PostgresState) RenewLease(id string) (bool, error) {
 	return result.RowsAffected == 1, nil
 }
 
-// ReleaseOwnedLeases expires every claim this instance holds and reports how
-// many it gave up, so the tasks it was monitoring are picked up by another
-// replica on its next sweep instead of waiting out the full TTL. It is how a
-// graceful shutdown hands its in-flight rollouts over.
-//
-// The owner is cleared as well as the deadline. Nothing waits for the monitoring
-// goroutines, so one of them can outlive this call by a few instructions; while
-// the row still named this instance, its next renewal would take the claim back
-// and undo the handover. Unowned, that renewal reports the claim lost and the
-// rollout stops without writing a status — which is what a replica on its way out
-// should do.
+// ReleaseOwnedLeases expires every claim this instance holds and reports how many it
+// gave up, so a graceful shutdown hands its in-flight rollouts to another replica's
+// next sweep instead of making them wait out the full TTL. A cleared owner alongside
+// a stamped deadline is what marks a row released; SetTaskStatus's fence reads both.
 func (state *PostgresState) ReleaseOwnedLeases() (int64, error) {
 	result := state.orm.Exec(`
 		UPDATE tasks

--- a/internal/state/lease_postgres_test.go
+++ b/internal/state/lease_postgres_test.go
@@ -343,6 +343,8 @@ func TestPostgresState_ReleaseOwnedLeases(t *testing.T) {
 
 		assert.False(t, env.storedModel(t, inserted.Id).OwnerId.Valid,
 			"a released task must name no owner")
+		assert.True(t, env.storedModel(t, inserted.Id).LeaseExpiresAt.Valid,
+			"a released task must keep a deadline: that is what tells it from one never claimed")
 
 		held, err := env.state.RenewLease(inserted.Id)
 		require.NoError(t, err)

--- a/internal/state/owner_fence_postgres_test.go
+++ b/internal/state/owner_fence_postgres_test.go
@@ -86,3 +86,43 @@ func TestPostgresState_SetTaskStatusRefusesTheNilUUID(t *testing.T) {
 	assertStatus(t, env.state, mine.Id, models.StatusInProgressMessage)
 	assertStatus(t, env.state, unclaimed.Id, models.StatusInProgressMessage)
 }
+
+// Shutdown releases this replica's claims without waiting for its monitors, one of
+// which can be inside the ten-second resource-tree fetch that precedes a failure
+// write. Writing after that defeats the handover: a sweep resumes only in-progress
+// tasks, so the status written here ends a deployment another replica would finish.
+func TestPostgresState_SetTaskStatusRefusesATaskThisReplicaReleased(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("app-fence"))
+	require.NoError(t, env.state.ClaimTask(task.Id))
+
+	released, err := env.state.ReleaseOwnedLeases()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), released)
+
+	err = env.state.SetTaskStatus(task.Id, models.StatusFailedMessage, "written after the handover")
+
+	require.ErrorIs(t, err, ErrTaskNotOwned)
+	assertStatus(t, env.state, task.Id, models.StatusInProgressMessage)
+
+	got, err := env.state.GetTask(task.Id)
+	require.NoError(t, err)
+	assert.Empty(t, got.StatusReason, "the refused write must leave no reason behind")
+}
+
+// The replica that resumes a released task owns it and must be able to finish it.
+func TestPostgresState_SetTaskStatusAcceptsTheReplicaThatResumedIt(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("app-fence"))
+	require.NoError(t, env.state.ClaimTask(task.Id))
+	_, err := env.state.ReleaseOwnedLeases()
+	require.NoError(t, err)
+
+	successor := env.secondReplica(t)
+	require.NoError(t, successor.ClaimTask(task.Id))
+
+	require.NoError(t, successor.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""))
+	assertStatus(t, env.state, task.Id, models.StatusDeployedMessage)
+}

--- a/internal/state/owner_fence_postgres_test.go
+++ b/internal/state/owner_fence_postgres_test.go
@@ -1,0 +1,88 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shini4i/argo-watcher/internal/models"
+)
+
+// A replica checks its lease, then spends seconds fetching the resource tree
+// before writing the outcome. If the lease lapsed in that window the new owner is
+// already monitoring the same rollout, so an unfenced write lands on top of the
+// outcome that owner is about to record — or has just recorded.
+func TestPostgresState_SetTaskStatusRefusesATaskOwnedElsewhere(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("app-fence"))
+	// The real sequence: this replica held the claim, its lease lapsed, and a sweep
+	// on another replica took the task over while the write was already under way.
+	require.NoError(t, env.state.ClaimTask(task.Id))
+	newOwner := env.secondReplica(t)
+	require.NoError(t, newOwner.ClaimTask(task.Id))
+
+	err := env.state.SetTaskStatus(task.Id, models.StatusFailedMessage, "written by the replica that lost it")
+
+	require.ErrorIs(t, err, ErrTaskNotOwned)
+	assertStatus(t, env.state, task.Id, models.StatusInProgressMessage)
+
+	got, err := env.state.GetTask(task.Id)
+	require.NoError(t, err)
+	assert.Empty(t, got.StatusReason, "the refused write must leave no reason behind")
+}
+
+// The owner writes its own outcome, which is the whole point of holding a claim.
+func TestPostgresState_SetTaskStatusAcceptsTheOwner(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("app-fence"))
+	require.NoError(t, env.state.ClaimTask(task.Id))
+
+	require.NoError(t, env.state.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""))
+	assertStatus(t, env.state, task.Id, models.StatusDeployedMessage)
+}
+
+// A task nobody claimed is still writable: AddTask's claim is best-effort, so a
+// database blip at submission must not leave the deployment unreportable.
+func TestPostgresState_SetTaskStatusAcceptsAnUnclaimedTask(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("app-fence"))
+
+	require.NoError(t, env.state.SetTaskStatus(task.Id, models.StatusDeployedMessage, ""))
+	assertStatus(t, env.state, task.Id, models.StatusDeployedMessage)
+}
+
+// An unknown id must stay distinguishable from a task held by someone else: one
+// is a bug in the caller, the other is an ordinary handover.
+func TestPostgresState_SetTaskStatusStillReportsAnUnknownTask(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	// Rows must be present, and one of them owned elsewhere: against an empty table
+	// an existence count with no id predicate would answer the same way, so the test
+	// would pass while the classification had become "is the table non-empty".
+	other := env.addTask(t, sampleTask("app-unrelated"))
+	require.NoError(t, env.secondReplica(t).ClaimTask(other.Id))
+
+	err := env.state.SetTaskStatus("00000000-0000-4000-8000-000000000000", models.StatusDeployedMessage, "")
+	assert.ErrorIs(t, err, ErrTaskNotFound)
+}
+
+// gorm drops a zero primary key from the WHERE clause. Before the fence that left
+// no condition at all and gorm refused the statement; with the fence it would pass
+// that check and rewrite every row this replica owns or nobody owns.
+func TestPostgresState_SetTaskStatusRefusesTheNilUUID(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	mine := env.addTask(t, sampleTask("app-nil-uuid"))
+	require.NoError(t, env.state.ClaimTask(mine.Id))
+	unclaimed := env.addTask(t, sampleTask("app-nil-uuid"))
+
+	err := env.state.SetTaskStatus("00000000-0000-0000-0000-000000000000", models.StatusFailedMessage, "mass update")
+
+	require.ErrorIs(t, err, ErrTaskNotFound)
+	assertStatus(t, env.state, mine.Id, models.StatusInProgressMessage)
+	assertStatus(t, env.state, unclaimed.Id, models.StatusInProgressMessage)
+}

--- a/internal/state/postgres_app_summary_test.go
+++ b/internal/state/postgres_app_summary_test.go
@@ -117,7 +117,7 @@ func TestPostgresState_GetTasks_AuthorFilter(t *testing.T) {
 	t.Run("matches exactly, ignoring case", func(t *testing.T) {
 		filter := window
 		filter.Author = "jane.doe@example.com"
-		tasks, total := env.state.GetTasks(filter)
+		tasks, total, _ := env.state.GetTasks(filter)
 		require.Equal(t, int64(1), total)
 		assert.Equal(t, "Jane.Doe@example.com", tasks[0].Author)
 	})
@@ -125,7 +125,7 @@ func TestPostgresState_GetTasks_AuthorFilter(t *testing.T) {
 	t.Run("is not a substring match", func(t *testing.T) {
 		filter := window
 		filter.Author = "jane"
-		_, total := env.state.GetTasks(filter)
+		_, total, _ := env.state.GetTasks(filter)
 		assert.Equal(t, int64(0), total)
 	})
 
@@ -133,7 +133,7 @@ func TestPostgresState_GetTasks_AuthorFilter(t *testing.T) {
 	t.Run("treats wildcards literally", func(t *testing.T) {
 		filter := window
 		filter.Author = "%"
-		_, total := env.state.GetTasks(filter)
+		_, total, _ := env.state.GetTasks(filter)
 		assert.Equal(t, int64(0), total)
 	})
 
@@ -141,11 +141,11 @@ func TestPostgresState_GetTasks_AuthorFilter(t *testing.T) {
 		filter := window
 		filter.Author = "jane.doe@example.com"
 		filter.Search = "nothing-here"
-		_, total := env.state.GetTasks(filter)
+		_, total, _ := env.state.GetTasks(filter)
 		assert.Equal(t, int64(0), total)
 
 		filter.Search = "checkout"
-		_, total = env.state.GetTasks(filter)
+		_, total, _ = env.state.GetTasks(filter)
 		assert.Equal(t, int64(1), total)
 	})
 }

--- a/internal/state/postgres_app_summary_test.go
+++ b/internal/state/postgres_app_summary_test.go
@@ -150,8 +150,9 @@ func TestPostgresState_GetTasks_AuthorFilter(t *testing.T) {
 	})
 }
 
-// The in-memory sort and the SQL must agree on which same-second task is newest;
-// see TestInMemoryState_GetAppSummaries_BreaksASameSecondTieById.
+// created is a timestamptz, so a tie needs microsecond-identical rows and id breaks
+// it only to keep the summary deterministic. The in-memory backend stores whole
+// seconds and breaks its far more common tie by insertion order instead.
 func TestPostgresState_GetAppSummaries_BreaksASameSecondTieById(t *testing.T) {
 	env := newPostgresTestEnv(t)
 

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -283,7 +283,8 @@ func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, i
 		query = query.Offset(filter.Offset)
 	}
 
-	// id breaks a tie so the page is totally ordered and matches sortByRecency.
+	// created is a timestamptz, so a tie needs microsecond-identical rows; id breaks
+	// it only to keep the page totally ordered across offsets.
 	query = query.Order("created DESC, id DESC")
 
 	var ormTasks []state_models.TaskModel

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -336,13 +336,13 @@ func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 		return ErrTaskNotFound
 	}
 
-	// Fenced on ownership: this instance checked its lease seconds ago, and a task
-	// claimed by someone else since then has that owner monitoring it too. Unclaimed
-	// stays writable, since AddTask's claim is best-effort; two monitors on one
-	// replica share an owner id, so the fence does not separate those.
+	// Fenced on ownership: a task claimed elsewhere since this instance checked its
+	// lease has that owner monitoring it too. A row never claimed at all stays
+	// writable, AddTask's claim being best-effort, and is told apart from one released
+	// at shutdown by having no lease deadline — a released row is somebody else's now.
 	var ormTask = state_models.TaskModel{Id: uuidv4}
 	result := state.orm.Model(ormTask).
-		Where("owner_id = ? OR owner_id IS NULL", state.ownerId).
+		Where("owner_id = ? OR (owner_id IS NULL AND lease_expires_at IS NULL)", state.ownerId).
 		Updates(state_models.TaskModel{Status: status, StatusReason: sql.NullString{String: reason, Valid: true}})
 	if result.Error != nil {
 		return result.Error

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -240,7 +240,7 @@ func (state *PostgresState) GetAppSummaries(filter models.TaskFilter) ([]models.
 
 // GetTasks retrieves the tasks matching filter. Empty filter values (App, Status,
 // Author, Search) are wildcards, and the Search clause mirrors models.Task.MatchesSearch.
-func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, int64) {
+func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, int64, error) {
 	startTimeUTC := time.Unix(int64(filter.StartTime), 0).UTC()
 	endTimeUTC := time.Unix(int64(filter.EndTime), 0).UTC()
 
@@ -273,7 +273,7 @@ func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, i
 	var total int64
 	if err := countQuery.Count(&total).Error; err != nil {
 		slog.Error("Failed to count tasks", "error", err)
-		return []models.Task{}, 0
+		return nil, 0, err
 	}
 
 	if filter.Limit > 0 {
@@ -283,12 +283,13 @@ func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, i
 		query = query.Offset(filter.Offset)
 	}
 
-	query = query.Order("created DESC")
+	// id breaks a tie so the page is totally ordered and matches sortByRecency.
+	query = query.Order("created DESC, id DESC")
 
 	var ormTasks []state_models.TaskModel
 	if err := query.Find(&ormTasks).Error; err != nil {
 		slog.Error("Failed to query tasks", "error", err)
-		return []models.Task{}, 0
+		return nil, 0, err
 	}
 
 	tasks := make([]models.Task, len(ormTasks))
@@ -296,7 +297,7 @@ func (state *PostgresState) GetTasks(filter models.TaskFilter) ([]models.Task, i
 		tasks[i] = *ormTask.ConvertToExternalTask()
 	}
 
-	return tasks, total
+	return tasks, total, nil
 }
 
 // GetTask retrieves a task by id. It returns ErrTaskNotFound when the id is
@@ -320,22 +321,51 @@ func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 	return ormTask.ConvertToExternalTask(), nil
 }
 
-// SetTaskStatus errors if the id is malformed and returns ErrTaskNotFound when no task matches.
+// SetTaskStatus errors if the id is malformed, returns ErrTaskNotFound when no task
+// exists, and ErrTaskNotOwned when another instance holds the claim.
 func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	uuidv4, err := uuid.Parse(id)
 	if err != nil {
 		return err
 	}
+	// gorm omits a zero primary key from the WHERE clause. That once left no
+	// condition at all and was caught as a missing where; the fence below would now
+	// satisfy that check and rewrite every unowned row instead.
+	if uuidv4 == uuid.Nil {
+		return ErrTaskNotFound
+	}
+
+	// Fenced on ownership: this instance checked its lease seconds ago, and a task
+	// claimed by someone else since then has that owner monitoring it too. Unclaimed
+	// stays writable, since AddTask's claim is best-effort; two monitors on one
+	// replica share an owner id, so the fence does not separate those.
 	var ormTask = state_models.TaskModel{Id: uuidv4}
-	result := state.orm.Model(ormTask).Updates(state_models.TaskModel{Status: status, StatusReason: sql.NullString{String: reason, Valid: true}})
+	result := state.orm.Model(ormTask).
+		Where("owner_id = ? OR owner_id IS NULL", state.ownerId).
+		Updates(state_models.TaskModel{Status: status, StatusReason: sql.NullString{String: reason, Valid: true}})
 	if result.Error != nil {
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
-		return ErrTaskNotFound
+		return state.classifyRefusedWrite(uuidv4)
 	}
 
 	return nil
+}
+
+// classifyRefusedWrite tells the two reasons SetTaskStatus matched no row apart:
+// an id that never existed is a caller bug, while a task held elsewhere is an
+// ordinary handover the caller must stop writing for.
+func (state *PostgresState) classifyRefusedWrite(id uuid.UUID) error {
+	var count int64
+	if err := state.orm.Model(&state_models.TaskModel{}).Where("id = ?", id).Count(&count).Error; err != nil {
+		return err
+	}
+	if count == 0 {
+		return ErrTaskNotFound
+	}
+
+	return ErrTaskNotOwned
 }
 
 // SupersedeAndAdd serialises submissions per app with an advisory lock, then

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"os"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	envConfig "github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/shini4i/argo-watcher/internal/config"
 	"github.com/shini4i/argo-watcher/internal/models"
@@ -140,19 +142,19 @@ func TestPostgresState_GetTasks(t *testing.T) {
 	env.addTask(t, sampleTask("ObsoleteApp"))
 	end := float64(time.Now().Add(time.Hour).Unix())
 
-	tasks, total := env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end})
+	tasks, total, _ := env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end})
 	assert.Len(t, tasks, 3)
 	assert.Equal(t, int64(3), total)
 
-	tasks, total = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, App: "Test"})
+	tasks, total, _ = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, App: "Test"})
 	assert.Len(t, tasks, 1)
 	assert.Equal(t, int64(1), total)
 
-	tasks, total = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, Status: models.StatusInProgressMessage})
+	tasks, total, _ = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, Status: models.StatusInProgressMessage})
 	assert.Len(t, tasks, 3)
 	assert.Equal(t, int64(3), total)
 
-	tasks, total = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, Status: "deployed"})
+	tasks, total, _ = env.state.GetTasks(models.TaskFilter{StartTime: start, EndTime: end, Status: "deployed"})
 	assert.Empty(t, tasks)
 	assert.Equal(t, int64(0), total)
 }
@@ -220,7 +222,7 @@ func TestPostgresState_GetTasksSearch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tasks, total := env.state.GetTasks(window(tt.search))
+			tasks, total, _ := env.state.GetTasks(window(tt.search))
 			assert.Equal(t, tt.want, total)
 			assert.Len(t, tasks, int(tt.want))
 		})
@@ -231,12 +233,12 @@ func TestPostgresState_GetTasksSearch(t *testing.T) {
 	t.Run("pagination applies after the search", func(t *testing.T) {
 		filter := window("v0.0.1")
 		filter.Limit = 1
-		tasks, total := env.state.GetTasks(filter)
+		tasks, total, _ := env.state.GetTasks(filter)
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, int64(2), total)
 
 		filter.Offset = 1
-		second, total := env.state.GetTasks(filter)
+		second, total, _ := env.state.GetTasks(filter)
 		assert.Len(t, second, 1)
 		assert.Equal(t, int64(2), total)
 		assert.NotEqual(t, tasks[0].Id, second[0].Id)
@@ -666,4 +668,80 @@ func TestPostgresState_Contract(t *testing.T) {
 	runTaskRepositoryContract(t, func(t *testing.T) TaskRepository {
 		return newPostgresTestEnv(t).state
 	})
+}
+
+// Re-swallowing the read at the backend would put the finding straight back: an
+// outage would render as an empty page again, and every caller above believes the
+// interface. This reaches the Count branch, which runs first.
+func TestPostgresState_GetTasks_ReportsABackendFailure(t *testing.T) {
+	state := newSchemalessState(t)
+
+	tasks, total, err := state.GetTasks(models.TaskFilter{
+		EndTime: float64(time.Now().Add(time.Hour).Unix()),
+	})
+
+	require.Error(t, err, "a failed read must never be reported as an empty page")
+	assert.Empty(t, tasks)
+	assert.Zero(t, total)
+}
+
+// The in-memory backend breaks a same-second tie by id; this is the SQL half, so
+// the two demonstrably agree rather than incidentally matching. detectRollback
+// reads the first deployed task as the current version, so an unstable first row
+// makes rollback detection non-deterministic on the backend that runs in production.
+func TestPostgresState_GetTasksBreaksAnExactTieById(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	var ids []string
+	for range 3 {
+		ids = append(ids, env.addTask(t, sampleTask("app-tie")).Id)
+	}
+
+	// Forced, because Postgres stores microseconds and would not otherwise tie.
+	db, err := env.state.orm.DB()
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE tasks SET created = now() WHERE app = $1", "app-tie")
+	require.NoError(t, err)
+
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+
+	for range 5 {
+		tasks, _, err := env.state.GetTasks(models.TaskFilter{
+			EndTime: float64(time.Now().Add(time.Hour).Unix()),
+			App:     "app-tie",
+		})
+		require.NoError(t, err)
+		require.Len(t, tasks, 3)
+		assert.Equal(t, ids, []string{tasks[0].Id, tasks[1].Id, tasks[2].Id},
+			"an exact tie must resolve by id, as sortByRecency does")
+	}
+}
+
+// The count and the row fetch fail independently, and only the count is covered by
+// the schemaless state — it never reaches the fetch. A fetch whose error was
+// dropped would serve an empty page beside a non-zero total and no error at all,
+// which is the shape this change set exists to make impossible.
+func TestPostgresState_GetTasks_ReportsAFailedRowFetch(t *testing.T) {
+	env := newPostgresTestEnv(t)
+	env.addTask(t, sampleTask("app-fetch"))
+
+	// The count runs first and must succeed, so the failure is injected on the
+	// second query of the call. Registered on this env's handle only.
+	var queries int
+	require.NoError(t, env.state.orm.Callback().Query().Before("gorm:query").
+		Register("test:fail_second_query", func(db *gorm.DB) {
+			queries++
+			if queries == 2 {
+				_ = db.AddError(errors.New("row fetch failed"))
+			}
+		}))
+
+	tasks, total, err := env.state.GetTasks(models.TaskFilter{
+		EndTime: float64(time.Now().Add(time.Hour).Unix()),
+		App:     "app-fetch",
+	})
+
+	require.Error(t, err, "a failed row fetch must not be served as an empty page")
+	assert.Empty(t, tasks)
+	assert.Zero(t, total, "a total beside an error would read as a real count")
 }

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -685,10 +685,10 @@ func TestPostgresState_GetTasks_ReportsABackendFailure(t *testing.T) {
 	assert.Zero(t, total)
 }
 
-// The in-memory backend breaks a same-second tie by id; this is the SQL half, so
-// the two demonstrably agree rather than incidentally matching. detectRollback
-// reads the first deployed task as the current version, so an unstable first row
-// makes rollback detection non-deterministic on the backend that runs in production.
+// created is a timestamptz, so a tie here needs microsecond-identical rows and id
+// breaks it only to keep a page totally ordered across offsets. detectRollback reads
+// the first deployed task as the current version, so an unstable first row makes
+// rollback detection non-deterministic on the backend that runs in production.
 func TestPostgresState_GetTasksBreaksAnExactTieById(t *testing.T) {
 	env := newPostgresTestEnv(t)
 
@@ -713,7 +713,7 @@ func TestPostgresState_GetTasksBreaksAnExactTieById(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, tasks, 3)
 		assert.Equal(t, ids, []string{tasks[0].Id, tasks[1].Id, tasks[2].Id},
-			"an exact tie must resolve by id, as sortByRecency does")
+			"an exact tie must resolve by id so paging stays total")
 	}
 }
 

--- a/internal/state/repository_contract_test.go
+++ b/internal/state/repository_contract_test.go
@@ -269,7 +269,7 @@ func runTaskRepositoryContract(t *testing.T, newRepository func(t *testing.T) Ta
 		}
 		assert.Equal(t, int64(submissions-1), totalCancelled, "every submission but the last must have been superseded")
 
-		stored, _ := repository.GetTasks(models.TaskFilter{
+		stored, _, _ := repository.GetTasks(models.TaskFilter{
 			EndTime: float64(time.Now().Add(time.Hour).Unix()),
 			App:     "app-a",
 		})

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,11 +17,11 @@ var errDesiredRetry = errors.New("desired retry error")
 // silently reported as a missing task.
 var ErrTaskNotFound = errors.New("task not found")
 
-// ErrTaskNotOwned is returned by SetTaskStatus when the task is claimed by
-// another instance. The caller checked its lease seconds earlier, so a lapse in
-// between is an ordinary handover: the new owner reaches its own outcome, and
-// writing here would land on top of it. Only the shared backend reports it.
-var ErrTaskNotOwned = errors.New("task is claimed by another instance")
+// ErrTaskNotOwned is returned by SetTaskStatus when the claim has moved on since
+// the caller checked it — taken by another instance, or released by this one at
+// shutdown. Either way the task is somebody else's to finish, and writing here
+// would land on the outcome they reach. Only the shared backend reports it.
+var ErrTaskNotOwned = errors.New("task is not this instance's to finish")
 
 // maySupersede reports whether a deployment may cancel an in-flight task, by
 // comparing the credential each one presented. Only the uncredentialed-cancels-

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,6 +17,12 @@ var errDesiredRetry = errors.New("desired retry error")
 // silently reported as a missing task.
 var ErrTaskNotFound = errors.New("task not found")
 
+// ErrTaskNotOwned is returned by SetTaskStatus when the task is claimed by
+// another instance. The caller checked its lease seconds earlier, so a lapse in
+// between is an ordinary handover: the new owner reaches its own outcome, and
+// writing here would land on top of it. Only the shared backend reports it.
+var ErrTaskNotOwned = errors.New("task is claimed by another instance")
+
 // maySupersede reports whether a deployment may cancel an in-flight task, by
 // comparing the credential each one presented. Only the uncredentialed-cancels-
 // credentialed direction is refused.
@@ -46,7 +52,10 @@ type TaskRepository interface {
 	// AddTask stores the task and returns it with the server-owned fields filled
 	// in: id, in-progress status, and Created/Updated as Unix seconds.
 	AddTask(task models.Task) (*models.Task, error)
-	GetTasks(filter models.TaskFilter) ([]models.Task, int64)
+	// GetTasks returns the page the filter selects and the total matching it,
+	// newest first. A backend failure is returned rather than rendered as an empty
+	// page: a caller cannot otherwise tell "no deployments" from "cannot read".
+	GetTasks(filter models.TaskFilter) ([]models.Task, int64, error)
 	// GetAppSummaries aggregates the filter's time window per application. Only
 	// StartTime and EndTime are honoured — the summary is a census of the
 	// window, so narrowing it by app or status would defeat its purpose.

--- a/internal/state/supersede_postgres_test.go
+++ b/internal/state/supersede_postgres_test.go
@@ -108,7 +108,7 @@ func TestPostgresState_RejectedInsertRollsBackTheSupersede(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got.StatusReason, "the rolled-back supersede must leave no reason behind")
 
-	stored, _ := env.state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Add(time.Hour).Unix()), App: "app-rollback"})
+	stored, _, _ := env.state.GetTasks(models.TaskFilter{EndTime: float64(time.Now().Add(time.Hour).Unix()), App: "app-rollback"})
 	assert.Len(t, stored, 1, "the rejected task must not be stored")
 }
 


### PR DESCRIPTION
Status writes matched on the task id alone, so a replica whose claim moved on mid-write overwrote the new owner's outcome; task reads answered an empty page for a backend failure; and the in-memory backend had no same-second tie-break, so which version counted as current was arbitrary.

- The zero uuid is refused explicitly because gorm omits a zero primary key from the WHERE, which would leave the ownership fence matching every unowned row.
- The web UI still swallows the new list error into a console warning, so that half stops at the API. Separate finding about `getList`, not fixed here.