### PR TITLE
fix(state): stop a late outcome landing on an ended deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A superseded deployment is no longer reported as `failed`. When two deployments of the same
+  application ran close together, the older one could finish deciding its own outcome just after
+  the newer one cancelled it, and write that outcome over the cancellation — so the pipeline was
+  told the deployment failed rather than that a newer one took over. A terminal status is now
+  written only while the deployment is still running, matching the rule already applied when a
+  deployment is cancelled. The same applies to a deployment the staleness sweep has given up on.
 - `gitops_writeback_duration_seconds` and `gitops_lock_wait_duration_seconds` are recorded again
   with `GIT_BATCH_WRITEBACK` enabled. Turning batching on silently stopped both, so the Grafana
   dashboard's write-back and lock-wait panels went blank and the documented alert on write-backs

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -210,10 +210,10 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		recorded = updater.monitor.ProcessDeploymentResult(&task, application, waited)
 	}
 
-	// The write was refused. On a handover the new owner reaches the same outcome and
-	// reports it, so this replica stays quiet. A task cancelled or given up on instead has
-	// no successor — a sweep only re-claims one still in progress — so its outcome is
-	// reported here or nowhere, exactly as the superseded and aborted arms above do.
+	// The write was refused. A handover has a successor that reports the outcome; a cancelled
+	// or aborted task has none, since a sweep only re-claims one still in progress, so its
+	// outcome is reported here or nowhere. A status that cannot be read stays silent as well:
+	// the stored outcome is right either way, and announcing a guess would not be.
 	if !recorded {
 		ended := updater.monitor.storedTaskStatus(task.Id)
 		if ended != models.StatusCancelledMessage && ended != models.StatusAborted {

--- a/internal/argocd/argo_status_updater.go
+++ b/internal/argocd/argo_status_updater.go
@@ -210,11 +210,16 @@ func (updater *ArgoStatusUpdater) WaitForRollout(task models.Task, resumed bool,
 		recorded = updater.monitor.ProcessDeploymentResult(&task, application, waited)
 	}
 
-	// The claim moved on while this replica was writing, so the outcome stored is
-	// the new owner's. Counting or announcing one here would report the deployment
-	// twice, and the two reports can disagree.
+	// The write was refused. On a handover the new owner reaches the same outcome and
+	// reports it, so this replica stays quiet. A task cancelled or given up on instead has
+	// no successor — a sweep only re-claims one still in progress — so its outcome is
+	// reported here or nowhere, exactly as the superseded and aborted arms above do.
 	if !recorded {
-		return
+		ended := updater.monitor.storedTaskStatus(task.Id)
+		if ended != models.StatusCancelledMessage && ended != models.StatusAborted {
+			return
+		}
+		task.Status = ended
 	}
 
 	// Counted once: the branches that return early leave the outcome to the replica that

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3086,4 +3087,56 @@ func TestWriteBackErrorKeepsThePrefixToTheReason(t *testing.T) {
 	assert.Equal(t, "push rejected", err.Error())
 	assert.Equal(t, "Git write-back error: push rejected", err.Reason())
 	assert.ErrorIs(t, err, cause)
+}
+
+// A deployment something else already ended must keep that outcome. There is no successor to
+// announce it either — a sweep only re-claims a task still in progress — so this replica
+// reports the stored result rather than its own, and never writes one of its own on top.
+func TestWaitForRolloutReportsTheOutcomeThatEndedItFirst(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	// In progress until the terminal write is refused: the race this closes is the store
+	// learning of the cancellation only when that write lands, not during the poll.
+	var endedElsewhere atomic.Bool
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		DoAndReturn(func(string) (*models.Task, error) {
+			if endedElsewhere.Load() {
+				return &models.Task{Status: models.StatusCancelledMessage}, nil
+			}
+			return &models.Task{Status: models.StatusInProgressMessage}, nil
+		}).AnyTimes()
+	stateMock.EXPECT().SetTaskStatus(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(string, string, string) error {
+			endedElsewhere.Store(true)
+			return state.ErrTaskEnded
+		})
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(&spyLocker{err: errors.New("boom")}), argo)
+
+	task := models.Task{Id: "test-id", App: "test-app", Validated: true,
+		Status: models.StatusInProgressMessage,
+		Images: []models.Image{{Image: "app", Tag: "v1"}}}
+
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(managedApp(), nil)
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes(task.App)
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// The outcome counted is the one that won, not the failure this replica had computed.
+	metricsMock.EXPECT().AddDeploymentOutcome(task.App, models.StatusCancelledMessage)
+
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	updater.WaitForRollout(task, false, neverDraining)
+
+	require.Len(t, capture.sent, 2, "the cancellation still has to be announced by someone")
+	assert.Equal(t, models.StatusCancelledMessage, capture.sent[1].Status)
 }

--- a/internal/argocd/argo_status_updater_test.go
+++ b/internal/argocd/argo_status_updater_test.go
@@ -3140,3 +3140,52 @@ func TestWaitForRolloutReportsTheOutcomeThatEndedItFirst(t *testing.T) {
 	require.Len(t, capture.sent, 2, "the cancellation still has to be announced by someone")
 	assert.Equal(t, models.StatusCancelledMessage, capture.sent[1].Status)
 }
+
+// The compound case: the write is refused AND the follow-up read fails. The winning status is
+// then unknown, so nothing is announced or counted — reporting a guess would be worse than
+// reporting nothing, and the stored outcome is still correct for the client that polls it.
+func TestWaitForRolloutStaysSilentWhenTheWinningOutcomeCannotBeRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	apiMock := newArgoApiMock(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	stateMock := newTaskRepositoryMock(ctrl)
+
+	argo := &Argo{}
+	argo.Init(stateMock, apiMock, metricsMock)
+
+	var writeRefused atomic.Bool
+	stateMock.EXPECT().GetTask(gomock.Any()).
+		DoAndReturn(func(string) (*models.Task, error) {
+			if writeRefused.Load() {
+				return nil, errors.New("database is unreachable")
+			}
+			return &models.Task{Status: models.StatusInProgressMessage}, nil
+		}).AnyTimes()
+	stateMock.EXPECT().SetTaskStatus(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(string, string, string) error {
+			writeRefused.Store(true)
+			return state.ErrTaskEnded
+		})
+
+	updater := initTestUpdater(t, newUpdaterTestConfig(&spyLocker{err: errors.New("boom")}), argo)
+
+	task := models.Task{Id: "test-id", App: "test-app", Validated: true,
+		Status: models.StatusInProgressMessage,
+		Images: []models.Image{{Image: "app", Tag: "v1"}}}
+
+	apiMock.EXPECT().GetApplication(gomock.Any(), task.App, gomock.Any()).Return(managedApp(), nil)
+	metricsMock.EXPECT().AddInProgressTask()
+	metricsMock.EXPECT().InitDeploymentOutcomes(task.App)
+	metricsMock.EXPECT().RemoveInProgressTask()
+	// No outcome and no failure gauge are declared: gomock fails the test if one is recorded
+	// for a deployment whose real result could not be read.
+
+	capture := &capturingStrategy{}
+	updater.notifier = notifications.NewNotifier(capture)
+
+	updater.WaitForRollout(task, false, neverDraining)
+
+	require.Len(t, capture.sent, 1, "only the start notification: the outcome is unknown")
+}

--- a/internal/argocd/deployment_monitor.go
+++ b/internal/argocd/deployment_monitor.go
@@ -440,6 +440,13 @@ func (monitor *DeploymentMonitor) recordStatus(task *models.Task, status, reason
 		slog.Info("Left the outcome to whichever replica resumes this deployment.", "id", task.Id)
 		return false
 	}
+	if errors.Is(err, state.ErrTaskEnded) {
+		// A newer deployment cancelled it, or the sweep gave up on it, while this replica
+		// was deciding. That outcome is stored and is what the client polling the task
+		// reads; announcing or counting one of our own here would contradict it.
+		slog.Info("Deployment was already ended by something else; leaving its outcome alone.", "id", task.Id)
+		return false
+	}
 	if err != nil {
 		slog.Error("Failed to change task status", "error", err, "id", task.Id)
 	}

--- a/internal/state/in_memory_state.go
+++ b/internal/state/in_memory_state.go
@@ -147,13 +147,20 @@ func (state *InMemoryState) GetTask(id string) (*models.Task, error) {
 	return nil, ErrTaskNotFound
 }
 
-// SetTaskStatus returns ErrTaskNotFound when no task matches.
+// SetTaskStatus returns ErrTaskNotFound when no task matches, and ErrTaskEnded when the task
+// already reached a terminal status.
 func (state *InMemoryState) SetTaskStatus(id, status, reason string) error {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
 	for idx, task := range state.tasks {
 		if task.Id == id {
+			// Only a task still running may be given an outcome: a newer deployment may
+			// have cancelled it, or the sweep given up on it, while this caller decided.
+			if task.Status != models.StatusInProgressMessage {
+				return ErrTaskEnded
+			}
+
 			state.tasks[idx].Status = status
 			state.tasks[idx].StatusReason = reason
 			state.tasks[idx].Updated = float64(time.Now().Unix())

--- a/internal/state/in_memory_state_test.go
+++ b/internal/state/in_memory_state_test.go
@@ -423,3 +423,27 @@ func TestInMemoryState_ProcessObsoleteTasksKeepsInsertionOrder(t *testing.T) {
 	require.NotEmpty(t, tasks)
 	assert.Equal(t, "kept-last", tasks[0].Id, "the last task stored in a second stays the current one")
 }
+
+// A newer deployment cancels an in-flight task while its own replica is still deciding an
+// outcome — the window that the resource-tree fetch on the failure path widens to seconds.
+// The late write must not land on top of the cancellation.
+func TestInMemorySetTaskStatusRefusesToOverwriteATerminalStatus(t *testing.T) {
+	store := &InMemoryState{}
+	_ = store.Connect(nil)
+
+	task, _, err := store.SupersedeAndAdd(models.Task{App: "demo", Images: []models.Image{{Image: "app", Tag: "v1"}}}, "")
+	require.NoError(t, err)
+
+	// The newer deployment for the same app cancels it.
+	_, cancelled, err := store.SupersedeAndAdd(models.Task{App: "demo", Images: []models.Image{{Image: "app", Tag: "v2"}}}, "superseded")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), cancelled)
+
+	err = store.SetTaskStatus(task.Id, models.StatusFailedMessage, "decided too late")
+
+	require.ErrorIs(t, err, ErrTaskEnded)
+	stored, err := store.GetTask(task.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, stored.Status, "the cancellation must stand")
+	assert.Equal(t, "superseded", stored.StatusReason)
+}

--- a/internal/state/postgres_state.go
+++ b/internal/state/postgres_state.go
@@ -322,8 +322,9 @@ func (state *PostgresState) GetTask(id string) (*models.Task, error) {
 	return ormTask.ConvertToExternalTask(), nil
 }
 
-// SetTaskStatus errors if the id is malformed, returns ErrTaskNotFound when no task
-// exists, and ErrTaskNotOwned when another instance holds the claim.
+// SetTaskStatus errors if the id is malformed, returns ErrTaskNotFound when no task exists,
+// ErrTaskNotOwned when another instance holds the claim, and ErrTaskEnded when the task already
+// reached a terminal status.
 func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	uuidv4, err := uuid.Parse(id)
 	if err != nil {
@@ -336,13 +337,14 @@ func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 		return ErrTaskNotFound
 	}
 
-	// Fenced on ownership: a task claimed elsewhere since this instance checked its
-	// lease has that owner monitoring it too. A row never claimed at all stays
-	// writable, AddTask's claim being best-effort, and is told apart from one released
-	// at shutdown by having no lease deadline — a released row is somebody else's now.
+	// Fenced on ownership — a task claimed elsewhere has that owner monitoring it too, while a
+	// row never claimed stays writable (AddTask's claim is best-effort) and is told apart from
+	// one released at shutdown by having no lease deadline. Fenced on the status too: whoever
+	// ended the task first wins, the same rule supersedeInProgress applies when it cancels.
 	var ormTask = state_models.TaskModel{Id: uuidv4}
 	result := state.orm.Model(ormTask).
 		Where("owner_id = ? OR (owner_id IS NULL AND lease_expires_at IS NULL)", state.ownerId).
+		Where(whereStatusEquals, models.StatusInProgressMessage).
 		Updates(state_models.TaskModel{Status: status, StatusReason: sql.NullString{String: reason, Valid: true}})
 	if result.Error != nil {
 		return result.Error
@@ -354,16 +356,22 @@ func (state *PostgresState) SetTaskStatus(id, status, reason string) error {
 	return nil
 }
 
-// classifyRefusedWrite tells the two reasons SetTaskStatus matched no row apart:
-// an id that never existed is a caller bug, while a task held elsewhere is an
-// ordinary handover the caller must stop writing for.
+// classifyRefusedWrite tells the three reasons SetTaskStatus matched no row apart: an id
+// that never existed is a caller bug, a task already in a terminal status was ended by
+// something else whose outcome stands, and one held elsewhere is an ordinary handover.
 func (state *PostgresState) classifyRefusedWrite(id uuid.UUID) error {
-	var count int64
-	if err := state.orm.Model(&state_models.TaskModel{}).Where("id = ?", id).Count(&count).Error; err != nil {
+	var stored state_models.TaskModel
+	// Only the status is read: decoding the row.s jsonb on an error path would add a failure
+	// mode to a function whose whole job is to classify one.
+	err := state.orm.Select("status").Where("id = ?", id).First(&stored).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return ErrTaskNotFound
+	}
+	if err != nil {
 		return err
 	}
-	if count == 0 {
-		return ErrTaskNotFound
+	if stored.Status != models.StatusInProgressMessage {
+		return ErrTaskEnded
 	}
 
 	return ErrTaskNotOwned

--- a/internal/state/postgres_state_test.go
+++ b/internal/state/postgres_state_test.go
@@ -745,3 +745,23 @@ func TestPostgresState_GetTasks_ReportsAFailedRowFetch(t *testing.T) {
 	assert.Empty(t, tasks)
 	assert.Zero(t, total, "a total beside an error would read as a real count")
 }
+
+// The shared backend must refuse the same late write the in-memory one does: a newer
+// deployment cancels an in-flight task while its own replica is still deciding an outcome,
+// and that outcome must not land on top of the cancellation.
+func TestPostgresState_SetTaskStatusRefusesToOverwriteATerminalStatus(t *testing.T) {
+	env := newPostgresTestEnv(t)
+
+	task := env.addTask(t, sampleTask("fenced-app"))
+
+	// Cancelled by whatever got there first — a newer deployment for the same app.
+	require.NoError(t, env.state.SetTaskStatus(task.Id, models.StatusCancelledMessage, "superseded"))
+
+	err := env.state.SetTaskStatus(task.Id, models.StatusFailedMessage, "decided too late")
+
+	require.ErrorIs(t, err, ErrTaskEnded)
+	stored, err := env.state.GetTask(task.Id)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusCancelledMessage, stored.Status, "the cancellation must stand")
+	assert.Equal(t, "superseded", stored.StatusReason)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,6 +23,12 @@ var ErrTaskNotFound = errors.New("task not found")
 // would land on the outcome they reach. Only the shared backend reports it.
 var ErrTaskNotOwned = errors.New("task is not this instance's to finish")
 
+// ErrTaskEnded is returned by SetTaskStatus when the task already holds a terminal
+// status — cancelled by a newer deployment, or given up by the staleness sweep — while
+// this caller was still deciding. Whatever wrote it got there first and its outcome is
+// the one that stands, so the caller must report that rather than its own.
+var ErrTaskEnded = errors.New("task already reached a terminal status")
+
 // maySupersede reports whether a deployment may cancel an in-flight task, by
 // comparing the credential each one presented. Only the uncredentialed-cancels-
 // credentialed direction is refused.
@@ -60,7 +66,9 @@ type TaskRepository interface {
 	// StartTime and EndTime are honoured — the summary is a census of the
 	// window, so narrowing it by app or status would defeat its purpose.
 	GetAppSummaries(filter models.TaskFilter) ([]models.AppSummary, error)
-	// GetTask and SetTaskStatus return ErrTaskNotFound when no task matches id.
+	// GetTask and SetTaskStatus return ErrTaskNotFound when no task matches id, and
+	// SetTaskStatus returns ErrTaskEnded — from either backend — when the task already
+	// reached a terminal status.
 	GetTask(id string) (*models.Task, error)
 	SetTaskStatus(id, status, reason string) error
 	// SupersedeAndAdd cancels the in-progress tasks the new one supersedes and stores


### PR DESCRIPTION
`SetTaskStatus` was fenced on ownership alone, so the replica that owned a task could write its own outcome over a cancellation a newer deployment had just recorded. The window runs from the poll loop's last check to the write, and the resource-tree fetch on the failure path widens it to seconds — long enough for two deployments of the same application to collide, leaving the pipeline told the deployment failed rather than that a newer one took over.

A terminal status is now written only while the task is still in progress, in both backends, which is the rule the supersede already applied when it cancels. `in progress` is the only status a live task holds: both backends insert it, and `accepted` appears only in the HTTP 202 body.

The refusal is reported as `ErrTaskEnded` and is deliberately not treated like a handover. A handover has a successor that reaches the same outcome and announces it; a cancelled or aborted task is never re-claimed, so nothing else would. The rollout adopts the stored outcome and reports that instead, as it already does when the poll loop spots the cancellation in time.

The PostgreSQL half is exercised by a test that needs a database, so it runs in CI rather than locally.