### PR TITLE
fix(notifications): keep the receiver URL out of delivery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,10 +111,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A failure to read the database no longer puts the driver's own text — the schema, the SQL error
   code, the database host — into the body of `GET /api/v1/tasks` or `POST /api/v1/tasks`. Both are
   served without a credential when OIDC is off. The cause stays in the server log.
-
 - A `ARGO_URL` containing basic-auth credentials no longer has its password written into the startup
   error, and from there into the container log, when the value is rejected. The configuration
   endpoint already stripped userinfo for the same reason.
+- A notification that cannot be delivered no longer writes the receiver's URL into the server log.
+  `WEBHOOK_URL` is a credential for most receivers — a Slack or Mattermost incoming hook carries its
+  secret in the path — and a single timeout logged the whole URL at `ERROR`, where anyone with read
+  access to the logs could take it and post into the channel. The failure is still reported with its
+  cause, so a timeout, a refused connection and a rejected certificate remain distinguishable.
+  `MATTERMOST_URL` is redacted on the same path.
 
 ## [1.3.0] - 2026-09-09
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -341,7 +341,7 @@ Also check whether `LOCKDOWN_SCHEDULE` covers the current time. Schedules are ev
 
 **How to verify**
 
-- Look for `Failed to dispatch notification` in the server log — it carries the response code and the receiver's body. `LOG_LEVEL=debug` additionally logs the rendered payload.
+- Look for `Failed to dispatch notification` in the server log — it carries the response code and the receiver's body. `LOG_LEVEL=debug` additionally logs the rendered payload. The receiver's URL is deliberately left out, since it is a secret for most receivers; a connection that never got that far is reported by its cause alone (`Post: dial tcp …`).
 - Reproduce the call by hand:
 
     ```bash

--- a/internal/notifications/mattermost.go
+++ b/internal/notifications/mattermost.go
@@ -139,7 +139,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/api/v4/posts", bytes.NewReader(payload))
 	if err != nil {
-		return "", fmt.Errorf("failed to create mattermost request: %w", err)
+		return "", fmt.Errorf("failed to create mattermost request: %w", redactURL(err))
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -147,7 +147,7 @@ func (s *MattermostStrategy) createPost(post mattermostPostRequest) (string, err
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send mattermost post: %w", err)
+		return "", fmt.Errorf("failed to send mattermost post: %w", redactURL(err))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {

--- a/internal/notifications/mattermost_test.go
+++ b/internal/notifications/mattermost_test.go
@@ -1,10 +1,12 @@
 package notifications
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"text/template"
@@ -293,12 +295,15 @@ func TestMattermostSend(t *testing.T) {
 
 	t.Run("Failed Request Creation", func(t *testing.T) {
 		service := newTestMattermostStrategy(t, unusedHTTPClient(t))
-		service.baseURL = ":invalid-url:"
+		// MATTERMOST_URL is never parsed at construction, so a malformed one first fails
+		// here — where the *url.Error would otherwise quote the whole configured base URL.
+		service.baseURL = "https://mattermost.internal.example.com/SuPerSecreT\n"
 
 		err := service.Send(models.Task{Id: "task-1", App: "app1", Status: models.StatusInProgressMessage})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create mattermost request")
+		assert.NotContains(t, err.Error(), "SuPerSecreT")
 	})
 
 	t.Run("Non-201 Status With Body Read Error", func(t *testing.T) {
@@ -327,4 +332,28 @@ func TestMattermostSend(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to execute mattermost template")
 	})
+}
+
+// config.MattermostConfig keeps the instance URL out of GET /api/v1/config, so it must
+// not arrive in an error either: the transport reports a failure as a *url.Error quoting
+// the whole request URL.
+func TestCreatePostDoesNotLeakTheMattermostURL(t *testing.T) {
+	const secretHost = "mattermost.internal.example.com"
+
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockHTTPClient(ctrl)
+	strategy := newTestMattermostStrategy(t, client)
+	strategy.baseURL = "https://" + secretHost + "/tenant/SuPerSecreT"
+
+	client.EXPECT().Do(gomock.Any()).Return(nil, &url.Error{
+		Op:  "Post",
+		URL: strategy.baseURL + "/api/v4/posts",
+		Err: context.DeadlineExceeded,
+	})
+
+	_, err := strategy.createPost(mattermostPostRequest{ChannelId: "channel123", Message: "hi"})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "SuPerSecreT")
+	assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
 }

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -126,17 +126,31 @@ func jsonStringBody(s string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(quoted, `"`), `"`)
 }
 
-// redactURL strips the request URL out of a transport error: net/http reports every failure
-// as a *url.Error quoting the whole URL, and a webhook URL is itself the credential. The inner
-// cause is kept because it tells a timeout from a refused connection from a bad certificate;
-// every cause reachable here names at most the host, never the path or query holding the secret.
+// redactURL strips every request URL out of a transport error: net/http reports a failure as a
+// *url.Error quoting the whole URL, and a webhook URL is itself the credential. Each layer is
+// unwrapped, because a nested *url.Error would quote its own URL once the cause is formatted.
+// The operations and the root cause are kept, so a timeout still reads as one.
 func redactURL(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return fmt.Errorf("%s: %w", urlErr.Op, urlErr.Err)
+	var ops []string
+
+	for {
+		var urlErr *url.Error
+		if !errors.As(err, &urlErr) {
+			break
+		}
+
+		ops = append(ops, urlErr.Op)
+		if urlErr.Err == nil {
+			return errors.New(strings.Join(ops, ": "))
+		}
+		err = urlErr.Err
 	}
 
-	return err
+	if len(ops) == 0 {
+		return err
+	}
+
+	return fmt.Errorf("%s: %w", strings.Join(ops, ": "), err)
 }
 
 // WebhookStrategy holds the configuration and a pre-compiled template for sending webhooks.

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"text/template"
@@ -125,6 +126,19 @@ func jsonStringBody(s string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(quoted, `"`), `"`)
 }
 
+// redactURL strips the request URL out of a transport error: net/http reports every failure
+// as a *url.Error quoting the whole URL, and a webhook URL is itself the credential. The inner
+// cause is kept because it tells a timeout from a refused connection from a bad certificate;
+// every cause reachable here names at most the host, never the path or query holding the secret.
+func redactURL(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return fmt.Errorf("%s: %w", urlErr.Op, urlErr.Err)
+	}
+
+	return err
+}
+
 // WebhookStrategy holds the configuration and a pre-compiled template for sending webhooks.
 type WebhookStrategy struct {
 	url                  string
@@ -189,7 +203,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.url, &payload)
 	if err != nil {
-		return fmt.Errorf("failed to create webhook request: %w", err)
+		return fmt.Errorf("failed to create webhook request: %w", redactURL(err))
 	}
 
 	req.Header.Set("Content-Type", s.contentType)
@@ -199,7 +213,7 @@ func (s *WebhookStrategy) Send(task models.Task) error {
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send webhook: %w", err)
+		return fmt.Errorf("failed to send webhook: %w", redactURL(err))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -470,3 +470,29 @@ func TestSendDoesNotLeakTheWebhookURLOnAMalformedURL(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "SuPerSecreT")
 }
+
+// A cause may itself be a *url.Error — an HTTPClient that retries and wraps, say. Stripping
+// only the outermost one leaves the nested URL to be quoted when the cause is formatted, so
+// every layer is stripped and only the operations survive.
+func TestSendDoesNotLeakANestedURLError(t *testing.T) {
+	tmpl := template.Must(template.New("webhook").Parse(`{"id":"{{.Id}}"}`))
+	root := errors.New("connect: connection refused")
+	inner := &url.Error{Op: "Get", URL: "https://hooks.example.com/services/InnerSecreT", Err: root}
+	outer := &url.Error{Op: "Post", URL: "https://hooks.example.com/services/OuterSecreT", Err: inner}
+
+	ctrl := gomock.NewController(t)
+	mockClient := mocks.NewMockHTTPClient(ctrl)
+	mockClient.EXPECT().Do(gomock.Any()).Return(nil, outer)
+
+	service := &WebhookStrategy{url: outer.URL, client: mockClient, template: tmpl}
+
+	err := service.Send(models.Task{Id: "task-id", App: "demo"})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "OuterSecreT")
+	assert.NotContains(t, err.Error(), "InnerSecreT")
+	// Both operations and the root cause are still reported.
+	assert.Contains(t, err.Error(), "Post")
+	assert.Contains(t, err.Error(), "Get")
+	assert.ErrorIs(t, err, root)
+}

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -1,10 +1,13 @@
 package notifications
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"testing"
@@ -405,4 +408,65 @@ func sortedKeys(m map[string]any) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// The webhook URL is the credential (config.WebhookConfig keeps it out of
+// GET /api/v1/config for that reason), and the transport reports a failure as a
+// *url.Error quoting the whole URL. One timeout would otherwise log the secret.
+func TestSendDoesNotLeakTheWebhookURL(t *testing.T) {
+	const secretURL = "https://hooks.example.com/services/T000/B000/SuPerSecreT"
+
+	tmpl := template.Must(template.New("webhook").Parse(`{"id":"{{.Id}}"}`))
+	task := models.Task{Id: "task-id", App: "demo"}
+
+	// Every shape the transport actually returns: the inner cause differs, the
+	// *url.Error wrapper carrying the URL does not.
+	testCases := []struct {
+		name   string
+		cause  error
+		wantIs error
+	}{
+		{name: "timeout", cause: context.DeadlineExceeded, wantIs: context.DeadlineExceeded},
+		{name: "connection refused", cause: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}},
+		{name: "dns", cause: &net.DNSError{Err: "no such host", Name: "hooks.example.com"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := mocks.NewMockHTTPClient(ctrl)
+			mockClient.EXPECT().Do(gomock.Any()).
+				Return(nil, &url.Error{Op: "Post", URL: secretURL, Err: tc.cause})
+
+			service := &WebhookStrategy{url: secretURL, client: mockClient, template: tmpl}
+
+			err := service.Send(task)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "SuPerSecreT", "the secret path must never reach the error")
+			assert.NotContains(t, err.Error(), secretURL)
+			// Still diagnosable: the operator must be able to tell these apart.
+			assert.Contains(t, err.Error(), tc.cause.Error())
+			// The chain must survive the redaction, or a caller can no longer classify it.
+			if tc.wantIs != nil {
+				assert.ErrorIs(t, err, tc.wantIs)
+			}
+		})
+	}
+}
+
+// A malformed URL fails in http.NewRequest, whose *url.Error quotes the value it
+// rejected — the same leak by a different route.
+func TestSendDoesNotLeakTheWebhookURLOnAMalformedURL(t *testing.T) {
+	tmpl := template.Must(template.New("webhook").Parse(`{"id":"{{.Id}}"}`))
+	service := &WebhookStrategy{
+		url:      "https://hooks.example.com/services/SuPerSecreT\n",
+		client:   unusedHTTPClient(t),
+		template: tmpl,
+	}
+
+	err := service.Send(models.Task{Id: "task-id", App: "demo"})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "SuPerSecreT")
 }


### PR DESCRIPTION
`net/http` reports every transport failure as a `*url.Error` quoting the whole request URL, so a single webhook timeout wrote `WEBHOOK_URL` into the server log at `ERROR` — a URL that is the credential for most receivers, since a Slack or Mattermost incoming hook carries its secret in the path, and which the configuration already keeps out of `GET /api/v1/config` for that reason. `redactURL` now replaces the `*url.Error` with its operation and inner cause at the four sites that can carry a URL: request construction and the round trip, in both the webhook and Mattermost strategies. The inner cause is kept so a timeout, a refused connection and a rejected certificate stay distinguishable — every cause reachable there names at most the host, never the path or query. `MATTERMOST_URL` is redacted on the same path, and it needs the request-construction site because it is never parsed at construction.