### PR TITLE
fix(argocd): stop blaming Argo CD for a failed git write-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A deployment that fails because the image tag could not be committed to the GitOps repository
+  now says so. The reason read `ArgoCD API Error: …` even though nothing had been asked of Argo CD,
+  and a git remote that could not be reached was recorded as `aborted` — the status meaning the
+  rollout's outcome could not be read — rather than `failed`. Such a failure now reads
+  `Git write-back error: …` and is always `failed`: the write-back did not complete, so there is
+  no rollout to wait on either way.
 - The Web UI now loads in a browser that blocks site data, such as a Safari private window or a
   Firefox with cookies blocked. Reading the saved theme threw before the page mounted, so nothing
   rendered at all. Preferences that are normally remembered — theme, timezone, refresh interval,

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -24,7 +24,7 @@ Coming from `argocd app wait`, API polling, or `kubectl rollout status`? [Wait f
 |---|---|
 | `in progress` | Waiting for the requested images to be running, synced, and healthy. |
 | `deployed` | The application is synced and healthy with the requested images. |
-| `failed` | Argo CD reported a health or sync failure, `DEPLOYMENT_TIMEOUT` elapsed, or the application finished rolling out without ever declaring the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)). |
+| `failed` | Argo CD reported a health or sync failure, `DEPLOYMENT_TIMEOUT` elapsed, the application finished rolling out without ever declaring the requested image (see [Image is not part of application](../operations/troubleshooting.md#image-is-not-part-of-application)), or the image tag could not be committed to the GitOps repository (reason prefix `Git write-back error:`). |
 | `app not found` | Argo CD has no application with that name, or the token cannot see it. Counted under `unconfirmed_deployment_failures`, or under `failed_deployment` in the rarer case where an application that was already confirmed disappeared mid-rollout. |
 | `aborted` | The outcome could not be confirmed: Argo CD was unreachable during the check, or the task sat in progress past the staleness window. Counts as a failure — under `failed_deployment` when Argo CD had already confirmed the application, under `unconfirmed_deployment_failures` when it never did; `argocd_unavailable` tells you whether Argo CD was the reason. |
 | `cancelled` | Superseded by a newer deployment of one of the same images before reaching a final state; polling stops. Not counted as a failure in the metrics, but the client still exits non-zero. |

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -36,7 +36,7 @@ Read the client's last log line first — it distinguishes these:
 
 | Client says | Meaning |
 |---|---|
-| `The deployment has failed` | Argo CD reported a failure, or the timeout elapsed. Continue with [Deployment times out](#deployment-times-out). |
+| `The deployment has failed` | Argo CD reported a failure, or the timeout elapsed. Continue with [Deployment times out](#deployment-times-out). A reason beginning `Git write-back error:` means the image tag was not committed to the GitOps repository, so there was no rollout to wait on — read the rest of that line and check the repository, not Argo CD. |
 | `Application <name> does not exist` | `ARGO_APP` does not match an Argo CD application (names are case-sensitive). |
 | `Image "<name>" is not part of application` | The application does not declare that image — see [Image is not part of application](#image-is-not-part-of-application). |
 | `The deployment was aborted before its outcome could be confirmed` | Argo CD became unreachable during the check. The application itself may be perfectly healthy — check Argo CD before blaming the deployment. |
@@ -121,9 +121,7 @@ curl -sSI "$ARGO_WATCHER_URL/api/v1/config"
 
 ## Managed-images annotation is rejected
 
-**Symptom:** the deployment fails immediately, reporting `ArgoCD API Error: invalid format for argo-watcher/managed-images annotation: "<entry>" is not alias=image`.
-
-Despite the label, nothing was asked of Argo CD — the annotation is parsed locally, before the write-back, and every failure on that path is reported through the same template.
+**Symptom:** the deployment fails immediately, reporting `Git write-back error: invalid format for argo-watcher/managed-images annotation: "<entry>" is not alias=image`.
 
 Each entry must read `alias=image`. Whitespace around the `=` is ignored, so `app = myimage` is accepted, but neither half may be empty or contain whitespace of its own, and the image may not contain a second `=`.
 

--- a/internal/argocd/argo.go
+++ b/internal/argocd/argo.go
@@ -47,6 +47,10 @@ const (
 const (
 	// ArgoAPIErrorTemplate is the template for ArgoCD API errors.
 	ArgoAPIErrorTemplate = "ArgoCD API Error: %s"
+	// GitWriteBackErrorTemplate is the template for a failure to commit the image
+	// tag to the GitOps repository. Kept apart from ArgoAPIErrorTemplate because the
+	// two send an operator to a different system: nothing reached ArgoCD at all.
+	GitWriteBackErrorTemplate = "Git write-back error: %s"
 	// supersededTaskReason is the status reason stored on a deployment that was
 	// cancelled because a newer deployment of the same image superseded it.
 	supersededTaskReason = "superseded by a newer deployment for the same image"

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -159,13 +159,16 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		// a sweep — so this replica is the last one able to announce it.
 	case draining():
 		// Covers the write-back errors shutdown raises (errBatcherClosed,
-		// errWritebackDraining) as well as a poll given up: the predicate is true from
-		// the first shutdown phase, before the batcher is torn down. Classifying those
-		// errors on their own instead would abandon a rollout nothing can resume.
+		// errWritebackDraining) as well as a poll given up. Only shared state reports
+		// draining, so with in-memory state those errors fall through and are reported:
+		// no replica could resume the task, and a dropped deployment is the worse answer.
 		err = errReplicaDraining
 	}
 
-	var imageErr *ImageNotPartOfAppError
+	var (
+		imageErr     *ImageNotPartOfAppError
+		writeBackErr *WriteBackError
+	)
 	// The arms that stop without writing leave this true: there is no refused write
 	// to suppress, and they return before it is read.
 	recorded := true
@@ -199,6 +202,8 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		// outcome the sweep decided.
 		slog.Info("Deployment already given up on by the staleness sweep; stopping.", "id", task.Id)
 		task.Status = models.StatusAborted
+	case errors.As(err, &writeBackErr):
+		recorded = updater.monitor.HandleWriteBackFailure(&task, writeBackErr)
 	case err != nil:
 		recorded = updater.monitor.HandleArgoAPIFailure(&task, err, confirmed)
 	default:
@@ -276,7 +281,9 @@ func (updater *ArgoStatusUpdater) waitForApplicationDeployment(task models.Task,
 		if errors.Is(err, ErrDeploymentSuperseded) {
 			return nil, 0, true, updater.abortedWriteBackCause(task.Id, abandoned())
 		}
-		return nil, 0, true, err
+		// Marked as the write-back's own so the failure is not reported against ArgoCD,
+		// which was never asked for anything here.
+		return nil, 0, true, &WriteBackError{Err: err}
 	}
 
 	application, waited, err := updater.monitor.WaitRollout(task, abandoned)

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -969,6 +969,63 @@ func TestDeploymentMonitorHandleArgoAPIFailureAbortCountsAsFailure(t *testing.T)
 	assert.Equal(t, models.StatusAborted, task.Status)
 }
 
+// A failed write-back is the deployment's own outcome, not Argo CD's: nothing was asked
+// of Argo CD, so naming its API would send an operator to read the wrong logs.
+func TestWaitForRolloutWriteBackFailure(t *testing.T) {
+	// Every case fails the write-back and must end the same way: "failed", blaming git.
+	// The network error matters most: the shared unavailability check cannot tell a git
+	// remote from the Argo CD API, so reaching it at all would classify this "aborted".
+	cases := []struct {
+		name      string
+		lockerErr error
+		reason    string
+	}{
+		{
+			name:      "a plain write-back failure names git",
+			lockerErr: errors.New("lock failed"),
+			reason:    "Git write-back error: lock failed",
+		},
+		{
+			name:      "an unreachable git remote is a failure, not an abort",
+			lockerErr: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")},
+			reason:    "Git write-back error: dial tcp: connect: connection refused",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			apiMock := newArgoApiMock(ctrl)
+			metricsMock := mocks.NewMockMetricsInterface(ctrl)
+			stateMock := notSupersededState(ctrl)
+
+			argo := &Argo{}
+			argo.Init(stateMock, apiMock, metricsMock)
+
+			updater := initTestUpdater(t, newUpdaterTestConfig(&spyLocker{err: tc.lockerErr}), argo)
+
+			task := models.Task{
+				Id:        "test-id",
+				App:       "test-app",
+				Validated: true,
+				Images:    []models.Image{{Image: "example.com/app", Tag: "v1"}},
+			}
+
+			apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(managedApp(), nil)
+			metricsMock.EXPECT().AddInProgressTask()
+			metricsMock.EXPECT().InitDeploymentOutcomes(task.App)
+			metricsMock.EXPECT().AddFailedDeployment(task.App)
+			metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusFailedMessage)
+			metricsMock.EXPECT().RemoveInProgressTask()
+			stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, tc.reason)
+
+			updater.WaitForRollout(task, false, neverDraining)
+		})
+	}
+}
+
 func TestGitUpdaterUpdateIfNeeded(t *testing.T) {
 	makeApp := func(managed bool) *models.Application {
 		app := &models.Application{}
@@ -2975,6 +3032,13 @@ func TestDeploymentMonitorRefusedWriteLeavesTheGaugesAlone(t *testing.T) {
 		assert.False(t, monitor.HandleImageNotPartOfApp(&task, imageErr))
 	})
 
+	t.Run("a write-back failure does not count one", func(t *testing.T) {
+		monitor, stateMock, task := newMonitor(t)
+		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusFailedMessage, gomock.Any()).Return(state.ErrTaskNotOwned)
+
+		assert.False(t, monitor.HandleWriteBackFailure(&task, &WriteBackError{Err: errors.New("push rejected")}))
+	})
+
 	t.Run("a success does not clear the app's failures", func(t *testing.T) {
 		monitor, stateMock, task := newMonitor(t)
 		stateMock.EXPECT().SetTaskStatus(task.Id, models.StatusDeployedMessage, "").Return(state.ErrTaskNotOwned)
@@ -3010,4 +3074,16 @@ func TestDeploymentMonitorRefusedWriteLeavesTheGaugesAlone(t *testing.T) {
 
 		assert.False(t, monitor.ProcessDeploymentResult(&task, app, time.Second))
 	})
+}
+
+// Error() must stay bare: it is what the slog line and any wrapping print, and
+// Reason() is the only place the user-facing prefix is added. A prefix in both
+// would render it twice in the log.
+func TestWriteBackErrorKeepsThePrefixToTheReason(t *testing.T) {
+	cause := errors.New("push rejected")
+	err := &WriteBackError{Err: cause}
+
+	assert.Equal(t, "push rejected", err.Error())
+	assert.Equal(t, "Git write-back error: push rejected", err.Reason())
+	assert.ErrorIs(t, err, cause)
 }

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -83,6 +83,27 @@ func (err *ImageNotPartOfAppError) Reason() string {
 	)
 }
 
+// WriteBackError reports that the git write-back did not complete, so the image tag is
+// not known to have reached the GitOps repository. It is a type of its own because the
+// failure names a different system than an ArgoCD API error does, and because there is
+// no rollout to wait on either way.
+type WriteBackError struct {
+	Err error
+}
+
+func (err *WriteBackError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *WriteBackError) Unwrap() error {
+	return err.Err
+}
+
+// Reason renders the user-facing task failure reason.
+func (err *WriteBackError) Reason() string {
+	return fmt.Sprintf(GitWriteBackErrorTemplate, err.Err.Error())
+}
+
 // DeploymentMonitor encapsulates the logic for tracking ArgoCD application rollouts.
 type DeploymentMonitor struct {
 	argo             Argo
@@ -456,6 +477,23 @@ func (monitor *DeploymentMonitor) HandleArgoAPIFailure(task *models.Task, err er
 	return recorded
 }
 
+// HandleWriteBackFailure fails the task with the git write-back as its reason. The status
+// is always "failed", never the "aborted" reserved for an unreachable ArgoCD: the write-back
+// did not complete, so this replica has no rollout to report at all. The app was confirmed
+// before the write-back ran, so its name may label the metric (issue #552).
+func (monitor *DeploymentMonitor) HandleWriteBackFailure(task *models.Task, writeBackErr *WriteBackError) bool {
+	slog.Warn("App deployment failed: the image tag could not be written back to git.",
+		"app", task.App, "error", writeBackErr.Err, "id", task.Id)
+
+	recorded := monitor.recordStatus(task, models.StatusFailedMessage, writeBackErr.Reason())
+	task.Status = models.StatusFailedMessage
+	if recorded {
+		monitor.argo.metrics.AddFailedDeployment(task.App)
+	}
+
+	return recorded
+}
+
 // HandleImageNotPartOfApp fails the task immediately instead of letting it run out its
 // timeout waiting for an image the application will never have.
 func (monitor *DeploymentMonitor) HandleImageNotPartOfApp(task *models.Task, imageErr *ImageNotPartOfAppError) bool {
@@ -597,6 +635,10 @@ func checkRolloutStatus(task models.Task, application *models.Application, statu
 	return errForceRetry
 }
 
+// determineFailureStatus classifies an error raised while talking to ArgoCD. Only such
+// errors may reach it: isArgoUnavailable treats any transport failure as ArgoCD being
+// unreachable, so an error from another system — a git write-back, say — would be blamed
+// on ArgoCD and aborted rather than failed.
 func determineFailureStatus(task models.Task, err error) string {
 	if task.IsAppNotFoundError(err) {
 		return models.StatusAppNotFoundMessage

--- a/internal/argocd/shutdown_rollout_test.go
+++ b/internal/argocd/shutdown_rollout_test.go
@@ -59,6 +59,10 @@ func TestWaitForRollout_ShutdownWriteBackIsNotADeploymentFailure(t *testing.T) {
 		writeBack    error
 		draining     bool
 		wantStatus   string
+		// wantReason fences the user-facing text, not just the status: the batch path is
+		// the one that used to blame ArgoCD for a git failure, so a wildcard here is what
+		// let that wording regress unnoticed.
+		wantReason string
 	}{
 		{
 			name:         "the batcher was closed before the write-back was queued",
@@ -78,6 +82,7 @@ func TestWaitForRollout_ShutdownWriteBackIsNotADeploymentFailure(t *testing.T) {
 			name:         "a write-back lost to shutdown with nobody to hand over to",
 			closeBatcher: true,
 			wantStatus:   models.StatusFailedMessage,
+			wantReason:   "Git write-back error: git write-back batcher is shutting down",
 		},
 		{
 			// The control: an ordinary write-back failure is still this deployment's
@@ -85,6 +90,7 @@ func TestWaitForRollout_ShutdownWriteBackIsNotADeploymentFailure(t *testing.T) {
 			name:       "an ordinary write-back failure still fails the deployment",
 			writeBack:  gitFailure,
 			wantStatus: models.StatusFailedMessage,
+			wantReason: "Git write-back error: remote refused the update",
 		},
 	}
 
@@ -127,7 +133,7 @@ func TestWaitForRollout_ShutdownWriteBackIsNotADeploymentFailure(t *testing.T) {
 			if tt.wantStatus != "" {
 				metricsMock.EXPECT().AddFailedDeployment(task.App)
 				metricsMock.EXPECT().AddDeploymentOutcome(task.App, tt.wantStatus)
-				stateMock.EXPECT().SetTaskStatus(task.Id, tt.wantStatus, gomock.Any())
+				stateMock.EXPECT().SetTaskStatus(task.Id, tt.wantStatus, tt.wantReason)
 			}
 
 			updater.WaitForRollout(task, false, func() bool { return tt.draining })

--- a/web/src/features/tasks/utils/failureReason.test.ts
+++ b/web/src/features/tasks/utils/failureReason.test.ts
@@ -43,6 +43,8 @@ const REAL = {
 
   apiError: 'ArgoCD API Error: applications.argoproj.io "checkout" not found',
 
+  gitWriteBack: 'Git write-back error: authentication required',
+
   imageNotPartOfApp: [
     'Application deployment failed. Image "app:v2" is not part of application "checkout".',
     '',
@@ -98,6 +100,14 @@ describe('summariseFailure on real backend reasons', () => {
   it('strips the ArgoCD API Error prefix, which the panel already conveys', () => {
     expect(summariseFailure(REAL.apiError)!.headline).toBe(
       'applications.argoproj.io "checkout" not found',
+    );
+  });
+
+  // Unlike the ArgoCD one, this prefix names which system to go and look at, so the
+  // panel must keep it. A regex generalised to any "… Error:" would swallow it.
+  it('keeps the git write-back prefix, which names the system at fault', () => {
+    expect(summariseFailure(REAL.gitWriteBack)!.headline).toBe(
+      'Git write-back error: authentication required',
     );
   });
 

--- a/web/src/features/tasks/utils/failureReason.ts
+++ b/web/src/features/tasks/utils/failureReason.ts
@@ -22,9 +22,10 @@ const truncate = (value: string): string =>
  * @description Extracts a one-line headline from a task's `status_reason`.
  * argo-watcher composes every reason itself and puts a purpose-built headline on
  * the first line (argocd.rolloutFailureHeadline, ImageNotPartOfAppError.Reason,
- * ArgoAPIErrorTemplate, StaleTaskAbortReason), so the first line IS the headline —
- * searching the body for an error-looking line would discard it in favour of a
- * nested one, and Argo CD sync messages routinely embed "Error:".
+ * ArgoAPIErrorTemplate, GitWriteBackErrorTemplate, StaleTaskAbortReason), so the
+ * first line IS the headline — searching the body for an error-looking line would
+ * discard it in favour of a nested one, and Argo CD sync messages routinely embed
+ * "Error:".
  * @param reason the stored status_reason, or nothing
  * @returns a summary whose `raw` is untouched, or null when there is no reason
  */


### PR DESCRIPTION
A git write-back failure was stored as `ArgoCD API Error: …` even though nothing had been asked of Argo CD, and because the shared unavailability check treats any transport error as Argo CD being unreachable, a git remote that could not be reached ended the task as `aborted` rather than `failed`. Such a failure now travels as its own `WriteBackError`, reads `Git write-back error: …`, and always fails the task — the write-back did not complete, so there is no rollout to wait on either way. Only Argo CD errors reach `determineFailureStatus` now, which is what makes its `net.Error` match correct rather than over-broad. The Web UI keeps this prefix in the failure headline, unlike the Argo CD one it strips, because it names which system to go and look at.