### PR TITLE
fix(observability): record write-back durations in batch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gitops_writeback_duration_seconds` and `gitops_lock_wait_duration_seconds` are recorded again
+  with `GIT_BATCH_WRITEBACK` enabled. Turning batching on silently stopped both, so the Grafana
+  dashboard's write-back and lock-wait panels went blank and the documented alert on write-backs
+  over 60s stopped firing — at exactly the moment contention made them worth watching. Both keep
+  the meaning they have without batching: the wait is measured from when a deployment's write-back
+  was queued, so an application waiting behind an in-flight batch is reported as waiting, and the
+  duration is the clone, commit and push its batch ran.
 - A deployment that fails because the image tag could not be committed to the GitOps repository
   now says so. The reason read `ArgoCD API Error: …` even though nothing had been asked of Argo CD,
   and a git remote that could not be reached was recorded as `aborted` — the status meaning the

--- a/internal/argocd/batch_writeback_integration_test.go
+++ b/internal/argocd/batch_writeback_integration_test.go
@@ -19,9 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-
-	"github.com/shini4i/argo-watcher/internal/mocks"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/updater"
@@ -203,49 +200,4 @@ func TestIntegration_BatchWriteBack_PushRaceRecovery(t *testing.T) {
 
 	require.GreaterOrEqual(t, lastOpens, int32(2),
 		"batch retry not observed after %d attempts: PlainOpen called %d times on final attempt", maxAttempts, lastOpens)
-}
-
-// The unit test covers a batch whose clone fails. The histograms matter most on the slow
-// successful path, and a failure-only test would still pass if the observation were moved
-// into an error branch — so the success case is pinned here, against a real Gitea.
-func TestIntegration_BatchWriteBack_ObservesDurationsOnASuccessfulBatch(t *testing.T) {
-	waitForGitea(t, 60*time.Second)
-	env := setupGitea(t)
-
-	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
-	t.Setenv("GIT_OP_TIMEOUT", "60s")
-	t.Setenv("GIT_MAX_ATTEMPTS", "3")
-
-	apps := []string{"app-a", "app-b"}
-
-	ctrl := gomock.NewController(t)
-	metrics := mocks.NewMockMetricsInterface(ctrl)
-	metrics.EXPECT().ObserveGitBatchSize(len(apps)).Times(1)
-	for _, app := range apps {
-		metrics.EXPECT().ObserveGitLockWaitDuration(app, gomock.Any()).Times(1)
-		metrics.EXPECT().ObserveGitWritebackDuration(app, gomock.Any()).Times(1)
-	}
-
-	b := NewBatcher(&spyLocker{}, t.TempDir(), 20, metrics)
-
-	batch := make([]*batchWriteRequest, 0, len(apps))
-	for i, app := range apps {
-		req := newBatchReqFor(app, fmt.Sprintf("v%d", i+1), nil)
-		req.task.App = app
-		req.gitopsRepo.RepoUrl = env.DirectRepoURL
-		req.enqueuedAt = time.Now()
-		batch = append(batch, req)
-	}
-
-	b.flush(batch)
-
-	// The observation only means anything if the batch really landed.
-	for _, req := range batch {
-		assert.NoError(t, <-req.resultCh, "app %s should succeed", req.task.App)
-	}
-	for i, app := range apps {
-		_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master",
-			fmt.Sprintf("apps/.argocd-source-%s.yaml", app))
-		assert.Contains(t, content, fmt.Sprintf("v%d", i+1))
-	}
 }

--- a/internal/argocd/batch_writeback_integration_test.go
+++ b/internal/argocd/batch_writeback_integration_test.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/shini4i/argo-watcher/internal/mocks"
 
 	"github.com/shini4i/argo-watcher/internal/models"
 	"github.com/shini4i/argo-watcher/internal/updater"
@@ -200,4 +203,49 @@ func TestIntegration_BatchWriteBack_PushRaceRecovery(t *testing.T) {
 
 	require.GreaterOrEqual(t, lastOpens, int32(2),
 		"batch retry not observed after %d attempts: PlainOpen called %d times on final attempt", maxAttempts, lastOpens)
+}
+
+// The unit test covers a batch whose clone fails. The histograms matter most on the slow
+// successful path, and a failure-only test would still pass if the observation were moved
+// into an error branch — so the success case is pinned here, against a real Gitea.
+func TestIntegration_BatchWriteBack_ObservesDurationsOnASuccessfulBatch(t *testing.T) {
+	waitForGitea(t, 60*time.Second)
+	env := setupGitea(t)
+
+	t.Setenv("SSH_KEY_PATH", env.SSHKeyPath)
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	t.Setenv("GIT_MAX_ATTEMPTS", "3")
+
+	apps := []string{"app-a", "app-b"}
+
+	ctrl := gomock.NewController(t)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	metrics.EXPECT().ObserveGitBatchSize(len(apps)).Times(1)
+	for _, app := range apps {
+		metrics.EXPECT().ObserveGitLockWaitDuration(app, gomock.Any()).Times(1)
+		metrics.EXPECT().ObserveGitWritebackDuration(app, gomock.Any()).Times(1)
+	}
+
+	b := NewBatcher(&spyLocker{}, t.TempDir(), 20, metrics)
+
+	batch := make([]*batchWriteRequest, 0, len(apps))
+	for i, app := range apps {
+		req := newBatchReqFor(app, fmt.Sprintf("v%d", i+1), nil)
+		req.task.App = app
+		req.gitopsRepo.RepoUrl = env.DirectRepoURL
+		req.enqueuedAt = time.Now()
+		batch = append(batch, req)
+	}
+
+	b.flush(batch)
+
+	// The observation only means anything if the batch really landed.
+	for _, req := range batch {
+		assert.NoError(t, <-req.resultCh, "app %s should succeed", req.task.App)
+	}
+	for i, app := range apps {
+		_, content := cloneRemoteState(t, env.DirectRepoURL, env.SSHKeyPath, "master",
+			fmt.Sprintf("apps/.argocd-source-%s.yaml", app))
+		assert.Contains(t, content, fmt.Sprintf("v%d", i+1))
+	}
 }

--- a/internal/argocd/batcher.go
+++ b/internal/argocd/batcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/shini4i/argo-watcher/internal/lock"
 	"github.com/shini4i/argo-watcher/internal/models"
@@ -79,6 +80,7 @@ func batchKey(repo *models.GitopsRepo) string {
 // returns that request's individual outcome, or errBatcherClosed when shutting down.
 func (b *Batcher) Submit(req *batchWriteRequest) error {
 	key := batchKey(req.gitopsRepo)
+	req.enqueuedAt = time.Now()
 
 	b.mu.Lock()
 	if b.closed {
@@ -149,10 +151,15 @@ func (b *Batcher) flush(batch []*batchWriteRequest) {
 	}
 
 	var outcomes map[*batchWriteRequest]error
-	// context.Background() mirrors the single-app path (updateGitRepo); git
-	// operations are bounded by GIT_OP_TIMEOUT per attempt rather than by a
-	// caller context.
+	// Both metrics keep the meaning they have on the single-app path: everything an app
+	// waited before its write-back started, then the work itself. Deferred so a failed
+	// batch — typically the slow, retried one — is measured too.
 	lockErr := b.locker.WithLock(repoURL, func() error {
+		workStart := time.Now()
+		defer func() { b.observeDurations(batch, workStart, time.Since(workStart)) }()
+
+		// context.Background() mirrors the single-app path (updateGitRepo); git operations
+		// are bounded by GIT_OP_TIMEOUT per attempt rather than by a caller context.
 		outcomes = runBatchWriteBack(context.Background(), repo, batch, b.drainCh)
 		return nil
 	})
@@ -165,6 +172,20 @@ func (b *Batcher) flush(batch []*batchWriteRequest) {
 
 	for _, req := range batch {
 		req.resultCh <- outcomes[req]
+	}
+}
+
+// observeDurations records the batch's timings against every app it carried. One clone,
+// commit and push serve the whole batch, so each app's write-back really did take that long;
+// the wait is per-app, because requests join a batch at different moments.
+func (b *Batcher) observeDurations(batch []*batchWriteRequest, workStart time.Time, writeback time.Duration) {
+	if b.metrics == nil {
+		return
+	}
+
+	for _, req := range batch {
+		b.metrics.ObserveGitLockWaitDuration(req.task.App, workStart.Sub(req.enqueuedAt).Seconds())
+		b.metrics.ObserveGitWritebackDuration(req.task.App, writeback.Seconds())
 	}
 }
 

--- a/internal/argocd/batcher_test.go
+++ b/internal/argocd/batcher_test.go
@@ -404,8 +404,9 @@ func TestBatcher_FlushThreadsDrainIntoRetryLoop(t *testing.T) {
 }
 
 // GIT_BATCH_WRITEBACK must not silently retire the two write-back histograms: both are
-// documented in observability.md with no batch caveat, the shipped Grafana dashboard queries
-// their buckets, and the alert rule in that page fires on one of them.
+// documented in observability.md with no batch caveat and the shipped dashboard queries them.
+// The clone fails here and in every batcher test — flush hardcodes updater.GitClient{}, whose
+// host-key check no ephemeral remote satisfies — so a successful batch is the e2e gate's job.
 func TestBatcher_FlushObservesDurationsForEveryAppInTheBatch(t *testing.T) {
 	// Only needs to be SET so updater.NewGitRepo can load its config; the clone that
 	// follows fails, which is deliberate — a failed write-back is the slow, retried one

--- a/internal/argocd/batcher_test.go
+++ b/internal/argocd/batcher_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -405,8 +407,7 @@ func TestBatcher_FlushThreadsDrainIntoRetryLoop(t *testing.T) {
 
 // GIT_BATCH_WRITEBACK must not silently retire the two write-back histograms: both are
 // documented in observability.md with no batch caveat and the shipped dashboard queries them.
-// The clone fails here and in every batcher test — flush hardcodes updater.GitClient{}, whose
-// host-key check no ephemeral remote satisfies — so a successful batch is the e2e gate's job.
+// The clone fails here; the successful batch is covered by its own test below.
 func TestBatcher_FlushObservesDurationsForEveryAppInTheBatch(t *testing.T) {
 	// Only needs to be SET so updater.NewGitRepo can load its config; the clone that
 	// follows fails, which is deliberate — a failed write-back is the slow, retried one
@@ -503,4 +504,94 @@ func TestBatcher_FlushWithoutAGitRepoDeliversTheErrorAndObservesNoDurations(t *t
 
 	require.Error(t, b.Submit(req))
 	assert.False(t, locker.called, "the batch must short-circuit before the lock")
+}
+
+// seedLocalRemote builds a bare git repository on disk, seeded with the apps/ directory the
+// write-back commits into. A filesystem remote needs no network and no host key, which is what
+// makes a SUCCESSFUL batch reachable here at all.
+func seedLocalRemote(t *testing.T) string {
+	t.Helper()
+
+	seed := t.TempDir()
+	repo, err := gogit.PlainInit(seed, false)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "apps"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "apps", ".gitkeep"), nil, 0o600))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("apps/.gitkeep")
+	require.NoError(t, err)
+	_, err = wt.Commit("seed", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	_, err = gogit.PlainClone(bare, true, &gogit.CloneOptions{URL: seed})
+	require.NoError(t, err)
+
+	return bare
+}
+
+// The failing-batch test above proves the observation is not skipped; this one proves it is
+// not confined to an error path. Without it, moving the defer into a failure branch would
+// leave the whole suite green.
+func TestBatcher_FlushObservesDurationsOnASuccessfulBatch(t *testing.T) {
+	t.Setenv("SSH_KEY_PATH", writeThrowawaySSHKey(t))
+	t.Setenv("GIT_OP_TIMEOUT", "60s")
+	t.Setenv("GIT_MAX_ATTEMPTS", "3")
+
+	remote := seedLocalRemote(t)
+	apps := []string{"app-a", "app-b"}
+
+	ctrl := gomock.NewController(t)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	metrics.EXPECT().ObserveGitBatchSize(len(apps)).Times(1)
+	for _, app := range apps {
+		metrics.EXPECT().ObserveGitLockWaitDuration(app, gomock.Any()).Times(1)
+		metrics.EXPECT().ObserveGitWritebackDuration(app, gomock.Any()).Times(1)
+	}
+
+	b := NewBatcher(&spyLocker{}, t.TempDir(), 20, metrics)
+
+	batch := make([]*batchWriteRequest, 0, len(apps))
+	for _, app := range apps {
+		req := newBatchReq(remote, "master")
+		req.gitopsRepo.Path = "apps"
+		req.app = newAppWithImages(app)
+		req.task = newImageTask()
+		req.task.App = app
+		req.enqueuedAt = time.Now()
+		batch = append(batch, req)
+	}
+
+	b.flush(batch)
+
+	// The observation only means anything if the batch actually landed.
+	for _, req := range batch {
+		assert.NoError(t, <-req.resultCh, "app %s must succeed", req.task.App)
+	}
+	assert.Equal(t, 2, countRemoteCommitsBeyondSeed(t, remote), "one commit per app")
+}
+
+// countRemoteCommitsBeyondSeed reports how many commits the write-back added on top of the
+// single seed commit.
+func countRemoteCommitsBeyondSeed(t *testing.T, remote string) int {
+	t.Helper()
+
+	dir := t.TempDir()
+	repo, err := gogit.PlainClone(dir, false, &gogit.CloneOptions{URL: remote})
+	require.NoError(t, err)
+
+	iter, err := repo.Log(&gogit.LogOptions{})
+	require.NoError(t, err)
+
+	total := 0
+	require.NoError(t, iter.ForEach(func(*object.Commit) error {
+		total++
+		return nil
+	}))
+
+	return total - 1
 }

--- a/internal/argocd/batcher_test.go
+++ b/internal/argocd/batcher_test.go
@@ -312,6 +312,11 @@ func TestBatcher_FlushDeliversLockError(t *testing.T) {
 
 	req := newBatchReq("git@example.com:test/repo.git", "main")
 	req.gitopsRepo.Path = "apps"
+	// Populated so this test fails on the assertion rather than on a nil dereference if a
+	// duration is ever observed on a path where the lock was never acquired.
+	req.app = newAppWithImages("app-a")
+	req.task = newImageTask()
+	req.task.App = "app-a"
 
 	err := b.Submit(req)
 
@@ -396,4 +401,105 @@ func TestBatcher_FlushThreadsDrainIntoRetryLoop(t *testing.T) {
 	assert.ErrorIs(t, err, errWritebackDraining, "flush must pass its drain channel into the retry loop")
 	assert.NotContains(t, err.Error(), "after 20 attempts", "the retry budget must not have been spent")
 	assert.True(t, locker.called, "the real flush path must have run")
+}
+
+// GIT_BATCH_WRITEBACK must not silently retire the two write-back histograms: both are
+// documented in observability.md with no batch caveat, the shipped Grafana dashboard queries
+// their buckets, and the alert rule in that page fires on one of them.
+func TestBatcher_FlushObservesDurationsForEveryAppInTheBatch(t *testing.T) {
+	// Only needs to be SET so updater.NewGitRepo can load its config; the clone that
+	// follows fails, which is deliberate — a failed write-back is the slow, retried one
+	// the histograms exist to surface, so it must still be measured.
+	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
+
+	apps := []string{"app-a", "app-b"}
+
+	ctrl := gomock.NewController(t)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	metrics.EXPECT().ObserveGitBatchSize(len(apps)).Times(1)
+	// One lock and one clone/commit/push serve the whole batch, so every app it carried
+	// waited that long and took that long.
+	// The wait is measured from Submit, not from the lock: flushLoop serialises flushes per
+	// repo, so timing the lock alone would report near-zero however long an app queued.
+	const queued = 40 * time.Millisecond
+	for _, app := range apps {
+		metrics.EXPECT().ObserveGitLockWaitDuration(app, gomock.Cond(func(v float64) bool {
+			return v >= queued.Seconds()
+		})).Times(1)
+		metrics.EXPECT().ObserveGitWritebackDuration(app, gomock.Any()).Times(1)
+	}
+
+	locker := &spyLocker{}
+	b := NewBatcher(locker, t.TempDir(), 20, metrics)
+
+	batch := make([]*batchWriteRequest, 0, len(apps))
+	for _, app := range apps {
+		req := newBatchReq("git@example.com:test/repo.git", "main")
+		req.gitopsRepo.Path = "apps"
+		req.app = newAppWithImages(app)
+		req.task = newImageTask()
+		req.task.App = app
+		req.enqueuedAt = time.Now().Add(-queued)
+		batch = append(batch, req)
+	}
+
+	// flush is called directly: the queueing that assembles a batch is covered elsewhere,
+	// and a hand-built batch makes the per-app fan-out deterministic.
+	b.flush(batch)
+
+	assert.True(t, locker.called, "the real flush path must have run")
+}
+
+// The wait is measured from the stamp Submit puts on the request, so that stamp has to be
+// covered through the real Submit path: without it every app would report the time since the
+// zero Time — about two millennia — and poison the histogram rather than leave it empty.
+func TestBatcher_SubmitStampsTheRequestSoLockWaitIsSane(t *testing.T) {
+	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
+
+	var lockWait float64
+	ctrl := gomock.NewController(t)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	metrics.EXPECT().ObserveGitBatchSize(1).Times(1)
+	metrics.EXPECT().ObserveGitLockWaitDuration("app-a", gomock.Any()).
+		Do(func(_ string, seconds float64) { lockWait = seconds }).Times(1)
+	metrics.EXPECT().ObserveGitWritebackDuration("app-a", gomock.Any()).Times(1)
+
+	b := NewBatcher(&spyLocker{}, t.TempDir(), 20, metrics)
+
+	req := newBatchReq("git@example.com:test/repo.git", "main")
+	req.gitopsRepo.Path = "apps"
+	req.app = newAppWithImages("app-a")
+	req.task = newImageTask()
+	req.task.App = "app-a"
+
+	// The clone fails, which is fine: the durations are recorded either way.
+	require.Error(t, b.Submit(req))
+
+	assert.GreaterOrEqual(t, lockWait, 0.0)
+	assert.Less(t, lockWait, 60.0, "an unstamped request would report the time since the zero Time")
+}
+
+// The shortcut before the lock: no lock was requested, so no wait and no work happened,
+// and reporting either would invent a measurement.
+func TestBatcher_FlushWithoutAGitRepoDeliversTheErrorAndObservesNoDurations(t *testing.T) {
+	t.Setenv("SSH_KEY_PATH", "/nonexistent/key")
+	// Rejected by NewGitConfig, so updater.NewGitRepo fails before flush reaches the lock.
+	t.Setenv("GIT_OP_TIMEOUT", "0s")
+
+	ctrl := gomock.NewController(t)
+	metrics := mocks.NewMockMetricsInterface(ctrl)
+	// Only the batch size is declared: any duration observation fails as an unexpected call.
+	metrics.EXPECT().ObserveGitBatchSize(1).Times(1)
+
+	locker := &spyLocker{}
+	b := NewBatcher(locker, t.TempDir(), 20, metrics)
+
+	req := newBatchReq("git@example.com:test/repo.git", "main")
+	req.gitopsRepo.Path = "apps"
+	req.app = newAppWithImages("app-a")
+	req.task = newImageTask()
+	req.task.App = "app-a"
+
+	require.Error(t, b.Submit(req))
+	assert.False(t, locker.called, "the batch must short-circuit before the lock")
 }

--- a/internal/argocd/git_writeback_batch.go
+++ b/internal/argocd/git_writeback_batch.go
@@ -26,6 +26,10 @@ type batchWriteRequest struct {
 	// resultCh is buffered (size 1) so the flush goroutine never blocks delivering
 	// a result even if the waiting task goroutine has already gone away.
 	resultCh chan error
+	// enqueuedAt is when Submit accepted the request, and is what the lock-wait metric
+	// measures from: batching moves the queueing out of the lock and into the pending
+	// queue, so timing the lock alone would report near-zero however long apps waited.
+	enqueuedAt time.Time
 }
 
 // runBatchWriteBack applies every request in batch to a single shared clone of the

--- a/test/e2e/scripts/batch-writeback.sh
+++ b/test/e2e/scripts/batch-writeback.sh
@@ -78,9 +78,9 @@ summary="$(mktemp)"
 drv=$?
 cat "$summary"
 
-# Reuse the soak gate. BATCH_MODE swaps the per-app writeback/lock-wait histogram
-# gates (0 by design on the batcher path) for the gitops_batch_size gate, while
-# keeping the zero-lost-update / zero-failed / race-detector gates intact.
+# Reuse the soak gate. BATCH_MODE adds the gitops_batch_size gate on top of the usual
+# ones, all of which — the per-app writeback and lock-wait histograms included — hold
+# on the batcher path too.
 BATCH_MODE=1 "${here}/collect.sh" "$summary"
 col=$?
 

--- a/test/e2e/scripts/collect.sh
+++ b/test/e2e/scripts/collect.sh
@@ -9,9 +9,8 @@
 #   - in_progress_tasks does not drain back to 0 (leaked/stuck task tracking)
 #   - any of the duration histograms recorded 0 observations, i.e. the
 #     refresh / git-writeback / lock-wait / deployment-duration code path never
-#     ran (silent regression). With BATCH_MODE set, the per-app writeback/lock-wait
-#     gates are replaced by a gitops_batch_size gate (that path records batch size
-#     instead, and must show mean batch size > 1 — real coalescing under contention)
+#     ran (silent regression). With BATCH_MODE set, a gitops_batch_size gate is added
+#     on top, which must show mean batch size > 1 — real coalescing under contention
 #   - a lost update: a fixture app's committed image tag != the last tag the
 #     driver deployed to it (per the driver summary JSON)
 #   - any failed task in the driver summary
@@ -63,9 +62,8 @@ lc=$(metric_sum gitops_lock_wait_duration_seconds_count "$metrics")
 # (all tasks deployed) this MUST be > 0; a zero means the deployment-duration timing
 # never ran.
 dc=$(metric_sum deployment_duration_seconds_count "$metrics")
-# Batch write-back (GIT_BATCH_WRITEBACK) routes through the coalescing batcher,
-# which records gitops_batch_size INSTEAD of the per-app writeback/lock-wait
-# histograms. Collected here so the BATCH_MODE gate below can assert on it.
+# Batch write-back (GIT_BATCH_WRITEBACK) routes through the coalescing batcher, which
+# additionally records gitops_batch_size. Collected here for the BATCH_MODE gate below.
 bc=$(metric_sum gitops_batch_size_count "$metrics")
 bs=$(metric_sum gitops_batch_size_sum "$metrics")
 
@@ -106,9 +104,12 @@ fi
 [[ "${ip:-1}" == "0" ]]  || bad "in_progress_tasks=${ip:-<absent>} did not drain to 0"
 [[ "${rc:-0}" -gt 0 ]]   || bad "argocd_refresh_duration_seconds_count=${rc} (expected > 0)"
 [[ "${dc:-0}" -gt 0 ]]   || bad "deployment_duration_seconds_count=${dc} (expected > 0)"
+# Both write-back paths record these, so they gate in either mode: the batcher times
+# the one lock and the one clone/commit/push it runs, against every app in the batch.
+[[ "${wc:-0}" -gt 0 ]] || bad "gitops_writeback_duration_seconds_count=${wc} (expected > 0)"
+[[ "${lc:-0}" -gt 0 ]] || bad "gitops_lock_wait_duration_seconds_count=${lc} (expected > 0)"
 if [[ -n "${BATCH_MODE:-}" ]]; then
-  # Batch write-back records gitops_batch_size instead of the per-app
-  # writeback/lock-wait histograms (those stay 0 by design in this mode).
+  # gitops_batch_size is the one metric only the batcher records.
   echo "  batch_size_count=${bc} batch_size_sum=${bs}"
   [[ "${bc:-0}" -gt 0 ]] || bad "gitops_batch_size_count=${bc} (batch write-back path never ran)"
   # sum > count => at least one flush coalesced more than one app (mean batch
@@ -116,9 +117,6 @@ if [[ -n "${BATCH_MODE:-}" ]]; then
   # contention rather than degenerating into one-app flushes.
   awk "BEGIN{exit !(${bs:-0} > ${bc:-0})}" \
     || bad "gitops_batch_size_sum=${bs} not > _count=${bc} (no coalescing observed)"
-else
-  [[ "${wc:-0}" -gt 0 ]] || bad "gitops_writeback_duration_seconds_count=${wc} (expected > 0)"
-  [[ "${lc:-0}" -gt 0 ]] || bad "gitops_lock_wait_duration_seconds_count=${lc} (expected > 0)"
 fi
 
 echo "=== no lost updates ==="


### PR DESCRIPTION
Turning on `GIT_BATCH_WRITEBACK` returned into the batcher before the two timers, so `gitops_writeback_duration_seconds` and `gitops_lock_wait_duration_seconds` stopped being recorded — the Grafana dashboard's write-back and lock-wait panels went blank and the documented alert on write-backs over 60s stopped firing, at exactly the moment contention made them worth watching. Nothing marked this deliberate: the commit that added batching caveated `gitops_batch_size` as batch-only in the same docs table and left these two unqualified.

The wait is measured from the moment `Submit` accepts a request rather than from the lock. Flushes are serialised per repository, so the lock itself is rarely contended under batching, and timing it would report near-zero however long an application queued behind an in-flight flush — a confidently wrong panel in place of an empty one. Measured this way, wait plus duration is the application's real write-back latency in either mode.

The e2e gate asserted these histograms stay at zero under batching; it now gates on them in both modes and adds the batch-size gate on top. The successful-batch case is pinned in the integration suite against a real Gitea, since a unit test can only reach the failing clone.